### PR TITLE
<EntrySelector> uses default name "[unnamed]"

### DIFF
--- a/lib/EntrySelector/EntrySelector.js
+++ b/lib/EntrySelector/EntrySelector.js
@@ -82,7 +82,7 @@ class EntrySelector extends React.Component {
     const { addButtonTitle, allEntries, paneTitle, parentMutator } = this.props;
 
     const links = _.sortBy(allEntries, ['name']).map(e => (
-      <Link key={e.id} to={this.linkPath(e.id)}>{e.name}</Link>
+      <Link key={e.id} to={this.linkPath(e.id)}>xx {e.name || '[unnamed]'} yy</Link>
     ));
 
     const ComponentToRender = this.props.detailComponent;

--- a/lib/EntrySelector/EntrySelector.js
+++ b/lib/EntrySelector/EntrySelector.js
@@ -48,6 +48,7 @@ class EntrySelector extends React.Component {
     // If a new item has been added to the list, push it to history to gain focus
     if (this.state.creatingEntry) {
       const entryDiffs = _.differenceBy(this.props.allEntries, prevProps.allEntries, 'id');
+      console.log('old entries =', prevProps.allEntries, '-- new entries =', this.props.allEntries, '-- diffs:', entryDiffs);
       this.props.history.push(`${this.props.match.path}/${entryDiffs[0].id}`);
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({
@@ -82,7 +83,7 @@ class EntrySelector extends React.Component {
     const { addButtonTitle, allEntries, paneTitle, parentMutator } = this.props;
 
     const links = _.sortBy(allEntries, ['name']).map(e => (
-      <Link key={e.id} to={this.linkPath(e.id)}>xx {e.name || '[unnamed]'} yy</Link>
+      <Link key={e.id} to={this.linkPath(e.id)}>{e.name || '[unnamed]'}</Link>
     ));
 
     const ComponentToRender = this.props.detailComponent;

--- a/lib/EntrySelector/EntrySelector.js
+++ b/lib/EntrySelector/EntrySelector.js
@@ -48,7 +48,6 @@ class EntrySelector extends React.Component {
     // If a new item has been added to the list, push it to history to gain focus
     if (this.state.creatingEntry) {
       const entryDiffs = _.differenceBy(this.props.allEntries, prevProps.allEntries, 'id');
-      console.log('old entries =', prevProps.allEntries, '-- new entries =', this.props.allEntries, '-- diffs:', entryDiffs);
       this.props.history.push(`${this.props.match.path}/${entryDiffs[0].id}`);
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({


### PR DESCRIPTION
Otherwise items with no name are invisible and unclickable.