### PR TITLE
Lint: separate component, element props. See STCOM-21

### DIFF
--- a/lib/Checkbox/Checkbox.js
+++ b/lib/Checkbox/Checkbox.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import separateComponentProps from '../../util/separateComponentProps';
 import css from './Checkbox.css';
 
 const propTypes = {
@@ -134,8 +135,9 @@ class Checkbox extends React.Component {
     let metaTouched;
     let metaWarning;
     if (this.props.input) {
-      const { input, meta: { error, warning, touched }, ...rest } = this.props;
-      const { onChange, onFocus, onBlur, value, ...inputAttr } = input;
+      const { input, meta: { warning, touched }, ...rest } = this.props;
+      const { value, ...inputAttr } = input;
+
       metaTouched = touched;
       metaWarning = warning;
       inputProps = { ...inputAttr };
@@ -146,7 +148,8 @@ class Checkbox extends React.Component {
       inputProps = null;
     }
 
-    const { label, required, fullWidth, marginBottom0, hover, checkedIcon, uncheckedIcon, tertiaryIcon, labelStyle, ...inputCustom } = cleanedProps;
+    const { label, checkedIcon, uncheckedIcon, tertiaryIcon } = cleanedProps;
+    const [, inputCustom] = separateComponentProps(this.props, Checkbox.propTypes);
 
     let warningElement;
     if (this.props.meta) {
@@ -182,6 +185,8 @@ class Checkbox extends React.Component {
             checked={inputChecked || inputCustom.checked}
             {...inputProps}
             {...inputCustom}
+            id={cleanedProps.id}
+            name={cleanedProps.name}
             className={this.getInputStyle()}
             onChange={this.handleChange}
             onFocus={this.handleFocus}

--- a/lib/DropdownMenu/DropdownMenu.js
+++ b/lib/DropdownMenu/DropdownMenu.js
@@ -3,6 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
 import PropTypes from 'prop-types';
+import separateComponentProps from '../../util/separateComponentProps';
 import css from './DropdownMenu.css';
 
 const propTypes = {
@@ -66,8 +67,8 @@ class DropdownMenu extends React.Component {
   }
 
   render() {
-    const { bsRole, onSelect, onToggle, open, pullRight, bsClass, labelledBy, onClose, rootCloseEvent, ...ddprops } = this.props;
-
+    const { onToggle, pullRight } = this.props;
+    const [, ddprops] = separateComponentProps(this.props, DropdownMenu.propTypes);
     const position = {
       left: pullRight ? 'initial' : '0',
       display: this.props.open ? 'block' : 'none',

--- a/lib/RadioButton/RadioButton.js
+++ b/lib/RadioButton/RadioButton.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import separateComponentProps from '../../util/separateComponentProps';
 import css from './RadioButton.css';
 
 const propTypes = {
@@ -29,10 +30,11 @@ class RadioButton extends React.Component {
   }
 
   render() {
-    const { inline, error, label, children, marginBottom0, ...inputProps } = this.props;
+    const { label } = this.props;
+    const [, inputProps] = separateComponentProps(this.props, RadioButton.propTypes);
     return (
       <div className={this.getRootStyle()}>
-        <input {...inputProps} className={css.input} type="radio" />
+        <input id={this.props.id} {...inputProps} className={css.input} type="radio" />
         <label htmlFor={this.props.id} className={this.getLabelStyle()}>{label}</label>
       </div>
     );

--- a/util/separateComponentProps.js
+++ b/util/separateComponentProps.js
@@ -1,0 +1,22 @@
+/**
+ * Given a props object and the prop-types object for a component, separate
+ * the props into two objects, one containing those props that are defined
+ * for the component and the other containing everything else. This makes
+ * it easy to separate the props that apply to a component from those that
+ * should be passed along to a child component or element.
+ *
+ */
+export default function separateComponentProps(props, propTypes) {
+  const eProps = {};
+  const cProps = {};
+
+  Object.entries(props).forEach(([propName, propValue]) => {
+    if (propName in propTypes) {
+      cProps[propName] = propValue;
+    } else {
+      eProps[propName] = propValue;
+    }
+  });
+
+  return [cProps, eProps];
+}


### PR DESCRIPTION
In some cases props passed to a component are then pushed down to a
child element and we would have to filter out irrelevant props with code
like this:

const { junk1, junk2, junk3, ...inputProps } = this.props;
<input type="checkbox" {...inputProps} />

The junkX variables are created solely for the purpose of pulling those
keys out of inputProps, which causes ESLint to complain about unused
variables.

The function separateComponentProps provides a better way of handling
this situation without creating unused variables.