### PR TITLE
Generalise `failIfNoQuery` argument to `makeQueryFunction`, now `failOnCondition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Implement `restrictWhenAllSelected` group flag for filter-groups. Fixes STCOM-204. Included in v2.0.1.
 * Update `<FilterGroups>` documentation for recent API changes. Fixes STCOM-206.
 * `<SearchForm>` does not add a placeholder to the dropdown of indexes if `searchableIndexesPlaceholder` is null. Fixes STCOM-220.
+* Generalise `failIfNoQuery` argument to `makeQueryFunction`, now `failOnCondition`. Fixes STCOM-219.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 * Implement `restrictWhenAllSelected` group flag for filter-groups. Fixes STCOM-204. Included in v2.0.1.
 * Update `<FilterGroups>` documentation for recent API changes. Fixes STCOM-206.
 * `<SearchForm>` does not add a placeholder to the dropdown of indexes if `searchableIndexesPlaceholder` is null. Fixes STCOM-220.
-* Generalise `failIfNoQuery` argument to `makeQueryFunction`, now `failOnCondition`. Fixes STCOM-219.
+* Generalise `failIfNoQuery` argument to `makeQueryFunction`, now `failOnCondition`. Fixes STCOM-219. Available from v2.0.2.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",

--- a/util/makeQueryFunction.js
+++ b/util/makeQueryFunction.js
@@ -1,12 +1,25 @@
 import { filters2cql } from '../lib/FilterGroups';
 import { compilePathTemplate } from '@folio/stripes-connect/RESTResource/RESTResource';
 
-function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failIfNoQuery) {
+// failOnCondition can take values:
+//      0: do not fail even if query and filters and empty
+//      1: fail if query is empty, whatever the filter state
+//      2: fail if both query and filters and empty.
+//
+// For compatibility, false and true may be used for 0 and 1 respectively.
+//
+function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOnCondition) {
   return (queryParams, pathComponents, resourceValues, logger) => {
     
     const { qindex, filters, query} = queryParams || {};
 
-    if ((query === undefined || query === '') && failIfNoQuery) {
+    if ((query === undefined || query === '') &&
+        (failOnCondition === 1 || failOnCondition === true)) {
+      return null;
+    }
+    if ((query === undefined || query === '') &&
+        (filters === undefined || filters === '') &&
+        (failOnCondition === 2)) {
       return null;
     }
 


### PR DESCRIPTION
Fixes STCOM-219. Available from v2.0.2.