### PR TITLE
Upgrade to React 16

### DIFF
--- a/lib/Dropdown/Dropdown.js
+++ b/lib/Dropdown/Dropdown.js
@@ -5,6 +5,7 @@ import TetherComponent from 'react-tether';
 import classNames from 'classnames';
 import css from './Dropdown.css';
 import omit from '../../util/omitProps';
+import { isStatefulComponent } from '../../util/isStatefulComponent';
 
 const propTypes = {
   disabled: PropTypes.bool,
@@ -137,7 +138,7 @@ class Dropdown extends React.Component {
       switch (child.props['data-role']) {
         case 'toggle': {
           return cloneElement(child, {
-            ref: (c) => { this._toggle = c; },
+            ref: isStatefulComponent(child) ? (c) => { this._toggle = c; } : undefined,
             disabled,
             onClick: this.handleToggle,
             onKeyDown: this.handleKeyDown,
@@ -154,7 +155,7 @@ class Dropdown extends React.Component {
               className,
               onToggle: this.handleToggle,
               onSelectItem: this.props.onSelectItem,
-              ref: (c) => { this._menu = c; },
+              ref: isStatefulComponent(child) ? (c) => { this._menu = c; } : undefined,
             });
           }
           return cloneElement(child, {
@@ -163,7 +164,7 @@ class Dropdown extends React.Component {
             labelledBy: id,
             className,
             onToggle: this.handleToggle,
-            ref: (c) => { this._menu = c; },
+            ref: isStatefulComponent(child) ? (c) => { this._menu = c; } : undefined,
           });
         }
         default: {

--- a/lib/Icon/Icon.js
+++ b/lib/Icon/Icon.js
@@ -4,56 +4,60 @@ import classNames from 'classnames';
 import css from './Icon.css';
 import icons from './icons';
 
-const propTypes = {
-  icon: PropTypes.oneOf(Object.keys(icons)),
-  size: PropTypes.oneOf([
-    'small',
-    'medium',
-    'large',
-  ]),
-  color: PropTypes.string,
-  iconClassName: PropTypes.string,
-  iconRootClass: PropTypes.string,
-  title: PropTypes.string,
-  id: PropTypes.string,
-};
+/* eslint-disable react/prefer-stateless-function */
+/* We write this as a class because other components apply and use a ref to it */
 
-const defaultProps = {
-  iconClassName: 'stripes__icon',
-  size: 'medium',
-};
-
-const Icon = ({ icon, color, title, iconClassName, id, size, iconRootClass }) => {
-  const getRootClass = classNames(
-    css.icon,
-    iconRootClass,
-    css[size],
-    // Icon is spiller (this is going to be deprecated later on)
-    { [css.iconSpinner]: icon === 'spinner-ellipsis' },
-  );
-
-  const style = color ? { fill: color } : {};
-
-  // Defaults to the default-icon
-  let IconSVG = icons.default;
-
-  if (typeof icons[icon] === 'function') {
-    IconSVG = icons[icon];
+class Icon extends React.Component {
+  static propTypes = {
+    icon: PropTypes.oneOf(Object.keys(icons)),
+    size: PropTypes.oneOf([
+      'small',
+      'medium',
+      'large',
+    ]),
+    color: PropTypes.string,
+    iconClassName: PropTypes.string,
+    iconRootClass: PropTypes.string,
+    title: PropTypes.string,
+    id: PropTypes.string,
   }
 
-  return (
-    <div
-      className={getRootClass}
-      tabIndex="-1"
-      title={title}
-      id={id}
-    >
-      <IconSVG style={style} className={iconClassName} />
-    </div>
-  );
-};
+  static defaultProps = {
+    iconClassName: 'stripes__icon',
+    size: 'medium',
+  }
 
-Icon.propTypes = propTypes;
-Icon.defaultProps = defaultProps;
+  render() {
+    const { icon, color, title, iconClassName, id, size, iconRootClass } = this.props;
+
+    const getRootClass = classNames(
+      css.icon,
+      iconRootClass,
+      css[size],
+      // Icon is spiller (this is going to be deprecated later on)
+      { [css.iconSpinner]: icon === 'spinner-ellipsis' },
+    );
+
+    const style = color ? { fill: color } : {};
+
+    // Defaults to the default-icon
+    let IconSVG = icons.default;
+
+    if (typeof icons[icon] === 'function') {
+      IconSVG = icons[icon];
+    }
+
+    return (
+      <div
+        className={getRootClass}
+        tabIndex="-1"
+        title={title}
+        id={id}
+      >
+        <IconSVG style={style} className={iconClassName} />
+      </div>
+    );
+  }
+}
 
 export default Icon;

--- a/package.json
+++ b/package.json
@@ -73,10 +73,8 @@
     "normalize.css": "^7.0.0",
     "prop-types": "^15.5.10",
     "prop-types-extra": "^1.0.1",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1",
     "react-flexbox-grid": "1.1.3",
-    "react-overlays": "^0.8.0",
+    "react-overlays": "^0.8.3",
     "react-router-dom": "^4.1.1",
     "react-test-renderer": "^15.6.1",
     "react-tether": "0.5.7",
@@ -85,6 +83,8 @@
     "typeface-source-sans-pro": "^0.0.44"
   },
   "peerDependencies": {
+    "react": "*",
+    "react-dom": "*",
     "stripes-core": "^2.7.0"
   }
 }

--- a/util/isStatefulComponent.js
+++ b/util/isStatefulComponent.js
@@ -1,0 +1,7 @@
+const isStatefulComponent = component => typeof component.type !== 'string' && component.type.prototype.render;
+const isStatefulComponentType = componentType => typeof componentType !== 'string' && componentType.prototype.render;
+
+export {
+  isStatefulComponent,
+  isStatefulComponentType,
+};


### PR DESCRIPTION
- Move to React as a peer dependency.
- React 16 (rightly) complains about setting a ref on a functional component so I changed `<Icon>` to be a class and added a helper function to introspect where that seemed like a better solution like in `<Dropdown>`.