### PR TITLE
STCOM-215 adjust heading levels and section tags - fix the H3 console error

### DIFF
--- a/docs/Accessibility.md
+++ b/docs/Accessibility.md
@@ -1,0 +1,33 @@
+# Accessibility in Stripes
+
+Accessibility involves the navigability, legibility, and general useability of the web application. Conversations around accessiblity typically involve the engagement of users that have impaired vision, motor-skills or a learning disability, but it can have great and positive impact on the experience of fully capable users as well. Much of the time it involves how assistive technology (screen readers, etc) interact with the content of the web page - but other areas involve the color contrast of styling, font choices/sizes, lack of input segregation (mouse vs touch vs keyboard-only navigation.)
+
+## Components to the rescue!
+
+Ensuring that your web application meets accessibility standards can be a daunting task for developers. Code-wise, it includes semantic html tags  and attributes that can make very little difference for sighted users, but the impact for those depending on screen-readers or other assistive technology is massive. React components allow for us to re-use packaged up code - so all of the tags and attributes are actually coded in one place and rendered accordingly through the API surface of props for each instance of a component. A great deal of accessibile mark-up is already written for you, and props can be a great deal more digestible than if you had to write all of the html-attributes and tags yourself. Form elements, for example:
+An accessible form text input, in raw HTML:
+```
+<label for="nameInput">Name</label>
+<input type="text" id="nameInput" name="personal.name" />
+```
+vs the same input via a component
+```
+<TextField id="nameInput" label="Name" name="personal.name" />
+```
+This simple example shows both the code reduction that components provide and the simplification of the API surface. If both an `id` and a `label` prop are supplied to the `<TextField>` component, then the component takes care of rendering the `<label>` tag, assigning the `id` to the text input, and connecting them via the `for` attribute (or `htmlFor`, in React-speak). When a user of a screen reader focuses the input, the text of the label will be read aloud to them along with any value present in the field.
+
+## Page structure
+
+The Stripes UI takes advantage of semantic tagging and hierarchical heading structure to support "Outline-able" modules. Assistive technology can arrange page content navigation in an outline according to its heading levels. A user of NVDA (free screen reader: https://www.nvaccess.org/) can use the "H" key on their keyboard to move to the next header in their page's structure, complete with announcement of the heading level. Placing heading levels out of numerical order (e.g. using an `<h3>` after an `<h1>`) can cause issues with the outlining functionality which makes page content more difficult to navigate. The hierarchy of a FOLIO ui application begins with an `<h1>` in the top menu bar of the application and continues through to `<h2>`s within pane headers, and `<h3>`s on `<Accordion>`s - the standard component for content sections. Additionally, we include a `<Headline>` component that can render `<h1-h6>` tags with easy styling via props for system-established `size` and `margin` settings. `<section>` tags are a standard part of HTML5 and should be use to create other sections of content if an `<Accordion>` cannot be used, for some reason. Often, proper heading structure is shyed away from because the sheer size of the text within a heading can be aesthetically disruptive. Given the mentioned props, that is not an issue with `stripes-components`.
+
+## Programmatic legibility
+
+Screen-readers are computer programs that, as their title suggests, read the textual content of the screen aloud to users with sight disabilities. They only see textual content - and any visual content is lost to them without supplying additional text for audible announcement. Imagine having to rely on someone else to read the text of a web page aloud to you, without them being able to verbally describe icons, colors and pictures based on what they're seeing on the screen if the text is not present anywhere. When you're creating a UI that works with a screen-reader, that's precisely the situation you're preparing for. Fear not! The packaged semantic tags, `roles`, and `aria-attributes` within components are there to do the heavy lifting! If all else would fail with mark-up, it's possible to use our screen-reader-specific component `<SRStatus>` to send a string that will be read aloud by the screen-reader.
+
+## Keyboard Navigation
+
+Productivity is key. The UI that allows users to work faster and increase efficiency will win the hearts of users - with or without any impairments (and their bosses heart as well!) Many users make the conscious decision to use keyboard rather than the mouse for the sheer speed. The time it takes to move a mouse pointer from one target area to another can make quite a difference. Web users interact with web pages via the `tab`, `enter`, `spacebar` and `arrow` keys. Users of screen-readers have additional hotkeys that they can take advantage of to navigate between the headings (`<h1-6>`), list items (`<li>`), links and buttons of a page. Stripes components strive for full keyboard support with very little overhead - another aspect of ui-development that can be quite time-consuming if it has to be coded from scratch. If more specific control is necessary for custom components, we use `stripes-react-hotkeys` to provide custom hotkey set-ups, with exposeable actions that can be set at higher levels in the UI.
+
+## Focus Management
+
+Focus is the key to the context of assistive technology. The focused element can be the text-input where a user is entering a value, a highlighted radio-button, or an outlined link that's awaiting a press of the enter key to help the user travel to another page. Stripes-components manage focus where necessary, making assurance that the User's focus indicator is where it needs to be when it needs to be there. Triggered actions might move focus to a different control on the page to save the user from having to navigate across numerous tabbable elements to get to the location in the UI where a change needs to be made. `<FocusLink>` is a component that can be used to make sections of content "skip-able" if so desired. This works well for skipping sets of filters after a search field and shifting focus directly to the results listing

--- a/lib/Accordion/headers/DefaultAccordionHeader.js
+++ b/lib/Accordion/headers/DefaultAccordionHeader.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import contains from 'dom-helpers/query/contains';
+import Headline from '../../Headline';
 import Icon from '../../Icon';
 import css from '../Accordion.css';
 
@@ -56,22 +57,24 @@ const DefaultAccordionHeader = (props) => {
   }
 
   return (
-    <div role="heading" aria-level="2" className={css.headerWrapper} ref={(ref) => { containerElem = ref; }} >
+    <div className={css.headerWrapper} ref={(ref) => { containerElem = ref; }} >
       <div className={`${css.header} ${css.default}`}>
-        <button
-          title={open ? 'collapse section' : 'expand section'}
-          type="button"
-          onClick={handleHeaderClick}
-          onKeyPress={handleKeyPress}
-          onKeyUp={e => e.preventDefault()}
-          ref={(ref) => { props.toggleRef(ref); toggleElem = ref; }}
-          className={css.defaultCollapseButton}
-        >
-          {openIcon}
-          <div className={css.labelArea} ref={(ref) => { labelElem = ref; }}>
-            {label}
-          </div>
-        </button>
+        <Headline size="medium" tag="h3">
+          <button
+            title={open ? 'collapse section' : 'expand section'}
+            type="button"
+            onClick={handleHeaderClick}
+            onKeyPress={handleKeyPress}
+            onKeyUp={e => e.preventDefault()}
+            ref={(ref) => { props.toggleRef(ref); toggleElem = ref; }}
+            className={css.defaultCollapseButton}
+          >
+            {openIcon}
+            <div className={css.labelArea} ref={(ref) => { labelElem = ref; }}>
+              {label}
+            </div>
+          </button>
+        </Headline>
       </div>
       { headerRight }
     </div>

--- a/lib/Accordion/headers/FilterAccordionHeader.js
+++ b/lib/Accordion/headers/FilterAccordionHeader.js
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import contains from 'dom-helpers/query/contains';
 import Icon from '../../Icon';
 import Button from '../../Button';
+import Headline from '../../Headline';
 import IconButton from '../../IconButton';
 import css from '../Accordion.css';
 
@@ -56,25 +57,27 @@ class FilterAccordionHeader extends React.Component {
     const { label, open, displayWhenOpen, displayWhenClosed, displayClearButton, onClearFilter, contentId } = this.props;
     const clearButtonVisible = displayClearButton && typeof onClearFilter === 'function';
     return (
-      <div role="heading" aria-level="2" className={css.headerWrapper} ref={(ref) => { this.containerElem = ref; }} >
-        <Button
-          buttonStyle="link"
-          type="button"
-          tabIndex="0"
-          onClick={this.handleHeaderClick}
-          onKeyPress={this.handleKeyPress}
-          aria-label={`${label} filter list`}
-          aria-controls={contentId}
-          aria-expanded={open}
-          className={classNames(css.filterSetHeader, { [css.clearButtonVisible]: clearButtonVisible })}
-          role="tab"
-          buttonRef={(ref) => { this.toggleElem = ref; }}
-        >
-          <Icon size="small" icon={`${open ? 'up' : 'down'}-caret`} ref={(r) => { this.iconElem = r; }} />
-          <div className={css.labelArea} ref={(ref) => { this.labelElem = ref; }}>
-            <div className={css.filterSetlabel} >{label}</div>
-          </div>
-        </Button>
+      <div className={css.headerWrapper} ref={(ref) => { this.containerElem = ref; }} >
+        <Headline size="small" tag="h3">
+          <Button
+            buttonStyle="link"
+            type="button"
+            tabIndex="0"
+            onClick={this.handleHeaderClick}
+            onKeyPress={this.handleKeyPress}
+            aria-label={`${label} filter list`}
+            aria-controls={contentId}
+            aria-expanded={open}
+            className={classNames(css.filterSetHeader, { [css.clearButtonVisible]: clearButtonVisible })}
+            role="tab"
+            buttonRef={(ref) => { this.toggleElem = ref; }}
+          >
+            <Icon size="small" icon={`${open ? 'up' : 'down'}-caret`} ref={(r) => { this.iconElem = r; }} />
+            <div className={css.labelArea} ref={(ref) => { this.labelElem = ref; }}>
+              <div className={css.filterSetlabel} >{label}</div>
+            </div>
+          </Button>
+        </Headline>
         { clearButtonVisible ?
           <IconButton
             size="small"

--- a/lib/LayoutHeader/LayoutHeader.js
+++ b/lib/LayoutHeader/LayoutHeader.js
@@ -28,7 +28,7 @@ const defaultProps = {
 };
 
 const LayoutHeader = (props) => {
-  const getHeader = () => React.createElement(`H${props.level}`, { style: { margin: 0 } }, props.title);
+  const getHeader = () => React.createElement(`h${props.level}`, { style: { margin: 0 } }, props.title);
 
 
   const renderActions = () => {

--- a/lib/MetaSection/MetaAccordionHeader.js
+++ b/lib/MetaSection/MetaAccordionHeader.js
@@ -59,7 +59,6 @@ const MetaAccordionHeader = (props) => {
         <div className={css.metaHeader}>
           {openIcon}
           <div ref={(ref) => { labelElem = ref; }}>
-            
             <div className={css.metaHeaderLabel}>{label}</div>
           </div>
         </div>

--- a/lib/MetaSection/MetaAccordionHeader.js
+++ b/lib/MetaSection/MetaAccordionHeader.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Icon from '../Icon';
+import Headline from '../Headline';
 import css from './MetaSection.css';
 
 const propTypes = {
@@ -43,7 +44,8 @@ const MetaAccordionHeader = (props) => {
   const { label, open, displayWhenOpen, displayWhenClosed, contentId } = props;
 
   return (
-    <div role="heading" aria-level="2" className={css.headerWrapper} ref={(ref) => { containerElem = ref; }} >
+    <div className={css.headerWrapper} ref={(ref) => { containerElem = ref; }} >
+      <Headline className="sr-only" size="small" margin="none" tag="h4">Update information</Headline>
       <button
         type="button"
         tabIndex="0"
@@ -57,7 +59,8 @@ const MetaAccordionHeader = (props) => {
         <div className={css.metaHeader}>
           {openIcon}
           <div ref={(ref) => { labelElem = ref; }}>
-            <div className={css.metaHeaderLabel} >{label}</div>
+            
+            <div className={css.metaHeaderLabel}>{label}</div>
           </div>
         </div>
       </button>

--- a/lib/Pane/Pane.js
+++ b/lib/Pane/Pane.js
@@ -130,7 +130,7 @@ class Pane extends React.Component {
   render() {
     const { paneTitle, paneSub, firstMenu, lastMenu, actionMenuItems, ...rest } = this.props;
     return (
-      <div className={css.pane} style={this.state.style} ref={(ref) => { this.el = ref; }}>
+      <section className={css.pane} style={this.state.style} ref={(ref) => { this.el = ref; }}>
         <PaneHeader
           paneTitle={paneTitle}
           paneSub={paneSub}
@@ -145,7 +145,7 @@ class Pane extends React.Component {
         <div key={`${this.id}-content`} className={this.getContentClass()}>
           {this.props.children}
         </div>
-      </div>
+      </section>
     );
   }
 }

--- a/lib/PaneHeader/PaneHeader.js
+++ b/lib/PaneHeader/PaneHeader.js
@@ -8,6 +8,7 @@ import { Dropdown } from '../Dropdown';
 import DropdownMenu from '../DropdownMenu';
 import NavList from '../NavList';
 import NavListSection from '../NavListSection';
+import Headline from '../Headline';
 import Icon from '../Icon';
 
 export default class PaneHeader extends Component {
@@ -140,10 +141,10 @@ export default class PaneHeader extends Component {
     const content = (
       <div>
         { paneTitle && (
-          <h3 title={paneTitle} className={css.paneTitle}>
+          <Headline tag="h2" title={paneTitle} className={css.paneTitle}>
             <span>{paneTitle}</span>
             { paneActionMenu && <Icon icon={actionMenuOpen ? 'down-caret' : 'up-caret'} size="small" iconRootClass={css.paneActionMenuIcon} />}
-          </h3>
+          </Headline>
           )
         }
         { paneSub && (<p title={paneSub} className={css.paneSub}><span>{paneSub}</span></p>) }
@@ -176,11 +177,11 @@ export default class PaneHeader extends Component {
     );
 
     return (
-      <section className={css.paneHeaderCenter} style={this.getCenteredContentAreaStyle()}>
+      <div className={css.paneHeaderCenter} style={this.getCenteredContentAreaStyle()}>
         <div className={css.paneHeaderCenterInner}>
           { paneActionMenu ? contentWithActionMenu : content }
         </div>
-      </section>
+      </div>
     );
   }
 
@@ -212,9 +213,9 @@ export default class PaneHeader extends Component {
     }
 
     return (
-      <section className={classes} ref={(el) => { this[`${placement}AreaElement`] = el; }}>
+      <div className={classes} ref={(el) => { this[`${placement}AreaElement`] = el; }}>
         { content }
-      </section>
+      </div>
     );
   }
 
@@ -246,15 +247,15 @@ export default class PaneHeader extends Component {
      */
 
     if (header) {
-      return (<header className={css.paneHeader}>{header}</header>);
+      return (<div className={css.paneHeader}>{header}</div>);
     }
 
     return (
-      <header className={css.paneHeader}>
+      <div className={css.paneHeader}>
         { getFirstContentArea() }
         { getCenteredContentArea() }
         { getLastContentArea() }
-      </header>
+      </div>
     );
   }
 }

--- a/lib/structures/AddressFieldGroup/AddressList/AddressList.js
+++ b/lib/structures/AddressFieldGroup/AddressList/AddressList.js
@@ -238,7 +238,7 @@ class AddressList extends React.Component {
 
     return (
       <div>
-        <Headline tag="h2" size="medium">{label}</Headline>
+        <Headline tag="h4" size="medium">{label}</Headline>
         {addAddressButton}
         <div aria-label="Address Section" tabIndex="0" role="tabpanel" ref={(ref) => { this.container = ref; }}>
           <Layout className="flex">

--- a/lib/structures/AddressFieldGroup/AddressView/AddressView.js
+++ b/lib/structures/AddressFieldGroup/AddressView/AddressView.js
@@ -62,7 +62,7 @@ function AddressView(props) {
 
   return (
     <div className={css.addressItem} aria-label={(addressObject.primaryAddress && 'Primary address') || 'Alternate address'} tabIndex="0" role="tabpanel" data-group-id={uiId}>
-      <LayoutHeader level={3} title={headerFormatter(addressObject)} actions={actions} noActions={!canEdit} />
+      <LayoutHeader level={5} title={headerFormatter(addressObject)} actions={actions} noActions={!canEdit} />
       <div className={css.addressItemContent}>
         {groupArray}
       </div>


### PR DESCRIPTION
As part of a headings/<section> overhaul to achieve a nice, accessible page outline, I found the culprit of the ugly and infamous: 
![image](https://user-images.githubusercontent.com/20704067/36742785-2ca29754-1bae-11e8-826d-9a6220009904.png)
and struck it down.
Additionally, this PR touched heavily on the Accordion headers and Pane Headers, making them work in conjunction with the `<h1>` added to the main FOLIO header in the stripes-core PR #206 https://github.com/folio-org/stripes-core/pull/206
