### PR TITLE
Updating AppIcon to support context

### DIFF
--- a/lib/AppIcon/AppIcon.js
+++ b/lib/AppIcon/AppIcon.js
@@ -10,19 +10,38 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import css from './AppIcon.css';
 
-const AppIcon = ({ size, icon, style, children, className, tag }) => {
+const AppIcon = ({ size, icon, style, children, className, tag, app }, { stripes }) => {
   /**
-   * Formatted Icon
+   * Icon from context
+   *
+   * We get the icons from the metadata which is passed down via context.
+   * The default app icon has a key of "icon".
+   * This is required for any app but we'll stll check for it to be sure.
+   *
+   * If no icon is found we display a placeholder.
+   *
+   */
+  const iconFromContext = () => {
+    const metadata = stripes && stripes.metadata;
 
-   ** Work in progress **
-    Here we determine what to return
-   from a icon object once this is in place
-   It's getting discussed here: https://issues.folio.org/browse/STCOR-117 */
-  const formattedIcon = () => {
-    /* Only setting this if statement to avoid linting error */
-    if (icon) {
-      return icon;
+    if(metadata && metadata[app] && metadata[app].icons && metadata[app].icons.icon) {
+      const icon = metadata[app].icons.icon;
+      let src = icon.src;
+
+      // Use png's for small icons
+      if (size === 'small' && src.low && src.low.src) {
+        src = src.low.src;
+      }
+
+      const props = {
+        src,
+        alt: icon.alt,
+        title: icon.title,
+      };
+
+      return (<img {...props} />);
     }
+
     return null;
   };
 
@@ -35,8 +54,18 @@ const AppIcon = ({ size, icon, style, children, className, tag }) => {
       return children;
     }
 
+    /* If we have an image passed as an object */
+    if (typeof icon === 'object') {
+      return (<img {...icon} />);
+    }
+
     /* Return formatted icon */
-    return formattedIcon();
+    if (iconFromContext()) {
+      return iconFromContext();
+    }
+
+    /* Show placeholder */
+    return null;
   };
 
   /**
@@ -66,8 +95,19 @@ const AppIcon = ({ size, icon, style, children, className, tag }) => {
   );
 };
 
+AppIcon.contextTypes = {
+  stripes: PropTypes.shape({
+    metadata: PropTypes.object,
+  }),
+};
+
 AppIcon.propTypes = {
-  icon: PropTypes.oneOfType([PropTypes.string, PropTypes.array, PropTypes.object]),
+  icon: PropTypes.shape({
+    alt: PropTypes.string,
+    src: PropTypes.string.isRequired,
+    title: PropTypes.string,
+  }),
+  app: PropTypes.string,
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   style: PropTypes.object,
   className: PropTypes.string,

--- a/lib/AppIcon/AppIcon.js
+++ b/lib/AppIcon/AppIcon.js
@@ -39,7 +39,7 @@ const AppIcon = ({ size, icon, style, children, className, tag, app }, context) 
         title: appIcon.title,
       };
 
-      return (<img src={appIconProps.src} alt={appIconProps.alt} title={appIconProps.title} {...appIconProps}  />);
+      return (<img src={appIconProps.src} alt={appIconProps.alt} title={appIconProps.title} {...appIconProps} />);
     }
 
     return null;
@@ -56,11 +56,11 @@ const AppIcon = ({ size, icon, style, children, className, tag, app }, context) 
 
     /* If we have an image passed as an object */
     if (typeof icon === 'object') {
-      return (<img {...icon} />);
+      return (<img src={icon.src} title={icon.title} alt={icon.alt} {...icon} />);
     }
 
     /* Return formatted icon - or placeholder if no icon was found */
-      return iconFromMetadataContext();
+    return iconFromMetadataContext();
   };
 
   /**

--- a/lib/AppIcon/AppIcon.js
+++ b/lib/AppIcon/AppIcon.js
@@ -7,10 +7,11 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { result } from 'lodash';
 import classNames from 'classnames';
 import css from './AppIcon.css';
 
-const AppIcon = ({ size, icon, style, children, className, tag, app }, { stripes }) => {
+const AppIcon = ({ size, icon, style, children, className, tag, app }, context) => {
   /**
    * Icon from context
    *
@@ -21,11 +22,10 @@ const AppIcon = ({ size, icon, style, children, className, tag, app }, { stripes
    * If no icon is found we display a placeholder.
    *
    */
-  const iconFromContext = () => {
-    const metadata = stripes && stripes.metadata;
+  const iconFromMetadataContext = () => {
+    const icon = result(context, `stripes.metadata.${app}.icons.app`);
 
-    if(metadata && metadata[app] && metadata[app].icons && metadata[app].icons.icon) {
-      const icon = metadata[app].icons.icon;
+    if(icon && icon.src) {
       let src = icon.src;
 
       // Use png's for small icons
@@ -59,13 +59,8 @@ const AppIcon = ({ size, icon, style, children, className, tag, app }, { stripes
       return (<img {...icon} />);
     }
 
-    /* Return formatted icon */
-    if (iconFromContext()) {
-      return iconFromContext();
-    }
-
-    /* Show placeholder */
-    return null;
+    /* Return formatted icon - or placeholder if no icon was found */
+      return iconFromMetadataContext();
   };
 
   /**

--- a/lib/AppIcon/AppIcon.js
+++ b/lib/AppIcon/AppIcon.js
@@ -23,23 +23,23 @@ const AppIcon = ({ size, icon, style, children, className, tag, app }, context) 
    *
    */
   const iconFromMetadataContext = () => {
-    const icon = result(context, `stripes.metadata.${app}.icons.app`);
+    const appIcon = result(context, `stripes.metadata.${app}.icons.app`);
 
-    if(icon && icon.src) {
-      let src = icon.src;
+    if (appIcon && appIcon.src) {
+      let src = appIcon.src;
 
-      // Use png's for small icons
+      // Use png's for small app icons
       if (size === 'small' && src.low && src.low.src) {
         src = src.low.src;
       }
 
-      const props = {
+      const appIconProps = {
         src,
-        alt: icon.alt,
-        title: icon.title,
+        alt: appIcon.alt,
+        title: appIcon.title,
       };
 
-      return (<img {...props} />);
+      return (<img src={appIconProps.src} alt={appIconProps.alt} title={appIconProps.title} {...appIconProps}  />);
     }
 
     return null;

--- a/lib/AppIcon/readme.md
+++ b/lib/AppIcon/readme.md
@@ -1,11 +1,38 @@
 # AppIcon
 
-Displays an app's icon in various sizes
+Displays an app's icon in various sizes.
+
+## Usage
+AppIcon supports different ways of loading icons. Option 1 is the recommended implementation and option 1/2 are to be used in edge cases.
+
+```js
+  import AppIcon from '@folio/stripes-components/lib/AppIcon';
+
+  // 1. Use context (recommended)
+  // Note: Make sure that the AppIcon has "stripes" in context as it relies on stripes.metadata.
+  <AppIcon app="users" size="small" />
+
+  // 2. Supply an object to the icon prop
+  const icon = {
+    src: '/static/some-icon.png',
+    alt: 'My icon',
+    title: 'My icon',
+  };
+
+  <AppIcon icon={icon} />
+
+  // 3. Pass img as child
+  <AppIcon>
+    <img src="/static/my-icon.png" alt="My icon" />
+  </AppIcon>
+
+```
 
 ## Props
 Name | Type | Description
 -- | -- | --
-icon | object | Icon in form of an object (Work-in-progress)
+app | string | The lowercased name of an app. E.g. "users" or "inventory". It will get the icon from metadata located in the stripes-object which should be available in React Context.
+icon | object | Icon in form of an object
 size | string | Determines the size of the icon. (small, medium, large)
 style | object | For adding custom style to component
 className | string | For adding custom class to component

--- a/lib/AppIcon/readme.md
+++ b/lib/AppIcon/readme.md
@@ -3,7 +3,9 @@
 Displays an app's icon in various sizes.
 
 ## Usage
-AppIcon supports different ways of loading icons. Option 1 is the recommended implementation and option 1/2 are to be used in edge cases.
+AppIcon supports different ways of loading icons.
+
+Option 1 is the recommended implementation but if needed (edge case) option 1 and 2 can be used.
 
 ```js
   import AppIcon from '@folio/stripes-components/lib/AppIcon';


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/640976/36488187-26ada6b6-1723-11e8-9dd0-e8eb1091d348.png)

This update adds support for React Context in the AppIcon-component.

It relies on stripes being in context which allows it to check for the metadata-key to find icon(s) for an app specified by the "app"-prop.

**Usage:**
`<AppIcon app="users" />`

I also updated the readme with examples.

**Note:** I have preserved two other options of adding icons even though the context one will be the recommended. This is mainly because of some apps not being actual apps yet - such as "Settings". In this case I needed another way of passing the icon data down.

In the future we'll probably limit the options to only using the context part (assuming we don't decide to use another way of implementation).

I have been adding icons to various apps so that they are ready for this change. I will also submit a PR for stripes-core that will activate icons in the MainNav and afterwards we can start adding icons other places in the application.