### PR TITLE
STCOM-202 remove unreliable tracking of focused row.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
   "rules": {
     "import/no-extraneous-dependencies": ["error", {
       "devDependencies": true
-    }]
+    }],
+    "no-console": ["error", { "allow": ["warn", "error"] }]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * In `<Button>`, omit "hollow" prop from those passed to `<button>`. Fixes STCOM-196.
 * Remove the old `<AuthorityList>`, which has been superseded by `<ControlledVocab>` in stripes-smart-components. Completes STSMACOM-6.
 * Remove `<MultiColumnList>`'s default click handler - component now checks for a supplied click handler before calling `preventDefault()`. Fixes STCOM-197
+* Remove `<MultColumnList>`'s focus-tracking via ref to rowFormatter. Fixes STCOM-202.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/lib/Accordion/Accordion.stories.js
+++ b/lib/Accordion/Accordion.stories.js
@@ -37,7 +37,7 @@ storiesOf('Accordion', module)
   ))
   .add('toggleKeyHandlers', () => {
     const handlers = {
-      delete() { console.log('delete'); },
+      delete() { console.log('delete'); }, // eslint-disable-line no-console
     };
     return (
       <Accordion toggleKeyHandlers={handlers}>

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import contains from 'dom-helpers/query/contains';
 import isEqual from 'lodash/isEqual';
 import Icon from '../Icon';
 import { HotKeys } from '../HotKeys';
@@ -81,7 +80,7 @@ class MCLRenderer extends React.Component {
     this.headerMaxLScroll = 0;
     this.bodyMaxLScroll = 0;
     this.focusedRow = null;
-    this.focusRowElement = null;
+    // this.focusRowElement = null;
 
     this.handleFiniteScroll = this.handleFiniteScroll.bind(this);
     this.handleInfiniteScroll = this.handleInfiniteScroll.bind(this);
@@ -261,12 +260,13 @@ class MCLRenderer extends React.Component {
       this.headerHeight = this.headerRow.offsetHeight;
     }
 
-    if (this.focusRowElement !== null && this.focusRowElement !== document.activeElement) {
-      if (document.activeElement === this.container || contains(this.container, document.activeElement)) {
-        this.focusRowElement.focus();
-        this.focusRowElement = null;
-      }
-    }
+    // commenting for now. FocusRowElement was originally found using refs - unreliable.
+    // if (this.focusRowElement !== null && this.focusRowElement !== document.activeElement) {
+    //   if (document.activeElement === this.container || contains(this.container, document.activeElement)) {
+    //     this.focusRowElement.focus();
+    //     this.focusRowElement = null;
+    //   }
+    // }
   }
 
   updateDimensions(height, data, avgHeight) {
@@ -480,7 +480,7 @@ class MCLRenderer extends React.Component {
         if (React.isValidElement(value)) {
           stringValue = value.props.title ? value.props.title : null;
         } else {
-          console.warn(`Formatter possibly needed for column '${col}': value is object`, value);
+          console.warn(`Formatter possibly needed for column '${col}': value is object`, value); // eslint-disable-line no-console
           stringValue = null;
         }
       }
@@ -806,7 +806,6 @@ class MCLRenderer extends React.Component {
         const defaultRowProps = {
           onClick: (e) => { this.handleRowClick(e, contentData[rowIndex], rowMetadata); },
           onFocus: () => { this.focusedRow = rowIndex; },
-          ref: (ref) => { if (this.focusedRow === rowIndex) this.focusRowElement = ref; },
           onBlur: () => { this.focusedRow = null; },
           style: defaultStyle,
         };

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -57,7 +57,6 @@ const defaultProps = {
   isEmptyMessage: 'The list contains no items',
   contentData: [],
   selectedClass: css.selected,
-  sortedClass: css.sorted,
   rowFormatter: defaultRowFormatter,
   scrollToIndex: 0,
   rowProps: {},

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "webpack": "1.11.0"
   },
   "dependencies": {
-    "@folio/eslint-config-stripes": "^1.1.100012",
     "@folio/stripes-form": "^0.8.2",
     "@folio/stripes-react-hotkeys": "^1.0.0",
     "classnames": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     ]
   },
   "devDependencies": {
+    "@folio/eslint-config-stripes": "^1.1.0",
     "@storybook/addon-actions": "^3.2.16",
     "@storybook/addon-knobs": "^3.3.11",
     "@storybook/addon-options": "^3.2.15",
@@ -42,7 +43,6 @@
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "eslint": "^4.8.0",
-    "@folio/eslint-config-stripes": "^1.1.0",
     "ignore-styles": "^5.0.1",
     "jsdom": "^9.3.0",
     "mocha": "^2.5.3",
@@ -63,6 +63,7 @@
     "webpack": "1.11.0"
   },
   "dependencies": {
+    "@folio/eslint-config-stripes": "^1.1.100012",
     "@folio/stripes-form": "^0.8.2",
     "@folio/stripes-react-hotkeys": "^1.0.0",
     "classnames": "^2.2.5",


### PR DESCRIPTION
MCL was sending a `ref` prop down to its rowFormatter - not good, as the formatter could be a functional component, in which case the ref would return null.
An additional lint tweak here as well: allow for `console.error` and `console.warn` but still bark at `console.log`.