### PR TITLE
Increase pane header min-height to include border

### DIFF
--- a/lib/PaneHeader/PaneHeader.css
+++ b/lib/PaneHeader/PaneHeader.css
@@ -6,7 +6,7 @@
   align-items: center;
   justify-content: space-between;
   border-bottom: 1px solid #dcdcdc;
-  min-height: 44px;
+  min-height: 45px;
   position: relative;
   will-change: transform;
 }


### PR DESCRIPTION
## Purpose
Pane headers that have a 44px-tall `IconButton` end up one pixel taller than pane headers that do not.
![localhost_3000_eholdings_vendors_2_searchtype vendors q e ipad pro](https://user-images.githubusercontent.com/230597/34579885-77bab984-f150-11e7-8640-85d4af116e63.png)

## Approach
Because `box-sizing` is set to `border-box`, the `height` calculation includes the 1px border. Increasing the `min-height` to 45px accommodates both a 44px-tall button and the border.