### PR TITLE
Do not show right border for final Pane in Paneset

### DIFF
--- a/lib/Pane/Pane.css
+++ b/lib/Pane/Pane.css
@@ -11,6 +11,10 @@
   overflow: hidden;
   position: relative;
   will-change: transform;
+
+  &:last-child {
+    border-right: none;
+  }
 }
 
 /**


### PR DESCRIPTION
## Purpose
All `Pane`s have a `border-right`. The rightmost `Pane` (in LTR languages) doesn't need a `border-right`.

## Approach
[`:last-child`](https://developer.mozilla.org/en-US/docs/Web/CSS/:last-child)

## Screenshots
### Before
![folio-testing aws indexdata com_inventory_view_5bb9722d-d412-4700-9210-81ce654b6a91_filters query sort title ipad](https://user-images.githubusercontent.com/230597/35043908-fbad3c1e-fb53-11e7-86b3-f5c011d6d292.png)

### After
![folio-testing aws indexdata com_inventory_view_5bb9722d-d412-4700-9210-81ce654b6a91_filters query sort title ipad 1](https://user-images.githubusercontent.com/230597/35043916-fe942a6e-fb53-11e7-8f68-a23b01cdf61e.png)