### PR TITLE
Establish global primary link color

### DIFF
--- a/lib/global.css
+++ b/lib/global.css
@@ -1,4 +1,5 @@
 @import "reset";
+@import "variables";
 
 * {
   box-sizing: border-box;
@@ -40,7 +41,12 @@ html {
 }
 
 a {
+  color: var(--primary);
   text-decoration: none;
+
+  &:visited {
+    color: var(--primary);
+  }
 }
 
 strong {


### PR DESCRIPTION
### Purpose
Since we have a place for a limited set of global styles, the color of `<a>`s makes sense to define on the global level.

### Questions
- Should there be a different hover state? Background? Underline? Darken the primary color? Lighten the primary color?
- Should there be a `:visited` state? My inclination is that coloring visited links purple (or any other type of indication it's been visited) is more detrimental than useful in an application like FOLIO. Other opinions welcome.