### PR TITLE
Make `makeQueryFunction` robust to failed substitutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@
 * Update `<FilterGroups>` documentation for recent API changes. Fixes STCOM-206.
 * `<SearchForm>` does not add a placeholder to the dropdown of indexes if `searchableIndexesPlaceholder` is null. Fixes STCOM-220.
 * Generalise `failIfNoQuery` argument to `makeQueryFunction`, now `failOnCondition`. Fixes STCOM-219. Available from v2.0.2.
-* Proper documentation for makeQueryFunction. Fixes STCOM-221.
+* Proper documentation for `makeQueryFunction`. Fixes STCOM-221.
+* Make `makeQueryFunction` robust to failed substitutions. Fixes STCOM-225. Available from v2.0.3.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",

--- a/util/makeQueryFunction.js
+++ b/util/makeQueryFunction.js
@@ -39,6 +39,10 @@ function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOn
       }
     } else if (query) {
       cql = compilePathTemplate(queryTemplate, queryParams, pathComponents, resourceValues);
+      if (cql === null) {
+        // Some part of the template requires something that we don't have.
+        return null;
+      }
     }
     
     const filterCql = filters2cql(filterConfig, filters);

--- a/util/makeQueryFunction.js
+++ b/util/makeQueryFunction.js
@@ -35,7 +35,7 @@ function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOn
       if (t.length === 1) {
         cql = `${qindex}="${query}*"`;
       } else {
-        cql = `${t[0]} =/${t[1]} "${query}*"`;
+        cql = `${t[0]} =\/${t[1]} "${query}*"`;
       }
     } else if (query) {
       cql = compilePathTemplate(queryTemplate, queryParams, pathComponents, resourceValues);


### PR DESCRIPTION
Fixes STCOM-225

Available from v2.0.3.