### PR TITLE
Teardown animation callbacks on Pane unmount.

### DIFF
--- a/lib/Pane/Pane.js
+++ b/lib/Pane/Pane.js
@@ -61,12 +61,13 @@ class Pane extends React.Component {
     }
     const paneObject = { transition, ref: this, id: this.id };
     this.context.paneset.registerPane(paneObject);
-    window.requestAnimationFrame(() => {
+    this.animationCallbackID = window.requestAnimationFrame(() => {
       this.setState({ contentMinWidth: this.getContentWidth() });
     });
   }
 
   componentWillUnmount() {
+    window.cancelAnimationFrame(this.animationCallbackID);
     this.context.paneset.removePane(this.id);
   }
 


### PR DESCRIPTION
Whenever a Pane component is mounted, it installs an animation callback to make sure that it syncs its `contentMinWidth` property with the actual content width of the frame as rendered. However, after the Pane component is unmounted, the callback remains installed and attempts to `setState` the component which is no longer present. It repeatedly spews Errors like the following to the console.

```
ERROR: 'Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the Pane component.'
ERROR: 'Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the Pane component.'
ERROR: 'Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the Pane component.'
```

This stores the callback ID for the state sync, and then cancels the callback when the component is torn down.