### PR TITLE
Datepicker - Fix for passThroughValue behavior on form reset

### DIFF
--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -106,7 +106,7 @@ class Datepicker extends React.Component {
 
     // if we aren't using redux form...
     if (typeof this.props.input === 'undefined') {
-      if (this.props.value === 'today' && typeof this.props.date === 'undefined') {
+      if (this.props.value === this.props.passThroughValue && typeof this.props.date === 'undefined') {
         presentedValue = this.props.passThroughValue;
         inputValue = moment().format(this._dateFormat);
       }
@@ -133,19 +133,22 @@ class Datepicker extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    let initDate;
     let inputValue;
     let presentedValue = null;
     if (nextProps.input) {
       if (nextProps.input.value !== '' && nextProps.input.value !== this.props.input.value) {
-        initDate = moment(nextProps.input.value, this._dateFormat);
-        inputValue = moment(nextProps.input.value).format(this._dateFormat);
+        const passRE = new RegExp(`^${nextProps.input.value}`, 'i');
+        if (nextProps.input.value === this.props.passThroughValue || passRE.test(this.props.passThroughValue)) {
+          presentedValue = nextProps.input.value;
+          inputValue = moment().format(this._dateFormat);
+        } else {
+          inputValue = moment(nextProps.input.value).format(this._dateFormat);
+        }
         this.setState({
           presentedValue,
           dateString: inputValue,
         });
       } else if (nextProps.input.value === '' && nextProps.input.value !== this.props.input.value) {
-        initDate = moment().format(this._dateFormat);
         inputValue = '';
         this.setState({
           presentedValue,
@@ -154,12 +157,10 @@ class Datepicker extends React.Component {
       }
     } else if (this.props.value !== '' && this.props.date !== nextProps.date) {
       if (nextProps.value === this.props.passThroughValue && nextProps.date === 'undefined') {
-        initDate = moment();
-        inputValue = initDate.format(this._dateFormat);
+        inputValue = moment().format(this._dateFormat);
         presentedValue = this.props.passThroughValue;
       } else {
-        initDate = moment(nextProps.date, this._dateFormat);
-        inputValue = initDate.format(this._dateFormat);
+        inputValue = moment().format(this._dateFormat);
       }
       this.setState({
         presentedValue,


### PR DESCRIPTION
Applied `passThroughValue` behavior for non-redux-form fields, and fixed issue with 'invalid date' appearing on form reset when a `passThroughValue` is employed.