### PR TITLE
Stutilnote 2 refactor notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-components
 
+## 1.8.0
+* Use metadata, not metaData. See MODNOTES-2.
+* Correctly update note's link when selected user changes. Fixes STUTILNOTE-1.
+
 ## [1.7.0](https://github.com/folio-org/stripes-components/tree/v1.7.0) (2017-09-01)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.6.0...v1.7.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * *New Component* `<Accordion>` added to fulfill STCOM-20.
 * `<Button>` includes prop `buttonRef` for obtaining a ref to its rendered element.
 * `down-triangle` and `up-triangled` added to `<Icon>`.
+* Refactor out `<Notes>`'s okapi interaction. See STUTILNOTE-2.
 
 ## [1.5.0](https://github.com/folio-org/stripes-components/tree/v1.5.0) (2017-08-25)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.4.0...v1.5.0)

--- a/lib/structures/Notes/NoteRenderer.js
+++ b/lib/structures/Notes/NoteRenderer.js
@@ -5,6 +5,7 @@ import { Row, Col } from '../../LayoutGrid';
 import Icon from '../../Icon';
 import Button from '../../Button';
 import DropdownMenu from '../../DropdownMenu';
+import IfPermission from '../../IfPermission';
 import NotesForm from './NotesForm';
 import css from './Notes.css';
 
@@ -12,8 +13,8 @@ class NoteRenderer extends React.Component {
   static propTypes = {
     stripes: PropTypes.object,
     note: PropTypes.object,
-    onDelete: PropTypes.func,
-    onUpdate: PropTypes.func,
+    onDelete: PropTypes.func.isRequired,
+    onUpdate: PropTypes.func.isRequired,
     noteKey: PropTypes.string,
   }
 
@@ -73,17 +74,21 @@ class NoteRenderer extends React.Component {
 
     if (this.state.editMode) {
       return (
-        <div key={`notes-${noteKey}`} className={`${css.noteWell} ${css.editing}`}>
-          <Row middle="xs">
-            <Col xs={10}>
-              <div className={css.byLine}>{stamp}</div>
-              <div className={css.byLine}>{note.metaData.createdByUserId}</div>
-            </Col>
-          </Row>
-          <NotesForm form={`noteEdit-${noteKey}`} initialValues={note} textRows="4" editMode onCancel={this.handleFormCancel} onSubmit={this.handleFormSubmit} />
-        </div>
+        <IfPermission perm="notes.item.put">
+          <div key={`notes-${noteKey}`} className={`${css.noteWell} ${css.editing}`}>
+            <Row middle="xs">
+              <Col xs={10}>
+                <div className={css.byLine}>{stamp}</div>
+                <div className={css.byLine}>{note.metaData.createdByUserId}</div>
+              </Col>
+            </Row>
+            <NotesForm form={`noteEdit-${noteKey}`} initialValues={note} textRows="4" editMode onCancel={this.handleFormCancel} onSubmit={this.handleFormSubmit} />
+          </div>
+        </IfPermission>
       );
     }
+
+    const canEditOrDelete = stripes.hasPerm('notes.item.put') || stripes.hasPerm('notes.item.delete');
 
     return (
       <div key={`notes-${noteKey}`} className={css.noteWell}>
@@ -93,27 +98,33 @@ class NoteRenderer extends React.Component {
             <div className={css.byLine}>{note.metaData.createdByUserId}</div>
           </Col>
           <Col xs={2}>
-            <Dropdown
-              id={`edit-delete-dropdown-${noteKey}`}
-              style={{ float: 'right' }}
-              pullRight
-              open={this.state.dropDownOpen}
-              onToggle={this.onToggleDropDown}
-            >
-              <Button buttonStyle="transparent slim" title="Edit or delete this note" bsRole="toggle" >
-                <Icon icon="down-caret" color="rgba(150, 150, 150, .5)" />
-              </Button>
-              <DropdownMenu
-                bsRole="menu"
-                width="5em"
-                minWidth="5em"
-                aria-label="Edit or delete this note"
+            {canEditOrDelete &&
+              <Dropdown
+                id={`edit-delete-dropdown-${noteKey}`}
+                style={{ float: 'right' }}
+                pullRight
+                open={this.state.dropDownOpen}
                 onToggle={this.onToggleDropDown}
               >
-                <Button buttonStyle="marginBottom0 hover fullWidth" onClick={this.handleClickEdit}>Edit</Button>
-                <Button buttonStyle="marginBottom0 hover fullWidth" onClick={() => { this.handleClickDelete(noteKey); }}>Delete</Button>
-              </DropdownMenu>
-            </Dropdown>
+                <Button buttonStyle="transparent slim" title="Edit or delete this note" bsRole="toggle" >
+                  <Icon icon="down-caret" color="rgba(150, 150, 150, .5)" />
+                </Button>
+                <DropdownMenu
+                  bsRole="menu"
+                  width="5em"
+                  minWidth="5em"
+                  aria-label="Edit or delete this note"
+                  onToggle={this.onToggleDropDown}
+                >
+                  <IfPermission perm="notes.item.put">
+                    <Button buttonStyle="marginBottom0 hover fullWidth" onClick={this.handleClickEdit}>Edit</Button>
+                  </IfPermission>
+                  <IfPermission perm="notes.item.delete">
+                    <Button buttonStyle="marginBottom0 hover fullWidth" onClick={() => { this.handleClickDelete(noteKey); }}>Delete</Button>
+                  </IfPermission>
+                </DropdownMenu>
+              </Dropdown>
+            }
           </Col>
         </Row>
         <Row>

--- a/lib/structures/Notes/NoteRenderer.js
+++ b/lib/structures/Notes/NoteRenderer.js
@@ -70,7 +70,7 @@ class NoteRenderer extends React.Component {
   render() {
     const { note, noteKey, stripes } = this.props;
 
-    const stamp = new Date(Date.parse(note.metaData.createdDate)).toLocaleString(stripes.locale);
+    const stamp = new Date(Date.parse(note.metadata.createdDate)).toLocaleString(stripes.locale);
 
     if (this.state.editMode) {
       return (
@@ -79,7 +79,7 @@ class NoteRenderer extends React.Component {
             <Row middle="xs">
               <Col xs={10}>
                 <div className={css.byLine}>{stamp}</div>
-                <div className={css.byLine}>{note.metaData.createdByUserId}</div>
+                <div className={css.byLine}>{note.metadata.createdByUserId}</div>
               </Col>
             </Row>
             <NotesForm form={`noteEdit-${noteKey}`} initialValues={note} textRows="4" editMode onCancel={this.handleFormCancel} onSubmit={this.handleFormSubmit} />
@@ -95,7 +95,7 @@ class NoteRenderer extends React.Component {
         <Row middle="xs">
           <Col xs={10}>
             <div className={css.byLine}>{stamp}</div>
-            <div className={css.byLine}>{note.metaData.createdByUserId}</div>
+            <div className={css.byLine}>{note.metadata.createdByUserId}</div>
           </Col>
           <Col xs={2}>
             {canEditOrDelete &&

--- a/lib/structures/Notes/Notes.js
+++ b/lib/structures/Notes/Notes.js
@@ -6,53 +6,51 @@ import NotesForm from './NotesForm';
 import NoteRenderer from './NoteRenderer';
 import css from './Notes.css';
 
-class Notes extends React.Component {
-  static propTypes = {
-    stripes: PropTypes.object.isRequired,
-    onToggle: PropTypes.func.isRequired,
-    onSubmit: PropTypes.func.isRequired,
-    onDelete: PropTypes.func.isRequired,
-    onUpdate: PropTypes.func.isRequired,
-    link: PropTypes.string.isRequired,
-    notes: PropTypes.arrayOf(PropTypes.object).isRequired,
-  }
-
-  render() {
-    const notes = this.props.notes;
-    const notesPaneTitle = (
-      <div style={{ textAlign: 'center' }}>
-        <strong>Notes</strong>
-        <div>
-          <em>{notes.length} Note{notes.length === 1 ? '' : 's'}</em>
-        </div>
+const Notes = (props) => {
+  const notes = props.notes;
+  const notesPaneTitle = (
+    <div style={{ textAlign: 'center' }}>
+      <strong>Notes</strong>
+      <div>
+        <em>{notes.length} Note{notes.length === 1 ? '' : 's'}</em>
       </div>
-    );
+    </div>
+  );
 
-    const noteList = notes.map((note, i) => (<NoteRenderer stripes={this.props.stripes} note={note} noteKey={note.id} onDelete={this.props.onDelete} onUpdate={this.props.onUpdate} key={`noteRender-${i}`} />));
+  const noteList = notes.map((note, i) => (<NoteRenderer stripes={props.stripes} note={note} noteKey={note.id} onDelete={props.onDelete} onUpdate={props.onUpdate} key={`noteRender-${i}`} />));
 
-    return (
-      <Pane
-        defaultWidth="20%"
-        paneTitle={notesPaneTitle}
-        dismissible
-        onClose={this.props.onToggle}
-      >
-        <IfPermission perm="notes.collection.get">
-          <div className={css.notesList}>
-            {noteList}
-          </div>
-        </IfPermission>
-        <IfPermission perm="notes.item.post">
-          <NotesForm
-            id="userform-addnote"
-            initialValues={{ link: this.props.link }}
-            form="newNote"
-            onSubmit={this.props.onSubmit}
-          />
-        </IfPermission>
-      </Pane>
-    );
-  }
-}
+  return (
+    <Pane
+      defaultWidth="20%"
+      paneTitle={notesPaneTitle}
+      dismissible
+      onClose={props.onToggle}
+    >
+      <IfPermission perm="notes.collection.get">
+        <div className={css.notesList}>
+          {noteList}
+        </div>
+      </IfPermission>
+      <IfPermission perm="notes.item.post">
+        <NotesForm
+          id="userform-addnote"
+          initialValues={{ link: props.link }}
+          form="newNote"
+          onSubmit={props.onSubmit}
+        />
+      </IfPermission>
+    </Pane>
+  );
+};
+
+Notes.propTypes = {
+  stripes: PropTypes.object.isRequired,
+  onToggle: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  onUpdate: PropTypes.func.isRequired,
+  link: PropTypes.string.isRequired,
+  notes: PropTypes.arrayOf(PropTypes.object).isRequired,
+};
 
 export default Notes;

--- a/lib/structures/Notes/Notes.js
+++ b/lib/structures/Notes/Notes.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Pane from '../../Pane';
+import IfPermission from '../../IfPermission';
 import NotesForm from './NotesForm';
 import NoteRenderer from './NoteRenderer';
 import css from './Notes.css';
@@ -8,83 +9,16 @@ import css from './Notes.css';
 class Notes extends React.Component {
   static propTypes = {
     stripes: PropTypes.object.isRequired,
-    onToggle: PropTypes.func,
-    mutator: PropTypes.shape({
-      notes: PropTypes.shape({
-        POST: PropTypes.func,
-        DELETE: PropTypes.func,
-        PUT: PropTypes.func,
-      }),
-    }).isRequired,
-    resources: PropTypes.shape({
-      notes: PropTypes.shape({
-        records: PropTypes.arrayOf(PropTypes.object),
-      }),
-    }),
-    match: PropTypes.shape({
-      params: PropTypes.shape({
-        id: PropTypes.string,
-      }),
-    }).isRequired,
-    link: PropTypes.string,
-  }
-
-  static manifest = Object.freeze({
-    notes: {
-      type: 'okapi',
-      path: 'notes',
-      records: 'notes',
-      clear: false,
-      GET: {
-        params: {
-          query: 'link=:{id}',
-        },
-      },
-    },
-  });
-
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      updating: false,
-    };
-
-    this.handleDelete = this.handleDelete.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
-    this.handleUpdate = this.handleUpdate.bind(this);
-  }
-
-  handleSubmit(note) {
-    this.setState({ updating: true });
-    this.props.mutator.notes.POST(note)
-    .then(() => {
-      this.setState({ updating: false });
-    });
-  }
-
-  handleUpdate(note) {
-    this.setState({ updating: true });
-    this.props.mutator.notes.PUT({
-      id: note.id,
-      link: note.link,
-      text: note.text,
-    })
-    .then(() => {
-      this.setState({ updating: false });
-    });
-  }
-
-  handleDelete(id) {
-    this.setState({ updating: true });
-    this.props.mutator.notes.DELETE({ id })
-    .then(() => {
-      this.setState({ updating: false });
-    });
+    onToggle: PropTypes.func.isRequired,
+    onSubmit: PropTypes.func.isRequired,
+    onDelete: PropTypes.func.isRequired,
+    onUpdate: PropTypes.func.isRequired,
+    link: PropTypes.string.isRequired,
+    notes: PropTypes.arrayOf(PropTypes.object).isRequired,
   }
 
   render() {
-    const notes = (this.props.resources.notes || {}).records || [];
+    const notes = this.props.notes;
     const notesPaneTitle = (
       <div style={{ textAlign: 'center' }}>
         <strong>Notes</strong>
@@ -94,7 +28,7 @@ class Notes extends React.Component {
       </div>
     );
 
-    const noteList = notes.map((note, i) => (<NoteRenderer stripes={this.props.stripes} note={note} noteKey={note.id} onDelete={this.handleDelete} onUpdate={this.handleUpdate} key={`noteRender-${i}`} />));
+    const noteList = notes.map((note, i) => (<NoteRenderer stripes={this.props.stripes} note={note} noteKey={note.id} onDelete={this.props.onDelete} onUpdate={this.props.onUpdate} key={`noteRender-${i}`} />));
 
     return (
       <Pane
@@ -103,15 +37,19 @@ class Notes extends React.Component {
         dismissible
         onClose={this.props.onToggle}
       >
-        <div className={css.notesList}>
-          {noteList}
-        </div>
-        <NotesForm
-          id="userform-addnote"
-          initialValues={{ link: `${this.props.link}/${this.props.match.params.id}` }}
-          form="newNote"
-          onSubmit={(record) => { this.handleSubmit(record); }}
-        />
+        <IfPermission perm="notes.collection.get">
+          <div className={css.notesList}>
+            {noteList}
+          </div>
+        </IfPermission>
+        <IfPermission perm="notes.item.post">
+          <NotesForm
+            id="userform-addnote"
+            initialValues={{ link: this.props.link }}
+            form="newNote"
+            onSubmit={this.props.onSubmit}
+          />
+        </IfPermission>
       </Pane>
     );
   }

--- a/lib/structures/Notes/NotesForm.js
+++ b/lib/structures/Notes/NotesForm.js
@@ -30,8 +30,8 @@ function NotesForm(props) {
   const {
     form,
     handleSubmit,
-    pristine, // eslint-disable-line no-unused-vars
-    submitting, // eslint-disable-line no-unused-vars
+    pristine,
+    submitting,
     textRows,
     editMode,
     onCancel,
@@ -75,4 +75,5 @@ NotesForm.propTypes = propTypes;
 
 export default stripesForm({
   form: 'NotesForm',
+  enableReinitialize: true,
 })(NotesForm);

--- a/lib/structures/Notes/NotesForm.js
+++ b/lib/structures/Notes/NotesForm.js
@@ -58,7 +58,7 @@ function NotesForm(props) {
         fullWidth
         id="note_textarea"
         component={renderTextArea}
-        onKeyDown={(e) => { handleKeyDown(e, handleSubmit); }}
+        onKeyDown={(e) => { handleKeyDown(e, handleClickSubmit); }}
         rows={textRows}
       />
       <div style={{ textAlign: 'right' }}>


### PR DESCRIPTION
Prep for refactoring the business logic of `<Notes>` into a separate repository, and a bug fix: re-render the new-note-form with updated props when the notes pane is left open and the selected-item, which sets the note's `link` prop, changes. 