### PR TITLE
restore checkbox position. Refs STCOM-227

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Make `makeQueryFunction` robust to failed substitutions. Fixes STCOM-225. Available from v2.0.3.
 * `makeQueryFunction` favours parameter-access via the anointed resource rather than the URL. Fixes STCOM-226. Available from v2.0.4.
 * In `<Checkbox>`, nest HTML checkboxes inside labels instead of associating the labels by ID. Fixes STCOM-227. Available from 2.0.5.
+* CSS tweak for `<Checkbox>` to bring the UI element back on screen. Refs STCOM-227. Available from 2.0.6. 
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/lib/Checkbox/Checkbox.css
+++ b/lib/Checkbox/Checkbox.css
@@ -120,7 +120,7 @@ input[type=checkbox].checkboxInput {
 input[type=checkbox].checkboxInput:checked,
 input[type=checkbox].checkboxInput:not(:checked) {
   position: absolute;
-  left: -9999px;
+  left: -10px;
 }
 
 .checkboxLabel::before,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
Prior to this change, the UI element was 9999 pixels offscreen, so there must have been some additional CSS/JS magic going on here prior to #270 (See [UIU-430](https://issues.folio.org/browse/UIU-430)). 

Tagging @rasmuswoelk in case there is any restorative CSS work to make this pretty again now that we've made it functional again. 
