### PR TITLE
STCOM-93 add advanced conditional rendering section to readme

### DIFF
--- a/lib/IfPermission/readme.md
+++ b/lib/IfPermission/readme.md
@@ -18,7 +18,7 @@ A single property is supported:
 
 ## Advanced Conditional Rendering
 
-If your situation requires conditional rendering in case the user does not have the required permission, use the stripes object's `hasPerm()` function directly instead of the `<IfPermission>` component in your JSX, like so:
+If your situation requires conditional rendering in case the user does not have the required permission, use the `stripes` object's `hasPerm()` function directly instead of the `<IfPermission>` component in your JSX, like so:
 
 ```
 <div>

--- a/lib/IfPermission/readme.md
+++ b/lib/IfPermission/readme.md
@@ -18,7 +18,7 @@ A single property is supported:
 
 ## Advanced Conditional Rendering
 
-If your situation requires conditional rendering in case the user does not have the required permission, use the stripes' object's `hasPerm()` function directly instead of the `<IfPermission>` component in your JSX, like so:
+If your situation requires conditional rendering in case the user does not have the required permission, use the stripes object's `hasPerm()` function directly instead of the `<IfPermission>` component in your JSX, like so:
 
 ```
 <div>

--- a/lib/IfPermission/readme.md
+++ b/lib/IfPermission/readme.md
@@ -15,3 +15,17 @@ Yields the child elements only if the permission named in the `perm` prop is pre
 A single property is supported:
 
 * `perm`: a short string containing the name of the permission that is required.
+
+## Advanced Conditional Rendering
+
+If your situation requires conditional rendering in case the user does not have the required permission, use the stripes' object's `hasPerm()` function directly instead of the `<IfPermission>` component in your JSX, like so:
+
+```
+<div>
+  {
+    this.props.stripes.hasPerm('user.examplePerm') ?
+      <Button>You have permission!</Button> :
+      <div>You don't have permission!</div>
+  }
+</div>
+```


### PR DESCRIPTION
Documentation for cases where an 'else' case is needed for <IfPermissions>. (use `hasPerm()` directly.)