### PR TITLE
Fix compilation errors in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,27 +1,25 @@
 /*form elements*/
-export {default} from './lib/Button';
-export {default} from './lib/Checkbox';
-export {default} from './lib/RadioButton';
-export {default} from './lib/Select';
-export {default} from './lib/Textfield';
-export {default} from './lib/InputList';
+export { default as Button } from './lib/Button';
+export { default as Checkbox } from './lib/Checkbox';
+export { default as RadioButton } from './lib/RadioButton';
+export { default as Select } from './lib/Select';
+export { default as Textfield } from './lib/Textfield';
 
 /*data containers*/
-export {default} from './lib/KeyValue';
-export {default} from './lib/LayoutGrid';
-export {default} from './lib/MultiColumnList';
+export { default as KeyValue } from './lib/KeyValue';
+export { default as LayoutGrid } from './lib/LayoutGrid';
+export { default as MultiColumnList } from './lib/MultiColumnList';
 
 /*layout containers*/
-export {default} from './lib/Pane';
-export {default} from './lib/PaneHeader';
-export {default} from './lib/PaneMenu';
-export {default} from './lib/Paneset';
+export { default as Pane } from './lib/Pane';
+export { default as PaneHeader } from './lib/PaneHeader';
+export { default as PaneMenu } from './lib/PaneMenu';
+export { default as Paneset } from './lib/Paneset';
 
 /*misc*/
-export {default} from './lib/Icon';
+export { default as Icon } from './lib/Icon';
 
 /*specific use */
-export {default} from './lib/FilterPane';
-export {default} from './lib/FilterControlGroup';
-export {default} from './lib/FilterPaneSearch';
-
+export { default as FilterPane } from './lib/FilterPane';
+export { default as FilterControlGroup } from './lib/FilterControlGroup';
+export { default as FilterPaneSearch } from './lib/FilterPaneSearch';


### PR DESCRIPTION
`lib/index.js` currently re-exports the `default` export from several packages as its own. However, every JS module can only have at most a single `default` export. This was giving rise to errors like:

```
ERROR in ../stripes-components/index.js
Module build failed: SyntaxError: Only one default export allowed per module. (3:8)

  1 | /*form elements*/
  2 | export {default} from './lib/Button';
> 3 | export {default} from './lib/Checkbox';
    |         ^
```

This change re-exports each referenced component module as a named
export so that you can import them by name. E.g.

```js
import { Button } from '@folio/stripes-components';
```

> Note: `InputList` does not appear to be in the codebase anymore, so
> that export was removed.