### PR TITLE
include dataKey in calls to connect. Fixes UICIRC-33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * `transitionToParams` uses `queryString.stringify` instead of by-hand gluing. Fixes STCOM-112
 * Fix defaultRoute in `<Settings>` when `pages` is not sorted by `label`. Fixes STCOM-113.
 * Add `<LayoutHeader>` and `<LayoutBox>` components for assistance with layout tasks. Covers STCOM-118.
+* Include `dataKey` in when connecting `<Settings>` components. Fixes UICIRC-33. 
 
 ## [1.9.0](https://github.com/folio-org/stripes-components/tree/v1.9.0) (2017-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.8.0...v1.9.0)

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -21,7 +21,7 @@ class Settings extends React.Component {
       .map(page => (
         {
           page,
-          component: stripes.connect(page.component),
+          component: stripes.connect(page.component, { dataKey: page.route }),
         }),
       );
   }


### PR DESCRIPTION
You gotta keep 'em separated

Like the latest data
Like a diff'rent `entry`
The keys are unique on their way to the table
Mapping values with the greatest of ease

The keys stake their own hashmap value
But if they share `resources` then it's curtains for you
If one key's label and the other's the same
They're gonna bash it up

Hey - man you got a copied key?
Take it out
You gotta keep 'em separated
