### PR TITLE
STCOM-175: Fixed bug when disabling filter checkboxes

### DIFF
--- a/lib/Checkbox/Checkbox.js
+++ b/lib/Checkbox/Checkbox.js
@@ -213,6 +213,7 @@ class Checkbox extends React.Component {
           onChange={this.handleChange}
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
+          disabled={cleanedProps.disabled}
           ref={(ref) => { this.input = ref; }}
         />
         <label className={this.getLabelStyle()} htmlFor={this.props.id}>


### PR DESCRIPTION
[Fixing STCOM-175.](https://issues.folio.org/browse/STCOM-175)

Adding the `disabled` prop to `<Checkbox>` pulled it off of the props that get spread onto the `<checkbox>` so we now have to apply it explicitly.