### PR TITLE
updated rendered button styles for SegmentedControl

### DIFF
--- a/lib/SegmentedControl/SegmentedControl.js
+++ b/lib/SegmentedControl/SegmentedControl.js
@@ -23,7 +23,7 @@ const SegmentedControl = (props) => {
 
   const renderedChildren = React.Children.map(props.children, (child, i) => {
     if (child.type === Button) {
-      const childDecoration = child.props.id === props.activeId ? 'primary noLRMargin' : 'primary noLRMargin hollow';
+      const childDecoration = child.props.id === props.activeId ? 'primary noLRMargin' : 'noLRMargin default';
       let childRadius;
       const lastIndex = React.Children.count(props.children) - 1;
       if (i === 0) {


### PR DESCRIPTION
After #209 Segmented control needed modification due to the removal of `hollow`. It now displays non-active buttons with the `default` class.