### PR TITLE
Modify default button style

### DIFF
--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -60,6 +60,39 @@
   */
 
   /**
+  * Button Style: Default
+  */
+
+  &.default {
+    background-color: transparent;
+    border: 1px solid var(--primary);
+    color: var(--primary);
+
+    & :global .stripes__icon {
+      fill: var(--primary);
+    }
+
+    &:focus:active {
+      transition: none;
+      box-shadow: 0 0 0 18px color(var(--primary) alpha(-30%));
+    }
+
+    &:focus {
+      transition: box-shadow 0.3s ease-out;
+      box-shadow: 0 0 0 3px color(var(--primary) alpha(-50%));
+    }
+
+    &:hover {
+      background-color: color(var(--primary) shade(8%));
+      color: #fff;
+
+      & :global .stripes__icon {
+        fill: #fff;
+      }
+    }
+  }
+
+  /**
   * Button Style: Primary
   */
 
@@ -77,62 +110,6 @@
     &:focus {
       transition: box-shadow 0.3s ease-out;
       box-shadow: 0 0 0 3px color(var(--primary) alpha(-50%));
-    }
-
-    &.hollow {
-      background-color: transparent;
-      color: var(--primary);
-
-      & :global .stripes__icon {
-        fill: var(--primary);
-      }
-
-      &:hover {
-        background-color: color(var(--primary) shade(8%));
-        color: #fff;
-
-        & :global .stripes__icon {
-          fill: #fff;
-        }
-      }
-    }
-  }
-
-  /**
-  * Button Style: secondary
-  */
-
-  &.secondary {
-    background-color: var(--secondary);
-    border: 1px solid var(--secondary);
-    color: #fff;
-
-    &:focus:active {
-      transition: none;
-      box-shadow: 0 0 0 18px color(var(--secondary) alpha(-30%));
-    }
-
-    &:focus {
-      transition: box-shadow 0.3s ease-out;
-      box-shadow: 0 0 0 3px color(var(--secondary) alpha(-50%));
-    }
-
-    &.hollow {
-      background-color: transparent;
-      color: var(--secondary);
-
-      & :global .stripes__icon {
-        fill: var(--secondary);
-      }
-
-      &:hover {
-        background-color: color(var(--secondary) shade(8%));
-        color: #fff;
-
-        & :global .stripes__icon {
-          fill: #fff;
-        }
-      }
     }
   }
 
@@ -154,24 +131,6 @@
       transition: box-shadow 0.3s ease-out;
       box-shadow: 0 0 0 3px color(var(--success) alpha(-50%));
     }
-
-    &.hollow {
-      background-color: transparent;
-      color: var(--success);
-
-      & :global .stripes__icon {
-        fill: var(--success);
-      }
-
-      &:hover {
-        background-color: color(var(--success) shade(8%));
-        color: #fff;
-
-        & :global .stripes__icon {
-          fill: #fff;
-        }
-      }
-    }
   }
 
   /**
@@ -192,94 +151,32 @@
       transition: box-shadow 0.3s ease-out;
       box-shadow: 0 0 0 3px color(var(--warn) alpha(-50%));
     }
-
-    &.hollow {
-      background-color: transparent;
-      color: var(--warn);
-
-      & :global .stripes__icon {
-        fill: var(--warn);
-      }
-
-      &:hover {
-        background-color: color(var(--warn) shade(8%));
-        color: #fff;
-
-        & :global .stripes__icon {
-          fill: #fff;
-        }
-      }
-    }
   }
 
   /**
-  * Button Style: Error
+  * Button Style: Danger
   */
 
-  &.error,
-  &.negative {
-    background-color: var(--error);
-    border: 1px solid var(--error);
+  &.danger {
+    background-color: var(--danger);
+    border: 1px solid var(--danger);
     color: #fff;
 
     &:focus:active {
       transition: none;
-      box-shadow: 0 0 0 18px color(var(--error) alpha(-30%));
+      box-shadow: 0 0 0 18px color(var(--danger) alpha(-30%));
     }
 
     &:focus {
       transition: box-shadow 0.3s ease-out;
-      box-shadow: 0 0 0 3px color(var(--error) alpha(-50%));
-    }
-
-    &.hollow {
-      background-color: transparent;
-      color: var(--error);
-
-      & :global .stripes__icon {
-        fill: var(--error);
-      }
-
-      &:hover {
-        background-color: color(var(--error) shade(8%));
-        color: #fff;
-
-        & :global .stripes__icon {
-          fill: #fff;
-        }
-      }
-    }
-  }
-
-  /**
-  * Button Style: Transparent
-  */
-
-  &.transparent {
-    &.hover {
-      background-color: transparent;
-      border: 1px solid transparent;
-
-      &:hover {
-        background-color: var(--bgHover);
-      }
-    }
-
-    &:focus:active {
-      transition: none;
-      box-shadow: 0 0 0 18px rgba(153, 153, 153, 0.2);
-    }
-
-    &:focus {
-      transition: box-shadow 0.3s ease-out;
-      box-shadow: 0 0 0 3px rgba(153, 153, 153, 0.2);
+      box-shadow: 0 0 0 3px color(var(--danger) alpha(-50%));
     }
   }
 
   &.dropdownActive {
     &[aria-expanded="true"],
     &:focus {
-      border: 1px solid var(--error);
+      border: 1px solid var(--danger);
     }
 
     &:focus {
@@ -376,11 +273,6 @@
 
   &.lastBorderOnly {
     border-right-color: transparent !important;
-  }
-
-  &.transparent {
-    background-color: transparent;
-    border: 1px solid transparent;
   }
 
   &.link {

--- a/lib/Button/Button.js
+++ b/lib/Button/Button.js
@@ -8,7 +8,6 @@ const propTypes = {
   buttonStyle: PropTypes.string,
   type: PropTypes.string,
   buttonClass: PropTypes.string,
-  hollow: PropTypes.bool,
   align: PropTypes.string,
   bottomMargin0: PropTypes.bool,
   marginBottom0: PropTypes.bool,
@@ -26,7 +25,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  buttonStyle: 'primary',
+  buttonStyle: 'default',
   type: 'button',
   role: 'button',
 };
@@ -47,7 +46,6 @@ function Button(props) {
       { [`${css.marginBottom0}`]: props.bottomMargin0 },
       { [`${css.paddingSide0}`]: props.paddingSide0 },
       { [`${css.fullWidth}`]: props.fullWidth },
-      { [`${css.hollow}`]: props.hollow },
       { [`${css.floatEnd}`]: props.align === 'end' },
       props.buttonClass,
     );
@@ -64,7 +62,7 @@ function Button(props) {
     }
   }
 
-  const inputCustom = omitProps(props, ['buttonClass', 'buttonStyle', 'bottomMargin0', 'marginBottom0', 'paddingSide0', 'align', 'hollow', 'fullWidth', 'bsRole', 'bsClass', 'onClick', 'allowAnchorClick', 'buttonRef', 'type']);
+  const inputCustom = omitProps(props, ['buttonClass', 'buttonStyle', 'bottomMargin0', 'marginBottom0', 'paddingSide0', 'align', 'fullWidth', 'bsRole', 'bsClass', 'onClick', 'allowAnchorClick', 'buttonRef', 'type']);
   const { children, onClick, type } = props;
 
   if (props.href) {

--- a/lib/Button/readme/general.md
+++ b/lib/Button/readme/general.md
@@ -19,7 +19,6 @@ Name | Type | Description
 buttonStyle | string | Change the style/color of the button (see the [styles section](/?selectedKind=Button&selectedStory=Styles)) |
 type | string | Change the button type |
 buttonClass | string | Add a custom class |
-hollow | bool | Converts to an outlined button (see the [styles section](/?selectedKind=Button&selectedStory=Styles)) |
 align | string | Change the alignment of the button (with flexbox) Options: start, center, end |
 className | string | Replace CSS classes completely |
 bottomMargin0 | bool | Remove bottom margin |

--- a/lib/Button/readme/styles.md
+++ b/lib/Button/readme/styles.md
@@ -6,25 +6,15 @@ Complete list of button colors and styles
 The color of the button can be modified by changing the buttonStyle-prop
 
 ```
-<Button buttonStyle="error">
-    Error
+<Button buttonStyle="danger">
+    Do something dangerous
 </Button>
 ```
 
 Name | Type | Description
 --- | --- | ---
-primary | string | This is the default color of the button component
-secondary | string | |
-error | string | |
+default | string | This is the default color of the button component
+primary | string | |
+danger | string | |
 success | string | |
 warning | string | |
-transparent | string | |
-
-
-## Hollow
-Any button can be transformed into an outlined button by adding the hollow-prop
-```
-<Button hollow>
-    Hollow Button
-</Button>
-```

--- a/lib/Button/stories/general.js
+++ b/lib/Button/stories/general.js
@@ -3,11 +3,10 @@ import Button from '../Button';
 
 export default () => (
   <div style={{ padding: '20px' }}>
-    <Button>Primary</Button>
-    <Button buttonStyle="secondary">Secondary</Button>
-    <Button buttonStyle="error">Error</Button>
+    <Button>Default</Button>
+    <Button buttonStyle="primary">Primary</Button>
+    <Button buttonStyle="danger">Danger</Button>
     <Button buttonStyle="success">Success</Button>
     <Button buttonStyle="warning">Warning</Button>
-    <Button buttonStyle="transparent">Transparent</Button>
   </div>
 );

--- a/lib/Button/stories/styles.js
+++ b/lib/Button/stories/styles.js
@@ -4,23 +4,15 @@ import Button from '../Button';
 export default () => (
   <div style={{ padding: '0px 20px', maxWidth: '800px' }}>
     <h3>Colors</h3>
-    <Button>Primary</Button>
-    <Button buttonStyle="secondary">Secondary</Button>
-    <Button buttonStyle="error">Error</Button>
+    <Button>Default</Button>
+    <Button buttonStyle="primary">Primary</Button>
+    <Button buttonStyle="danger">Danger</Button>
     <Button buttonStyle="success">Success</Button>
     <Button buttonStyle="warning">Warning</Button>
-    <Button buttonStyle="transparent">Transparent</Button>
-    <hr />
-    <h3>Hollow</h3>
-    <Button hollow>Primary</Button>
-    <Button hollow buttonStyle="secondary">Secondary</Button>
-    <Button hollow buttonStyle="error">Error</Button>
-    <Button hollow buttonStyle="success">Success</Button>
-    <Button hollow buttonStyle="warning">Warning</Button>
     <hr />
     <h3>Full width</h3>
-    <Button fullWidth>Primary</Button>
-    <Button fullWidth buttonStyle="secondary">Secondary</Button>
-    <Button fullWidth buttonStyle="error">Error</Button>
+    <Button fullWidth>Default</Button>
+    <Button fullWidth buttonStyle="primary">Primary</Button>
+    <Button fullWidth buttonStyle="danger">Danger</Button>
   </div>
 );

--- a/lib/variables.css
+++ b/lib/variables.css
@@ -4,6 +4,7 @@
   --primary: #2b75bb;
   --secondary: #999;
   --error: #900;
+  --danger: #900;
   --warn: #e27c3e;
   --success: #070;
   --labelColor: #333;


### PR DESCRIPTION
## Purpose
The FOLIO button styles available take a very similar approach to [Bootstrap](https://getbootstrap.com/docs/4.0/components/buttons/) and [Foundation](https://foundation.zurb.com/sites/docs/button.html). That means there are a wide variety of styles available, but they are unprescriptive about use.

### Before
![before](https://user-images.githubusercontent.com/230597/35635516-1a911378-0674-11e8-9607-914f30aed51a.png)

Weaknesses of the current strategy:
- Primary buttons (in solid blue) are the default if no specific style of button has been specified. That means there are frequently multiple primary buttons visible at the same time.
- Secondary buttons can be confused with a disabled state.
- Secondary buttons have a very similar visual weight to primary buttons. We're solely relying on color to distinguish between them.
- Hollow buttons don't have an explicit purpose.

## Approach
Based on a session at the FOLIO Madrid dev summit and a conversation with @filipjakobsen, here are new naming conventions and styles for buttons. It shifts to a more prescriptive set more similar to [MailChimp's Pattern Library](https://ux.mailchimp.com/patterns/forms) or [Salesforce's Lightning Design System](https://www.lightningdesignsystem.com/components/buttons/).

### After
![after](https://user-images.githubusercontent.com/230597/35635540-2e4b64d6-0674-11e8-887e-92bfb42ab5f8.png)

- There's now a `default` button style different from the `primary` button style. When in doubt, use `default`.
- When in the context of a form, use the primary button to denote what will happen if the user submits the form.
- In almost every case, the primary button should only be used if typing Enter/Return will trigger it.
- "Error" has been renamed to "Danger" to better reflect when it gets used. It's intended for buttons where clicking them will cause something "dangerous" to happen.
- `danger`, `success`, and `warning` buttons should be used sparingly.
- `hollow` is no longer an available button prop.
- `transparent` and `secondary` are no longer available `buttonStyles`.
- The disabled state is now distinct from every enabled button style.

### Disabled buttons
![disabled](https://user-images.githubusercontent.com/230597/35635590-578bfd6a-0674-11e8-8465-3fe5237f4098.png)

## Risk
This _is_ a breaking change. A few quick searches around the `folio-org` revealed a small number of uses of `hollow`, `transparent`, and `error`. Module developers should comb over their buttons to ensure they're now using the right options.