### PR TITLE
Use valid icon-name

### DIFF
--- a/lib/FilterPaneSearch/FilterPaneSearch.js
+++ b/lib/FilterPaneSearch/FilterPaneSearch.js
@@ -27,7 +27,7 @@ const FilterPaneSearch = props => (
     <Button className={css.headerSearchClearButton} id={props.clearSearchId} onClick={props.onClear} aria-label="Clear search field"><Icon icon="clearX" iconClassName={css.clearIcon} /></Button>
     { props.resultsList &&
       <FocusLink target={props.resultsList} aria-label="Skip to results" style={{ alignSelf: 'stretch', paddingTop: '14px' }} component="div" showOnFocus >
-        <Icon icon="right-double-chevron-bold" />
+        <Icon icon="right-double-chevron" />
       </FocusLink>
     }
   </div>


### PR DESCRIPTION
Really weird new console warning from Stripes:
```
Warning: Failed prop type: Invalid prop `icon` of value `right-double-chevron-bold` supplied to `Icon`, expected one of ["info","plus-sign","validation-check","validation-error","default","clearX","closeX","calendar","trashBin","comment","bookmark","search","duplicate","edit","hollowX","archive","forward-arrow","back-arrow","down-arrow","up-arrow","down-caret","up-caret","down-triangle","up-triangle","right-double-chevron","left-double-chevron","eye-open","eye-close","end-mark","ellipsis","spinner-ellipsis"].
    in Icon (created by FilterPaneSearch)
    in FilterPaneSearch (created by SearchAndSort)
    in header (created by PaneHeader)
```

But `<FilterPaneSearch>` has been asking for this very icon since commit cea23c807c6da5eec3bed030d1c12718bb48b1f7 of 30th June.

Turns out it's the validation that's new: https://github.com/folio-org/stripes-components/commit/73b113e4c8b46895828aaaa4db74890b59084193

So I guess this has _always_ been wrong, and we are only now seeing that.

I'm fixing `<FilterPaneSearch>` to ask for the icon "right-double-chevron" rather than "right-double-chevron-bold" as previously.