### PR TITLE
Move storybook addons to devDependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,7 @@
   "parser": "babel-eslint",
   "rules": {
     "import/no-extraneous-dependencies": ["error", {
-      "devDependencies": ["**/*.stories.js"]
+      "devDependencies": ["**/*.stories.js", "**/stories/*.js"]
     }]
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     ]
   },
   "devDependencies": {
+    "@storybook/addon-actions": "^3.2.16",
+    "@storybook/addon-knobs": "^3.2.16",
     "@storybook/addon-options": "^3.2.15",
     "@storybook/react": "^3.2.15",
     "autoprefixer": "^7.1.6",
@@ -60,8 +62,6 @@
   "dependencies": {
     "@folio/stripes-form": "^0.8.2",
     "@folio/stripes-react-hotkeys": "^1.0.0",
-    "@storybook/addon-actions": "^3.2.16",
-    "@storybook/addon-knobs": "^3.2.16",
     "classnames": "^2.2.5",
     "create-react-class": "^15.5.3",
     "dom-helpers": "^3.2.1",


### PR DESCRIPTION
I noticed `@storybook/addon-actions` and `@storybook/addon-knobs` were being pulled in as dependencies of `ui-eholdings`. I assume they were moved because ESLint was throwing a `import/no-extraneous-dependencies` warning, but that rule is now ignored for all story files. We can move them back to simply being `devDependencies`.