### PR TITLE
Stcom 173 disabled select options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Adjust address read only view. Fixes STCOM-152.
 * `<FilterPaneSearch>` supports `searchableIndexes`, `selectedIndex` and `onChangeIndex` properties. Fixes STCOM-171.
 * Functions made by `makeQueryFunction` support the `qindex` parameter, which is interpreted as the name of the _only_ field to search. This allows us to support field-specific searching. Fixes STCOM-172.
+* `<Select>` options can be disabled via a 'disabled' property in dataOptions. Fixes STCOM-173.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/lib/Select/Select.js
+++ b/lib/Select/Select.js
@@ -77,7 +77,7 @@ class Select extends React.Component {
 
     if (dataOptions) {
       dataOptions.forEach((option, i) => {
-        options.push(<option value={option.value} key={option.id || `option-${i}`}>{option.label}</option>);
+        options.push(<option value={option.value} key={option.id || `option-${i}`} disabled={option.disabled}>{option.label}</option>);
       });
     }
 

--- a/lib/Select/readme.md
+++ b/lib/Select/readme.md
@@ -36,7 +36,7 @@ If `<Select>` is used within a redux-form `<Field>` component (currently the mos
 * input - object - contains necessary props for the input itself such as the field's `value`
 * meta - object - contains good-to-have info for the field such as `touched`
 
-## Usage with Redux-form's <Field> component
+## Usage with Redux-form's `<Field>` component
 In Short, `<Field>` requires a `name` and a `component` prop. The `name` is the data field and the `component` prop takes the `<Select>`. Additional props supplied are passed into the rendered `<Select>` component.
 See the [redux-form website](https://redux-form.com/7.2.0/) for more information.
 

--- a/lib/Select/readme.md
+++ b/lib/Select/readme.md
@@ -1,0 +1,58 @@
+# Select
+Renders a basic HTMLSelect field.
+
+## Usage
+
+```
+<Select
+  dataOptions={[
+    {value: "Y", label: "Yes"},
+    {value: "N", label: "No"},
+    {value: "M", label: "Maybe", disabled: true}
+   ]} 
+/>
+```
+
+## Properties
+
+Name | type | description | default | required
+--- | --- | --- | --- | ---
+label | string | Adds an html `<label>` tag container a string to the element. | | false
+id | string | HTML id attribute applied to input - will also set the HtmlFor attribute of the label. |  | false
+dataOptions | array | Array of objects for options in the shape of `{value:<string>, label: <string>, disabled:<bool>}` |  | true 
+placeHolder | string | Sets a disabled first option in the options list. |  | false  
+required | bool | Sets the required attribute on the select field. | false | false
+rounded | bool | Applies a border-radius to the Select input | | false
+marginBottom0 | bool | Styles the input with no bottom margin. | | false
+fullWidth | bool | Styles input to a width of 100% of its container. | | false
+validationEnabled | bool | Controls whether or not the select displays validation icons. | true | false
+value | string | Sets the selected value for the input. **not necessary if part of a redux-form** | | false
+onChange | func | Event handler for the select's `onChange` event. **not necessary if part of a redux-form** | | false
+
+## Properties set by Redux-form
+If `<Select>` is used within a redux-form `<Field>` component (currently the most common case.) You don't have to set any of these props yourself.
+
+* value - Sets the selected value for the input.
+* input - object - contains necessary props for the input itself such as the field's `value`
+* meta - contains good-to-have info for the field such as `touched`
+
+## Usage with Redux-form's <Field> component
+Used within a `<Field>` component. See the [redux-form website](https://redux-form.com/7.2.0/) for more details and documents on the `<Field>` component.
+In Short, `<Field>` requires a `name` and a `component` prop. The `name` is the data field and the `component` prop takes the `<Select>`. Additional props supplied are passed into the rendered `<Select>` component.
+
+```
+import Select from '@folio/stripes-components/lib/Select';
+
+...
+
+<Field 
+  name="country2" 
+  id="countrySelect2" 
+  component={Select} 
+  fullWidth 
+  dataOptions={[
+    {value: "Yes", label: "Y"},
+    {value: "No", label: "N", disabled: true}
+  ]}
+/>
+```

--- a/lib/Select/readme.md
+++ b/lib/Select/readme.md
@@ -26,19 +26,19 @@ rounded | bool | Applies a border-radius to the Select input | false | false
 marginBottom0 | bool | Styles the input with no bottom margin. | false | false
 fullWidth | bool | Styles input to a width of 100% of its container. | | false
 validationEnabled | bool | Controls whether or not the select displays validation icons. | true | false
-value | string | Sets the selected value for the input. **not necessary if part of a redux-form** | | false
-onChange | func | Event handler for the select's `onChange` event. **not necessary if part of a redux-form** | | false
+value | string | Sets the selected value for the input. **This prop isn't necessary if part of a redux-form (see below)** | | false
+onChange | func | Event handler for the select's `onChange` event. **This prop isn't necessary if part of a redux-form (see below)** | | false
 
 ## Properties set by Redux-form
-If `<Select>` is used within a redux-form `<Field>` component (currently the most common case.) You don't have to set any of these props yourself.
+If `<Select>` is used within a redux-form `<Field>` component (currently the most common case.) You don't have to set any of these props yourself. See the [redux-form website](https://redux-form.com/7.2.0/) for more details.
 
 * value - Sets the selected value for the input.
 * input - object - contains necessary props for the input itself such as the field's `value`
-* meta - contains good-to-have info for the field such as `touched`
+* meta - object - contains good-to-have info for the field such as `touched`
 
 ## Usage with Redux-form's <Field> component
-Used within a `<Field>` component. See the [redux-form website](https://redux-form.com/7.2.0/) for more details and documents on the `<Field>` component.
 In Short, `<Field>` requires a `name` and a `component` prop. The `name` is the data field and the `component` prop takes the `<Select>`. Additional props supplied are passed into the rendered `<Select>` component.
+See the [redux-form website](https://redux-form.com/7.2.0/) for more information.
 
 ```
 import Select from '@folio/stripes-components/lib/Select';

--- a/lib/Select/readme.md
+++ b/lib/Select/readme.md
@@ -19,11 +19,11 @@ Name | type | description | default | required
 --- | --- | --- | --- | ---
 label | string | Adds an html `<label>` tag container a string to the element. | | false
 id | string | HTML id attribute applied to input - will also set the HtmlFor attribute of the label. |  | false
-dataOptions | array | Array of objects for options in the shape of `{value:<string>, label: <string>, disabled:<bool>}` |  | true 
+dataOptions | array | Array of objects for options in the shape of `{value:<string>, label: <string>, disabled:<bool>}` |  | required 
 placeHolder | string | Sets a disabled first option in the options list. |  | false  
 required | bool | Sets the required attribute on the select field. | false | false
-rounded | bool | Applies a border-radius to the Select input | | false
-marginBottom0 | bool | Styles the input with no bottom margin. | | false
+rounded | bool | Applies a border-radius to the Select input | false | false
+marginBottom0 | bool | Styles the input with no bottom margin. | false | false
 fullWidth | bool | Styles input to a width of 100% of its container. | | false
 validationEnabled | bool | Controls whether or not the select displays validation icons. | true | false
 value | string | Sets the selected value for the input. **not necessary if part of a redux-form** | | false


### PR DESCRIPTION
Allows for `<Select>` dropdowns to have options greyed out via a 'disabled' property supplied in the `dataOptions` prop such as:
```
<Select
  dataOptions={[
    {value: "Y", label: "Yes"},
    {value: "N", label: "No"},
    {value: "M", label: "Maybe", disabled: true}
   ]} 
/>
```