### PR TITLE
`makeQueryFunction` supports relation-modifiers in the `qindex` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Adjust address read only view. Fixes STCOM-152.
 * `<FilterPaneSearch>` supports `searchableIndexes`, `selectedIndex` and `onChangeIndex` properties. Fixes STCOM-171.
 * Functions made by `makeQueryFunction` support the `qindex` parameter, which is interpreted as the name of the _only_ field to search. This allows us to support field-specific searching. Fixes STCOM-172.
+* `makeQueryFunction` support relation-modifiers in the `qindex` parameter. Fixes STCOM-174.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/util/makeQueryFunction.js
+++ b/util/makeQueryFunction.js
@@ -6,7 +6,12 @@ function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig) {
 
     let cql = undefined;
     if (query && qindex) {
-      cql = `${qindex}="${query}*"`;
+      const t = qindex.split('/', 2);
+      if (t.length === 1) {
+        cql = `${qindex}="${query}*"`;
+      } else {
+        cql = `${t[0]} =/${t[1]} "${query}*"`;
+      }
     } else if (query) {
       cql = queryTemplate.replace(/\$QUERY/g, query);
     }


### PR DESCRIPTION
Fixes STCOM-174.