### PR TITLE
Mcl clickable header style

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -126,7 +126,7 @@
   color: rgba(0, 0, 0, 0.5);
   text-transform: capitalize;
 
-  .clickable {
+  &.clickable {
     cursor: pointer;
   }
 

--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -122,10 +122,13 @@
   flex-shrink: 0;
   flex-grow: 0;
   padding: 6px 5px;
-  cursor: pointer;
   font-weight: 600;
   color: rgba(0, 0, 0, 0.5);
   text-transform: capitalize;
+
+  .clickable {
+    cursor: pointer;
+  }
 
   &.sorted {
     text-decoration: underline;

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -141,6 +141,8 @@ class MCLRenderer extends React.Component {
       unfocusRow: this.unFocusRow,
       focusBeyond: this.focusBeyond,
     }, this.props.hotKeys.handlers);
+
+    console.log(this.props.onHeaderClick.toString());
   }
 
   componentDidMount() {
@@ -528,8 +530,10 @@ class MCLRenderer extends React.Component {
   getHeaderClassName(column) {
     const isSortHeader = (this.props.sortOrder === this.getMappedColumnName(column) ||
       this.props.sortedColumn === this.getMappedColumnName(column));
+      
     return classnames(
       css.header,
+      { [`${css.clickable}`]: (this.props.onHeaderClick.toString() !== '() => {}') },
       { [`${css.sorted}`]: isSortHeader },
       { [`${css.ascending}`]: (isSortHeader && this.props.sortDirection === 'ascending') },
       { [`${css.descending}`]: (isSortHeader && this.props.sortDirection === 'descending') },

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -527,7 +527,7 @@ class MCLRenderer extends React.Component {
   getHeaderClassName(column) {
     const isSortHeader = (this.props.sortOrder === this.getMappedColumnName(column) ||
       this.props.sortedColumn === this.getMappedColumnName(column));
-      
+
     return classnames(
       css.header,
       { [`${css.clickable}`]: (Object.prototype.hasOwnProperty.call(this.props, 'onHeaderClick')) },

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -52,7 +52,6 @@ const propTypes = {
 const defaultProps = {
   onScroll: () => { },
   onRowClick: () => { },
-  onHeaderClick: () => { },
   columnMapping: {},
   columnOverflow: {},
   formatter: {},
@@ -141,8 +140,6 @@ class MCLRenderer extends React.Component {
       unfocusRow: this.unFocusRow,
       focusBeyond: this.focusBeyond,
     }, this.props.hotKeys.handlers);
-
-    console.log(this.props.onHeaderClick.toString());
   }
 
   componentDidMount() {
@@ -533,7 +530,7 @@ class MCLRenderer extends React.Component {
       
     return classnames(
       css.header,
-      { [`${css.clickable}`]: (this.props.onHeaderClick.toString() !== '() => {}') },
+      { [`${css.clickable}`]: (Object.prototype.hasOwnProperty.call(this.props, 'onHeaderClick')) },
       { [`${css.sorted}`]: isSortHeader },
       { [`${css.ascending}`]: (isSortHeader && this.props.sortDirection === 'ascending') },
       { [`${css.descending}`]: (isSortHeader && this.props.sortDirection === 'descending') },
@@ -548,7 +545,9 @@ class MCLRenderer extends React.Component {
         meta[prop] = this.props.headerMetadata[name][prop];
       });
     }
-    this.props.onHeaderClick(e, meta);
+    if (Object.prototype.hasOwnProperty.call(this.props, 'onHeaderClick')) {
+      this.props.onHeaderClick(e, meta);
+    }
   }
 
   generateHeaders() {

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -559,10 +559,10 @@ class MCLRenderer extends React.Component {
       let clickableId;
       if (header === ' ') {
         columnId = `list-column-${i}`;
-        clickableId = `list-column-clickable-${i}`;
+        clickableId = `clickable-list-column-${i}`;
       } else {
         columnId = `list-column-${header.replace(/\s/g, '').toLowerCase()}`;
-        clickableId = `list-column-clickable-${header.replace(/\s/g, '').toLowerCase()}`;
+        clickableId = `clickable-list-column-${header.replace(/\s/g, '').toLowerCase()}`;
       }
 
       let headerStyle;


### PR DESCRIPTION
This considers the presence of an `onHeaderClick` handler before assigning a 'clickable' class to the rendered column headers.