### PR TITLE
STCOM-238 Update list of exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,20 @@
-/*form elements*/
+/* form elements */
+export { default as Badge } from './lib/Badge';
 export { default as Button } from './lib/Button';
 export { default as Checkbox } from './lib/Checkbox';
+export { default as Datepicker } from './lib/Datepicker';
 export { default as RadioButton } from './lib/RadioButton';
+export { default as SearchField } from './lib/structures/SearchField';
 export { default as Select } from './lib/Select';
+export { default as TextArea } from './lib/TextArea';
 export { default as TextField } from './lib/TextField';
-export { default as Badge } from './lib/Badge';
 
-/*data containers*/
+/* data containers */
 export { default as KeyValue } from './lib/KeyValue';
 export { default as MultiColumnList } from './lib/MultiColumnList';
 export { default as List } from './lib/List';
 
-/*layout containers*/
+/* layout containers */
 export { default as Pane } from './lib/Pane';
 export { default as PaneHeader } from './lib/PaneHeader';
 export { default as PaneMenu } from './lib/PaneMenu';
@@ -20,10 +23,12 @@ export { Grid, Row, Col } from './lib/LayoutGrid';
 export { default as Layout } from './lib/Layout';
 export { Accordion, AccordionSet, FilterAccordionHeader } from './lib/Accordion';
 
-/*misc*/
+/* misc */
 export { default as Icon } from './lib/Icon';
+export { default as IconButton } from './lib/IconButton';
+export { default as Modal } from './lib/Modal';
 
-/*specific use */
+/* specific use */
 export { default as FilterPane } from './lib/FilterPane';
 export { default as FilterGroups } from './lib/FilterGroups';
 export { default as FilterControlGroup } from './lib/FilterControlGroup';


### PR DESCRIPTION
Per conversation at https://github.com/folio-org/ui-eholdings/pull/295#discussion_r176257629, we'd rather do:
```
import {
  Button,
  Icon,
  IconButton
} from '@folio/stripes-components';
```
than
```
import Button from '@folio/stripes-components/lib/Button';
import Icon from '@folio/stripes-components/lib/Icon';
import IconButton from '@folio/stripes-components/lib/IconButton';
```
... but the list of exports in `index.js` is out of date. I just added the components lacking to have `ui-eholdings` use the more elegant imports, but there are plenty more components in the library not being exported. I'll make a JIRA issue to make sure the rest of the components get added to the index.

As future components get added to the library, we should make sure they get added to `index.js`.