### PR TITLE
use canEdit prop to display add button

### DIFF
--- a/lib/structures/AddressFieldGroup/AddressList/AddressList.js
+++ b/lib/structures/AddressFieldGroup/AddressList/AddressList.js
@@ -235,6 +235,11 @@ class AddressList extends React.Component {
       (<AddressEdit form={`addressForm-new-${ad}`} addresses={addresses} key={ad} addressObject={{ id: ad }} headerComponent={headerFormatter ? headerFormatter.edit : undefined} handleCancel={this.handleCancelNew} uiId={ad} initialValues={{ guiid: ad }} onSubmit={this.handleSubmitNew} prevFocused={document.activeElement} {...viewProps} />),
     );
 
+    let addAddressButton = null;
+    if (this.props.canEdit) {
+      addAddressButton = (<Button onClick={this.handleAddNew}>+ Add another address</Button>);
+    }
+
     return (
       <Accordion
         open={this.props.expanded}
@@ -243,9 +248,7 @@ class AddressList extends React.Component {
           (<h2 style={{ marginTop: 0 }}>{sectionLabel}</h2>)
         }
         id={this.props.accordionId}
-        displayWhenOpen={
-          (<Button onClick={this.handleAddNew}>+ Add another address</Button>)
-        }
+        displayWhenOpen={addAddressButton}
       >
         <div aria-label="Address Section" tabIndex="0" role="tabpanel" ref={(ref) => { this.container = ref; }}>
           <Layout className="indent">


### PR DESCRIPTION
Enables UIU-242. Uses the `canEdit` prop to determine if the "Add Address" button appears.