### PR TITLE
STCOM-164: Removed "Reset all" button from the FilterGroups component

### DIFF
--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -176,19 +176,15 @@ export function handleFilterClear(name) {
 
 export function handleClearAllFilters() {
   // Access the initialFilters that were passed to the calling component. This is probably SearchAndSort.
-  this.transitionToParams({ filters: this.props.initialFilters || '' });
+  this.transitionToParams({ filters: this.props.initialFilters || '', query: '' });
 }
 
 const FilterGroups = (props) => {
-  const { config, filters, onChangeFilter: ocf, onClearFilter, onClearAllFilters } = props;
+  const { config, filters, onChangeFilter: ocf, onClearFilter } = props;
   const disableNames = props.disableNames || {};
 
   return (
     <div>
-      <Button buttonStyle="transparent" hollow paddingSide0 onClick={onClearAllFilters}>
-        <Icon size="small" icon="clearX" />
-        <div>Reset all</div>
-      </Button>
       <AccordionSet>
         {config.map((group, index) => (
           <Accordion
@@ -240,7 +236,6 @@ FilterGroups.propTypes = {
   onChangeFilter: PropTypes.func.isRequired,
   disableNames: PropTypes.shape({}),
   onClearFilter: PropTypes.func.isRequired,
-  onClearAllFilters: PropTypes.func.isRequired,
 };
 
 export default FilterGroups;


### PR DESCRIPTION
We need the button to be located above the SearchField component which is above the filters. 

Since it doesn't make much sense to start shoving that component and the functionality into the FilterGroups component, SearchAndSort now instantiates the SearchField component and the "Reset all" button.