### PR TITLE
use "title" prop for stringValue. Refs STCOM-36

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -432,8 +432,13 @@ class MCLRenderer extends React.Component {
       }
 
       if (typeof value === 'object') {
-        console.warn(`Formatter possibly needed for column '${col}': value is object`, value);
-        stringValue = null;
+        if (React.isValidElement(value) && value.props.title) {
+          stringValue = value.props.title;
+        }
+        else {
+          console.warn(`Formatter possibly needed for column '${col}': value is object`, value);
+          stringValue = null;
+        }
       }
 
       if (typeof value === 'boolean') {


### PR DESCRIPTION
If a non-string value such as a valid React Element is handed to a cell
for rendering and that element has a title property, use it instead of
displaying a warning.