### PR TITLE
pass inputProps to country fields for Typeahead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Proper documentation for `makeQueryFunction`. Fixes STCOM-221.
 * Make `makeQueryFunction` robust to failed substitutions. Fixes STCOM-225. Available from v2.0.3.
 * `makeQueryFunction` favours parameter-access via the anointed resource rather than the URL. Fixes STCOM-226. Available from v2.0.4.
+* Pass `inputProps` to country fields for consumption by `<Autocomplete>`. Refs UIU-427. Available from v2.0.5.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/lib/structures/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
+++ b/lib/structures/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
@@ -145,6 +145,16 @@ class EmbeddedAddressForm extends React.Component {
                 dataOptions={list}
               />
             );
+          } else if (fieldName === 'country') {
+              field = (
+                <Field
+                  name={`${addressFieldName}.${fieldName}`}
+                  label={fieldLabel}
+                  component={mergedFieldComponents[fieldName].component}
+                  {...mergedFieldComponents[fieldName].props}
+                  inputProps={{ name: `${addressFieldName}.${fieldName}` }}
+                />
+              );
           } else {
             field = (
               <Field

--- a/lib/structures/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
+++ b/lib/structures/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
@@ -146,15 +146,15 @@ class EmbeddedAddressForm extends React.Component {
               />
             );
           } else if (fieldName === 'country') {
-              field = (
-                <Field
-                  name={`${addressFieldName}.${fieldName}`}
-                  label={fieldLabel}
-                  component={mergedFieldComponents[fieldName].component}
-                  {...mergedFieldComponents[fieldName].props}
-                  inputProps={{ name: `${addressFieldName}.${fieldName}` }}
-                />
-              );
+            field = (
+              <Field
+                name={`${addressFieldName}.${fieldName}`}
+                label={fieldLabel}
+                component={mergedFieldComponents[fieldName].component}
+                {...mergedFieldComponents[fieldName].props}
+                inputProps={{ name: `${addressFieldName}.${fieldName}` }}
+              />
+            );
           } else {
             field = (
               <Field

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
`<Typeahead>`, used in the ui-users `<Autocomplete>` implementation, deprecated the `name` prop in favor of `inputProps`. Somewhere along the line, the `name` prop passed to `<Field>` in EmbeddedAddressForm is swallowed, but `inputProps` sails on through.

Refs [UIU-427](https://issues.folio.org/browse/UIU-427)