### PR TITLE
Relax Layer's propType for container. Fixes STCOM-98

### DIFF
--- a/lib/Layer/Layer.js
+++ b/lib/Layer/Layer.js
@@ -14,10 +14,7 @@ import Paneset from '../Paneset';
 // import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 const propTypes = {
   isOpen: PropTypes.bool,
-  container: PropTypes.oneOfType([
-    componentOrElement,
-    PropTypes.node,
-  ]),
+  container: componentOrElement,
   contentLabel: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.node,

--- a/lib/Layer/Layer.js
+++ b/lib/Layer/Layer.js
@@ -6,13 +6,18 @@
 import React from 'react';
 import { Portal } from 'react-overlays';
 import PropTypes from 'prop-types';
+import componentOrElement from 'prop-types-extra/lib/componentOrElement'; // eslint-disable-line import/no-extraneous-dependencies
+
 import css from './Layer.css';
 import Paneset from '../Paneset';
 
 // import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 const propTypes = {
   isOpen: PropTypes.bool,
-  container: PropTypes.any,
+  container: PropTypes.oneOfType([
+    componentOrElement,
+    PropTypes.node,
+  ]),
   contentLabel: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.node,

--- a/lib/Layer/Layer.js
+++ b/lib/Layer/Layer.js
@@ -12,7 +12,7 @@ import Paneset from '../Paneset';
 // import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 const propTypes = {
   isOpen: PropTypes.bool,
-  container: PropTypes.node,
+  container: PropTypes.any,
   contentLabel: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.node,

--- a/lib/Layer/Layer.js
+++ b/lib/Layer/Layer.js
@@ -6,7 +6,7 @@
 import React from 'react';
 import { Portal } from 'react-overlays';
 import PropTypes from 'prop-types';
-import componentOrElement from 'prop-types-extra/lib/componentOrElement'; // eslint-disable-line import/no-extraneous-dependencies
+import componentOrElement from 'prop-types-extra/lib/componentOrElement';
 
 import css from './Layer.css';
 import Paneset from '../Paneset';

--- a/package.json
+++ b/package.json
@@ -31,15 +31,15 @@
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-2": "^6.18.0",
     "babel-register": "^6.18.0",
-    "eslint": "^4.7.0",
-    "eslint-config-stripes": "^0.0.1",
-    "webpack": "1.11.0",
     "chai": "^3.5.0",
     "enzyme": "^2.5.0",
+    "eslint": "^4.7.0",
+    "eslint-config-stripes": "^0.0.1",
     "ignore-styles": "^5.0.1",
     "jsdom": "^9.3.0",
     "mocha": "^2.5.3",
-    "sinon": "^1.17.4"
+    "sinon": "^1.17.4",
+    "webpack": "1.11.0"
   },
   "dependencies": {
     "@folio/stripes-form": "^0.8.1",
@@ -52,6 +52,7 @@
     "moment-range": "^3.0.3",
     "mousetrap": "^1.6.1",
     "prop-types": "^15.5.10",
+    "prop-types-extra": "^1.0.1",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-flexbox-grid": "1.1.3",


### PR DESCRIPTION
When I tried to pass `document.body` or `document.getElementById('ModuleContainer')` as a container to the `Layer` I would get:

`warning.js:36 Warning: Failed prop type: Invalid prop `container` supplied to `Layer`, expected a ReactNode.`