### PR TITLE
`makeQueryFunction` favours parameter-access via the anointed resource rather than the URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Generalise `failIfNoQuery` argument to `makeQueryFunction`, now `failOnCondition`. Fixes STCOM-219. Available from v2.0.2.
 * Proper documentation for `makeQueryFunction`. Fixes STCOM-221.
 * Make `makeQueryFunction` robust to failed substitutions. Fixes STCOM-225. Available from v2.0.3.
+* `makeQueryFunction` favours parameter-access via the anointed resource rather than the URL. Fixes STCOM-226. Available from v2.0.4.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",

--- a/util/makeQueryFunction.js
+++ b/util/makeQueryFunction.js
@@ -24,8 +24,8 @@ function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOn
     }
 
     //This check should remain in place until all uses of the $QUERY syntax have been removed from stripes modules
-    if(queryTemplate.includes("$QUERY")) {
-      logger.log('mquery', 'Use of "$QUERY" in the queryTemplate is deprecated. Use the "?{query}" syntax instead, as found https://github.com/folio-org/stripes-connect/blob/master/doc/api.md#text-substitution')
+    if (queryTemplate.includes("$QUERY")) {
+      console.warn('Use of "$QUERY" in the queryTemplate is deprecated. Use the "?{query}" syntax instead, as found at https://github.com/folio-org/stripes-connect/blob/master/doc/api.md#text-substitution')
       queryTemplate = queryTemplate.replace(/\$QUERY/g, '?{query}');
     }
     

--- a/util/makeQueryFunction.js
+++ b/util/makeQueryFunction.js
@@ -11,7 +11,7 @@ import { compilePathTemplate } from '@folio/stripes-connect/RESTResource/RESTRes
 function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOnCondition) {
   return (queryParams, pathComponents, resourceValues, logger) => {
     
-    const { qindex, filters, query} = queryParams || {};
+    const { qindex, filters, query, sort } = queryParams || {};
 
     if ((query === undefined || query === '') &&
         (failOnCondition === 1 || failOnCondition === true)) {
@@ -54,7 +54,6 @@ function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOn
       }
     }
     
-    let { sort } = queryParams || {};
     if (sort) {
       const sortIndexes = sort.split(',').map((sort1) => {
         let reverse = false;

--- a/util/makeQueryFunction.js
+++ b/util/makeQueryFunction.js
@@ -11,7 +11,7 @@ import { compilePathTemplate } from '@folio/stripes-connect/RESTResource/RESTRes
 function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOnCondition) {
   return (queryParams, pathComponents, resourceValues, logger) => {
     
-    const { qindex, filters, query, sort } = queryParams || {};
+    const { qindex, filters, query, sort } = resourceValues.query || {};
 
     if ((query === undefined || query === '') &&
         (failOnCondition === 1 || failOnCondition === true)) {
@@ -25,7 +25,7 @@ function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOn
 
     //This check should remain in place until all uses of the $QUERY syntax have been removed from stripes modules
     if (queryTemplate.includes("$QUERY")) {
-      console.warn('Use of "$QUERY" in the queryTemplate is deprecated. Use the "?{query}" syntax instead, as found at https://github.com/folio-org/stripes-connect/blob/master/doc/api.md#text-substitution')
+      console.warn('Use of "$QUERY" in the queryTemplate is deprecated. Use the "%{query.query}" syntax instead, as found at https://github.com/folio-org/stripes-connect/blob/master/doc/api.md#text-substitution')
       queryTemplate = queryTemplate.replace(/\$QUERY/g, '?{query}');
     }
     


### PR DESCRIPTION
Fixes STCOM-226.

Available from v2.0.4.