### PR TITLE
Give explicit class names instead of .root

### DIFF
--- a/lib/Accordion/Accordion.css
+++ b/lib/Accordion/Accordion.css
@@ -10,7 +10,7 @@
   to { background-color: var(--bgHover); }
 }
 
-.root {
+.accordion {
   width: 100%;
 }
 

--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -212,7 +212,7 @@ class Accordion extends React.Component {
   // eslint-disable-next-line class-methods-use-this
   getRootClasses() {
     return classNames(
-      css.root,
+      css.accordion,
       { [css.hasSeparator]: this.props.separator },
     );
   }

--- a/lib/Badge/Badge.css
+++ b/lib/Badge/Badge.css
@@ -1,6 +1,6 @@
 @import '../variables.css';
 
-.root {
+.badge {
   border-radius: 40%;
   padding: 2px 5px;
   font-weight: 600;

--- a/lib/Badge/Badge.js
+++ b/lib/Badge/Badge.js
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import css from './Badge.css';
 
 const Badge = props =>
-  (<div className={classnames(props.className, css.root, css[props.color])}>{props.children}</div>);
+  (<div className={classnames(props.className, css.badge, css[props.color])}>{props.children}</div>);
 
 Badge.propTypes = {
   children: PropTypes.node,

--- a/lib/Callout/Callout.css
+++ b/lib/Callout/Callout.css
@@ -1,6 +1,6 @@
 @import '../variables.css';
 
-.calloutRoot {
+.callout {
   position: fixed;
   top: 0;
   left: 0;

--- a/lib/Callout/Callout.js
+++ b/lib/Callout/Callout.js
@@ -43,7 +43,7 @@ class Callout extends React.Component {
   render() {
     return (
       <Portal container={document.body}>
-        <div className={css.calloutRoot}>
+        <div className={css.callout}>
           <TransitionGroup className={css.calloutContainer} aria-live="polite" aria-relevant="additions">
             {this.state.callouts.map(calloutProps => (
               <CalloutElement key={calloutProps.id} transition="slide" {...calloutProps} />

--- a/lib/Checkbox/Checkbox.css
+++ b/lib/Checkbox/Checkbox.css
@@ -10,7 +10,7 @@
   transition: background-color 0.2s ease;
   position: relative;
 
-  &.rootFullWidth {
+  &.fullWidth {
     width: 100%;
   }
 
@@ -18,7 +18,7 @@
     margin-bottom: 0;
   }
 
-  &.rootHover {
+  &.hover {
     border-radius: 6px;
 
     &:hover {

--- a/lib/Checkbox/Checkbox.js
+++ b/lib/Checkbox/Checkbox.js
@@ -66,9 +66,9 @@ class Checkbox extends React.Component {
   getRootStyle() {
     return classNames(
       [`${css.checkbox}`],
-      { [`${css.rootHover}`]: this.props.hover },
+      { [`${css.hover}`]: this.props.hover },
       { [`${css.hovered}`]: (this.props.hover && this.state.inputInFocus) },
-      { [`${css.rootFullWidth}`]: this.props.fullWidth },
+      { [`${css.fullWidth}`]: this.props.fullWidth },
       { [`${css.marginBottom0}`]: this.props.marginBottom0 },
       { [`${css.inline}`]: this.props.inline },
       this.getFeedbackClasses(),
@@ -119,7 +119,7 @@ class Checkbox extends React.Component {
   // getContainerStyle() {
   //   return classNames(
   //     // [`${css.checkbox}`],
-  //     { [`${css.rootFullWidth}`]: this.props.fullWidth },
+  //     { [`${css.fullWidth}`]: this.props.fullWidth },
   //     { [`${css.marginBottom0}`]: this.props.marginBottom0 },
   //     { [`${css.inline}`]: this.props.inline },
   //   );

--- a/lib/Datepicker/Calendar.css
+++ b/lib/Datepicker/Calendar.css
@@ -1,4 +1,4 @@
-.root {
+.calendar {
   position: relative;
   background: #fff;
   border-radius: 4px;
@@ -17,7 +17,7 @@
   overflow: hidden;
 }
 
-.calendar {
+.calendarInner {
   & td {
     vertical-align: middle;
   }

--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -367,8 +367,8 @@ class Calendar extends React.Component {
     const arrowStyle = { padding: '4px' };
 
     return (
-      <div className={css.root}>
-        <div className={css.calendar}>
+      <div className={css.calendar}>
+        <div className={css.calendarInner}>
           <table role="presentation">
             <thead>
 

--- a/lib/Icon/Icon.css
+++ b/lib/Icon/Icon.css
@@ -1,4 +1,4 @@
-.root {
+.icon {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -8,7 +8,7 @@
   }
 }
 
-.root svg {
+.icon svg {
   height: inherit;
   width: inherit;
 }

--- a/lib/Icon/Icon.js
+++ b/lib/Icon/Icon.js
@@ -21,7 +21,7 @@ const defaultProps = {
 class Icon extends React.Component {
   getRootClass() {
     return classNames(
-      css.root,
+      css.icon,
       this.props.iconRootClass,
       css[this.props.size],
       // Icon is spiller (this is going to be deprecated later on)

--- a/lib/List/List.css
+++ b/lib/List/List.css
@@ -1,6 +1,6 @@
 @import "../variables";
 
-.root {
+.list {
   margin-bottom: 1rem;
 
   &.marginBottom0 {

--- a/lib/List/List.js
+++ b/lib/List/List.js
@@ -38,7 +38,7 @@ const List = (props) => {
    * Get list classes
    */
   const getListClass = () => classNames(
-    css.root,
+    css.list,
     props.listClass,
     { [css.marginBottom0]: props.marginBottom0 },
     [css[camelCase(`list style ${props.listStyle}`)]]: props.listStyle,

--- a/lib/SegmentedControl/SegmentedControl.css
+++ b/lib/SegmentedControl/SegmentedControl.css
@@ -1,4 +1,4 @@
-.root {
+.segmentedControl {
   display: flex;
   justify-content: space-between;
 }

--- a/lib/SegmentedControl/SegmentedControl.js
+++ b/lib/SegmentedControl/SegmentedControl.js
@@ -58,7 +58,7 @@ const SegmentedControl = (props) => {
   });
 
   return (
-    <Tag className={css.root}>
+    <Tag className={css.segmentedControl}>
       {renderedChildren}
     </Tag>
   );

--- a/lib/Select/Select.css
+++ b/lib/Select/Select.css
@@ -1,6 +1,6 @@
 @import '../variables.css';
 
-.root {
+.select {
   &.fullWidth {
     width: 100%;
   }

--- a/lib/Select/Select.js
+++ b/lib/Select/Select.js
@@ -31,7 +31,7 @@ const defaultProps = {
 class Select extends React.Component {
   getRootClass() {
     return classNames(
-      css.root,
+      css.select,
       formStyles.inputGroup,
       { [`${css.fullWidth}`]: this.props.fullWidth },
     );

--- a/lib/TextArea/TextArea.css
+++ b/lib/TextArea/TextArea.css
@@ -1,10 +1,10 @@
 @import '../variables.css';
 
-.root {
+.textArea {
   position: relative;
   max-width: 100%;
 
-  &.rootFull {
+  &.fullWidth {
     width: 100%;
   }
 }

--- a/lib/TextArea/TextArea.js
+++ b/lib/TextArea/TextArea.js
@@ -52,13 +52,10 @@ const defaultProps = {
 
 class TextArea extends React.Component {
   getRootStyle() {
-    // let rootStyle = css.root;
-    // rootStyle += this.props.fullWidth ? ' ' + css.rootFull : '';
-    // return rootStyle;
     return className(
       formStyles.inputGroup,
-      css.root,
-      { [`${css.rootFull}`]: this.props.fullWidth },
+      css.textArea,
+      { [`${css.fullWidth}`]: this.props.fullWidth },
     );
   }
 

--- a/lib/TextField/TextField.css
+++ b/lib/TextField/TextField.css
@@ -1,6 +1,6 @@
 @import '../variables.css';
 
-.root {
+.textField {
   position: relative;
   width: 100%;
 }

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -240,7 +240,7 @@ class TextField extends React.Component {
     }
 
     return (
-      <div className={css.root}>
+      <div className={css.textField}>
         { label && <label htmlFor={this.props.id} className={formStyles.label}>{label}</label> }
         <div className={formStyles.inputGroup}>
           {startControlElement}

--- a/lib/structures/AddressFieldGroup/AddressEdit/AddressEdit.css
+++ b/lib/structures/AddressFieldGroup/AddressEdit/AddressEdit.css
@@ -1,6 +1,6 @@
 @import '../../../variables.css';
 
-.root {
+.addressEditList {
   margin-bottom: 1rem;
 }
 

--- a/lib/structures/AddressFieldGroup/AddressEdit/AddressEditList.js
+++ b/lib/structures/AddressFieldGroup/AddressEdit/AddressEditList.js
@@ -48,7 +48,7 @@ class AddressEditList extends React.Component {
   renderFieldGroups({ fields }) {
     return (
 
-      <div className={css.root}>
+      <div className={css.addressEditList}>
         <Row>
           <Col xs>
             <div className={css.legend} id="addressGroupLabel">{this.props.label}</div>


### PR DESCRIPTION
When debugging markup and writing tests for the browser, it'd be more helpful to have explicit class names for components, instead of `.root--${MODULE_HASH}`.

Many `stripes-components` already follow this pattern.