### PR TITLE
UIU-260 Address Fieldgroup Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Added `<Callout>` component for supplying feedback to the user with various actions. Supports STCOM-66. See [docs](lib/Callout/readme.md).
 * Fix connect in `<Settings>`. Fixes STCOM-99.
 * Update `<EntrySelector>`. Fixes STCOM-100.
+* Address FieldGroup uses a radio button for setting 'Primary' field. Fixes UIU-260.
+* Address FieldGroup's Address Type field will only display options that are previously unused in the address form. Fixes UIU-260.
+* Aesthetic updates - Delete button is now a trashcan Icon. Fixes UIU-260.
+* Changes in field order- Address Type comes first, Country is last. Fixes UIU-260.
 
 ## 2.0.0 (IN PROGRESS)
 

--- a/lib/Layout/Layout.css
+++ b/lib/Layout/Layout.css
@@ -45,3 +45,12 @@
 .marginTop1{
   margin-top: .1rem;
 }
+
+[dir="rtl"]{
+  & .right {
+    float: left;
+  }
+  & .left {
+    float: right;
+  }
+}

--- a/lib/structures/AddressFieldGroup/AddressEdit/AddressEdit.css
+++ b/lib/structures/AddressFieldGroup/AddressEdit/AddressEdit.css
@@ -1,3 +1,5 @@
+@import '../../../variables.css';
+
 .root{
   margin-bottom: 1rem;
 }
@@ -18,13 +20,6 @@
   font-size: 18px;
   line-height: 21px;
   color: #777;
-}
-
-.addressSlab{
-  padding: 4px;
-  &:nth-of-type(odd){
-    background-color: #f5f5f5;
-  }
 }
 
 .indent{
@@ -52,5 +47,77 @@
     & :global .stripes__icon{
       fill: color(#900 blend(#aaa 50%));
     }
+  }
+}
+
+.addressFormList{
+  list-style: none;
+  padding: 0;
+  margin-bottom: 0;
+}
+
+.addressFormListItem{
+  width: 100%;
+  border-color: #999;
+  border-width: 1px 1px 0 1px;
+  border-style: solid;
+  &:last-of-type {
+    border-bottom: 1px solid #999;
+    margin-bottom: 4px;
+  }
+}
+
+.addressFormHeader{
+  background-color: var(--bgHover);
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 0 14px;
+}
+
+.addressHeaderActions{
+  margin: 0 0 0 auto; /*align to end of header*/
+  padding: 4px 0;
+  & button {
+    &:hover{
+      & :global .stripes__icon {
+        fill: #333;
+      }
+    }
+    & :global .stripes__icon {
+      transition: fill .3s;
+    }
+  }
+}
+
+.addressLabel{
+  font-weight: bold;
+}
+
+.addressFormBody{
+  padding: 14px;
+  background-color: color(var(--bg) blend(var(--bgHover) 20%));
+  width: 100%;
+}
+
+.addressForm{
+
+}
+
+.primaryToggle{
+  padding: 4px 8px;
+  color: #555;
+  font-size: 12px;
+  cursor: pointer;
+  margin-bottom: 0;
+  & input[type="radio"]{
+    margin: 0 4px;
+    vertical-align: text-top;
+  }
+}
+
+[dir="rtl"]{
+  .addressHeaderActions{
+    margin: 0 auto 0 0;
   }
 }

--- a/lib/structures/AddressFieldGroup/AddressEdit/AddressEditList.js
+++ b/lib/structures/AddressFieldGroup/AddressEdit/AddressEditList.js
@@ -4,7 +4,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FieldArray } from 'redux-form'; // eslint-disable-line
-import { Row, Col } from 'react-flexbox-grid';
+import { Row, Col } from '../../../LayoutGrid';
+import Layout from '../../../Layout';
 import EmbeddedAddressForm from './EmbeddedAddressForm';
 import css from './AddressEdit.css';
 import Button from '../../../Button';
@@ -46,24 +47,39 @@ class AddressEditList extends React.Component {
 
   renderFieldGroups({ fields }) {
     return (
+
       <div className={css.root}>
         <Row>
-          <Col xs={8} sm={8}>
-            <div className={css.legend}>{this.props.label}</div>
+          <Col xs>
+            <div className={css.legend} id="addressGroupLabel">{this.props.label}</div>
           </Col>
-          <Col xs={4} sm={4}>
-            <Button type="button" buttonStyle="fullWidth secondary" onClick={() => { this.onAdd(fields); }}>+ Add another address</Button>
+          <Col xs={4}>
+            <Layout className="right">
+              <Button type="button" onClick={() => { this.onAdd(fields); }}>+ New</Button>
+            </Layout>
           </Col>
         </Row>
-        {fields.length === 0 &&
-          <div><em>- No addresses stored -</em></div>
-        }
-        {fields.map((fieldName, i) => (
-          <div key={i} className={css.addressSlab} style={{ width: '100%' }}>
-            <EmbeddedAddressForm fieldKey={i} addressFieldName={fieldName} handleDelete={(index) => { this.onDelete(fields, index); }} {...this.props} />
-          </div>
-        ))}
+        <Row>
+          <Col xs>
+            {fields.length === 0 &&
+              <div><em>- No addresses stored -</em></div>
+            }
+            <ul className={css.addressFormList} aria-labelledby="addressGroupLabel">
+              {fields.map((fieldName, i) => (
+                <li className={css.addressFormListItem} key={i}>
+                  <EmbeddedAddressForm
+                    fieldKey={i}
+                    addressFieldName={fieldName}
+                    handleDelete={(index) => { this.onDelete(fields, index); }}
+                    {...this.props}
+                  />
+                </li>
+              ))}
+            </ul>
+          </Col>
+        </Row>
       </div>
+
     );
   }
 

--- a/lib/structures/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
+++ b/lib/structures/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
@@ -1,17 +1,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'redux-form'; // eslint-disable-line
-
+import findIndex from 'lodash/findIndex';
+import cloneDeep from 'lodash/cloneDeep';
 import Button from '../../../Button';
-import Checkbox from '../../../Checkbox';
 import TextField from '../../../TextField';
 import Select from '../../../Select';
+import Icon from '../../../Icon';
 import { Row, Col } from '../../../LayoutGrid';
 import css from './AddressEdit.css';
 
+const omitUsedOptions = (list, usedValues, key, id) => {
+  const unUsedValues = cloneDeep(list);
+  usedValues.forEach((item, i) => {
+    if (id !== i) {
+      const usedValueIndex = findIndex(unUsedValues, v => v.value === item[key]);
+      if (usedValueIndex !== -1) {
+        unUsedValues.splice(usedValueIndex, 1);
+      }
+    }
+  });
+  return unUsedValues;
+};
+
 class EmbeddedAddressForm extends React.Component {
   static propTypes = {
-    // addressObject: PropTypes.object,
+    // addressObject: PropTypes.object,)
+    primary: PropTypes.func,
     addressFieldName: PropTypes.string,
     canDelete: PropTypes.bool,
     handleDelete: PropTypes.func,
@@ -26,30 +41,52 @@ class EmbeddedAddressForm extends React.Component {
   static defaultProps = {
     headerFields: ['primaryAddress'],
     visibleFields: [
-      'country',
+      'addressType',
       'addressLine1',
       'addressLine2',
       'city',
       'stateRegion',
       'zipCode',
-      'addressType',
+      'country',
     ],
     fieldComponents: {
-      country: { component: Select, props: { placeholder: 'Select Country' } },
+      addressType: Select,
       addressLine1: TextField,
       addressLine2: TextField,
       city: TextField,
       stateRegion: TextField,
       zipCode: TextField,
-      addressType: TextField,
+      country: { component: Select, props: { placeholder: 'Select Country' } },
     },
     labelMap: {
+      addressType: 'Address Type',
       addressLine1: 'Address line 1',
       addressLine2: 'Address line 2',
       stateRegion: 'State/Prov./Region',
       zipCode: 'Zip/Postal Code',
-      addressType: 'Address Type',
     },
+  }
+
+  static contextTypes = {
+    _reduxForm: PropTypes.object,
+  }
+
+  constructor(props) {
+    super(props);
+    this.singlePrimary = this.singlePrimary.bind(this);
+  }
+
+  singlePrimary(id) {
+    const { values, dispatch, change } = this.context._reduxForm;
+    values.personal.addresses.forEach((a, i) => {
+      if (i === id) {
+        dispatch(change(`personal.addresses[${i}].primaryAddress`, true));
+        dispatch(change(`personal.addresses[${i}].primary`, true));
+      } else {
+        dispatch(change(`personal.addresses[${i}].primaryAddress`, false));
+        dispatch(change(`personal.addresses[${i}].primary`, false));
+      }
+    });
   }
 
   render() {
@@ -62,23 +99,25 @@ class EmbeddedAddressForm extends React.Component {
       visibleFields,
     } = this.props;
 
-    const mergedFieldComponents = Object.assign(EmbeddedAddressForm.defaultProps.fieldComponents, fieldComponents);
-    const staticFields = (
-      <Row>
-        <Col xs={12} sm={4}>
-          <div style={{ paddingTop: '8px' }}>
-            <Field
-              label="Primary Address"
-              name={`${addressFieldName}.primaryAddress`}
-              id={`PrimaryAddress---${addressFieldName}`}
-              component={Checkbox}
-              type="checkbox"
-              marginBottom0
-            />
-          </div>
-        </Col>
-      </Row>
+    const {
+      values,
+    } = this.context._reduxForm;
+
+    const PrimaryRadio = ({ input, ...props }) => (
+      <label className={css.primaryToggle}>
+        <input
+          type="radio"
+          checked={input.value}
+          id={props.id}
+          onChange={() => { this.singlePrimary(fieldKey); }}
+          name="primary"
+          aria-labelledby={`Use address ${fieldKey + 1} as primary address`}
+        />
+        Use as primary address
+      </label>
     );
+
+    const mergedFieldComponents = Object.assign(EmbeddedAddressForm.defaultProps.fieldComponents, fieldComponents);
 
     const renderedFields = visibleFields.map((fieldName, i) => {
       const fieldLabel = Object.prototype.hasOwnProperty.call(labelMap, fieldName) ?
@@ -87,14 +126,32 @@ class EmbeddedAddressForm extends React.Component {
       let field;
       if (Object.prototype.hasOwnProperty.call(mergedFieldComponents, fieldName)) {
         if (typeof (mergedFieldComponents[fieldName]) === 'object') {
-          field = (
-            <Field
-              name={`${addressFieldName}.${fieldName}`}
-              label={fieldLabel}
-              component={mergedFieldComponents[fieldName].component}
-              {...mergedFieldComponents[fieldName].props}
-            />
-          );
+          if (fieldName === 'addressType') {
+            const list = omitUsedOptions(
+              mergedFieldComponents[fieldName].props.dataOptions,
+              values.personal.addresses,
+              'addressType',
+              fieldKey,
+            );
+            field = (
+              <Field
+                name={`${addressFieldName}.${fieldName}`}
+                label={fieldLabel}
+                component={mergedFieldComponents[fieldName].component}
+                {...mergedFieldComponents[fieldName].props}
+                dataOptions={list}
+              />
+            );
+          } else {
+            field = (
+              <Field
+                name={`${addressFieldName}.${fieldName}`}
+                label={fieldLabel}
+                component={mergedFieldComponents[fieldName].component}
+                {...mergedFieldComponents[fieldName].props}
+              />
+            );
+          }
         } else {
           field = (
             <Field
@@ -106,42 +163,43 @@ class EmbeddedAddressForm extends React.Component {
         }
       }
       return (
-        <Col xs={12} sm={4} key={`${fieldKey}-${i}`}>
+        <Col xs={12} sm={3} key={`${fieldKey}-${i}`}>
           {field}
         </Col>
       );
     });
 
     return (
-      <div style={{ marginBottom: '8px' }}>
-        <Row>
-          <Col xs={11}>
-            <div className={css.subLegend}>Address {this.props.fieldKey + 1}</div>
-          </Col>
-        </Row>
-        <div className={css.indent}>
-          {staticFields}
+      <div className={css.addressForm}>
+        <div className={css.addressFormHeader} start="xs">
+          <div className={css.addressLabel}>Address {this.props.fieldKey + 1}</div>
+          <div>
+            <Field
+              component={PrimaryRadio}
+              name={`${addressFieldName}.primary`}
+              id={`PrimaryAddress---${addressFieldName}`}
+              fieldKey={this.props.fieldKey}
+            />
+          </div>
+          <div className={css.addressHeaderActions}>
+            {
+              canDelete &&
+              <Button
+                buttonStyle="transparent slim"
+                style={{ margin: 0, padding: 0 }}
+                title={`remove address ${this.props.fieldKey + 1}`}
+                onClick={() => { this.props.handleDelete(fieldKey); }}
+              >
+                <Icon icon="trashBin" width="24px" height="24px" /> <span className="sr-only">Remove Address {this.props.fieldKey + 1}</span>
+              </Button>
+            }
+          </div>
+        </div>
+        <div className={css.addressFormBody}>
           <Row key={fieldKey}>
             {renderedFields}
           </Row>
         </div>
-        <Row>
-          <Col xs={12}>
-            <div style={{ textAlign: 'right' }}>
-              {
-                canDelete &&
-
-                <Button
-                  title={`remove address ${this.props.fieldKey + 1}`}
-                  onClick={() => { this.props.handleDelete(fieldKey); }}
-                >
-                  Remove Address {this.props.fieldKey + 1}
-                </Button>
-
-              }
-            </div>
-          </Col>
-        </Row>
       </div>
     );
   }

--- a/lib/structures/AddressFieldGroup/AddressList/AddressList.js
+++ b/lib/structures/AddressFieldGroup/AddressList/AddressList.js
@@ -237,7 +237,7 @@ class AddressList extends React.Component {
 
     let addAddressButton = null;
     if (this.props.canEdit) {
-      addAddressButton = (<Button onClick={this.handleAddNew}>+ Add another address</Button>);
+      addAddressButton = (<Button onClick={this.handleAddNew}>+ New</Button>);
     }
 
     return (

--- a/lib/structures/AddressFieldGroup/AddressView/AddressView.js
+++ b/lib/structures/AddressFieldGroup/AddressView/AddressView.js
@@ -21,13 +21,13 @@ const propTypes = {
 const defaultProps = {
   headerField: 'primaryAddress',
   visibleFields: [
-    'country',
+    'addressType',
     'addressLine1',
     'addressLine2',
     'city',
     'stateRegion',
     'zipCode',
-    'addressType',
+    'country',
   ],
   labelMap: {
     addressLine1: 'Address line 1',
@@ -46,11 +46,11 @@ function AddressView(props) {
 
   props.visibleFields.forEach((field, i) => {
     const fieldLabel = _.has(labelMap, field) ? labelMap[field] : field;
-    const fieldComponent = (<Col xs={4} key={`${fieldLabel}-${field}`} ><KeyValue label={fieldLabel} value={addressObject[field]} /></Col>);
+    const fieldComponent = (<Col xs={3} key={`${fieldLabel}-${field}`} ><KeyValue label={fieldLabel} value={addressObject[field]} /></Col>);
     rowArray.push(fieldComponent);
 
     // 3 fields per row...
-    if (rowArray.length === 3 || i === visibleFields.length - 1) {
+    if (rowArray.length === 4 || i === visibleFields.length - 1) {
       groupArray.push(<Row key={i}>{rowArray}</Row>);
       rowArray = [];
     }


### PR DESCRIPTION
A few aesthetic and functional changes to Address Fieldgroup:

- Fields are re-arranged. AddressType is displayed first. Country displayed last.
- Delete action represented as icon.
- Primary represented as radio button.
- AddressType only displays options that have not been previously used in the form.

Field re-arrangement was applied to both the edit and read-only views.
