### PR TITLE
makeQueryFunction supports the "qfield" parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Adjust address read only view. Fixes STCOM-152.
 * `<FilterPaneSearch>` supports `searchableFields` and `onChangeField` properties. Fixes STCOM-171.
+* Functons made by `makeQueryFunction` support the `qfield` parameter, which is interpreted as the name of the _only_ field to search. This allows us to support field-specific searching. Fixes STCOM-172.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/util/makeQueryFunction.js
+++ b/util/makeQueryFunction.js
@@ -2,9 +2,14 @@ import { filters2cql } from '../lib/FilterGroups';
 
 function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig) {
   return (queryParams, _pathComponents, _resourceValues, logger) => {
-    const { query, filters } = queryParams || {};
+    const { qfield, query, filters } = queryParams || {};
 
-    let cql = !query ? undefined : queryTemplate.replace(/\$QUERY/g, query);
+    let cql = undefined;
+    if (query && qfield) {
+      cql = `${qfield}="${query}"`;
+    } else if (query) {
+      cql = queryTemplate.replace(/\$QUERY/g, query);
+    }
     const filterCql = filters2cql(filterConfig, filters);
     if (filterCql) {
       if (cql) {


### PR DESCRIPTION
Functions made by `makeQueryFunction` now operate as follos: if the `qfield` query-parameter is defined, it is interpreted as the name of the _only_ field to search, superseding the queryTemplate that was passed in when the function was created.

This allows us to support field-specific searching.

Fixes STCOM-172.
