### PR TITLE
push all props down to generated components. Fixes STCOM-84

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for stripes-components
 
+## 1.9.0 IN progress
+* Really restore missing props to generated component in `<TextField>` and `<Button>`. See STCOM-83. Fixes STCOM-84.
+
 ## [1.8.0](https://github.com/folio-org/stripes-components/tree/v1.8.0) (2017-09-28)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.7.0...v1.8.0)
 

--- a/lib/Button/Button.js
+++ b/lib/Button/Button.js
@@ -2,7 +2,7 @@ import React from 'react';
 import className from 'classnames';
 import PropTypes from 'prop-types';
 import css from './Button.css';
-import separateComponentProps from '../../util/separateComponentProps';
+import omitProps from '../../util/omitProps';
 
 const propTypes = {
   buttonStyle: PropTypes.string,
@@ -67,24 +67,20 @@ function Button(props) {
     }
   }
 
-  const [componentProps, otherProps] = separateComponentProps(props, propTypes);
-
-  // eslint-disable-next-line no-unused-vars
-  // const { buttonStyle, bottomMargin0, marginBottom0, align, hollow, fullWidth, bsRole, bsClass, onClick, allowAnchorClick, buttonRef, ...buttonProps } = props;
-
-  const { children, onClick, type } = componentProps;
+  const inputCustom = omitProps(props, ['buttonStyle', 'bottomMargin0', 'marginBottom0', 'align', 'hollow', 'fullWidth', 'bsRole', 'bsClass', 'onClick', 'allowAnchorClick', 'buttonRef']);
+  const { children, onClick, type } = props;
 
   if (props.href) {
     return (
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-      <a className={getStyle()} onClick={handleAnchorClick} ref={getButtonRef} {...otherProps}>
+      <a className={getStyle()} onClick={handleAnchorClick} ref={getButtonRef} {...inputCustom}>
         {children}
       </a>
     );
   }
 
   return (
-    <button className={getStyle()} type={type} onClick={onClick} ref={getButtonRef} {...otherProps}>
+    <button className={getStyle()} type={type} onClick={onClick} ref={getButtonRef} {...inputCustom}>
       {children}
     </button>
   );

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import Icon from '../Icon';
 import Button from '../Button';
 import css from './TextField.css';
-import separateComponentProps from '../../util/separateComponentProps';
+import omitProps from '../../util/omitProps';
 
 const propTypes = {
   /**
@@ -193,38 +193,21 @@ class TextField extends React.Component {
       inputProps = null;
     }
 
-    const [cProps, inputCustom] = separateComponentProps(cleanedProps, propTypes);
-    const { label, endControl, startControl, required } = cProps;
-    // const {
-    //   label,
-    //   endControl,
-    //   startControl,
-    //   rounded, // eslint-disable-line no-unused-vars
-    //   required,
-    //   fullWidth, // eslint-disable-line no-unused-vars
-    //   marginBottom0, // eslint-disable-line no-unused-vars
-    //   noBorder, // eslint-disable-line no-unused-vars
-    //   ...inputCustom
-    // } = cleanedProps;
-    // delete inputCustom.validationEnabled;
+    const { label, endControl, startControl, required } = cleanedProps;
 
-    // note that id, value, onChange, and type must be explicitly passed
-    // down to the generated component. Because those keys are defined as props
-    // on this component, `[cProps, inputCustom] = separateComponentProps()`
-    // filters them into cProps whereas a line like
-    //     const { foo, bar, bat, ...inputCustom } = cleanedProps
-    // leaves them inputCustom (but also pollutes the namespace with foo, bar,
-    // and bat, which is why we have separateComponentProps).
+    // Use omitProps here instead of separateComponentProps because
+    // redux-form needs the abililty to directly manage the props it passes
+    // down to the fields it manages. separateComponentProps requires us to
+    // know the names of all the props we want to pass along, but we don't
+    // know them.
+    // this still feels kinda clumsy, but at least it's not broken.
+    const inputCustom = omitProps(cleanedProps, ['label', 'endControl', 'startControl', 'rounded', 'required', 'fullWidth', 'marginBottom0', 'noBorder', 'validationEnabled']);
     const component = (
       <input
         ref={(ref) => { this.input = ref; }}
         className={this.getInputStyle()}
         {...inputProps}
         {...inputCustom}
-        id={cProps.id}
-        value={cProps.value}
-        onChange={cProps.onChange}
-        type={cProps.type}
         aria-required={required}
       />
     );


### PR DESCRIPTION
In an effort to appease ESLint by removing unused variables, we changed
the way some props destined for a child component were pulled from
`props` by using `separateComponentProps()` but this add some unintended
consequences. Namely, by requiring that those props be explicitly named,
we prevented tools like redux-form from implicitly handling their own
props on the components they managed. IOW, things broke. Things broke
BADLY.

Replacing the naively-conceived `separateComponentProps()` with
`omitProps()` feels kludgy since we're back to hard-coding a list of
props to ignore instead of but since doing it automatically didn't
actually work, the brute-force approach wins for now.