### PR TITLE
STCOM-187 `<RepeatableField>` `addButtonId` prop

### DIFF
--- a/lib/structures/RepeatableField/FieldRow.js
+++ b/lib/structures/RepeatableField/FieldRow.js
@@ -37,7 +37,7 @@ class FieldRow extends React.Component {
     this.srstatus = null;
     this.action = null;
 
-    this.addButtonId =  this.props.addButtonId || uniqueId(`${this.props.label}AddButton`);
+    this.addButtonId = this.props.addButtonId || uniqueId(`${this.props.label}AddButton`);
   }
 
   componentDidMount() {

--- a/lib/structures/RepeatableField/FieldRow.js
+++ b/lib/structures/RepeatableField/FieldRow.js
@@ -23,6 +23,7 @@ const FieldRowPropTypes = {
   addLabel: PropTypes.string,
   containerRef: PropTypes.func,
   onAddField: PropTypes.func,
+  addButtonId: PropTypes.string,
 };
 
 class FieldRow extends React.Component {
@@ -36,7 +37,7 @@ class FieldRow extends React.Component {
     this.srstatus = null;
     this.action = null;
 
-    this.addButtonId = uniqueId(`${this.props.label}AddButton`);
+    this.addButtonId =  this.props.addButtonId || uniqueId(`${this.props.label}AddButton`);
   }
 
   componentDidMount() {

--- a/lib/structures/RepeatableField/RepeatableField.js
+++ b/lib/structures/RepeatableField/RepeatableField.js
@@ -13,6 +13,7 @@ const RepeatableFieldPropTypes = {
   name: PropTypes.string.isRequired,
   addLabel: PropTypes.string,
   addDefaultItem: PropTypes.bool,
+  addButtonId: PropTypes.string,
 };
 
 const contextTypes = {
@@ -86,6 +87,7 @@ class RepeatableField extends React.Component {
         addDefault={this.addDefaultField}
         addDefaultItem={this.props.addDefaultItem}
         addLabel={this.props.addLabel}
+        addButtonId={this.props.addButtonId}
         lastRowRef={(ref) => { this.lastRow = ref; }}
       />
     );

--- a/lib/structures/RepeatableField/readme.md
+++ b/lib/structures/RepeatableField/readme.md
@@ -30,8 +30,10 @@ Name | type | description | default | required
 name | string | Name of particular array of data that the rendered array of fields will refer to. |  | yes
 label  | string | The visible label of the array of fields | | yes
 addLabel | string | text for the 'Add item' button that's rendered with the fields. | |
+addButtonId | string | HTML `id` attribute to assign to the add button. If not provided, one will be generated. | |
 template | array of objects | Each object within the array represents props that will be passed to the rendered redux-form `<Field>` inputs. | | yes
 newItemTemplate | object | Object representing the default field values applied when a new item is added to the array. | | yes
+addDefaultItem | bool | Sets whether or not the list will add a default, empty item. | `false` | 
 
 ## Single field example
 Renders a single `<TextField>` for each item...


### PR DESCRIPTION
Bugfix to correctly apply a custom id to `<RepeatableField>`'s 'add' button.