### PR TITLE
In `<Checkbox>`, nest HTML checkboxes inside labels instead of associating the labels by ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Proper documentation for `makeQueryFunction`. Fixes STCOM-221.
 * Make `makeQueryFunction` robust to failed substitutions. Fixes STCOM-225. Available from v2.0.3.
 * `makeQueryFunction` favours parameter-access via the anointed resource rather than the URL. Fixes STCOM-226. Available from v2.0.4.
+* In `<Checkbox>`, nest HTML checkboxes inside labels instead of associating the labels by ID. Fixes STCOM-227. Available from 2.0.5.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/lib/Checkbox/Checkbox.js
+++ b/lib/Checkbox/Checkbox.js
@@ -201,6 +201,9 @@ class Checkbox extends React.Component {
 
     return (
       <div className={this.getRootStyle()}>
+        <label className={this.getLabelStyle()}>
+          {label}
+          {this.getFeedbackElement()}
         <input
           type="checkbox"
           {...inputAriaProps}
@@ -216,9 +219,6 @@ class Checkbox extends React.Component {
           disabled={cleanedProps.disabled}
           ref={(ref) => { this.input = ref; }}
         />
-        <label className={this.getLabelStyle()} htmlFor={this.props.id}>
-          {label}
-          {this.getFeedbackElement()}
         </label>
       </div>
     );

--- a/lib/Checkbox/Checkbox.js
+++ b/lib/Checkbox/Checkbox.js
@@ -204,21 +204,21 @@ class Checkbox extends React.Component {
         <label className={this.getLabelStyle()}>
           {label}
           {this.getFeedbackElement()}
-        <input
-          type="checkbox"
-          {...inputAriaProps}
-          checked={(inputChecked !== undefined && inputChecked) || (inputCustom.checked !== undefined && inputCustom.checked)}
-          {...inputProps}
-          {...inputCustom}
-          id={this.props.id}
-          name={cleanedProps.name}
-          className={css.checkboxInput}
-          onChange={this.handleChange}
-          onFocus={this.handleFocus}
-          onBlur={this.handleBlur}
-          disabled={cleanedProps.disabled}
-          ref={(ref) => { this.input = ref; }}
-        />
+          <input
+            type="checkbox"
+            {...inputAriaProps}
+            checked={(inputChecked !== undefined && inputChecked) || (inputCustom.checked !== undefined && inputCustom.checked)}
+            {...inputProps}
+            {...inputCustom}
+            id={this.props.id}
+            name={cleanedProps.name}
+            className={css.checkboxInput}
+            onChange={this.handleChange}
+            onFocus={this.handleFocus}
+            onBlur={this.handleBlur}
+            disabled={cleanedProps.disabled}
+            ref={(ref) => { this.input = ref; }}
+          />
         </label>
       </div>
     );

--- a/lib/FilterGroups/readme.md
+++ b/lib/FilterGroups/readme.md
@@ -103,10 +103,10 @@ Library`.
 ### Representation in the user-interface URL
 
 The state of the filters is communicated back to the caller by
-invoking its `transitionTo` method to set the value of a single query
+invoking its `transitionToParams` method to set the value of a single query
 parameter, `filters`, whose value is a comma-separated list of the
 full names of all selected filters. Typically, the caller's
-`transitionTo` method will set its values into the anointed
+`transitionToParams` method will set its values into the anointed
 stripes-connect resource resulting in a change in the user-interface's
 URL. For example:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
Fixes STCOM-227.

Available from 2.0.5.