### PR TITLE
Updated paddings/margins on MCL

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -31,6 +31,8 @@
   border-radius: 7px;
   color: #333;
   text-decoration: none;
+  margin-left: 9px;
+  margin-right: 9px;
 
   & a {
     color: var(--primary);
@@ -100,7 +102,11 @@
   display: flex;
   justify-content: flex-start;
   overflow: hidden;
-  width: calc(100% - 16px);
+  width: calc(100% - 22px);
+
+  /* header columns has padding of their own and we need a total of 15px from edge to text */
+  padding-top: 6px;
+  padding-left: 10px;
 
   &.hScroll {
     overflow: auto;
@@ -117,6 +123,7 @@
   font-weight: 600;
   color: rgba(0, 0, 0, 0.5);
   text-transform: capitalize;
+  line-height: 1;
 
   &.sorted {
     text-decoration: underline;

--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -105,8 +105,7 @@
   width: calc(100% - 22px);
 
   /* header columns has padding of their own and we need a total of 15px from edge to text */
-  padding-top: 6px;
-  padding-left: 10px;
+  padding: 6px 10px 0;
 
   &.hScroll {
     overflow: auto;


### PR DESCRIPTION
Updated paddings/margins to achieve 15px padding from edge to text (in connection with the padContent=false prop on Pane).

The padContent prop should be set on all panes that that has MultiColumnList as direct child. I will submit a pull request for stripes-smart-components once this, #123  and #125 is merged.