### PR TITLE
Fix defaultRoute in Settings when pages is not sorted. Fixes STCOM-113.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Changes in field order- Address Type comes first, Country is last. Fixes UIU-260.
 * Add onClick callback to `<EntrySelector>`. Refs UICIRC-20 Scenario 5.
 * `transitionToParams` uses `queryString.stringify` instead of by-hand gluing. Fixes STCOM-112
+* Fix defaultRoute in `<Settings>` when `pages` is not sorted by `label`. Fixes STCOM-113.
 
 ## [1.9.0](https://github.com/folio-org/stripes-components/tree/v1.9.0) (2017-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.8.0...v1.9.0)

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -16,7 +16,7 @@ class Settings extends React.Component {
     this.context = context;
     const stripes = context.stripes;
 
-    this.routes = props.pages
+    this.routes = _.sortBy(props.pages, ['label'])
       .filter(p => !p.perm || stripes.hasPerm(p.perm))
       .map(page => (
         {


### PR DESCRIPTION
Fix defaultRoute in Settings when pages is not sorted by label. Fixes STCOM-113.