### PR TITLE
Add `filterState` method for FilterGroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Remove `<Accordion>` from `<AddressList`. Fixes STCOM-138.
 * Add `interactive` to `<MultiColumnList>` to toggle cursor CSS on non-interactive lists. Fixes STCOM-139.
 * Add `handleFilterChange` method for FilterGroups. Works with anointed resource instead of component state. Fixes STCOM-148.
+* Add `filterState` method for FilterGroups. Like `initialFilterState` but doesn't need the configuraton object. Fixes STCOM-147.
 
 ## [1.9.0](https://github.com/folio-org/stripes-components/tree/v1.9.0) (2017-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.8.0...v1.9.0)

--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -58,7 +58,7 @@ FilterGroup.propTypes = {
 };
 
 
-// public
+// DEPRECATED in favour of filterState
 export function initialFilterState(config, filters) {
   const state = {};
 
@@ -75,6 +75,20 @@ export function initialFilterState(config, filters) {
         const fullName = `${group.name}.${valueName}`;
         if (register[fullName]) state[fullName] = true;
       }
+    }
+  }
+
+  return state;
+}
+
+
+export function filterState(filters) {
+  const state = {};
+
+  if (filters) {
+    const fullNames = filters.split(',');
+    for (const fullName of fullNames) {
+      state[fullName] = true;
     }
   }
 
@@ -131,14 +145,9 @@ export function onChangeFilter(e) {
 
 // Relies on caller providing both queryParam and transitionToParams
 export function handleFilterChange(e) {
-  const keys = this.queryParam('filters').split(',');
-  const filters = {};
-  for (const key of keys) {
-    filters[key] = true;
-  }
-
-  filters[e.target.name] = e.target.checked;
-  this.transitionToParams({ filters: Object.keys(filters).filter(key => filters[key]).join(',') });
+  const state = filterState(this.queryParam('filters'));
+  state[e.target.name] = e.target.checked;
+  this.transitionToParams({ filters: Object.keys(state).filter(key => state[key]).join(',') });
 }
 
 const FilterGroups = (props) => {

--- a/lib/FilterGroups/index.js
+++ b/lib/FilterGroups/index.js
@@ -1,1 +1,1 @@
-export { default, initialFilterState, filters2cql, onChangeFilter, handleFilterChange } from './FilterGroups';
+export { default, initialFilterState, filterState, filters2cql, onChangeFilter, handleFilterChange } from './FilterGroups';


### PR DESCRIPTION
This is like `initialFilterState`, but doesn't need the configuraton
object.

Also, modify handleFilterChange to use this rather then duplicating
its code.

Fixes STCOM-147.