### PR TITLE
Added styling for disabled FilterGroups and Accordions

### DIFF
--- a/lib/Accordion/Accordion.css
+++ b/lib/Accordion/Accordion.css
@@ -15,9 +15,9 @@
 }
 
 .disabled {
-  /* Doing this math since the SAS pane has padding that surrounds Accordians 
+  /* Doing this math since the SAS pane has padding that surrounds Accordians
      and makes the disabled background-color not run to the edges. These rules
-     could become an issue if disabled Accordions become used with a parent 
+     could become an issue if disabled Accordions become used with a parent
      that does not use major-padding. */
   margin-left: calc(0 - var(--major-padding));
   padding-left: var(--major-padding);

--- a/lib/Accordion/Accordion.css
+++ b/lib/Accordion/Accordion.css
@@ -158,7 +158,7 @@
 
 .filterSetLabel {
   font-weight: 600;
-  color: #8e8e8e;
+  color: #000;
   pointer-events: none;
   user-select: none;
 }

--- a/lib/Accordion/Accordion.css
+++ b/lib/Accordion/Accordion.css
@@ -14,6 +14,20 @@
   width: 100%;
 }
 
+.disabled {
+  /* Doing this math since the SAS pane has padding that surrounds Accordians 
+     and makes the disabled background-color not run to the edges. These rules
+     could become an issue if disabled Accordions become used with a parent 
+     that does not use major-padding. */
+  margin-left: calc(0 - var(--major-padding));
+  padding-left: var(--major-padding);
+  width: calc(100% + (2 * var(--major-padding)));
+
+  & .header {
+    opacity: 0.5;
+  }
+}
+
 /**
  * Header
  */
@@ -142,9 +156,9 @@
   height: 14px;
 }
 
-.filterSetlabel {
+.filterSetLabel {
   font-weight: 600;
-  color: #000;
+  color: #8e8e8e;
   pointer-events: none;
   user-select: none;
 }

--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -17,6 +17,7 @@ const propTypes = {
   header: PropTypes.oneOfType([PropTypes.node, PropTypes.string, PropTypes.func]),
   contentRef: PropTypes.func,
   separator: PropTypes.bool,
+  disabled: PropTypes.bool,
   toggleKeyHandlers: PropTypes.object,
   toggleKeyMap: PropTypes.object,
   children: PropTypes.oneOfType([
@@ -221,6 +222,7 @@ class Accordion extends React.Component {
     return classNames(
       css.accordion,
       { [css.hasSeparator]: this.props.separator },
+      { [`${css.disabled}`]: this.props.disabled },
     );
   }
 

--- a/lib/Accordion/headers/FilterAccordionHeader.js
+++ b/lib/Accordion/headers/FilterAccordionHeader.js
@@ -16,6 +16,7 @@ class FilterAccordionHeader extends React.Component {
     onToggle: PropTypes.func,
     label: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
     open: PropTypes.bool,
+    disabled: PropTypes.bool,
     displayWhenOpen: PropTypes.element,
     displayWhenClosed: PropTypes.element,
     displayClearButton: PropTypes.bool,
@@ -54,7 +55,7 @@ class FilterAccordionHeader extends React.Component {
   }
 
   render() {
-    const { label, open, displayWhenOpen, displayWhenClosed, displayClearButton, onClearFilter, contentId } = this.props;
+    const { label, open, disabled, displayWhenOpen, displayWhenClosed, displayClearButton, onClearFilter, contentId } = this.props;
     const clearButtonVisible = displayClearButton && typeof onClearFilter === 'function';
     return (
       <div className={css.headerWrapper} ref={(ref) => { this.containerElem = ref; }} >
@@ -68,13 +69,14 @@ class FilterAccordionHeader extends React.Component {
             aria-label={`${label} filter list`}
             aria-controls={contentId}
             aria-expanded={open}
+            disabled={disabled}
             className={classNames(css.filterSetHeader, { [css.clearButtonVisible]: clearButtonVisible })}
             role="tab"
             buttonRef={(ref) => { this.toggleElem = ref; }}
           >
-            <Icon size="small" icon={`${open ? 'up' : 'down'}-caret`} ref={(r) => { this.iconElem = r; }} />
+            { disabled ? null : <Icon size="small" icon={`${open ? 'up' : 'down'}-caret`} ref={(r) => { this.iconElem = r; }} /> }
             <div className={css.labelArea} ref={(ref) => { this.labelElem = ref; }}>
-              <div className={css.filterSetlabel} >{label}</div>
+              <div className={css.filterSetLabel} >{label}</div>
             </div>
           </Button>
         </Headline>

--- a/lib/Checkbox/Checkbox.css
+++ b/lib/Checkbox/Checkbox.css
@@ -72,7 +72,7 @@
 
   &.disabledLabel {
     opacity: 0.65;
-    cursor: default;
+    cursor: not-allowed;
   }
 }
 

--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -197,6 +197,7 @@ const FilterGroups = (props) => {
             key={index}
             separator={false}
             header={FilterAccordionHeader}
+            disabled={disableNames[group.name]}
             // If any of the filters start with this group's name, then we should display the 'clear all'
             // button for this accordion.
             displayClearButton={Object.keys(filters).some(filter => filter.startsWith(group.name))}


### PR DESCRIPTION
Disabled FilterGroups didn't have obvious styling to show they were disabled beyond the CheckBox itself. This adds background styling by adding a `disabled` prop to `<Accordion>`s themselves and CSS styles on that class.

Did it this way since we wanted both the header and `<FilterGroup>` styled and it'd let us just have the one set of rules. The ruleset is general enough to work for an Accordion in any parent that has a `major-padding` for its padding (like SearchAndSort).

Screenie:
<img width="478" alt="screen shot 2018-03-06 at 3 26 55 pm" src="https://user-images.githubusercontent.com/5324374/37056575-d84e605c-2152-11e8-8bbb-c8b3790712c3.png">
