### PR TITLE
Prevents EditableListForm from re-rendering before confirming success

### DIFF
--- a/lib/AuthorityList/AuthorityList.js
+++ b/lib/AuthorityList/AuthorityList.js
@@ -58,19 +58,19 @@ class AuthorityList extends React.Component {
 
   onCreateType(type) {
     console.log('ui-items - settings - onCreateType called');
-    this.props.mutator.values.POST(type);
+    return this.props.mutator.values.POST(type);
   }
 
   onUpdateType(type) {
     console.log('ui-items - settings - onUpdateType called');
     this.props.mutator.activeRecord.update({ id: type.id });
-    this.props.mutator.values.PUT(type);
+    return this.props.mutator.values.PUT(type);
   }
 
   onDeleteType(typeId) {
     console.log('ui-items - settings - onDeleteType called');
     this.props.mutator.activeRecord.update({ id: typeId });
-    this.props.mutator.values.DELETE(this.props.resources.values.records.find(t => t.id === typeId));
+    return this.props.mutator.values.DELETE(this.props.resources.values.records.find(t => t.id === typeId));
   }
 
   render() {


### PR DESCRIPTION
Prevents EditableListForm from re-rendering before confirming success from the backend