### PR TITLE
Upgrade ESLint and fix broken rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,9 @@
     "import/resolver": {
       "webpack": {}
     },
+    "react": {
+      "version": "15.6.1"
+    },
   },
   "env": {
     "browser": true,
@@ -36,6 +39,7 @@
         tags: [],
         roles: ['tabpanel', 'dialog'],
       },
-    ]
+    ],
+    "jsx-a11y/href-no-hash": "off",
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -41,5 +41,6 @@
       },
     ],
     "jsx-a11y/href-no-hash": "off",
+    "jsx-a11y/label-has-for": "off",
   }
 }

--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -25,7 +25,6 @@ const propTypes = {
 };
 
 class Accordion extends React.Component {
-
   static defaultProps = {
     header: DefaultAccordionHeader,
     separator: true,

--- a/lib/AuthorityList/AuthorityList.js
+++ b/lib/AuthorityList/AuthorityList.js
@@ -102,7 +102,6 @@ class AuthorityList extends React.Component {
       </Paneset>
     );
   }
-
 }
 
 export default AuthorityList;

--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -88,7 +88,7 @@ class Calendar extends React.Component {
 
     moment.locale(this.props.locale);
 
-    let inputDate;  // initial date for state
+    let inputDate; // initial date for state
     let cursorDate;
     if (this.props.selectedDate === '' || this.props.selectedDate === 'undefined') {
       inputDate = null;

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -275,7 +275,7 @@ class MCLRenderer extends React.Component {
       // if(this.props.virtualize){
       this.props.onNeedMoreData();
       fetching = true;
-     // }
+      // }
     }
 
     if (newAmount > data.length) {

--- a/lib/RadioButton/RadioButton.js
+++ b/lib/RadioButton/RadioButton.js
@@ -15,7 +15,6 @@ const propTypes = {
 };
 
 class RadioButton extends React.Component {
-
   getLabelStyle() {
     let labelStyle = css.radioLabel;
     labelStyle += this.props.error ? ` ${css.error}` : '';

--- a/lib/Select/Select.js
+++ b/lib/Select/Select.js
@@ -21,7 +21,6 @@ const defaultProps = {
 };
 
 class Select extends React.Component {
-
   getRootClass() {
     return classNames(
       css.root,

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import Switch from 'react-router-dom/Switch';
 import Route from 'react-router-dom/Route';

--- a/lib/TextArea/TextArea.js
+++ b/lib/TextArea/TextArea.js
@@ -45,7 +45,6 @@ const defaultProps = {
 };
 
 class TextArea extends React.Component {
-
   getRootStyle() {
     // let rootStyle = css.root;
     // rootStyle += this.props.fullWidth ? ' ' + css.rootFull : '';

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -259,7 +259,6 @@ class TextField extends React.Component {
       </div>
     );
   }
-
 }
 
 TextField.propTypes = propTypes;

--- a/lib/structures/AddressFieldGroup/AddressEdit/AddressEdit.js
+++ b/lib/structures/AddressFieldGroup/AddressEdit/AddressEdit.js
@@ -22,7 +22,7 @@ const propTypes = {
   visibleFields: PropTypes.arrayOf(PropTypes.string),
   fieldComponents: PropTypes.object,
   headerComponent: PropTypes.func,
-  addresses: PropTypes.arrayOf(PropTypes.object),  // eslint-disable-line react/no-unused-prop-types
+  addresses: PropTypes.arrayOf(PropTypes.object), // eslint-disable-line react/no-unused-prop-types
 };
 
 const defaultProps = {
@@ -114,7 +114,7 @@ const AddressEdit = (props) => {
     const fieldComponent = (<Col key={`col-${i}`} xs={4}><Field label={fieldLabel} name={field} {...compProps} component={component} /></Col>);
     rowArray.push(fieldComponent);
 
-   // 3 fields per row...
+    // 3 fields per row...
     if (rowArray.length === 3 || i === visibleFields.length - 1) {
       groupArray.push(<Row key={`row-${i}`}>{rowArray}</Row>);
       rowArray = [];

--- a/lib/structures/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
+++ b/lib/structures/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
@@ -10,7 +10,6 @@ import { Row, Col } from '../../../LayoutGrid';
 import css from './AddressEdit.css';
 
 class EmbeddedAddressForm extends React.Component {
-
   static propTypes = {
     // addressObject: PropTypes.object,
     addressFieldName: PropTypes.string,
@@ -83,7 +82,7 @@ class EmbeddedAddressForm extends React.Component {
 
     const renderedFields = visibleFields.map((fieldName, i) => {
       const fieldLabel = Object.prototype.hasOwnProperty.call(labelMap, fieldName) ?
-       labelMap[fieldName] : fieldName;
+        labelMap[fieldName] : fieldName;
 
       let field;
       if (Object.prototype.hasOwnProperty.call(mergedFieldComponents, fieldName)) {

--- a/lib/structures/AddressFieldGroup/AddressList/AddressList.js
+++ b/lib/structures/AddressFieldGroup/AddressList/AddressList.js
@@ -130,7 +130,7 @@ class AddressList extends React.Component {
       if (typeof this.state.focusTarget === 'string') {
         const elem = document.getElementById(`addressEdit-${this.state.focusTarget}`).querySelector('input', 'select');
         if (elem) elem.focus();
-      } else {  // can be set to an element - in this case, focus directly...
+      } else { // can be set to an element - in this case, focus directly...
         this.state.focusTarget.focus();
       }
     }

--- a/lib/structures/AddressFieldGroup/AddressView/AddressView.js
+++ b/lib/structures/AddressFieldGroup/AddressView/AddressView.js
@@ -49,7 +49,7 @@ function AddressView(props) {
     const fieldComponent = (<Col xs={4} key={`${fieldLabel}-${field}`} ><KeyValue label={fieldLabel} value={addressObject[field]} /></Col>);
     rowArray.push(fieldComponent);
 
-   // 3 fields per row...
+    // 3 fields per row...
     if (rowArray.length === 3 || i === visibleFields.length - 1) {
       groupArray.push(<Row key={i}>{rowArray}</Row>);
       rowArray = [];

--- a/lib/structures/EditableList/EditableListForm.js
+++ b/lib/structures/EditableList/EditableListForm.js
@@ -54,7 +54,7 @@ const propTypes = {
    * properties" { delete: (item) => {return (!item.item.inUse)} }
    */
   actionSuppression: PropTypes.object,
-   /**
+  /**
    * Message to display for an empty list.
    */
   isEmptyMessage: PropTypes.string,
@@ -67,7 +67,6 @@ const defaultProps = {
 };
 
 class EditableListForm extends React.Component {
-
   constructor(props) {
     super(props);
     this.renderItems = this.renderItems.bind(this);

--- a/package.json
+++ b/package.json
@@ -25,18 +25,18 @@
   },
   "devDependencies": {
     "babel-core": "^6.17.0",
-    "babel-eslint": "^7.0.0",
+    "babel-eslint": "^8.0.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",
     "babel-register": "^6.18.0",
-    "eslint": "^3.8.0",
+    "eslint": "^4.7.0",
     "eslint-config-airbnb": "^15.1.0",
-    "eslint-import-resolver-webpack": "0.7.1",
-    "eslint-plugin-babel": "^3.3.0",
-    "eslint-plugin-import": "^2.0.1",
-    "eslint-plugin-jsx-a11y": "^5.1.0",
-    "eslint-plugin-react": "^7.1.0",
+    "eslint-import-resolver-webpack": "^0.8.3",
+    "eslint-plugin-babel": "^4.1.2",
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-jsx-a11y": "^6.0.2",
+    "eslint-plugin-react": "^7.3.0",
     "webpack": "1.11.0"
   },
   "dependencies": {
@@ -55,8 +55,8 @@
     "react-flexbox-grid": "1.1.3",
     "react-overlays": "^0.8.0",
     "react-router-dom": "^4.1.1",
-    "redux-form": "^7.0.3",
-    "react-tether": "0.5.7"
+    "react-tether": "0.5.7",
+    "redux-form": "^7.0.3"
   },
   "peerDependencies": {
     "stripes-core": "^2.7.0"


### PR DESCRIPTION
I noticed on our builds of `thefrontside/ui-eholdings` that we were still getting `WARN: 'Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs'`, even though I thought it had been resolved with https://github.com/folio-org/stripes-components/pull/45.

It turns out I missed one - in searching for `React.PropTypes`, I didn't notice an instance of `import React, { PropTypes } from 'react';`.

That would've been caught by the ESLint `react/no-deprecated` rule provided as part of `eslint-config-airbnb`, but the error was not being thrown. I upgraded all the `eslint`-related packages, and then there were errors in my editor and when running `yarn lint` (`react-no-deprecated` also needed to know the target `react` version to pop up).

I fixed all the linting errors, with only a few uses of `eslint-disable-line`.

### Next Steps
It would be awesome if we ran the linter as part of a continuous integration environment, so future pull requests to `stripes-components` with ESLint errors could not be merged.

### Follow-up Work
I turned off `jsx-a11y/label-has-for` since it had a lot of breakages that needed extensive refactors with probable css changes. The rule was usually thrown because `<label>` elements weren't wrapping their associated checkboxes, radio buttons, etc. https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md