### PR TITLE
STCOM 66 delete confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change history for stripes-components
+## In-Progress
+
+* Added `<ConfirmationModal>` component to 'structures' folder. Supports STCOM-66. See [docs](lib/structures/ConfirmationModal/readme.md).
+* Added `<Callout>` component for supplying feedback to the user with various actions. Supports STCOM-66. See [docs](lib/Callout/readme.md).
 
 ## [1.9.0](https://github.com/folio-org/stripes-components/tree/v1.9.0) (2017-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.8.0...v1.9.0)

--- a/lib/Callout/Callout.css
+++ b/lib/Callout/Callout.css
@@ -1,0 +1,136 @@
+@import '../variables.css';
+
+.calloutRoot{
+  position: fixed;
+  top: 0;
+  left: 0;
+  display: flex;
+  flex-direction: column-reverse;
+  flex-wrap: wrap;
+  width: 100vw;
+  height: 100vh;
+  pointer-events: none;
+  padding: 1.5rem 1rem;
+}
+
+.base{
+  padding: 1rem;
+  border-radius: 4px;
+  background-color: #fff;
+  width: 35%;
+  pointer-events: all;
+  position: relative;
+  transition: all .2s ease;
+  display: flex;
+  box-shadow: 0px 4px 19px 0px rgba(0,0,0,0.39);
+  &.error{
+    background-color: color(var(--error, #900) tint(25%));
+    border-color: var(--error);
+    color: #fff;
+    box-shadow: 0px 4px 19px 0px rgba(153,0,0,0.39);
+    & :global .stripes__icon{
+            fill: #fff;
+      }
+  }
+  &.success{
+    background-color: color(var(--success, #060) tint(25%));
+    border-color: var(--success);
+    color: #fff;
+    box-shadow: 0px 4px 19px 0px rgba(0,112,0,0.39);
+    & :global .stripes__icon{
+            fill: #fff;
+      }
+  }
+}
+
+.calloutContainer{
+  display: block;
+  overflow: auto;
+}
+
+.calloutRow{
+  width: 100%;
+  display: block;
+  overflow: hidden;
+  max-width: 100%;
+}
+
+.calloutBase{
+  width: 45vw;
+  position: relative;
+  pointer-events: all;
+  background-color: #fff;
+  padding: 2px 6px;
+  opacity: 0;
+  transition: left .4s, right .4s, opacity .4s;
+  border: 1px solid transparent;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items:center;
+  border-radius: var(--radius, 4px);
+  margin-bottom: 4px;
+  & .message{
+    flex-grow: 2;
+    padding: 0 6px;
+  }
+
+  &.error{
+    border-color: var(--error);
+    background-color: color(var(--error, #600) tint(75%));
+  }
+
+  &.success{
+    border-color: var(--success);
+    background-color: color(var(--success, #060) tint(75%));
+  }
+
+  &.slide-entering{
+    left: 100%;
+    opacity: 0;
+  }
+  
+  &.slide-entered{
+    left: 50%;
+    opacity: 1;
+  }
+  
+  &.slide-exiting{
+    left: 100%;
+    opacity: 0;
+  }
+  
+  &.slide-exited{
+    left: 50%;
+    opacity: 0;
+  }
+}
+
+
+[dir="rtl"]{
+  & .calloutBase{
+    &.slide-entering{
+      left: 0;
+      right: 100%;
+      opacity: 0;
+    }
+    
+    &.slide-entered{
+      left: 0;
+      right: 50%;
+      opacity: 1;
+    }
+    
+    &.slide-exiting{
+      left: 0;
+      right: 100%;
+      opacity: 0;
+    }
+    
+    &.slide-exited{
+      left: 0;
+      right: 50%;
+      opacity: 0;
+    }
+  }
+}

--- a/lib/Callout/Callout.js
+++ b/lib/Callout/Callout.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Portal } from 'react-overlays'; // eslint-disable-line
+import cloneDeep from 'lodash/cloneDeep';
+import uniqueId from 'lodash/uniqueId';
+import findIndex from 'lodash/findIndex';
+import TransitionGroup from 'react-transition-group/TransitionGroup';
+import CalloutElement from './CalloutElement';
+import css from './Callout.css';
+
+class Callout extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      callouts: [],
+    };
+
+    this.sendCallout = this.sendCallout.bind(this);
+    this.removeCallout = this.removeCallout.bind(this);
+  }
+
+  sendCallout({ type = 'success', message, timeout = 60000 }) {
+    this.setState((curState) => {
+      const newState = cloneDeep(curState);
+      const newCallout = Object.assign({ id: uniqueId('callout-'), onDismiss: this.removeCallout }, { type, message, timeout });
+      newState.callouts.push(newCallout);
+      if (timeout !== 0) {
+        window.setTimeout(() => { this.removeCallout(newCallout.id); }, timeout);
+      }
+      return newState;
+    });
+  }
+
+  removeCallout(id) {
+    const toHide = findIndex(this.state.callouts, c => c.id === id);
+    if (toHide === -1) { return; }
+    this.setState((curState) => {
+      const newState = cloneDeep(curState);
+      newState.callouts.splice(toHide, 1);
+      return newState;
+    });
+  }
+
+  render() {
+    return (
+      <Portal container={document.body}>
+        <div className={css.calloutRoot}>
+          <TransitionGroup className={css.calloutContainer} aria-live="polite" aria-relevant="additions">
+            {this.state.callouts.map(calloutProps => (
+              <CalloutElement key={calloutProps.id} transition="slide" {...calloutProps} />
+            ))}
+          </TransitionGroup>
+        </div>
+      </Portal>
+    );
+  }
+}
+
+export default Callout;

--- a/lib/Callout/CalloutElement.js
+++ b/lib/Callout/CalloutElement.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Transition } from 'react-transition-group';
+import Button from '../Button';
+import Icon from '../Icon';
+import css from './Callout.css';
+
+const getClassNamefromTransitionState = (tState, cType, baseClass, tType) =>
+  `${baseClass} ${css[`${cType}`]} ${css[`${tType}-${tState}`]}`;
+
+const getIconForType = (type) => {
+  switch (type) {
+    case 'success':
+      return 'validation-check';
+    case 'error':
+      return 'validation-error';
+    default:
+      return 'right-double-chevron-bold';
+  }
+};
+
+const propTypes = {
+  type: PropTypes.string,
+  timeout: PropTypes.number,
+  transition: PropTypes.string,
+  message: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.string,
+  ]).isRequired,
+  id: PropTypes.string.isRequired,
+  onDismiss: PropTypes.func.isRequired,
+};
+
+const defaultProps = {
+  type: 'success',
+  timeout: '6000',
+  transition: 'slide',
+};
+
+const CalloutElement = props => (
+  <Transition
+    {...props}
+    timeout={300}
+    appear
+  >
+    {transitionState => (
+      <div className={css.calloutRow}>
+        <div className={getClassNamefromTransitionState(transitionState, props.type, css.calloutBase, props.transition)} >
+          <Icon icon={getIconForType(props.type)} />
+          <div className={css.message}>{props.message}</div>
+          <Button buttonStyle="transparent slim marginBottom0" onClick={() => props.onDismiss(props.id)}>
+            <Icon icon="closeX" color="#777" />
+          </Button>
+        </div>
+      </div>
+    )}
+  </Transition>
+);
+
+CalloutElement.propTypes = propTypes;
+CalloutElement.defaultProps = defaultProps;
+
+export default CalloutElement;

--- a/lib/Callout/index.js
+++ b/lib/Callout/index.js
@@ -1,0 +1,2 @@
+export { default } from './Callout';
+export { CalloutElement } from './CalloutElement';

--- a/lib/Callout/readme.md
+++ b/lib/Callout/readme.md
@@ -1,0 +1,25 @@
+# Callouts
+Keep your user informed about the actions they take! Callouts creates a small alert that appears at the bottom of the workspace.
+
+## Usage
+Simply add the `<Callout>` component to your module with a ref. This works best at the highest level of your module.
+```
+// ... in your JSX...
+<Callout ref={(ref)={this.callout = ref;}}/>
+```
+Use the ref to the `<Callout>` to call the `sendCallout` method, supplying a configuration object for the callout:
+```
+  announce(){
+    this.callout.sendCallout({
+      type: 'success',
+      message: (<span><strong>Hey!!</strong> This is a <strong>callout!</strong></span> )
+    })
+  }
+```
+
+## Callout Configuration
+prop | description | default | required
+-- | -- | -- | --
+type | 'error' or 'success'. | 'success' |
+timeout | timeout for automatic dismissal. Can be set to 0 to only allow for user-dismissal. | 6000 | 
+message | String or HTML to render in the content of the callout. | | #&10004;

--- a/lib/Modal/Modal.css
+++ b/lib/Modal/Modal.css
@@ -1,3 +1,5 @@
+@import '../variables.css';
+
 .modalRoot{
   display: flex;
   justify-content: center;
@@ -16,6 +18,8 @@
   max-height: 80vh;
   width: 60%;
   overflow: hidden;
+  border-radius: var(--radius, 4px);
+  box-shadow: 0px 5px 28px 1px rgba(0,0,0,0.75);
   &.small{
     width: 40%;
   }
@@ -74,4 +78,12 @@
   width: 100%;
   height: 100%;
   background-color: rgba(0,0,0,0.4);
+}
+
+@media(--small){
+  .modal{
+    &.small, &.large{
+      width: 80vw;
+    }
+  }
 }

--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -36,6 +36,7 @@ const propTypes = {
   /** If true, renders a close 'X' in the starting corner of the modal */
   dismissible: PropTypes.bool,
   children: PropTypes.node.isRequired,
+  showHeader: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -44,6 +45,7 @@ const defaultProps = {
   closeOnBackgroundClick: false,
   dismissible: false,
   open: false,
+  showHeader: true,
 };
 
 const Modal = (props) => {
@@ -82,27 +84,28 @@ const Modal = (props) => {
         aria-label={props['aria-label'] || props.label} // eslint-disable-line react/prop-types
         id={props.id}
       >
-        <div className={css.modalHeader}>
-          <div className={css.modalLabel}>
-            {props.label}
+        { props.showHeader && 
+          <div className={css.modalHeader}>
+            <div className={css.modalLabel}>
+              {props.label}
+            </div>
+            <div className={css.modalControls}>
+              {props.dismissible &&
+                <button
+                  className={css.closeModal}
+                  onClick={props.onClose}
+                  title="Dismiss modal"
+                  aria-label="Dismiss modal"
+                >
+                  <Icon icon="closeX" />
+                </button>
+              }
+            </div>
           </div>
-          <div className={css.modalControls}>
-            {props.dismissible &&
-              <button
-                className={css.closeModal}
-                onClick={props.onClose}
-                title="Dismiss modal"
-                aria-label="Dismiss modal"
-              >
-                <Icon icon="closeX" />
-              </button>
-            }
-          </div>
-        </div>
+        }
         <div className={css.modalContent}>
           {props.children}
         </div>
-
       </div>
     </OverlayModal>
   );

--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -84,7 +84,7 @@ const Modal = (props) => {
         aria-label={props['aria-label'] || props.label} // eslint-disable-line react/prop-types
         id={props.id}
       >
-        { props.showHeader && 
+        { props.showHeader &&
           <div className={css.modalHeader}>
             <div className={css.modalLabel}>
               {props.label}

--- a/lib/structures/ConfirmationModal/ConfirmationModal.js
+++ b/lib/structures/ConfirmationModal/ConfirmationModal.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Modal from '../../Modal';
+import { Row, Col } from '../../LayoutGrid';
+import Button from '../../Button';
+
+const propTypes = {
+  heading: PropTypes.string.isRequired,
+  message: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]),
+  cancelLabel: PropTypes.string,
+  confirmLabel: PropTypes.string,
+  onCancel: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  open: PropTypes.bool.isRequired,
+};
+
+const defaultProps = {
+  cancelLabel: "Cancel",
+  confirmLabel: "Submit"
+};
+
+const ConfirmationModal = (props) => {
+  return (
+    <Modal
+      open={props.open}
+      label={props.heading}
+      id={props.heading}
+      scope="root"
+      size="small"
+      showHeader={false}
+    >
+      <h1>{props.heading}</h1>
+      <Row>
+        <Col xs>
+          <p>{props.message}</p>
+        </Col>
+      </Row>
+      <Row>
+        <Col xs>
+          <Button buttonStyle="secondary" onClick={props.onCancel}>{props.cancelLabel}</Button>
+          <Button onClick={props.onConfirm}>{props.confirmLabel}</Button>
+        </Col>
+      </Row>
+    </Modal>
+  );
+};
+
+ConfirmationModal.propTypes = propTypes;
+ConfirmationModal.defaultProps = defaultProps;
+
+export default ConfirmationModal;

--- a/lib/structures/ConfirmationModal/ConfirmationModal.js
+++ b/lib/structures/ConfirmationModal/ConfirmationModal.js
@@ -18,35 +18,33 @@ const propTypes = {
 };
 
 const defaultProps = {
-  cancelLabel: "Cancel",
-  confirmLabel: "Submit"
+  cancelLabel: 'Cancel',
+  confirmLabel: 'Submit',
 };
 
-const ConfirmationModal = (props) => {
-  return (
-    <Modal
-      open={props.open}
-      label={props.heading}
-      id={props.heading}
-      scope="root"
-      size="small"
-      showHeader={false}
-    >
-      <h1>{props.heading}</h1>
-      <Row>
-        <Col xs>
-          <p>{props.message}</p>
-        </Col>
-      </Row>
-      <Row>
-        <Col xs>
-          <Button buttonStyle="secondary" onClick={props.onCancel}>{props.cancelLabel}</Button>
-          <Button onClick={props.onConfirm}>{props.confirmLabel}</Button>
-        </Col>
-      </Row>
-    </Modal>
-  );
-};
+const ConfirmationModal = props => (
+  <Modal
+    open={props.open}
+    label={props.heading}
+    id={props.heading}
+    scope="root"
+    size="small"
+    showHeader={false}
+  >
+    <h1>{props.heading}</h1>
+    <Row>
+      <Col xs>
+        <p>{props.message}</p>
+      </Col>
+    </Row>
+    <Row>
+      <Col xs>
+        <Button buttonStyle="secondary" onClick={props.onCancel}>{props.cancelLabel}</Button>
+        <Button onClick={props.onConfirm}>{props.confirmLabel}</Button>
+      </Col>
+    </Row>
+  </Modal>
+);
 
 ConfirmationModal.propTypes = propTypes;
 ConfirmationModal.defaultProps = defaultProps;

--- a/lib/structures/ConfirmationModal/index.js
+++ b/lib/structures/ConfirmationModal/index.js
@@ -1,0 +1,1 @@
+export { default } from './ConfirmationModal';

--- a/lib/structures/ConfirmationModal/readme.md
+++ b/lib/structures/ConfirmationModal/readme.md
@@ -1,0 +1,48 @@
+# ConfirmationModal
+
+A basic confirmation modal with props to support a heading (required) and brief message along with customizeable 'cancel' and 'submit' action labeling.
+
+## Basic usage
+
+```
+// Handlers for showing/hiding and submitting for application.
+
+showConfirm() {
+  this.setState({
+    confirming: true,
+  });
+}
+
+hideConfirm() {
+  this.setState({
+    confirming: false,
+  });
+}
+
+handleSubmit() {
+  alert('submitting!');
+  this.hideConfirm();
+}
+
+// ...in JSX...
+
+<ConfirmationModal
+  open={this.state.confirming}
+  heading="Please confirm!"
+  message="Description of the thing that needs confirming"
+  onConfirm={this.handleSubmit}
+  onCancel={this.hideConfirm}
+/>
+```
+
+## Properties
+
+Name | type | description | default | required
+--- | --- | --- | --- | ---
+heading | string | String to appear as the modal's H1 tag. Doubles as the modal's ARIA-label |  | &#10004;
+message | node or array of nodes | Renderable content rendered within a `<p>` tag. |  |
+open | bool | Boolean reflecting modal's open/closed status |  | &#10004;
+cancelLabel | string | String to render on the Cancel action. | "Cancel" |
+confirmLabel | string | String to render on the Submit action. | "Submit" |
+onConfirm | func | Callback fired when the Submit button is clicked |  | &#10004;
+onCancel | func | Callback fired when the Cancel button is clicked |  | &#10004; 

--- a/package.json
+++ b/package.json
@@ -54,11 +54,12 @@
     "prop-types": "^15.5.10",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
-    "react-test-renderer": "^15.6.1",
     "react-flexbox-grid": "1.1.3",
     "react-overlays": "^0.8.0",
     "react-router-dom": "^4.1.1",
+    "react-test-renderer": "^15.6.1",
     "react-tether": "0.5.7",
+    "react-transition-group": "^2.2.1",
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
This contains 2 significant additions to our toolset.
A) An alert pop-up component (`<Callout>`) that's super-easy to use and nicely accessible.
B) A reusable confirmation modal component for all of those 'Yes' or 'No' (or 'Submit' or 'Cancel') scenarios.
Submitted for approval!
