### PR TITLE
Render children passed to KeyValue component

### DIFF
--- a/lib/KeyValue/KeyValue.js
+++ b/lib/KeyValue/KeyValue.js
@@ -8,13 +8,16 @@ const propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]),
+  children: PropTypes.node,
 };
 
 function KeyValue(props) {
   return (
     <div className={css.kvRoot}>
       <div className={css.kvLabel}>{props.label}</div>
-      <div className={css.kvValue}>{props.value}</div>
+      {props.children || (
+        <div>{props.value}</div>
+      )}
     </div>
   );
 }

--- a/lib/KeyValue/readme.md
+++ b/lib/KeyValue/readme.md
@@ -12,3 +12,12 @@ import { KeyValue } from '@folio/stripes-components/lib/KeyValue';
   value="Some value"
 />
 ```
+
+The "value" can also be a node, passed as children. This version is useful for acceptance testing.
+```
+<KeyValue label="Some label">
+  <span data-test-id="my-test-string">Some node</span>
+</KeyValue>
+```
+
+If the `value` prop is set and children exist, the `value` prop is ignored.

--- a/lib/KeyValue/stories/BasicUsage.js
+++ b/lib/KeyValue/stories/BasicUsage.js
@@ -13,7 +13,7 @@ const BasicUsage = () => (
       </Col>
       <Col md={2}>
         <KeyValue
-          label="Birtday"
+          label="Birthday"
           value="February 26, 1932"
         />
       </Col>
@@ -26,22 +26,19 @@ const BasicUsage = () => (
     </Row>
     <Row>
       <Col md={2}>
-        <KeyValue
-          label="Occupation"
-          value="Singer-songwriter guitarist actor author"
-        />
+        <KeyValue label="Occupation">
+          Singer-songwriter guitarist actor author
+        </KeyValue>
       </Col>
       <Col md={2}>
-        <KeyValue
-          label="Genres"
-          value="Country rock and roll folk gospel"
-        />
+        <KeyValue label="Genres">
+          <span>Country rock and roll folk gospel</span>
+        </KeyValue>
       </Col>
       <Col md={2}>
-        <KeyValue
-          label="Instruments"
-          value="Vocals guitar"
-        />
+        <KeyValue label="Instruments">
+          <span>Vocals guitar</span>
+        </KeyValue>
       </Col>
     </Row>
   </div>


### PR DESCRIPTION
## Purpose
Over six months ago in `ui-eholdings`, we made a fork of the `KeyValue` component to accept a child node for the "value," instead of a `value` prop.

Like this:
```
<KeyValue label="Instruments">
  <span>Vocals guitar</span>
</KeyValue>
```

## Approach
This makes that child-rendering pattern available for `KeyValue`. The change is backwards-compatible - the `value` prop can still be passed in before, as either a string or node.

If there are children and a `value` prop, the children are rendered and the `value` prop is ignored.

I removed the unused `kvValue` class.

### Next Steps
- Replace the `KeyValueLabel` component in `ui-eholdings` with the `KeyValue` from `stripes-components`.