### PR TITLE
support columnOverflow prop. Refs UIU-128

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -87,6 +87,9 @@
   flex-grow:0;
   padding: 6px;
   overflow: hidden;
+  &.showOverflow {
+    overflow: visible;
+  }
 }
 
 .scrollable{

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -40,6 +40,7 @@ const propTypes = {
   selectedRow: PropTypes.object,
   selectedClass: PropTypes.string,
   id: PropTypes.string,
+  columnOverflow: PropTypes.object,
 };
 
 const defaultProps = {
@@ -47,6 +48,7 @@ const defaultProps = {
   onRowClick: () => {},
   onHeaderClick: () => {},
   columnMapping: {},
+  columnOverflow: {},
   formatter: {},
   isEmptyMessage: 'The list contains no items',
   contentData: [],
@@ -414,7 +416,7 @@ class MCLRenderer extends React.Component {
   }
 
   renderCells(rowIndex) {
-    const { formatter, contentData } = this.props;
+    const { formatter, contentData, columnOverflow } = this.props;
     const { columnWidths } = this.state;
 
     const cells = [];
@@ -454,12 +456,12 @@ class MCLRenderer extends React.Component {
         cellStyle = { flex: `0 0 ${cellWidth}`, width: `${cellWidth}` };
       }
 
-
+      const showOverflow = (columnOverflow[col]) ? css.showOverflow : '';
       cells.push((
         <div
           role="gridcell"
           key={`${col}-${rowIndex}`}
-          className={css.cell}
+          className={`${css.cell} ${showOverflow}`}
           style={cellStyle}
           title={stringValue}
         >


### PR DESCRIPTION
By default cells in an MCL hide any overflow, but a cell which contains
a dropdown list, which will extends beyond the borders, needs to show
that overflow.