### PR TITLE
IconButton: Fixed bug where a badgeCount of 0 wouldn't render a Badge

### DIFF
--- a/lib/IconButton/IconButton.js
+++ b/lib/IconButton/IconButton.js
@@ -12,7 +12,12 @@ import Badge from '../Badge';
 const IconButton = ({ icon, onClick, onMouseDown, title, ariaLabel, id, style, className, badgeCount, iconClassName, size, tabIndex }) => (
   <button onMouseDown={onMouseDown} tabIndex={tabIndex} className={classNames(css.iconButton, className, css[size])} title={title} onClick={onClick} aria-label={ariaLabel} id={id} style={style}>
     <Icon icon={icon} iconClassName={iconClassName} />
-    { badgeCount && (<Badge color="red" className={css.badgeCount}>{badgeCount}</Badge>)}
+    {
+      badgeCount !== undefined ?
+        <Badge color="red" className={css.badgeCount}>{badgeCount}</Badge>
+        :
+        null
+    }
   </button>
 );
 


### PR DESCRIPTION
The short-circuiting of the expression will still result in the first part of the expression being rendered, so any falsey value gets rendered to the page.

Note that if we didn't want to show a badge when the count was 0, then the logic would still be off since the "0" gets rendered out as DOM text.