### PR TITLE
Adjust devDependency linting for .stories.js files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,5 +8,10 @@
     "mount":true,
   },
   "extends": "stripes",
-  "parser": "babel-eslint"
+  "parser": "babel-eslint",
+  "rules": {
+    "import/no-extraneous-dependencies": ["error", {
+      "devDependencies": ["**/*.stories.js"]
+    }]
+  }
 }

--- a/lib/Accordion/Accordion.stories.js
+++ b/lib/Accordion/Accordion.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import withReadme from 'storybook-readme/with-readme'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
 import Readme from './readme.md';
 
 import Accordion from './Accordion';

--- a/lib/Modal/Modal.stories.js
+++ b/lib/Modal/Modal.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import withReadme from 'storybook-readme/with-readme'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
 import Readme from './readme.md';
 
 import Modal from './Modal';

--- a/lib/TextField/TextField.stories.js
+++ b/lib/TextField/TextField.stories.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
 import TextField from './TextField';
 
 storiesOf('TextField', module)


### PR DESCRIPTION
## Purpose
Storybook is currently a `devDependency` of `stripes-components`, since consuming applications don't need to pull in Storybook.

The `import/no-extraneous-dependencies` ESLint rule was breaking on `.stories.js` files that need to import pieces of Storybook, because Storybook is simply a `devDependency`. We were disabling the rule on lines that violated it, but that won't scale well.

## Approach
This `.eslintrc` change will affect files that end in `.stories.js`:
```
"import/no-extraneous-dependencies": ["error", {
  "devDependencies": ["**/*.stories.js"]
}]
```
Any file that matches that pattern will not complain about dependencies anymore. All other files will continue to lint the same as before.