### PR TITLE
supply generated id to clear button if none is supplied

### DIFF
--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import uniqueId from 'lodash/uniqueId';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import TextFieldIcon from './TextFieldIcon';
@@ -76,6 +77,13 @@ class TextField extends React.Component {
 
     this.calcPadding = this.calcPadding.bind(this);
     this.clearField = this.clearField.bind(this);
+
+    // if no id has been supplied, generate a unique one
+    if (Object.prototype.hasOwnProperty.call(props, 'id')) {
+      this.testId = props.id;
+    } else {
+      this.testId = uniqueId('text-input-');
+    }
   }
 
   componentDidMount() {
@@ -218,7 +226,7 @@ class TextField extends React.Component {
 
     if (this.props.meta) {
       if (this.props.hasClearIcon && this.props.meta.active && !this.props.meta.asyncValidating && this.props.input && this.props.input.value !== '') {
-        clearField = <TextFieldIcon title="Clear this field" onMouseDown={this.clearField} tabIndex="-1" icon="clearX" id={clearFieldId} />;
+        clearField = <TextFieldIcon title="Clear this field" onMouseDown={this.clearField} tabIndex="-1" icon="clearX" id={clearFieldId || `clickable-${this.testId}-clear-field`} />;
       }
 
       if (validationEnabled && this.props.meta.asyncValidating) {
@@ -226,14 +234,14 @@ class TextField extends React.Component {
       }
 
       if (validationEnabled && this.props.meta.touched && this.props.meta.dirty && !this.props.meta.active && this.props.meta.valid && !this.props.meta.asyncValidating) {
-        validation = <TextFieldIcon iconClassName={css.successIcon} title="Field is valid" icon="validation-check" />;
+        validation = <TextFieldIcon iconClassName={css.successIcon} title="Field is valid" icon="validation-check" id={`icon-${this.testId}-validation-success`} />;
       }
       if (this.props.meta.touched && !this.props.meta.active && !this.props.meta.valid && !this.props.meta.asyncValidating) {
         if (this.input && (this.input.value === '' || !this.input.value)) {
-          validation = validationEnabled && <TextFieldIcon iconClassName={css.errorIcon} title="Field has error" icon="validation-error" />;
+          validation = validationEnabled && <TextFieldIcon iconClassName={css.errorIcon} title="Field has error" icon="validation-error" id={`icon-${this.testId}-validation-error`} />;
         } else {
-          validation = validationEnabled && <TextFieldIcon title="Field has error" onClick={this.clearField} iconClassName={css.errorIcon} icon="validation-error" />;
-          clearField = this.props.hasClearIcon && <TextFieldIcon title="Clear this field" onClick={this.clearField} icon="clearX" id={clearFieldId} />;
+          validation = validationEnabled && <TextFieldIcon title="Field has error" onClick={this.clearField} iconClassName={css.errorIcon} icon="validation-error" id={`icon-${this.testId}-validation-error`} />;
+          clearField = this.props.hasClearIcon && <TextFieldIcon title="Clear this field" onClick={this.clearField} icon="clearX" id={clearFieldId || `clickable-${this.testId}-clear-field`} />;
         }
       }
     }


### PR DESCRIPTION
Id's... tests need them. Having a good way for automated tests to clear the <Textfield> component regardless of how the devs have implemented the field is a good idea...
This PR also adds id's to the validation icons.