### PR TITLE
Use min-width media queries instead of max-width

### DIFF
--- a/docs/CSSinStripes.md
+++ b/docs/CSSinStripes.md
@@ -18,8 +18,8 @@ We also make use of [PostCSS](https://github.com/postcss/postcss) and a few of i
 CSS files can be written as normal. For class-naming, camelCase is recommended, but not enforced. These files should live in the same directory as the component's .js file.
 ```
 /* ComponentName.css */
-.className{
-    color: #090;
+.className {
+  color: #090;
 }
 ```
 Then in your component's .js...
@@ -40,36 +40,52 @@ When the element is inspected in the browser, you can see that the CSS class is 
 We use PostCSS to allow CSS to be written using an easy syntax that meets the upcoming CSS4 spec. Here are some syntax examples of the features we make use of:
 #### Nesting
 ```
-.parentClass{
-    &.specificityClass{ ... }
-    &:pseudoSelector{ ... }
-    & .childClass{ ... }
-    &>.directDescendant{ ... }
+.parentClass {
+  &.specificityClass { ... }
+  &:pseudoSelector { ... }
+  & .childClass { ... }
+  &>.directDescendant { ... }
 }
 ```
 #### Color Manipulation
 You can see a list of available [color functions](https://github.com/postcss/postcss-color-function/blob/master/README.md#list-of-color-adjuster), e.g.
 ```
-.darkerBG{
-    background-color: color(#fff shade(8%))
+.darkerBG {
+  background-color: color(#fff shade(8%))
 }
 ```
 #### CSS Variables
 ```
 /* Conforming to spec, these *must* be declared on root */
-:root{
-    --primary: #106c9e;
+:root {
+  --primary: #106c9e;
 }
 
 /* the second parameter is a fallback in case the variable isn't present */
-.primaryButton{
-    background-color: var(--primary, #106c9e;);
+.primaryButton {
+  background-color: var(--primary, #106c9e);
 }
 ```
 For consistency, there is a [shared set](../lib/variables.css) of established CSS variables/values.
 It is subject to change.
 
-### Bootstrap deprecation
-Currently there are a low number of components that still make use of Bootstrap classes. We are currently working to remove Bootstrap.css and React-Bootstrap from our dependencies. That said, Bootstrap class names *should not* be used if your component needs custom styling.
+### Media Queries
+`stripes-components` provides [pre-set breakpoints](../lib/variables.css) that you can use to adjust styles at different browser window widths.
+```
+@media (--mediumUp) {
+  .button {
+    height: 2em;
+  }
+}
+```
 
+Use `min-width` breakpoints like `smallUp`, `mediumUp`, and `largeUp` when possible. There are `max-width` breakpoints available, but the cases for their use should be rare. Leaning on `min-width` promotes a mobile-first CSS workflow, where the narrowest screen size is the default. Layout can gradually be added as the width increases.
 
+This:
+```
+x ≥ 321px, x ≥ 641px, x ≥ 1025px, x ≥ 1441px
+```
+is easier to debug and reason about than this:
+```
+x ≤ 640px, 641px ≤ x ≤ 1024px, 1025px ≤ x < 1440px, x ≥ 1441px
+```

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -6,7 +6,7 @@
 
 .button {
   padding: 3px 10px 7px;
-  height: 24px;
+  height: var(--controlHeightSmall);
   text-align: center;
   -webkit-appearance: none;
   cursor: pointer;
@@ -19,7 +19,7 @@
   /* margin-bottom: var(--controlMarginBottom); */
   margin-left: 2px;
   margin-right: 2px;
-  max-height: var(--controlHeight);
+  max-height: var(--controlHeightSmall);
   overflow: hidden;
   white-space: nowrap;
   line-height: 100%;
@@ -450,9 +450,9 @@
   }
 }
 
-@media (--small) {
+@media (--mediumUp) {
   .button {
-    height: var(--controlHeightSmall);
-    max-height: var(--controlHeightSmall);
+    height: var(--controlHeight);
+    max-height: var(--controlHeight);
   }
 }

--- a/lib/Dropdown/Dropdown.css
+++ b/lib/Dropdown/Dropdown.css
@@ -18,7 +18,7 @@
   z-index: 1000;
   display: none;
   float: left;
-  min-width: 20vw;
+  min-width: 90vw;
   font-size: 14px;
   text-align: left;
   list-style: none;
@@ -38,14 +38,14 @@
   }
 }
 
-@media (--medium) {
+@media (--mediumUp) {
   .DropdownMenuTether {
     min-width: 40vw;
   }
 }
 
-@media (--small) {
+@media (--largeUp) {
   .DropdownMenuTether {
-    min-width: 90vw;
+    min-width: 20vw;
   }
 }

--- a/lib/DropdownMenu/DropdownMenu.css
+++ b/lib/DropdownMenu/DropdownMenu.css
@@ -7,7 +7,7 @@
   z-index: 1000;
   display: none;
   float: left;
-  min-width: 20vw;
+  min-width: 90vw;
   padding: 5px 0;
   margin: 2px 0 0;
   font-size: 14px;
@@ -25,14 +25,14 @@
   }
 }
 
-@media (--medium) {
+@media (--mediumUp) {
   .DropdownMenu {
     min-width: 40vw;
   }
 }
 
-@media (--small) {
+@media (--largeUp) {
   .DropdownMenu {
-    min-width: 90vw;
+    min-width: 20vw;
   }
 }

--- a/lib/Modal/Modal.css
+++ b/lib/Modal/Modal.css
@@ -16,18 +16,10 @@
   top: 10vh;
   background-color: #fff;
   max-height: 80vh;
-  width: 60%;
+  width: 80vw;
   overflow: hidden;
   border-radius: var(--radius, 4px);
   box-shadow: 0 5px 28px 1px rgba(0, 0, 0, 0.75);
-
-  &.small {
-    width: 40%;
-  }
-
-  &.large {
-    width: 90%;
-  }
 }
 
 .modalHeader {
@@ -82,11 +74,16 @@
   background-color: rgba(0, 0, 0, 0.4);
 }
 
-@media (--small) {
+@media (--mediumUp) {
   .modal {
-    &.small,
+    width: 60%;
+
+    &.small {
+      width: 40%;
+    }
+
     &.large {
-      width: 80vw;
+      width: 90%;
     }
   }
 }

--- a/lib/Pane/Pane.css
+++ b/lib/Pane/Pane.css
@@ -1,15 +1,19 @@
 @import '../variables.css';
 
 .pane {
+  background-color: #fff;
   border-right: 1px solid #ccc;
   height: 100%;
   max-height: calc(100vh - 44px);
   display: flex;
   flex-direction: column;
+  top: 0;
+  left: 0;
+  width: 100%;
 
   /* transition: all .25s ease-in-out; */
   overflow: hidden;
-  position: relative;
+  position: absolute;
   will-change: transform;
 }
 
@@ -31,12 +35,8 @@
   }
 }
 
-@media (--small) {
+@media (--mediumUp) {
   .pane {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    background-color: #fff;
+    position: relative;
   }
 }

--- a/lib/Paneset/Paneset.css
+++ b/lib/Paneset/Paneset.css
@@ -3,8 +3,8 @@
 .paneset {
   width: 100%;
   height: 100%;
-  position: absolute;
-  display: flex;
+  position: relative;
+  display: block;
   flex-direction: row;
   align-items: stretch;
   justify-content: flex-start;
@@ -21,7 +21,9 @@
   }
 }
 
-@media (--small) {
-  position: relative;
-  display: block;
+@media (--mediumUp) {
+  .paneset {
+    display: flex;
+    position: absolute;
+  }
 }

--- a/lib/Select/Select.css
+++ b/lib/Select/Select.css
@@ -23,6 +23,12 @@
 .selectIcon {
   position: absolute;
   right: 0;
-  top: 0;
+  top: 10px;
   pointer-events: none;
+}
+
+@media (--mediumUp) {
+  .selectIcon {
+    top: 0;
+  }
 }

--- a/lib/TextField/TextField.css
+++ b/lib/TextField/TextField.css
@@ -18,18 +18,20 @@
 
 .startControls {
   padding-left: 2px;
+  height: 100%;
   justify-content: flex-start;
 }
 
 .endControls {
   padding-right: 2px;
+  height: 100%;
   width: 100%;
   justify-content: flex-end;
 }
 
 .controlGroup {
   pointer-events: all;
-  height: var(--controlHeight);
+  height: var(--controlHeightSmall);
   display: flex;
   align-items: center;
 }
@@ -54,13 +56,8 @@
   align-items: center;
 }
 
-@media (--small) {
-  .input {
-    height: var(--controlHeightSmall);
-  }
-
-  .startControls,
-  .endControls {
-    height: var(--controlHeightSmall, 100%);
+@media (--mediumUp) {
+  .controlGroup {
+    height: var(--controlHeight);
   }
 }

--- a/lib/sharedStyles/form.css
+++ b/lib/sharedStyles/form.css
@@ -98,8 +98,8 @@
  * Specific <input> style
  */
 input.input {
-  height: var(--controlHeight);
-  min-height: var(--controlHeight);
+  height: var(--controlHeightSmall);
+  min-height: var(--controlHeightSmall);
   padding: var(--input-horizontal-padding) var(--input-vertical-padding);
 }
 
@@ -107,7 +107,7 @@ input.input {
  * Specific <select> style
  */
 select.input {
-  height: var(--controlHeight);
+  height: var(--controlHeightSmall);
   padding: 0 var(--input-vertical-padding);
   appearance: none;
 }
@@ -116,7 +116,7 @@ select.input {
  * Sepcific <textarea> style
  */
 textarea.input {
-  min-height: var(--controlHeight);
+  min-height: var(--controlHeightSmall);
   padding: var(--input-horizontal-padding) var(--input-vertical-padding);
 }
 
@@ -141,4 +141,22 @@ textarea.input {
 .feedbackWarning {
   composes: feedbackBlock;
   color: var(--warn);
+}
+
+/**
+ * Wider screens
+ */
+@media (--mediumUp) {
+  input.input {
+    height: var(--controlHeight);
+    min-height: var(--controlHeight);
+  }
+
+  select.input {
+    height: var(--controlHeight);
+  }
+
+  textarea.input {
+    min-height: var(--controlHeight);
+  }
 }

--- a/lib/variables.css
+++ b/lib/variables.css
@@ -25,11 +25,16 @@
   --major-padding: 15px;
 }
 
+/* Lean on min-width queries to create mobile-first CSS. */
+@custom-media --smallUp (min-width: 321px);
+@custom-media --mediumUp (min-width: 641px);
+@custom-media --largeUp (min-width: 1025px);
+@custom-media --xlargeUp (min-width: 1441px);
+@custom-media --xxlargeUp (min-width: 1921px);
+
+/* Use these max-width queries as infrequently as possible. */
 @custom-media --small (max-width: 640px);
 @custom-media --mediumDown (max-width: 1024px);
-@custom-media --medium (min-width: 641px) and (max-width:1024px);
-@custom-media --mediumUp (min-width: 641px);
-@custom-media --large (min-width:1025px) and (max-width: 1440px);
-@custom-media --largeUp (min-width:1025px);
+@custom-media --medium (min-width: 641px) and (max-width: 1024px);
+@custom-media --large (min-width: 1025px) and (max-width: 1440px);
 @custom-media --xlarge (min-width: 1441px) and (max-width: 1920px);
-@custom-media --xxlarge (min-width: 1921px);


### PR DESCRIPTION
## Purpose
Justification added to `CSSinStripes.md`:

`stripes-components` provides [pre-set breakpoints](../lib/variables.css) that you can use to adjust styles at different browser window widths.
```
@media (--mediumUp) {
  .button {
    height: 2em;
  }
}
```

Use `min-width` breakpoints like `smallUp`, `mediumUp`, and `largeUp` when possible. There are `max-width` breakpoints available, but the cases for their use should be rare. Leaning on `min-width` promotes a mobile-first CSS workflow, where the narrowest screen size is the default. Layout can gradually be added as the width increases with breakpoints like `--mediumUp` and `--largeUp`.

This:
```
x ≥ 321px, x ≥ 641px, x ≥ 1025px, x ≥ 1441px
```
is easier to debug and reason about than this:
```
x ≤ 640px, 641px ≤ x ≤ 1024px, 1025px ≤ x < 1440px, x ≥ 1441px
```

## Approach
Styles that previously used breakpoints like `--small` and `--medium` have been flipped. Now whatever was the smallest screen width style is the default, and styles get modified as the screen size increases.

## Risk
There is a slight chance of visual regressions, but they should be very easy to fix if they come up.

## Follow-up
The majority of the media queries in `stripes-core` have to do with the `MainNav`, so I'll wait until https://github.com/folio-org/stripes-core/pull/152 is merged to go apply this same pattern in `stripes-core`.