### PR TITLE
Account for removal of multiple panes in Paneset.

### DIFF
--- a/lib/Pane/Pane.js
+++ b/lib/Pane/Pane.js
@@ -56,6 +56,8 @@ class Pane extends React.Component {
     this.getContentWidth = this.getContentWidth.bind(this);
     this.handleClose = this.handleClose.bind(this);
     this.getContentStyle = this.getContentStyle.bind(this);
+    this.isThisMounted = this.isThisMounted.bind(this);
+    this._isMounted = false;
   }
 
   componentDidMount() {
@@ -68,21 +70,29 @@ class Pane extends React.Component {
     this.animationCallbackID = window.requestAnimationFrame(() => {
       this.setState({ contentMinWidth: this.getContentWidth() });
     });
+    this._isMounted = true;
   }
 
   componentWillUnmount() {
     window.cancelAnimationFrame(this.animationCallbackID);
-    this.context.paneset.removePane(this.id);
+    this._isMounted = false;
+    this.context.paneset.removePane();
+  }
+
+  isThisMounted() {
+    return this._isMounted;
   }
 
   setStyle(style) {
-    this.setState((oldState) => {
-      const nextState = oldState;
-      // clone because you can't mutate style....
-      const newStyle = Object.assign({}, nextState.style, style);
-      nextState.style = newStyle;
-      return nextState;
-    });
+    if (this._isMounted) {
+      this.setState((oldState) => {
+        const nextState = Object.assign({}, oldState);
+        // clone because you can't mutate style....
+        const newStyle = Object.assign({}, nextState.style, style);
+        nextState.style = newStyle;
+        return nextState;
+      });
+    }
   }
 
   getContentWidth() {

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -40,8 +40,10 @@ class Paneset extends React.Component {
     this.removePane = this.removePane.bind(this);
     this.handleClose = this.handleClose.bind(this);
     this.getContainer = this.getContainer.bind(this);
+    this.isThisMounted = this.isThisMounted.bind(this);
     this.widths = [];
     this.interval = null;
+    this._isMounted = false;
   }
 
   getChildContext() {
@@ -59,12 +61,18 @@ class Paneset extends React.Component {
         });
       }
     }
+    this._isMounted = true;
   }
 
   componentWillUnmount() {
+    this._isMounted = false;
     if (!this.props.isRoot && this.context.paneset) {
-      this.context.paneset.removePane(this.id);
+      this.context.paneset.removePane();
     }
+  }
+
+  isThisMounted() {
+    return this._isMounted;
   }
 
   getContainer() {
@@ -96,13 +104,13 @@ class Paneset extends React.Component {
     });
   }
 
-  removePane(id) {
-    const index = this.state.panes.findIndex(p => p.id === id);
+  removePane() {
     this.setState((oldState) => {
-      const newState = oldState;
-      if (index !== -1) {
-        newState.panes.splice(index, 1);
-      }
+      // accounts for odd situations where multiple Panes are dismissed/dismounted at once...
+      // simply filters out any that have dismounted.
+      const newPanes = oldState.panes.filter(p => p.ref && p.ref.isThisMounted());
+      const newState = Object.assign({}, oldState);
+      newState.panes = newPanes;
       const widths = this.calcWidths(newState.panes);
       this.resizePanes(newState.panes, widths);
       return newState;
@@ -119,7 +127,7 @@ class Paneset extends React.Component {
 
   registerPane(paneObject) {
     this.setState((oldState) => {
-      const newState = oldState;
+      const newState = Object.assign({}, oldState);
       let widths;
       // if the new pane has a transition just set its starting appearance...
       // otherwise resize all the panes...


### PR DESCRIPTION
Fixes a symptom called when multiple Panes are unmounted at once. One of them can leave its ghost registered with Paneset and resizing happens under the belief that the dismissed Pane is still there, leaving a blank space. This fixes STSMACOM-17