### PR TITLE
STCOM-192 added ids to `<Datepicker>` sub-components based on id prop

### DIFF
--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -55,6 +55,7 @@ const propTypes = {
   onBlur: PropTypes.func,
   onKeyDown: PropTypes.func,
   buttonFocus: PropTypes.func,
+  id: PropTypes.string,
   excludeDates: PropTypes.oneOfType([
     PropTypes.array,
     PropTypes.object,
@@ -299,6 +300,7 @@ class Calendar extends React.Component {
   }
 
   render() {
+    const { id } = this.props;
     let weekCount = 0;
     const weeks = this.state.calendar.map(
       (week) => {
@@ -346,6 +348,7 @@ class Calendar extends React.Component {
                   onKeyDown={this.props.onKeyDown}
                   onBlur={this.props.onBlur}
                   tabIndex="-1"
+                  id={`datepicker-choose-date-button-${day.format('D')}-${id}`}
                 >
                   {day.format('D')}
                 </button>
@@ -367,24 +370,23 @@ class Calendar extends React.Component {
     const arrowStyle = { padding: '4px' };
 
     return (
-      <div className={css.calendar}>
+      <div className={css.calendar} id={`datepicker-calendar-container-${id}`}>
         <div className={css.calendarInner}>
           <table role="presentation">
             <thead>
-
               <tr>
                 <td>
-                  <button className={css.nav} type="button" onClick={this.previousYear} onKeyDown={this.props.onKeyDown} tabIndex="-1" style={arrowStyle} title="Go to previous year"><Icon icon="left-double-chevron" /></button>
+                  <button id={`datepicker-previous-year-button-${id}`} className={css.nav} type="button" onClick={this.previousYear} onKeyDown={this.props.onKeyDown} tabIndex="-1" style={arrowStyle} title="Go to previous year"><Icon icon="left-double-chevron" /></button>
                 </td>
                 <td>
-                  <button href="#" className={css.nav} type="button" onClick={this.previousMonth} onKeyDown={this.props.onKeyDown} tabIndex="-1" style={arrowStyle} title="Go to previous month"><Icon icon="left-arrow" /></button>
+                  <button id={`datepicker-previous-month-button-${id}`} href="#" className={css.nav} type="button" onClick={this.previousMonth} onKeyDown={this.props.onKeyDown} tabIndex="-1" style={arrowStyle} title="Go to previous month"><Icon icon="left-arrow" /></button>
                 </td>
                 <td colSpan="3"><span className={css.selectedMonth}>{moment().month(this.state.month).format('MMMM')} {this.state.year}</span></td>
                 <td>
-                  <button href="#" className={css.nav} type="button" onClick={this.nextMonth} onKeyDown={this.props.onKeyDown} tabIndex="-1" style={arrowStyle} title="Go to next month" ><Icon icon="right-arrow" /></button>
+                  <button href="#" id={`datepicker-next-month-button-${id}`} className={css.nav} type="button" onClick={this.nextMonth} onKeyDown={this.props.onKeyDown} tabIndex="-1" style={arrowStyle} title="Go to next month" ><Icon icon="right-arrow" /></button>
                 </td>
                 <td>
-                  <button href="#" className={css.nav} type="button" onClick={this.nextYear} onKeyDown={this.props.onKeyDown} tabIndex="-1" style={arrowStyle} title="Go to next year"><Icon icon="right-double-chevron" /></button>
+                  <button href="#" id={`datepicker-next-year-button-${id}`} className={css.nav} type="button" onClick={this.nextYear} onKeyDown={this.props.onKeyDown} tabIndex="-1" style={arrowStyle} title="Go to next year"><Icon icon="right-double-chevron" /></button>
                 </td>
               </tr>
               <tr>

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -5,6 +5,7 @@ import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
 import moment from 'moment';
 import contains from 'dom-helpers/query/contains';
 import debounce from 'lodash/debounce';
+import uniqueId from 'lodash/uniqueId';
 
 import Button from '../Button';
 import TextField from '../TextField';
@@ -119,6 +120,12 @@ class Datepicker extends React.Component {
       showCalendar: this.props.showCalendar || false,
       srMessage: '',
     };
+
+    if (props.id) {
+      this.testId = props.id;
+    } else {
+      this.testId = uniqueId('dp-');
+    }
   }
 
   componentWillReceiveProps(nextProps) {
@@ -403,6 +410,7 @@ class Datepicker extends React.Component {
             buttonStyle="fieldControl"
             onClick={this.clearDate}
             title="Clear field value"
+            id={`datepicker-clear-button-${id}`}
             tabIndex="-1"
           >
             <Icon icon="clearX" />
@@ -414,6 +422,7 @@ class Datepicker extends React.Component {
             onKeyDown={this.handleKeyDown}
             title="Show/hide datepicker"
             ref={(ref) => { this.calendarButton = ref; }}
+            id={`datepicker-toggle-calendar-button-${id}`}
             tabIndex="-1"
           >
             <Icon icon="calendar" />
@@ -430,6 +439,7 @@ class Datepicker extends React.Component {
           onKeyDown={this.handleKeyDown}
           title="Show/hide datepicker"
           ref={(ref) => { this.calendarButton = ref; }}
+          id={`datepicker-toggle-calendar-button-${id}`}
           tabIndex="-1"
         >
           <Icon icon="calendar" />
@@ -456,7 +466,7 @@ class Datepicker extends React.Component {
           onChange={this.handleFieldChange}
           readOnly={readOnly}
           disabled={disabled}
-          id={id}
+          id={this.testId}
           required={required}
           hasClearIcon={false}
         />
@@ -477,7 +487,7 @@ class Datepicker extends React.Component {
           onFocus={!readOnly ? this.handleFieldFocus : null}
           readOnly={readOnly}
           disabled={disabled}
-          id={id}
+          id={this.testId}
           required={required}
           hasClearIcon={false}
         />
@@ -506,6 +516,7 @@ class Datepicker extends React.Component {
               excludeDates={excludeDates}
               buttonFocus={this.focusTextfield}
               onNavigation={this.handleDateNavigation}
+              id={this.testId}
             />
           </RootCloseWrapper>
         }


### PR DESCRIPTION
ITPR, supplying an `id` prop to <Datepicker> will apply it as a suffix to sub-components that are used to operate the calendar widget and clear the text.
If no prop is supplied, the id suffix will be automatically generated via `lodash/uniqueId` (currently workable solution for multiple instances on page)