### PR TITLE
Add style for new-of-type button. See UIU-164

### DIFF
--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -122,8 +122,11 @@ a.button{
         }
       }
     }
+    &.paneHeaderNewButton{
+      margin-right: 17px;
+    }
     &.noRadius{
-      border-radius: 0; 
+      border-radius: 0;
     }
     &.transparent{
       background-color: transparent;
@@ -155,7 +158,7 @@ a.button{
     &:not(.fullWidth, .fieldControl)+ .button{
         margin: 0 4px;
     }
-    
+
     &.mega{
       width: 100%;
       max-height: 16rem;


### PR DESCRIPTION
"+ New" buttons in a pane header need a right-margin. 