### PR TITLE
Added disabled property to EditableListForm's save button

### DIFF
--- a/lib/structures/EditableList/EditableListForm.js
+++ b/lib/structures/EditableList/EditableListForm.js
@@ -83,6 +83,18 @@ const propTypes = {
    * manually set column widths, if necessary.
    */
   columnWidths: PropTypes.object,
+  /**
+   * boolean that shows if the form has been modified.
+   */
+  pristine: PropTypes.bool,
+  /**
+   * boolean that indicates that the form is being submitted.
+   */
+  submitting: PropTypes.bool,
+  /**
+   * boolean that indicates if there are validation errors.
+   */
+  invalid: PropTypes.bool,
 };
 
 const defaultProps = {

--- a/lib/structures/EditableList/EditableListForm.js
+++ b/lib/structures/EditableList/EditableListForm.js
@@ -297,12 +297,11 @@ class EditableListForm extends React.Component {
   }
 
   getActions = (fields, item) => {
-    const { actionSuppression } = this.props;
-
+    const { actionSuppression, pristine, submitting, invalid } = this.props;
     if (this.state.status[item.rowIndex].editing) {
       return (
         <div style={{ display: 'flex' }}>
-          <Button marginBottom0 id={`clickable-save-${this.testingId}-${item.rowIndex}`} title="Save changes to this item" onClick={() => this.onSave(fields, item.rowIndex)}>Save</Button>
+          <Button disabled={pristine || submitting || invalid} marginBottom0 id={`clickable-save-${this.testingId}-${item.rowIndex}`} title="Save changes to this item" onClick={() => this.onSave(fields, item.rowIndex)}>Save</Button>
           <Button marginBottom0 id={`clickable-cancel-${this.testingId}-${item.rowIndex}`} title="Cancel editing this item" onClick={() => this.onCancel(fields, item.rowIndex)}>Cancel</Button>
         </div>
       );


### PR DESCRIPTION
Resolves [STCOM-218](https://issues.folio.org/browse/STCOM-218)

The EditableList already had a validation function, but was not using it. This PR is disabling the 'create' button when the value is unchanged, in the process of being submitted, or the validation function returns a validation error.