### PR TITLE
STCOM-29 add height monitoring to componentWillReceiveProps

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -185,7 +185,7 @@ class MCLRenderer extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     const { columns } = this.state;
-    const newState = {};
+    let newState = {};
 
     // sync number of rows...
     if (nextProps.contentData.length !== this.props.contentData.length) {
@@ -206,6 +206,14 @@ class MCLRenderer extends React.Component {
         newState.firstIndex = 0;
         newState.contentTop = 0;
         newState.adjustedHeight = null;
+      }
+    }
+
+    // stcom-29 update dimensions on height change...
+    if (nextProps.contentData.length > 0) {
+      if (nextProps.height !== this.props.height) {
+          const newDims = this.updateDimensions(nextProps.height, nextProps.contentData);
+          newState = Object.assign({}, newState, newDims);
       }
     }
 


### PR DESCRIPTION
This ensures MCL will fill its supplied height prop with resize if `autosize` prop is used.