### PR TITLE
UIU-431: Added actionProps prop to EditableListForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * `makeQueryFunction` favours parameter-access via the anointed resource rather than the URL. Fixes STCOM-226. Available from v2.0.4.
 * In `<Checkbox>`, nest HTML checkboxes inside labels instead of associating the labels by ID. Fixes STCOM-227. Available from 2.0.5.
 * CSS tweak for `<Checkbox>` to bring the UI element back on screen. Refs STCOM-227. Available from 2.0.6. 
+* In `<EditableList>` (via `<EditableListForm>`), added a new `actionProps` prop to allow for direct prop edits for action buttons.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/lib/structures/EditableList/EditableListForm.js
+++ b/lib/structures/EditableList/EditableListForm.js
@@ -60,6 +60,13 @@ const propTypes = {
    */
   actionSuppression: PropTypes.object,
   /**
+   * Object containing properties of list action names: 'delete', 'edit' and
+   * values of sentinel functions that return objects to destructure onto the
+   * action button props: 
+   * { delete: (item) => {return { disabled: item.item.inUse } } }
+   */
+  actionProps: PropTypes.object,
+  /**
    * Message to display for an empty list.
    */
   isEmptyMessage: PropTypes.string,
@@ -101,6 +108,7 @@ const defaultProps = {
   createButtonLabel: '+ Add new',
   uniqueField: 'id',
   actionSuppression: { delete: () => false, edit: () => false },
+  actionProps: {},
   itemTemplate: {},
 };
 
@@ -294,6 +302,7 @@ class EditableListForm extends React.Component {
         item={rowData}
         rowIndex={rowIndex}
         actionSuppression={this.props.actionSuppression}
+        actionProps={this.props.actionProps}
         visibleFields={this.getVisibleColumns()}
         onCancel={() => this.onCancel(fields, rowIndex)}
         onSave={() => this.onSave(fields, rowIndex)}
@@ -309,12 +318,25 @@ class EditableListForm extends React.Component {
   }
 
   getActions = (fields, item) => {
-    const { actionSuppression, pristine, submitting, invalid } = this.props;
+    const { actionProps, actionSuppression, pristine, submitting, invalid } = this.props;
     if (this.state.status[item.rowIndex].editing) {
       return (
         <div style={{ display: 'flex' }}>
-          <Button disabled={pristine || submitting || invalid} marginBottom0 id={`clickable-save-${this.testingId}-${item.rowIndex}`} title="Save changes to this item" onClick={() => this.onSave(fields, item.rowIndex)}>Save</Button>
-          <Button marginBottom0 id={`clickable-cancel-${this.testingId}-${item.rowIndex}`} title="Cancel editing this item" onClick={() => this.onCancel(fields, item.rowIndex)}>Cancel</Button>
+          <Button
+            disabled={pristine || submitting || invalid}
+            marginBottom0
+            id={`clickable-save-${this.testingId}-${item.rowIndex}`}
+            title="Save changes to this item"
+            onClick={() => this.onSave(fields, item.rowIndex)}
+            {...(typeof actionProps.save === 'function' ? actionProps.save(item) : {})}
+          >Save</Button>
+          <Button
+            marginBottom0
+            id={`clickable-cancel-${this.testingId}-${item.rowIndex}`}
+            title="Cancel editing this item"
+            onClick={() => this.onCancel(fields, item.rowIndex)}
+            {...(typeof actionProps.cancel === 'function' ? actionProps.cancel(item) : {})}
+          >Cancel</Button>
         </div>
       );
     }
@@ -327,6 +349,7 @@ class EditableListForm extends React.Component {
             id={`clickable-edit-${this.testingId}-${item.rowIndex}`}
             onClick={() => this.onEdit(item.rowIndex)}
             title="Edit this item"
+            {...(typeof actionProps.edit === 'function' ? actionProps.edit(item) : {})}
           >
             <Icon icon="edit" />
           </Button>
@@ -338,6 +361,7 @@ class EditableListForm extends React.Component {
             id={`clickable-delete-${this.testingId}-${item.rowIndex}`}
             onClick={() => this.onDelete(fields, item.rowIndex)}
             title="Delete this item"
+            {...(typeof actionProps.delete === 'function' ? actionProps.delete(item) : {})}
           >
             <Icon icon="trashBin" />
           </Button>

--- a/lib/structures/EditableList/EditableListForm.js
+++ b/lib/structures/EditableList/EditableListForm.js
@@ -62,7 +62,7 @@ const propTypes = {
   /**
    * Object containing properties of list action names: 'delete', 'edit' and
    * values of sentinel functions that return objects to destructure onto the
-   * action button props: 
+   * action button props:
    * { delete: (item) => {return { disabled: item.item.inUse } } }
    */
   actionProps: PropTypes.object,
@@ -329,14 +329,18 @@ class EditableListForm extends React.Component {
             title="Save changes to this item"
             onClick={() => this.onSave(fields, item.rowIndex)}
             {...(typeof actionProps.save === 'function' ? actionProps.save(item) : {})}
-          >Save</Button>
+          >
+            Save
+          </Button>
           <Button
             marginBottom0
             id={`clickable-cancel-${this.testingId}-${item.rowIndex}`}
             title="Cancel editing this item"
             onClick={() => this.onCancel(fields, item.rowIndex)}
             {...(typeof actionProps.cancel === 'function' ? actionProps.cancel(item) : {})}
-          >Cancel</Button>
+          >
+            Cancel
+          </Button>
         </div>
       );
     }

--- a/lib/structures/EditableList/readme.md
+++ b/lib/structures/EditableList/readme.md
@@ -42,6 +42,7 @@ visibleFields | array of strings | Array of fields to render. These will also be
 itemTemplate | object | Object that reflects the shape of list item objects. Values should be strings indicating the type: `{name: 'string'}` | {} | no
 uniqueField | string | Fieldname that includes the unique identifier for the list. | `id` | yes
 actionSuppression | object | Object containing properties of list action names: `delete`, `edit` and values of sentinel functions that return booleans based on object properties. | `{ delete: () => false, edit: () => false }` | no
+actionProps | object | Object containing properties of list action names: 'delete', 'edit' and values of sentinel functions that return objects to destructure onto the action button props. | `{ delete: (item) => {return { disabled: item.item.inUse } } }`
 isEmptyMessage | string | Message to display for an empty list. | | no
 readOnlyFields | array of strings | Array of non-editable columns - good for displaying meta information within the row. | | no
 formatter | object | Allows custom content/components to be displayed in the grid. see example below. | | no

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
- The existing `actionSuppressors` props allows the hiding of Edit and Delete actions buttons but sometimes more fine control of the buttons is necessary.
- E.g., now you can set the `disabled` or `title` attributes on the action buttons depending on the item being rendered.
- The prop type of actionProps is the same as actionSuppressors: an object of callbacks per action type.