### PR TITLE
use column map to map header values. See UIU-176

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -520,7 +520,7 @@ class MCLRenderer extends React.Component {
 
       headers.push(
         <div key={`header-${header}`} role="columnheader" onClick={(e) => { this.handleHeaderClick(e, header); }} className={this.getHeaderClassName(header)} style={headerStyle}>
-          {header}
+          {this.getMappedColumnName(header)}
         </div>,
       );
     });


### PR DESCRIPTION
Curiously, the column map wasn't being used to handle the display
of column headers.