### PR TITLE
EditableListForm: Changed action buttons use IconButton

### DIFF
--- a/lib/structures/EditableList/EditableListForm.js
+++ b/lib/structures/EditableList/EditableListForm.js
@@ -12,7 +12,7 @@ import Button from '../../Button';
 import EditableItem from './EditableItem';
 import MultiColumnList from '../../MultiColumnList';
 import css from './EditableList.css';
-import Icon from '../../Icon';
+import IconButton from '../../IconButton';
 
 const propTypes = {
   /**
@@ -347,28 +347,22 @@ class EditableListForm extends React.Component {
     return (
       <div style={{ display: 'flex' }}>
         {!actionSuppression.edit(item) &&
-          <Button
-            marginBottom0
-            buttonStyle="link"
+          <IconButton
+            icon="edit"
             id={`clickable-edit-${this.testingId}-${item.rowIndex}`}
             onClick={() => this.onEdit(item.rowIndex)}
             title="Edit this item"
             {...(typeof actionProps.edit === 'function' ? actionProps.edit(item) : {})}
-          >
-            <Icon icon="edit" />
-          </Button>
+          />
         }
         {!actionSuppression.delete(item) &&
-          <Button
-            marginBottom0
-            buttonStyle="link"
+          <IconButton
+            icon="trashBin"
             id={`clickable-delete-${this.testingId}-${item.rowIndex}`}
             onClick={() => this.onDelete(fields, item.rowIndex)}
             title="Delete this item"
             {...(typeof actionProps.delete === 'function' ? actionProps.delete(item) : {})}
-          >
-            <Icon icon="trashBin" />
-          </Button>
+          />
         }
       </div>
     );


### PR DESCRIPTION
Converting the buttons used to `<IconButton>`s per @rasmuswoelk suggestion on [STCOM-229](https://issues.folio.org/browse/STCOM-229). 

Note that STCOM-229 is still valid, and `<IconButton>` does not have disabled styles either. However, because of a change from UX, we won't be disabling the buttons in `<ControlledVocab>` so it's not _as_ pressing an issue.