### PR TITLE
Limit timepicker range for 24h

### DIFF
--- a/lib/Timepicker/TimeDropdown.js
+++ b/lib/Timepicker/TimeDropdown.js
@@ -158,6 +158,13 @@ class TimeDropdown extends React.Component {
           if (parsedHours < 1) {
             parsedHours = 1;
           }
+        } else {
+          if (parsedHours > 23) {
+            parsedHours = 23;
+          }
+          if (parsedHours < 0) {
+            parsedHours = 0;
+          }
         }
       }
       this.setState({


### PR DESCRIPTION
Before: time picker dropdown would accept values 0-99 for the hour field in 24hr mode. 
After: If input hours is greater that 23, it is automatically set to 23.