### PR TITLE
Implement restrictWhenAllSelected group flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Remove `<MultiColumnList>`'s default click handler - component now checks for a supplied click handler before calling `preventDefault()`. Fixes STCOM-197
 * Remove `<MultColumnList>`'s focus-tracking via ref to rowFormatter. Fixes STCOM-202.
 * Adjust EditableListForm setup. Fixes STCOM-203.
+* Implement `restrictWhenAllSelected` group flag for filter-groups. Fixes STCOM-204.
 * Update `<FilterGroups>` documentation for recent API changes. Fixes STCOM-206.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 * Remove `<MultiColumnList>`'s default click handler - component now checks for a supplied click handler before calling `preventDefault()`. Fixes STCOM-197
 * Remove `<MultColumnList>`'s focus-tracking via ref to rowFormatter. Fixes STCOM-202.
 * Adjust EditableListForm setup. Fixes STCOM-203.
-* Implement `restrictWhenAllSelected` group flag for filter-groups. Fixes STCOM-204.
+* Implement `restrictWhenAllSelected` group flag for filter-groups. Fixes STCOM-204. Included in v2.0.1.
 * Update `<FilterGroups>` documentation for recent API changes. Fixes STCOM-206.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)

--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -105,7 +105,9 @@ export function filterState(filters) {
 // Filters come in groups. Within each group, we want to OR together
 // the filters that have been selected; and we want to AND together
 // the output of each group. Groups where no filter has been selected
-// have no effect at all.
+// have no effect at all. And Groups where all filters have been
+// selected have no effect unless the `restrictWhenAllSelected`
+// setting is on.
 //
 export function filters2cql(config, filters) {
   if (!filters) return undefined;
@@ -124,6 +126,9 @@ export function filters2cql(config, filters) {
     const cqlIndex = group.cql;
 
     const values = groups[groupName];
+    if (values.length === group.values.length && !group.restrictWhenAllSelected)
+      continue;
+
     const mappedValues = values.map((v) => {
       // If the field is a {name,cql} object, use the CQL.
       const obj = group.values.filter(f => typeof f === 'object' && f.name === v);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
As a result, selecting all filters in a group now has no effect -- except for groups where `restrictWhenAllSelected` is true, where the old behaviour is retained.

Version patchlevel bumped (yielding 2.0.1) so we can depend on this new functionality in accordance with the recent document [Depending on unreleased features](https://github.com/folio-org/stripes-core/blob/master/doc/depending-on-unreleased-features.md). This is a test-case for the procedure described therein.

Fixes STCOM-204.