### PR TITLE
show overflow in wrapper elements. Refs UIU-128.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 * Add boolean prop to control validation rendering for `<TextField>`. Fixes STCOM-39.
 * Avoid "Unknown prop `validationEnabled` on `<input>` tag" warning. Fixes STCOM-42.
 * MultiColumnList doesn't issue console warnings when displaying React elements. Fixes STCOM-36.
-* MultiColumnList will allow overflow to be visible if requested. Fixes UIU-128. 
+* MultiColumnList cells show overflow if requested. Refs UIU-128.
+* MultiColumnList wrapper elements show overflow. Refs UIU-128.
 * `<TabButton>` component added. Part of UIU-128. 
 
 ## [1.4.0](https://github.com/folio-org/stripes-components/tree/v1.4.0) (2017-08-01)

--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -24,7 +24,7 @@
   display: flex;
   justify-content: flex-start;
   align-items: stretch;
-  
+
   &.selected{
     color: #fff;
     background-color: color(var(--primary) shade(8%));
@@ -94,7 +94,7 @@
 
 .scrollable{
   position: relative;
-  overflow: auto;
+  overflow: visible;
   width: 100%;
 }
 

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -652,7 +652,7 @@ class MCLRenderer extends React.Component {
   getContainerStyle() {
     const containerStyle = {
       position: 'relative',
-      overflow: 'hidden',
+      overflow: 'visible',
     };
 
     if (this.props.autosize) {


### PR DESCRIPTION
The wrapper elements around a list, in addition to the individual cells,
need to allow visible overflow in order for the cells' overflow settings
to bubble up. This is necessary to allow overflow in the trailing cells
of a list; otherwise their overflow is simply cropped by the wrapper
element.