### PR TITLE
FOLIO-398 doc tweaks 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 * Fix multiple addresses displaying side by side. Fixes STCOM-230.
 * `<MultiColumnList>` properly fills height when `autosize` prop is used - even on browser resize. Fixes STCOM-29.
 * `<Timepicker>` component added. See [docs](lib/Timepicker/readme.md).
-* Fixed text overflowing icon in <Select>
+* Fixed text overflowing icon in `<Select>`.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)


### PR DESCRIPTION
Escape angle brackets in Markdown 
Otherwise "`<Foo>`" names are rendered invisible.