### PR TITLE
Updating AppIcon

### DIFF
--- a/lib/AppIcon/AppIcon.js
+++ b/lib/AppIcon/AppIcon.js
@@ -11,24 +11,24 @@ import { result } from 'lodash';
 import classNames from 'classnames';
 import css from './AppIcon.css';
 
-const AppIcon = ({ size, icon, style, children, className, tag, app }, context) => {
+const AppIcon = ({ size, icon, style, children, className, tag, app, key }, context) => {
   /**
    * Icon from context
    *
    * We get the icons from the metadata which is passed down via context.
    * The default app icon has a key of "icon".
-   * This is required for any app but we'll still check for it to be sure.
+   * This is required for any app but we'll stll check for it to be sure.
    *
    * If no icon is found we display a placeholder.
    *
    */
   const iconFromMetadataContext = () => {
-    const appIcon = result(context, `stripes.metadata.${app}.icons.app`);
+    const appIcon = result(context, `stripes.metadata.${app}.icons.${key}`);
 
     if (appIcon && appIcon.src) {
       let src = appIcon.src;
 
-      // Use PNGs for small app icons
+      // Use png's for small app icons
       if (size === 'small' && src.low && src.low.src) {
         src = src.low.src;
       }
@@ -103,6 +103,7 @@ AppIcon.propTypes = {
     title: PropTypes.string,
   }),
   app: PropTypes.string,
+  key: PropTypes.string,
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   style: PropTypes.object,
   className: PropTypes.string,
@@ -113,6 +114,7 @@ AppIcon.propTypes = {
 AppIcon.defaultProps = {
   size: 'medium',
   tag: 'span',
+  key: 'app',
 };
 
 export default AppIcon;

--- a/lib/AppIcon/AppIcon.js
+++ b/lib/AppIcon/AppIcon.js
@@ -11,19 +11,18 @@ import { result } from 'lodash';
 import classNames from 'classnames';
 import css from './AppIcon.css';
 
-const AppIcon = ({ size, icon, style, children, className, tag, app, key }, context) => {
+const AppIcon = ({ size, icon, style, children, className, tag, app, iconKey }, context) => {
   /**
    * Icon from context
    *
    * We get the icons from the metadata which is passed down via context.
-   * The default app icon has a key of "icon".
-   * This is required for any app but we'll stll check for it to be sure.
+   * The default app icon has an iconKey of "app".
    *
    * If no icon is found we display a placeholder.
    *
    */
   const iconFromMetadataContext = () => {
-    const appIcon = result(context, `stripes.metadata.${app}.icons.${key}`);
+    const appIcon = result(context, `stripes.metadata.${app}.icons.${iconKey}`);
 
     if (appIcon && appIcon.src) {
       let src = appIcon.src;
@@ -103,7 +102,7 @@ AppIcon.propTypes = {
     title: PropTypes.string,
   }),
   app: PropTypes.string,
-  key: PropTypes.string,
+  iconKey: PropTypes.string,
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   style: PropTypes.object,
   className: PropTypes.string,
@@ -114,7 +113,7 @@ AppIcon.propTypes = {
 AppIcon.defaultProps = {
   size: 'medium',
   tag: 'span',
-  key: 'app',
+  iconKey: 'app',
 };
 
 export default AppIcon;

--- a/lib/AppIcon/readme.md
+++ b/lib/AppIcon/readme.md
@@ -7,14 +7,16 @@ AppIcon supports different ways of loading icons.
 
 Option 1 is the recommended implementation but if needed (edge case) option 1 and 2 can be used.
 
+1. Use context (recommended)
 ```js
   import AppIcon from '@folio/stripes-components/lib/AppIcon';
 
-  // 1. Use context (recommended)
   // Note: Make sure that the AppIcon has "stripes" in context as it relies on stripes.metadata.
   <AppIcon app="users" size="small" />
+  ```
 
-  // 2. Supply an object to the icon prop
+2. Supply an object to the icon prop
+```js  
   const icon = {
     src: '/static/some-icon.png',
     alt: 'My icon',
@@ -22,18 +24,20 @@ Option 1 is the recommended implementation but if needed (edge case) option 1 an
   };
 
   <AppIcon icon={icon} />
+  ```
 
-  // 3. Pass img as child
+3. Pass img as child
+  ```js
   <AppIcon>
     <img src="/static/my-icon.png" alt="My icon" />
   </AppIcon>
-
 ```
 
 ## Props
 Name | Type | Description
 -- | -- | --
 app | string | The lowercased name of an app, e.g. "users" or "inventory". It will get the icon from metadata located in the stripes-object which should be available in React Context.
+key | string | A specific icon-key for apps with multiple icons. Defaults to "app" which corresponds to the required default app-icon of an app.
 icon | object | Icon in form of an object
 size | string | Determines the size of the icon. (small, medium, large)
 style | object | For adding custom style to component

--- a/lib/AppIcon/readme.md
+++ b/lib/AppIcon/readme.md
@@ -7,15 +7,19 @@ AppIcon supports different ways of loading icons.
 
 Option 1 is the recommended implementation but if needed (edge case) option 1 and 2 can be used.
 
-1. Use context (recommended)
+***1. Use context (recommended)***
 ```js
   import AppIcon from '@folio/stripes-components/lib/AppIcon';
 
   // Note: Make sure that the AppIcon has "stripes" in context as it relies on stripes.metadata.
   <AppIcon app="users" size="small" />
   ```
+  Optional: You can supply an iconKey if you need a specific icon within an app. If the specific icon isn't bundled with the app it will simply render a placeholder.
+```js
+  <AppIcon app="inventory" iconKey="holdings" />
+```
 
-2. Supply an object to the icon prop
+***2. Supply an object to the icon prop***
 ```js  
   const icon = {
     src: '/static/some-icon.png',
@@ -26,7 +30,7 @@ Option 1 is the recommended implementation but if needed (edge case) option 1 an
   <AppIcon icon={icon} />
   ```
 
-3. Pass img as child
+***3. Pass img as child***
   ```js
   <AppIcon>
     <img src="/static/my-icon.png" alt="My icon" />
@@ -37,7 +41,7 @@ Option 1 is the recommended implementation but if needed (edge case) option 1 an
 Name | Type | Description
 -- | -- | --
 app | string | The lowercased name of an app, e.g. "users" or "inventory". It will get the icon from metadata located in the stripes-object which should be available in React Context.
-key | string | A specific icon-key for apps with multiple icons. Defaults to "app" which corresponds to the required default app-icon of an app.
+iconKey | string | A specific icon-key for apps with multiple icons. Defaults to "app" which corresponds to the required default app-icon of an app.
 icon | object | Icon in form of an object
 size | string | Determines the size of the icon. (small, medium, large)
 style | object | For adding custom style to component


### PR DESCRIPTION
Adding iconKey from to use when you need another app icon than the default one.

Example: In Inventory we need to get an items-icon in some cases so you can do:

`<AppIcon app="inventory" iconKey="items" />`