### PR TITLE
Import PropTypes directly from package, not React

### DIFF
--- a/lib/Select/Select.js
+++ b/lib/Select/Select.js
@@ -4,8 +4,8 @@ import classNames from 'classnames';
 import css from './Select.css';
 
 const propTypes = {
-  dataOptions: React.PropTypes.arrayOf(React.PropTypes.object),
-  meta: React.PropTypes.object,
+  dataOptions: PropTypes.arrayOf(PropTypes.object),
+  meta: PropTypes.object,
   fullWidth: PropTypes.bool,
   input: PropTypes.object,
   placeholder: PropTypes.string,

--- a/lib/structures/AddressFieldGroup/AddressEdit/AddressEdit.js
+++ b/lib/structures/AddressFieldGroup/AddressEdit/AddressEdit.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 
 import { Field } from 'redux-form';
@@ -11,16 +12,16 @@ import TextField from '../../../TextField';
 import { Row, Col } from '../../../LayoutGrid';
 
 const propTypes = {
-  addressObject: React.PropTypes.object,
-  canDelete: React.PropTypes.bool,
-  handleDelete: React.PropTypes.func,
-  handleCancel: React.PropTypes.func,
-  handleSubmit: React.PropTypes.func,
-  uiId: React.PropTypes.string,
-  labelMap: React.PropTypes.object,
-  visibleFields: React.PropTypes.array,
-  fieldComponents: React.PropTypes.object,
-  headerComponent: React.PropTypes.func,
+  addressObject: PropTypes.object,
+  canDelete: PropTypes.bool,
+  handleDelete: PropTypes.func,
+  handleCancel: PropTypes.func,
+  handleSubmit: PropTypes.func,
+  uiId: PropTypes.string,
+  labelMap: PropTypes.object,
+  visibleFields: PropTypes.array,
+  fieldComponents: PropTypes.object,
+  headerComponent: PropTypes.func,
 };
 
 const defaultProps = {

--- a/lib/structures/AddressFieldGroup/AddressList/AddressList.js
+++ b/lib/structures/AddressFieldGroup/AddressList/AddressList.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 
 import AddressView from '../AddressView';
@@ -13,66 +14,66 @@ const propTypes = {
   /**
    *  Array of address objects with properties: id, country, addressLine1, addressLine2, city, stateRegion, zipCode....
    */
-  addresses: React.PropTypes.arrayOf(React.PropTypes.object),
+  addresses: PropTypes.arrayOf(PropTypes.object),
 
   /**
    *  Address Editing Privilege/Switch....
    */
-  canEdit: React.PropTypes.bool,
+  canEdit: PropTypes.bool,
 
   /**
    *  Address Deletion Privilege/Switch....
    */
-  canDelete: React.PropTypes.bool,
+  canDelete: PropTypes.bool,
 
   /**
    *  in case the unique identifier is something besides 'id' - defaults to 'id'
    */
-  uniqueField: React.PropTypes.string,
+  uniqueField: PropTypes.string,
 
   /**
    *  Displays a custom <h2> tag at top of listing. Default: 'Address'
    */
-  sectionLabel: React.PropTypes.string,
+  sectionLabel: PropTypes.string,
 
   /**
    *  callback for new address record creation... should accept address object...
    */
-  onCreate: React.PropTypes.func,
+  onCreate: PropTypes.func,
 
   /**
    *  callback for saving record... should accept address object...
    */
-  onUpdate: React.PropTypes.func,
+  onUpdate: PropTypes.func,
 
   /**
    *  callback for deleting record... should accept id or unique identifier...
    */
-  onDelete: React.PropTypes.func,
+  onDelete: PropTypes.func,
   /**
    *  boolean for default to show all addresses or only show primary (defaults to false(primary Only));
    *  Toggleable by the 'show alternate addresses' button below the list...(appears if more than 1 address is stored)
    */
-  showAll: React.PropTypes.bool,
+  showAll: PropTypes.bool,
 
   /**
    * object to match field names with custom labels for UI rendering.
    */
-  labelMap: React.PropTypes.object,
+  labelMap: PropTypes.object,
 
   /**
    * fields from Address objects to render to the body of the display/form. Also specifies the order of fields. Header field is not included.
    */
-  visibleFields: React.PropTypes.array,
+  visibleFields: PropTypes.array,
 
   /**
    * header formatter in both view mode and edit mode. in view mode, it's a formatter in the form of
    *  (addressObject) => addressObject[addressProperty] - so it's possible to render a user-provided name or some other field of address info...
    *  for edit mode, a <Field> component can be passed with all of its necessary props.
    */
-  headerFormatter: React.PropTypes.shape({
-    view: React.PropTypes.func,
-    edit: React.PropTypes.func,
+  headerFormatter: PropTypes.shape({
+    view: PropTypes.func,
+    edit: PropTypes.func,
   }),
 
   /**
@@ -80,7 +81,7 @@ const propTypes = {
    * ex { city:Select } will render a select dropdown for the city field.
    * components are passed through the redux-form Field component.
    */
-  fieldComponents: React.PropTypes.object,
+  fieldComponents: PropTypes.object,
 };
 
 const defaultProps = {

--- a/lib/structures/AddressFieldGroup/AddressView/AddressView.js
+++ b/lib/structures/AddressFieldGroup/AddressView/AddressView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 
 import KeyValue from '../../../KeyValue';
@@ -8,13 +9,13 @@ import { Row, Col } from '../../../LayoutGrid';
 import Icon from '../../../Icon';
 
 const propTypes = {
-  addressObject: React.PropTypes.object,
-  canEdit: React.PropTypes.bool,
-  handleEdit: React.PropTypes.func,
-  uiId: React.PropTypes.string,
-  labelMap: React.PropTypes.object,
-  visibleFields: React.PropTypes.array,
-  headerFormatter: React.PropTypes.func,
+  addressObject: PropTypes.object,
+  canEdit: PropTypes.bool,
+  handleEdit: PropTypes.func,
+  uiId: PropTypes.string,
+  labelMap: PropTypes.object,
+  visibleFields: PropTypes.array,
+  headerFormatter: PropTypes.func,
 };
 
 const defaultProps = {

--- a/lib/structures/EditableList/EditableList.js
+++ b/lib/structures/EditableList/EditableList.js
@@ -7,7 +7,7 @@ const propTypes = {
   /**
    * Array of objects to be rendered as list items.
    */
-  contentData: PropTypes.arrayOf(React.PropTypes.object).isRequired,
+  contentData: PropTypes.arrayOf(PropTypes.object).isRequired,
   /**
    * The key that uniquely names listed objects: defaults to 'name'.
    */

--- a/lib/structures/EditableList/EditableListForm.js
+++ b/lib/structures/EditableList/EditableListForm.js
@@ -37,7 +37,7 @@ const propTypes = {
   /**
    * Array of fields to render. These will also be editable.
    */
-  visibleFields: PropTypes.arrayOf(React.PropTypes.string).isRequired,
+  visibleFields: PropTypes.arrayOf(PropTypes.string).isRequired,
   /**
    * Object that reflects the shape of list item objects. values should be strings
    * indicating the type: {name:'string'}

--- a/lib/structures/EditableList/ItemEdit.js
+++ b/lib/structures/EditableList/ItemEdit.js
@@ -38,7 +38,7 @@ ItemEdit.propTypes = {
   field: PropTypes.string,
   onCancel: PropTypes.func,
   onSave: PropTypes.func,
-  visibleFields: PropTypes.arrayOf(React.PropTypes.string),
+  visibleFields: PropTypes.arrayOf(PropTypes.string),
 };
 
 export default ItemEdit;

--- a/lib/structures/EditableList/ItemView.js
+++ b/lib/structures/EditableList/ItemView.js
@@ -33,7 +33,7 @@ ItemView.propTypes = {
   actionSuppression: PropTypes.object.isRequired,
   onEdit: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
-  visibleFields: PropTypes.arrayOf(React.PropTypes.string),
+  visibleFields: PropTypes.arrayOf(PropTypes.string),
 };
 
 export default ItemView;


### PR DESCRIPTION
Removes this warning:
`Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see` https://fb.me/prop-types-docs