### PR TITLE
Uiu 128 tab button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Change history for stripes-components
 
 ## 1.5.0 (IN PROGRESS)
-* `<Notes>` component added. Part of STCOM-30. 
+* `<Notes>` component added. Part of STCOM-30.
 * `minWidth` prop added to `<DropdownMenu>`.
 * 'slim' class added to Button.css.
 * New icons added to <Icon> ('down-caret', 'up-caret').
 * Fix currently selected item in Settings. Fixes STCOM-37.
 * Add support for unsaved changes notification to `<AddressEdit>`. Fixes STCOM-35.
+* `<TabButton>` component added. Part of UIU-128. 
 
 ## [1.4.0](https://github.com/folio-org/stripes-components/tree/v1.4.0) (2017-08-01)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.3.0...v1.4.0)

--- a/lib/TabButton/TabButton.css
+++ b/lib/TabButton/TabButton.css
@@ -1,0 +1,28 @@
+button.tabButton{
+    background-color: transparent;
+    border-width: 0;
+    height: 42px;
+    cursor: pointer;
+    padding: 9px 5px;
+    transition: transform .2s ease;
+    & img, & div, & svg{
+      margin: 0 0px;
+      &+span{
+        align-self: center;
+        display: inline-block;
+      }
+    }
+    & > span{
+      display: flex;
+      font-weight: bold; 
+    }
+}
+
+.tabButton{
+  & .selected{
+    position: absolute;
+    width: 100%;
+    height: 4px;
+    background-color: #3d75b5;
+  }
+}

--- a/lib/TabButton/TabButton.css
+++ b/lib/TabButton/TabButton.css
@@ -1,4 +1,5 @@
-button.tabButton{
+div.tabButton{
+    display: inline-block; 
     background-color: transparent;
     border-width: 0;
     height: 42px;
@@ -14,7 +15,7 @@ button.tabButton{
     }
     & > span{
       display: flex;
-      font-weight: bold; 
+      font-weight: bold;
     }
 }
 

--- a/lib/TabButton/TabButton.js
+++ b/lib/TabButton/TabButton.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import css from './TabButton.css';
+
+const propTypes = {
+  children: PropTypes.node.isRequired,
+  selected: PropTypes.bool,
+};
+
+function TabButton(props) {
+  const { children, ...buttonProps } = props;
+
+  return (
+    <button
+      type="button"
+      className={css.tabButton}
+      {...buttonProps}
+    >
+      <span style={{ position: 'relative' }}>
+        {children}
+        {props.selected && <div className={css.selected} />}
+      </span>
+    </button>
+  );
+}
+
+TabButton.propTypes = propTypes;
+
+export default TabButton;

--- a/lib/TabButton/TabButton.js
+++ b/lib/TabButton/TabButton.js
@@ -11,7 +11,7 @@ function TabButton(props) {
   const { children, ...buttonProps } = props;
 
   return (
-    <button
+    <div
       type="button"
       className={css.tabButton}
       {...buttonProps}
@@ -20,7 +20,7 @@ function TabButton(props) {
         {children}
         {props.selected && <div className={css.selected} />}
       </span>
-    </button>
+    </div>
   );
 }
 

--- a/lib/TabButton/index.js
+++ b/lib/TabButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './TabButton';


### PR DESCRIPTION
A UI element for navigation on a tab-like interface where each tab represents a different filter applied to a list of data. See the screen shot for https://issues.folio.org/browse/UIU-128; this is used to implement the "Open Loans" and "Closed Loans" filters. 