### PR TITLE
Add `handleFilterChange` method for FilterGroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Add `react-tether` to `<Datepicker>`. Fixes STCOM-125.
 * Remove `<Accordion>` from `<AddressList`. Fixes STCOM-138.
 * Add `interactive` to `<MultiColumnList>` to toggle cursor CSS on non-interactive lists. Fixes STCOM-139.
+* Add `handleFilterChange` method for FilterGroups. Works with anointed resource instead of component state. Fixes STCOM-148.
 
 ## [1.9.0](https://github.com/folio-org/stripes-components/tree/v1.9.0) (2017-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.8.0...v1.9.0)

--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -120,12 +120,25 @@ export function filters2cql(config, filters) {
 
 
 // Requires calling component to have a this.updateFilters method
+// DEPRECATED in favour of handleFilterChange
 //
 export function onChangeFilter(e) {
   const filters = Object.assign({}, this.state.filters);
   filters[e.target.name] = e.target.checked;
   this.setState({ filters });
   this.updateFilters(filters);
+}
+
+// Relies on caller providing both queryParam and transitionToParams
+export function handleFilterChange(e) {
+  const keys = this.queryParam('filters').split(',');
+  const filters = {};
+  for (const key of keys) {
+    filters[key] = true;
+  }
+
+  filters[e.target.name] = e.target.checked;
+  this.transitionToParams({ filters: Object.keys(filters).filter(key => filters[key]).join(',') });
 }
 
 const FilterGroups = (props) => {

--- a/lib/FilterGroups/index.js
+++ b/lib/FilterGroups/index.js
@@ -1,1 +1,1 @@
-export { default, initialFilterState, filters2cql, onChangeFilter } from './FilterGroups';
+export { default, initialFilterState, filters2cql, onChangeFilter, handleFilterChange } from './FilterGroups';


### PR DESCRIPTION
Works with anointed resource instead of component state.

Fixes STCOM-148.