### PR TITLE
STCOM-164: Add buttons to clear filters

### DIFF
--- a/lib/Accordion/Accordion.css
+++ b/lib/Accordion/Accordion.css
@@ -40,10 +40,6 @@
     margin: 0;
   }
 
-  & > button {
-    flex-shrink: 0;
-  }
-
   &:focus {
     outline: none;
   }

--- a/lib/Accordion/headers/FilterAccordionHeader.js
+++ b/lib/Accordion/headers/FilterAccordionHeader.js
@@ -5,21 +5,24 @@ import Icon from '../../Icon';
 import Button from '../../Button';
 import css from '../Accordion.css';
 
-const propTypes = {
-  contentId: PropTypes.string,
-  onToggle: PropTypes.func,
-  label: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
-  open: PropTypes.bool,
-  displayWhenOpen: PropTypes.element,
-  displayWhenClosed: PropTypes.element,
-};
+class FilterAccordionHeader extends React.Component {
+  static propTypes = {
+    id: PropTypes.string,
+    contentId: PropTypes.string,
+    onToggle: PropTypes.func,
+    label: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
+    open: PropTypes.bool,
+    displayWhenOpen: PropTypes.element,
+    displayWhenClosed: PropTypes.element,
+    displayClearButton: PropTypes.bool,
+    onClearFilters: PropTypes.func,
+  };
 
-const FilterAccordionHeader = (props) => {
-  let toggleElem = null;
-  let labelElem = null;
-  let iconElem = null;
-  let containerElem = null;
+  static defaultProps = {
+    displayClearButton: true,
+  };
 
+<<<<<<< HEAD
   let openIcon = (<Icon size="small" icon="up-caret" ref={(r) => { iconElem = r; }} />);
   if (props.open) {
     openIcon = (<Icon size="small" icon="down-caret" ref={(r) => { iconElem = r; }} />);
@@ -32,47 +35,69 @@ const FilterAccordionHeader = (props) => {
       e.target === iconElem) {
       const { id, label } = props;
       props.onToggle({ id, label });
+=======
+  handleHeaderClick = (e) => {
+    if (contains(this.clearElem, e.target)) {
+      this.props.onClearFilters(e);
+      e.stopPropagation();
+    } else if (contains(this.toggleElem, e.target) ||
+      e.target === this.labelElem ||
+      e.target === this.containerElem ||
+      e.target === this.iconElem) {
+      const { id, label } = this.props;
+      this.props.onToggle({ id, label });
+>>>>>>> filters: added clear-all button to headers
       e.stopPropagation();
     }
   }
 
-  function handleKeyPress(e) {
+  handleKeyPress = (e) => {
     e.preventDefault();
     if (e.charCode === 13 || e.charCode === 32) { // enter key or space key...
-      if (e.target === toggleElem || e.target === labelElem || e.target === containerElem) {
-        const { id, label } = props;
-        props.onToggle({ id, label });
+      if (e.target === this.clearElem) {
+        this.props.onClearFilters(e);
+        e.stopPropagation();
+      } else if (e.target === this.toggleElem || e.target === this.labelElem || e.target === this.containerElem) {
+        const { id, label } = this.props;
+        this.props.onToggle({ id, label });
       }
     }
   }
 
-  const { label, open, displayWhenOpen, displayWhenClosed, contentId } = props;
+  render() {
+    const { label, open, displayWhenOpen, displayWhenClosed, displayClearButton, contentId } = this.props;
 
-  return (
-    <div role="heading" aria-level="2" className={css.headerWrapper} ref={(ref) => { containerElem = ref; }} >
-      <Button
-        buttonStyle="transparent"
-        type="button"
-        tabIndex="0"
-        onClick={handleHeaderClick}
-        onKeyPress={handleKeyPress}
-        aria-label={`${label} filter list`}
-        aria-controls={contentId}
-        aria-expanded={open}
-        className={css.filterSetHeader}
-        role="tab"
-        buttonRef={(ref) => { toggleElem = ref; }}
-      >
-        {openIcon}
-        <div className={css.labelArea} ref={(ref) => { labelElem = ref; }}>
-          <div className={css.filterSetlabel} >{label}</div>
-        </div>
-      </Button>
-      {open ? displayWhenOpen : displayWhenClosed}
-    </div>
-  );
-};
-
-FilterAccordionHeader.propTypes = propTypes;
+    return (
+      <div role="heading" aria-level="2" className={css.headerWrapper} ref={(ref) => { this.containerElem = ref; }} >
+        <Button
+          buttonStyle="transparent"
+          type="button"
+          tabIndex="0"
+          onClick={this.handleHeaderClick}
+          onKeyPress={this.handleKeyPress}
+          aria-label={`${label} filter list`}
+          aria-controls={contentId}
+          aria-expanded={open}
+          className={css.filterSetHeader}
+          role="tab"
+          buttonRef={(ref) => { this.toggleElem = ref; }}
+        >
+          <Icon size="small" icon={`${open ? 'up' : 'down'}-caret`} ref={(r) => { this.iconElem = r; }} />
+          <div className={css.labelArea} ref={(ref) => { this.labelElem = ref; }}>
+            <div className={css.filterSetlabel} >{label}</div>
+          </div>
+          { displayClearButton ?
+            <span ref={(r) => { this.clearElem = r; }}>
+              <Icon size="small" icon="clearX" />
+            </span>
+            :
+            null
+          }
+        </Button>
+        {open ? displayWhenOpen : displayWhenClosed}
+      </div>
+    );
+  }
+}
 
 export default FilterAccordionHeader;

--- a/lib/Accordion/headers/FilterAccordionHeader.js
+++ b/lib/Accordion/headers/FilterAccordionHeader.js
@@ -35,7 +35,7 @@ class FilterAccordionHeader extends React.Component {
       e.target === this.iconElem) {
       const { id, label } = this.props;
       this.props.onToggle({ id, label });
-      
+
       e.stopPropagation();
     }
   }

--- a/lib/Accordion/headers/FilterAccordionHeader.js
+++ b/lib/Accordion/headers/FilterAccordionHeader.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import contains from 'dom-helpers/query/contains';
 import Icon from '../../Icon';
 import Button from '../../Button';
+import IconButton from '../../IconButton';
 import css from '../Accordion.css';
 
 class FilterAccordionHeader extends React.Component {
@@ -24,12 +25,7 @@ class FilterAccordionHeader extends React.Component {
   };
 
   handleHeaderClick = (e) => {
-    if (this.props.displayClearButton && contains(this.clearElem, e.target)) {
-      const { name } = this.props;
-      this.props.onClearFilter(name);
-
-      e.stopPropagation();
-    } else if (contains(this.toggleElem, e.target) ||
+    if (contains(this.toggleElem, e.target) ||
       e.target === this.labelElem ||
       e.target === this.containerElem ||
       e.target === this.iconElem) {
@@ -40,15 +36,15 @@ class FilterAccordionHeader extends React.Component {
     }
   }
 
+  handleClearButtonClick = (e) => {
+    this.props.onClearFilter(this.props.name);
+  }
+
   handleKeyPress = (e) => {
     e.preventDefault();
 
     if (e.charCode === 13 || e.charCode === 32) { // enter key or space key...
-      if (e.target === this.clearElem) {
-        const { name } = this.props;
-        this.props.onClearFilter(name);
-        e.stopPropagation();
-      } else if (e.target === this.toggleElem || e.target === this.labelElem || e.target === this.containerElem) {
+      if (e.target === this.toggleElem || e.target === this.labelElem || e.target === this.containerElem) {
         const { id, label } = this.props;
         this.props.onToggle({ id, label });
       }
@@ -56,7 +52,7 @@ class FilterAccordionHeader extends React.Component {
   }
 
   render() {
-    const { label, name, open, displayWhenOpen, displayWhenClosed, displayClearButton, contentId } = this.props;
+    const { label, open, displayWhenOpen, displayWhenClosed, displayClearButton, contentId } = this.props;
 
     return (
       <div role="heading" aria-level="2" className={css.headerWrapper} ref={(ref) => { this.containerElem = ref; }} >
@@ -77,14 +73,16 @@ class FilterAccordionHeader extends React.Component {
           <div className={css.labelArea} ref={(ref) => { this.labelElem = ref; }}>
             <div className={css.filterSetlabel} >{label}</div>
           </div>
-          { displayClearButton ?
-            <span name={name} ref={(r) => { this.clearElem = r; }}>
-              <Icon size="small" icon="clearX" />
-            </span>
-            :
-            null
-          }
         </Button>
+        { displayClearButton ?
+          <IconButton
+            size="small"
+            icon="clearX"
+            title={`Clear selected filters for "${label}"`}
+            ariaLabel={`Clear selected filters for "${label}"`}
+            onClick={this.handleClearButtonClick}
+          /> : null
+        }
         {open ? displayWhenOpen : displayWhenClosed}
       </div>
     );

--- a/lib/Accordion/headers/FilterAccordionHeader.js
+++ b/lib/Accordion/headers/FilterAccordionHeader.js
@@ -23,24 +23,11 @@ class FilterAccordionHeader extends React.Component {
     displayClearButton: true,
   };
 
-<<<<<<< HEAD
-  let openIcon = (<Icon size="small" icon="up-caret" ref={(r) => { iconElem = r; }} />);
-  if (props.open) {
-    openIcon = (<Icon size="small" icon="down-caret" ref={(r) => { iconElem = r; }} />);
-  }
-
-  function handleHeaderClick(e) {
-    if (contains(toggleElem, e.target) ||
-      e.target === labelElem ||
-      e.target === containerElem ||
-      e.target === iconElem) {
-      const { id, label } = props;
-      props.onToggle({ id, label });
-=======
   handleHeaderClick = (e) => {
     if (this.props.displayClearButton && contains(this.clearElem, e.target)) {
       const { name } = this.props;
       this.props.onClearFilter(name);
+
       e.stopPropagation();
     } else if (contains(this.toggleElem, e.target) ||
       e.target === this.labelElem ||
@@ -48,7 +35,7 @@ class FilterAccordionHeader extends React.Component {
       e.target === this.iconElem) {
       const { id, label } = this.props;
       this.props.onToggle({ id, label });
->>>>>>> filters: added clear-all button to headers
+      
       e.stopPropagation();
     }
   }

--- a/lib/Accordion/headers/FilterAccordionHeader.js
+++ b/lib/Accordion/headers/FilterAccordionHeader.js
@@ -8,6 +8,7 @@ import css from '../Accordion.css';
 class FilterAccordionHeader extends React.Component {
   static propTypes = {
     id: PropTypes.string,
+    name: PropTypes.string,
     contentId: PropTypes.string,
     onToggle: PropTypes.func,
     label: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
@@ -15,7 +16,7 @@ class FilterAccordionHeader extends React.Component {
     displayWhenOpen: PropTypes.element,
     displayWhenClosed: PropTypes.element,
     displayClearButton: PropTypes.bool,
-    onClearFilters: PropTypes.func,
+    onClearFilter: PropTypes.func,
   };
 
   static defaultProps = {
@@ -37,8 +38,9 @@ class FilterAccordionHeader extends React.Component {
       props.onToggle({ id, label });
 =======
   handleHeaderClick = (e) => {
-    if (contains(this.clearElem, e.target)) {
-      this.props.onClearFilters(e);
+    if (this.props.displayClearButton && contains(this.clearElem, e.target)) {
+      const { name } = this.props;
+      this.props.onClearFilter(name);
       e.stopPropagation();
     } else if (contains(this.toggleElem, e.target) ||
       e.target === this.labelElem ||
@@ -53,9 +55,11 @@ class FilterAccordionHeader extends React.Component {
 
   handleKeyPress = (e) => {
     e.preventDefault();
+
     if (e.charCode === 13 || e.charCode === 32) { // enter key or space key...
       if (e.target === this.clearElem) {
-        this.props.onClearFilters(e);
+        const { name } = this.props;
+        this.props.onClearFilter(name);
         e.stopPropagation();
       } else if (e.target === this.toggleElem || e.target === this.labelElem || e.target === this.containerElem) {
         const { id, label } = this.props;
@@ -65,7 +69,7 @@ class FilterAccordionHeader extends React.Component {
   }
 
   render() {
-    const { label, open, displayWhenOpen, displayWhenClosed, displayClearButton, contentId } = this.props;
+    const { label, name, open, displayWhenOpen, displayWhenClosed, displayClearButton, contentId } = this.props;
 
     return (
       <div role="heading" aria-level="2" className={css.headerWrapper} ref={(ref) => { this.containerElem = ref; }} >
@@ -87,7 +91,7 @@ class FilterAccordionHeader extends React.Component {
             <div className={css.filterSetlabel} >{label}</div>
           </div>
           { displayClearButton ?
-            <span ref={(r) => { this.clearElem = r; }}>
+            <span name={name} ref={(r) => { this.clearElem = r; }}>
               <Icon size="small" icon="clearX" />
             </span>
             :

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -396,6 +396,11 @@
     margin-bottom: 0;
   }
 
+  &.paddingSide0 {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
   &.fullWidth {
     width: 100%;
   }

--- a/lib/Button/Button.js
+++ b/lib/Button/Button.js
@@ -12,6 +12,7 @@ const propTypes = {
   align: PropTypes.string,
   bottomMargin0: PropTypes.bool,
   marginBottom0: PropTypes.bool,
+  paddingSide0: PropTypes.bool,
   fullWidth: PropTypes.bool,
   href: PropTypes.string,
   allowAnchorClick: PropTypes.bool,
@@ -44,6 +45,7 @@ function Button(props) {
       buttonBuiltIn,
       { [`${css.marginBottom0}`]: props.marginBottom0 },
       { [`${css.marginBottom0}`]: props.bottomMargin0 },
+      { [`${css.paddingSide0}`]: props.paddingSide0 },
       { [`${css.fullWidth}`]: props.fullWidth },
       { [`${css.hollow}`]: props.hollow },
       { [`${css.floatEnd}`]: props.align === 'end' },
@@ -62,7 +64,7 @@ function Button(props) {
     }
   }
 
-  const inputCustom = omitProps(props, ['buttonClass', 'buttonStyle', 'bottomMargin0', 'marginBottom0', 'align', 'hollow', 'fullWidth', 'bsRole', 'bsClass', 'onClick', 'allowAnchorClick', 'buttonRef']);
+  const inputCustom = omitProps(props, ['buttonClass', 'buttonStyle', 'bottomMargin0', 'marginBottom0', 'paddingSide0', 'align', 'hollow', 'fullWidth', 'bsRole', 'bsClass', 'onClick', 'allowAnchorClick', 'buttonRef']);
   const { children, onClick, type } = props;
 
   if (props.href) {

--- a/lib/Button/readme/general.md
+++ b/lib/Button/readme/general.md
@@ -24,6 +24,7 @@ align | string | Change the alignment of the button (with flexbox) Options: star
 className | string | Replace CSS classes completely |
 bottomMargin0 | bool | Remove bottom margin |
 marginBottom0 | bool | Remove bottom margin |
+paddingSide0 | bool | Remove padding on the sides |
 fullWidth | fullWidth | Forces the button width to 100% |
 href | string | Returns an anchor-tag with an href-attribute |
 allowAnchorClick | bool | Allow anchor click |

--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -7,6 +7,8 @@ import {
   FilterAccordionHeader,
 } from '../Accordion';
 import Checkbox from '../Checkbox';
+import Button from '../Button/Button';
+import Icon from '../Icon';
 
 
 // private
@@ -141,11 +143,8 @@ export function filters2cql(config, filters) {
 // DEPRECATED in favour of handleFilterChange
 //
 export function onChangeFilter(e) {
-  const filters = {};
-  if (e.target.name !== undefined && e.target.checked !== undefined) {
-    Object.assign(filters, this.state.filters);
-    filters[e.target.name] = e.target.checked;
-  }
+  const filters = Object.assign({}, this.state.filters);
+  filters[e.target.name] = e.target.checked;
 
   this.setState({ filters });
   this.updateFilters(filters);
@@ -153,42 +152,65 @@ export function onChangeFilter(e) {
 
 // Relies on caller providing both queryParam and transitionToParams
 export function handleFilterChange(e) {
-  let state = {};
-  if (e.target.name !== undefined && e.target.checked !== undefined) {
-    state = filterState(this.queryParam('filters'));
-    state[e.target.name] = e.target.checked;
-  }
-
+  const state = filterState(this.queryParam('filters'));
   state[e.target.name] = e.target.checked;
   this.transitionToParams({ filters: Object.keys(state).filter(key => state[key]).join(',') });
 }
 
+export function handleFilterClear(name) {
+  const state = filterState(this.queryParam('filters'));
+
+  Object.keys(state).forEach((key) => {
+    if (key.startsWith(`${name}.`)) {
+      state[key] = false;
+    }
+  });
+
+  this.transitionToParams({ filters: Object.keys(state).filter(key => state[key]).join(',') });
+}
+
+export function handleClearAllFilters() {
+  this.transitionToParams({ filters: '' });
+}
+
 const FilterGroups = (props) => {
-  const { config, filters, onChangeFilter: ocf } = props;
+  const { config, filters, onChangeFilter: ocf, onClearFilter, onClearAllFilters } = props;
   const disableNames = props.disableNames || {};
 
-  return (<AccordionSet>
-    {config.map((group, index) => (
-      <Accordion
-        label={group.label}
-        id={`${group.label}-${index}`}
-        key={index}
-        separator={false}
-        header={FilterAccordionHeader}
-        onClearFilters={ocf}
-      >
-        <FilterGroup
-          key={index}
-          label={group.label}
-          groupName={group.name}
-          disabled={disableNames[group.name]}
-          names={group.values.map(f => ((typeof f === 'object') ? f.name : f))}
-          filters={filters}
-          onChangeFilter={ocf}
-        />
-      </Accordion>
-    ))}
-  </AccordionSet>);
+  return (
+    <div>
+      <Button buttonStyle="transparent" hollow paddingSide0 onClick={onClearAllFilters}>
+        <Icon size="small" icon="clearX" />
+        <div>Reset All</div>
+      </Button>
+      <AccordionSet>
+        {config.map((group, index) => (
+          <Accordion
+            label={group.label}
+            id={`${group.label}-${index}`}
+            name={group.name}
+            key={index}
+            separator={false}
+            header={FilterAccordionHeader}
+            // If any of the filters start with this group's name, then we should display the 'clear all'
+            // button for this accordion.
+            displayClearButton={Object.keys(filters).some(filter => filter.startsWith(group.name))}
+            onClearFilter={onClearFilter}
+          >
+            <FilterGroup
+              key={index}
+              label={group.label}
+              groupName={group.name}
+              disabled={disableNames[group.name]}
+              names={group.values.map(f => ((typeof f === 'object') ? f.name : f))}
+              filters={filters}
+              onChangeFilter={ocf}
+            />
+          </Accordion>
+        ))}
+      </AccordionSet>
+    </div>
+  );
 };
 
 FilterGroups.propTypes = {
@@ -211,6 +233,8 @@ FilterGroups.propTypes = {
   filters: PropTypes.object.isRequired,
   onChangeFilter: PropTypes.func.isRequired,
   disableNames: PropTypes.shape({}),
+  onClearFilter: PropTypes.func.isRequired,
+  onClearAllFilters: PropTypes.func.isRequired,
 };
 
 export default FilterGroups;

--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -170,7 +170,8 @@ export function handleFilterClear(name) {
 }
 
 export function handleClearAllFilters() {
-  this.transitionToParams({ filters: '' });
+  // Access the initialFilters that were passed to the calling component. This is probably SearchAndSort.
+  this.transitionToParams({ filters: this.props.initialFilters || '' });
 }
 
 const FilterGroups = (props) => {
@@ -181,7 +182,7 @@ const FilterGroups = (props) => {
     <div>
       <Button buttonStyle="transparent" hollow paddingSide0 onClick={onClearAllFilters}>
         <Icon size="small" icon="clearX" />
-        <div>Reset All</div>
+        <div>Reset all</div>
       </Button>
       <AccordionSet>
         {config.map((group, index) => (

--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -141,15 +141,24 @@ export function filters2cql(config, filters) {
 // DEPRECATED in favour of handleFilterChange
 //
 export function onChangeFilter(e) {
-  const filters = Object.assign({}, this.state.filters);
-  filters[e.target.name] = e.target.checked;
+  const filters = {};
+  if (e.target.name !== undefined && e.target.checked !== undefined) {
+    Object.assign(filters, this.state.filters);
+    filters[e.target.name] = e.target.checked;
+  }
+
   this.setState({ filters });
   this.updateFilters(filters);
 }
 
 // Relies on caller providing both queryParam and transitionToParams
 export function handleFilterChange(e) {
-  const state = filterState(this.queryParam('filters'));
+  let state = {};
+  if (e.target.name !== undefined && e.target.checked !== undefined) {
+    state = filterState(this.queryParam('filters'));
+    state[e.target.name] = e.target.checked;
+  }
+
   state[e.target.name] = e.target.checked;
   this.transitionToParams({ filters: Object.keys(state).filter(key => state[key]).join(',') });
 }
@@ -160,7 +169,14 @@ const FilterGroups = (props) => {
 
   return (<AccordionSet>
     {config.map((group, index) => (
-      <Accordion label={group.label} id={`${group.label}-${index}`} key={index} separator={false} header={FilterAccordionHeader}>
+      <Accordion
+        label={group.label}
+        id={`${group.label}-${index}`}
+        key={index}
+        separator={false}
+        header={FilterAccordionHeader}
+        onClearFilters={ocf}
+      >
         <FilterGroup
           key={index}
           label={group.label}

--- a/lib/FilterGroups/index.js
+++ b/lib/FilterGroups/index.js
@@ -1,1 +1,10 @@
-export { default, initialFilterState, filterState, filters2cql, onChangeFilter, handleFilterChange } from './FilterGroups';
+export {
+  default,
+  initialFilterState,
+  filterState,
+  filters2cql,
+  onChangeFilter,
+  handleFilterChange,
+  handleFilterClear,
+  handleClearAllFilters,
+} from './FilterGroups';


### PR DESCRIPTION
Implements the first part of [STCOM-164](https://issues.folio.org/browse/STCOM-164)

- Added a `Reset All` button at the top of the `FilterGroups` component which clears all existing filters.
- Added a "clear" X to the right of every `FilterAccordionHeader` which clears the filters in that FilterGroup.

- This requires `SearchAndSort` to be used by the module. Decided against backporting this functionality to modules that don't use SAS yet per discussion on the JIRA.
- There's a dependent change in SAS that'll have a PR in stripes-smart-components as well.

Be as pedantic and overcorrective as you want with this PR since it's my first. If I didn't catch some corner-case or idiosyncrasy or my style doesn't match I'd love to know. 👍 

Reviewers assigned based on Github suggestions or people who chatted on related JIRAs. Feel free to ignore. 😝 
  