### PR TITLE
Timepicker pass-through

### DIFF
--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -38,7 +38,7 @@ const propTypes = {
     PropTypes.object,
     PropTypes.string,
   ]),
-
+  passThroughValue: PropTypes.string,
 };
 
 const defaultProps = {
@@ -95,26 +95,31 @@ class Datepicker extends React.Component {
     this.standardizeDate = this.standardizeDate.bind(this);
     this.handleFieldChange = this.handleFieldChange.bind(this);
     this.datePickerIsFocused = this.datePickerIsFocused.bind(this);
+    this.getPresentedValue = this.getPresentedValue.bind(this);
 
     moment.locale(this.context.stripes.locale);
     this._dateFormat = moment.localeData()._longDateFormat.L;
 
-    // inputValue will eventually be rendered as the value of he TextField.
+    // non-null presentedValue will eventually be rendered as the value of he TextField.
     let inputValue = '';
+    let presentedValue = null;
 
     // if we aren't using redux form...
     if (typeof this.props.input === 'undefined') {
       if (this.props.value === 'today' && typeof this.props.date === 'undefined') {
+        presentedValue = this.props.passThroughValue;
         inputValue = moment().format(this._dateFormat);
       }
       // if we are using redux-form...
-    } else if (this.props.input.value === 'today') {
+    } else if (this.props.input.value === this.props.passThroughValue) {
+      presentedValue = this.props.passThroughValue;
       inputValue = moment().format(this._dateFormat);
     } else if (this.props.input.value !== '') {
       inputValue = moment(this.props.input.value).format(this._dateFormat);
     }
 
     this.state = {
+      presentedValue,
       dateString: inputValue,
       showCalendar: this.props.showCalendar || false,
       srMessage: '',
@@ -130,29 +135,34 @@ class Datepicker extends React.Component {
   componentWillReceiveProps(nextProps) {
     let initDate;
     let inputValue;
+    let presentedValue = null;
     if (nextProps.input) {
       if (nextProps.input.value !== '' && nextProps.input.value !== this.props.input.value) {
         initDate = moment(nextProps.input.value, this._dateFormat);
         inputValue = moment(nextProps.input.value).format(this._dateFormat);
         this.setState({
+          presentedValue,
           dateString: inputValue,
         });
       } else if (nextProps.input.value === '' && nextProps.input.value !== this.props.input.value) {
         initDate = moment().format(this._dateFormat);
         inputValue = '';
         this.setState({
+          presentedValue,
           dateString: inputValue,
         });
       }
     } else if (this.props.value !== '' && this.props.date !== nextProps.date) {
-      if (nextProps.value === 'today' && nextProps.date === 'undefined') {
+      if (nextProps.value === this.props.passThroughValue && nextProps.date === 'undefined') {
         initDate = moment();
         inputValue = initDate.format(this._dateFormat);
+        presentedValue = this.props.passThroughValue;
       } else {
         initDate = moment(nextProps.date, this._dateFormat);
         inputValue = initDate.format(this._dateFormat);
       }
       this.setState({
+        presentedValue,
         dateString: inputValue,
       });
     }
@@ -302,6 +312,7 @@ class Datepicker extends React.Component {
       // preventing it from attempting a parse using independable js Date object.
       if (moment(tempString, this._dateFormat, true).isValid()) {
         this.setState({
+          presentedValue: null,
           dateString: e.target.value,
         });
       } else {
@@ -326,11 +337,27 @@ class Datepicker extends React.Component {
   }
 
   handleFieldChange(e) {
-    this.handleSetDate(e, e.target.value, e.target.value);
+    if (e.target.value === '') {
+      this.clearDate();
+    } else {
+      const ptREx = new RegExp(`^${e.target.value}`, 'i');
+      if (ptREx.test(this.props.passThroughValue)) {
+        if (this.props.onChange) { this.props.onChange(e); }
+        if (this.props.input) {
+          this.props.input.onChange(e.target.value);
+        }
+        this.setState({
+          presentedValue: e.target.value,
+        });
+      } else {
+        this.handleSetDate(e, e.target.value, e.target.value);
+      }
+    }
   }
 
   clearDate(e) {
     this.setState({
+      presentedValue: null,
       dateString: '',
     });
     if (this.props.onChange) { this.props.onChange(e); }
@@ -388,6 +415,12 @@ class Datepicker extends React.Component {
     }
   }
 
+  getPresentedValue() {
+    if (this.state.presentedValue !== null) {
+      return this.state.presentedValue;
+    }
+    return this.state.dateString;
+  }
 
   render() {
     const {
@@ -461,7 +494,7 @@ class Datepicker extends React.Component {
         <TextField
           ref={(ref) => { this.textfield = ref; }}
           input={input}
-          value={this.state.dateString}
+          value={this.getPresentedValue()}
           label={label}
           aria-label={ariaLabel}
           endControl={!readOnly ? endElement : null}
@@ -484,7 +517,7 @@ class Datepicker extends React.Component {
         <TextField
           ref={(ref) => { this.textfield = ref; }}
           label={label}
-          value={this.state.dateString}
+          value={this.getPresentedValue()}
           onChange={this.handleSetDate}
           aria-label={ariaLabel}
           endControl={!readOnly ? endElement : null}

--- a/lib/Datepicker/readme.md
+++ b/lib/Datepicker/readme.md
@@ -22,6 +22,8 @@ value | string | date to be displayed in the textfield. In forms, this is suppli
 onChange | func | Event handler to handle updates to the datefield text. | | false
 screenReaderMessage | string | Additional message to be read by screenreaders when textfield is focused in addition to the label and format - which are always read. | | false
 excludeDates | array, string or Moment object | Disables supplied dates from being selected in the calendar. | | false
+`passThroughValue` | string | Can be used to set dynamic values up to the form - values should be inspected/adjusted in a handler at submission time (like a button click that calls `submit()`.) See below for usage example. |  |
+
 <!-- locale | string | locale for datepicker to use to display calendar. e.g. "de" will display calendar using the German locale | "en" | false -->
 <!-- dateFormat | string | system formatting for date. [Moment.js formats](https://momentjs.com/docs/#/displaying/format/) are supported | "MM/DD/YYYY" | false-->
 
@@ -38,3 +40,9 @@ excludeDates | array, string or Moment object | Disables supplied dates from bei
 * **Ctrl + PgDown** - forwards 1 year
 * **Enter** - Select date at cursor
 * **Esc** - Close calendar
+
+## Passthrough value
+Using the prop `passThroughValue` means that you expect a non-date string to be passed as a value, and want to use that to derive the time value that you do want submitted. An example of this would be to pass through "Today" and actually submit the current time (whenever the submit button is pressed.) "Today" can be set as an initial value, or the user can enter "Today". 
+```
+<Field name="exampleDateReturned" label="Date returned" id="dateReturnDP" placeholder="Select Date" component={Datepicker} passThroughValue="Today"/>
+```

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -28,6 +28,7 @@ const propTypes = {
   showTimepicker: PropTypes.bool,
   tether: PropTypes.object,
   rounded: PropTypes.bool,
+  passThroughValue: PropTypes.string,
 };
 
 const defaultProps = {
@@ -82,29 +83,34 @@ class Timepicker extends React.Component {
     this.pickerIsFocused = this.pickerIsFocused.bind(this);
     this.handlePickTime = this.handlePickTime.bind(this);
     this.deriveHoursFormat = this.deriveHoursFormat.bind(this);
+    this.getPresentationValue = this.getPresentationValue.bind(this);
+    this.getLocalTime = this.getLocalTime.bind(this);
 
     moment.locale(this.context.stripes.locale);
     this._timeFormat = moment.localeData()._longDateFormat.LT;
 
     // inputValue will eventually be rendered as the value of he TextField.
     let inputValue = '';
-
+    let presentedValue = null;
     // if we aren't using redux form...
     if (typeof this.props.input !== 'undefined') {
       if (this.props.input.value !== '') {
-        if (this.props.input.value === 'now') {
+        if (this.props.input.value === this.props.passThroughValue) {
+          presentedValue = this.props.passThroughValue;
           inputValue = moment().format(this._timeFormat);
         } else {
           inputValue = moment(this.props.input.value, this._timeFormat).format(this._timeFormat);
         }
       }
-    } else if (this.props.value === 'now') {
+    } else if (this.props.value === this.props.passThroughValue) {
+      presentedValue = this.props.passThroughValue;
       inputValue = moment().format(this._timeFormat);
     } else {
       inputValue = moment(this.props.value, this._timeFormat).format(this._timeFormat);
     }
 
     this.state = {
+      presentedValue,
       timeString: inputValue,
       showTimepicker: this.props.showTimepicker || false,
       timeFormat: this._timeFormat,
@@ -119,6 +125,40 @@ class Timepicker extends React.Component {
   }
 
   componentWillReceiveProps(nextProps, nextContext) {
+    let inputValue;
+    let presentedValue = null;
+    if (nextProps.input) { // if we're using redux-form....
+      // if value has changed....
+      if (nextProps.input.value !== '' && nextProps.input.value !== this.props.input.value) {
+        if (nextProps.input.value === nextProps.passThroughValue) {
+          presentedValue = nextProps.passThroughValue;
+          inputValue = moment().format(this._timeFormat);
+          this.setState({
+            presentedValue,
+            timeString: inputValue,
+          });
+        }
+        // if value is blank....
+      } else if (nextProps.input.value === '' && nextProps.input.value !== this.props.input.value) {
+        inputValue = '';
+        this.setState({
+          presentedValue,
+          timeString: inputValue,
+        });
+      }
+    } else if (this.props.value !== '' && this.props.value !== nextProps.value) {
+      if (nextProps.value === this.props.passThroughValue) {
+        inputValue = moment().format(this._timeFormat);
+        presentedValue = this.props.passThroughValue;
+      } else {
+        inputValue = moment().format(this._timeFormat);
+      }
+      this.setState({
+        presentedValue,
+        timeString: inputValue,
+      });
+    }
+
     // adjust displayed time format for a change in locale
     if (nextContext.stripes.locale !== this.context.stripes.locale) {
       moment.locale(nextContext.stripes.locale);
@@ -128,6 +168,7 @@ class Timepicker extends React.Component {
         newTimeString = moment(newTimeString, this.state.timeFormat).format(this._timeFormat);
       }
       this.setState({
+        presentedValue: null,
         timeFormat: this._timeFormat,
         timeString: newTimeString,
       });
@@ -147,6 +188,13 @@ class Timepicker extends React.Component {
       return '12';
     }
     return '24';
+  }
+
+  getLocalTime(t, f) { // eslint-disable-line
+    if (t) {
+      return moment(t).format(f);
+    }
+    return moment().format(this._timeFormat);
   }
 
   handleFieldClick() {
@@ -252,7 +300,10 @@ class Timepicker extends React.Component {
         tString = `${hours}:${minutes}`;
       }
 
-      this.setState({ timeString: tString });
+      this.setState({
+        presentedValue: null,
+        timeString: tString,
+      });
 
       standardizedTime = this.standardizeTime(`${hours}:${minutes} ${ampm}`);
       if (this.props.input) {
@@ -264,6 +315,9 @@ class Timepicker extends React.Component {
         this.props.onChange(e, standardizedTime);
       }
     } else if (e.type === 'change') {
+      // if e.target.value is even a substring of props.passThroughValue, pass it through...
+
+
       // be sure that value is parseable as a date in the required format...
       // the boolean parameter suppresses moment's deprecation warning,
       // preventing it from attempting a parse using independable js Date object.
@@ -274,6 +328,9 @@ class Timepicker extends React.Component {
       if (this.props.onChange) { this.props.onChange(e); }
       if (this.props.input) {
         if (moment(e.target.value, this._timeFormat, true).isValid()) {
+          this.setState({
+            timeString: e.target.value,
+          });
           // convert date to ISO 8601-ish format for backend (everything after the 'T')
           if (!ampm) {
             standardizedTime = this.standardizeTime(`${hours}:${minutes}`);
@@ -295,53 +352,66 @@ class Timepicker extends React.Component {
       this.clearTime();
       return;
     }
-    let hoursMins = e.target.value.split(/[:\s]/g);
-    hoursMins = hoursMins.filter(val => val); // remove any blank items...
-    if (hoursMins.length > 0) {
-      let hours = hoursMins[0];
-      const intHours = parseInt(hours, 10);
-      if (intHours < 10) {
-        hours = `0${intHours}`;
+    const ptREx = new RegExp(`^${e.target.value}`, 'i');
+    if (ptREx.test(this.props.passThroughValue)) {
+      if (this.props.onChange) { this.props.onChange(e); }
+      if (this.props.input) {
+        this.props.input.onChange(e.target.value);
       }
-
-      if (hoursMins.length < 2) {
-        this.handleSetTime(e, hours, '00');
-        return;
-      }
-      let mins = hoursMins[1];
-      let ampm;
-      if (hoursMins.length < 3) {
-        if (mins.length > 2) { // handle 3:00PM (no space between minutes and meridiem)
-          if (this.deriveHoursFormat() === '12') {
-            ampm = 'PM';
-            if (/[aA]/.test(mins)) {
-              ampm = 'AM';
-            }
-            const intMins = parseInt(mins, 10);
-            if (intMins < 10) {
-              mins = `0${intMins}`;
-            } else {
-              mins = intMins.toString();
-            }
-            this.handleSetTime(e, hours, mins, ampm);
-          }
+      this.setState({
+        presentedValue: e.target.value,
+      });
+    } else {
+      let hoursMins = e.target.value.split(/[:\s]/g);
+      hoursMins = hoursMins.filter(val => val); // remove any blank items...
+      if (hoursMins.length > 0) {
+        let hours = hoursMins[0];
+        const intHours = parseInt(hours, 10);
+        if (intHours < 10) {
+          hours = `0${intHours}`;
         }
-        this.handleSetTime(e, hours, mins);
-        return;
+
+        if (hoursMins.length < 2) {
+          this.handleSetTime(e, hours, '00');
+          return;
+        }
+        let mins = hoursMins[1];
+        let ampm;
+        if (hoursMins.length < 3) {
+          if (mins.length > 2) { // handle 3:00PM (no space between minutes and meridiem)
+            if (this.deriveHoursFormat() === '12') {
+              ampm = 'PM';
+              if (/[aA]/.test(mins)) {
+                ampm = 'AM';
+              }
+              const intMins = parseInt(mins, 10);
+              if (intMins < 10) {
+                mins = `0${intMins}`;
+              } else {
+                mins = intMins.toString();
+              }
+              this.handleSetTime(e, hours, mins, ampm);
+            }
+          }
+          this.handleSetTime(e, hours, mins);
+          return;
+        }
+        ampm = hoursMins[2];
+        this.handleSetTime(e, hours, mins, ampm);
       }
-      ampm = hoursMins[2];
-      this.handleSetTime(e, hours, mins, ampm);
     }
   }
 
   clearTime(e) {
     this.setState({
+      presentedValue: null,
       timeString: '',
     });
     if (this.props.onChange) { this.props.onChange(e); }
     if (this.props.input) {
       this.props.input.onChange('');
     }
+    this.textfield.getInput().focus();
   }
 
   cleanForScreenReader(str) { // eslint-disable-line class-methods-use-this
@@ -386,6 +456,13 @@ class Timepicker extends React.Component {
     this.hideTimepicker();
   }
 
+  getPresentationValue() {
+    if (this.state.presentedValue !== null) {
+      return this.state.presentedValue;
+    }
+    return this.state.timeString;
+  }
+
   render() {
     const {
       input,
@@ -408,7 +485,7 @@ class Timepicker extends React.Component {
     }
 
     let endElement;
-    if (this.state.timeString !== '') {
+    if (this.state.timeString !== '' || this.state.presentedValue !== null) {
       endElement = (
         <div style={{ display: 'flex' }}>
           <Button
@@ -461,7 +538,7 @@ class Timepicker extends React.Component {
         <TextField
           ref={(ref) => { this.textfield = ref; }}
           input={input}
-          value={this.state.timeString}
+          value={this.getPresentationValue()}
           label={label}
           aria-label={ariaLabel}
           endControl={!readOnly ? endElement : null}
@@ -486,7 +563,7 @@ class Timepicker extends React.Component {
         <TextField
           ref={(ref) => { this.textfield = ref; }}
           label={label}
-          value={this.state.timeString}
+          value={this.getPresentationValue()}
           aria-label={ariaLabel}
           endControl={!readOnly ? endElement : null}
           placeholder={this._timeFormat.toUpperCase()}

--- a/lib/Timepicker/readme.md
+++ b/lib/Timepicker/readme.md
@@ -15,10 +15,16 @@ Name | type | description | default | required
 `rounded` | bool | Sets the 'rounded' style for the input (rounded corners via border-radius) | | 
 `value` | string | Sets the value for the control. **Not necessary if using redux-form.** | | 
 `onChange` | function | Callback function that will recieve the control's current value and the onChange event object. `fn(e, value)` **Not necessary if using redux-form,** but it will still work if callback from a change is needed.
+`passThroughValue` | string | Can be used to set dynamic values up to the form - values should be inspected/adjusted in a handler at submission time (like a button click that calls `submit()`.) See below for usage example. |  |
 
 ## Usage in Redux-form
 Redux form will provide `input` and `meta` props to the component when its used with a redux-form `<Field>` component. The component's value and validation are supplied through these.
 ```
 <Field name="exampleTimeReturned" label="Time returned" id="timeReturnTP" placeholder="Select Time" component={Timepicker} />
 
+```
+## Passthrough value
+Using the prop `passThroughValue` means that you expect a non-time string to be passed as a value, and want to use that to derive the time value that you do want submitted. An example of this would be to pass through "Now" and actually submit the current time (whenever the submit button is pressed.) "Now" can be set as an initial value, or the user can enter "Now". 
+```
+<Field name="exampleTimeReturned" label="Time returned" id="timeReturnTP" placeholder="Select Time" component={Timepicker} passThroughValue="Now"/>
 ```


### PR DESCRIPTION
Creates a prop for pass-throughs on Datepicker and Timepicker: passThroughValue - this is used for passing through a string like 'today' or 'now' to be interpreted and adjusted at the time of submission. Doing this as a prop will allow for it to be localized.