### PR TITLE
Datepickers should only show a single clear icon

### DIFF
--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -458,6 +458,7 @@ class Datepicker extends React.Component {
           disabled={disabled}
           id={id}
           required={required}
+          hasClearIcon={false}
         />
       );
     } else {
@@ -478,6 +479,7 @@ class Datepicker extends React.Component {
           disabled={disabled}
           id={id}
           required={required}
+          hasClearIcon={false}
         />
       );
     }


### PR DESCRIPTION
Errored datepicker fields were showing two clear icons.

### Before
<img width="361" alt="screen shot 2017-12-27 at 5 04 00 pm" src="https://user-images.githubusercontent.com/230597/34397182-92944802-eb28-11e7-8128-47de49baa11c.png">

### After
<img width="360" alt="screen shot 2017-12-27 at 5 06 20 pm" src="https://user-images.githubusercontent.com/230597/34397183-9863f3e0-eb28-11e7-9a8e-299a8ca1af21.png">
