### PR TITLE
Update textfield value proptypes to accept both string and number

### DIFF
--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -10,7 +10,7 @@ import omitProps from '../../util/omitProps';
 
 const propTypes = {
   /**
-   * Can be "type" or "number". Standard html attribute.
+   * Can be "text" or "number". Standard html attribute.
    */
   // eslint-disable-next-line react/no-unused-prop-types
   type: PropTypes.string,
@@ -29,7 +29,10 @@ const propTypes = {
   /**
    * String of text to display.
    */
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]),
   /**
    * Event handler for text input. Required if a value is supplied.
    */


### PR DESCRIPTION
Since type of a textfield can be either "text" or "number", proptype of its value can be either string or number. 

This resolves a JS console warning of the type below:
```warning.js:33 Warning: Failed prop type: Invalid prop `value` of type `number` supplied to `TextField`, expected `string`.
    in TextField
    in Unknown (created by ConnectedField)
    in ConnectedField (created by Connect(ConnectedField))
    in Connect(ConnectedField) (created by Field)
    in Field (created by CustomEmbargoForm)```

This warning occurs when redux form tries to pass value of type "number" to TextField which accepts only string