### PR TITLE
UIEH-212 Make Settings component responsive

### DIFF
--- a/lib/Settings/Settings.css
+++ b/lib/Settings/Settings.css
@@ -1,0 +1,7 @@
+@import '../variables.css';
+
+.settingsBackButton {
+  @media (--mediumUp) {
+    display: none;
+  }
+}

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -56,14 +56,6 @@ class Settings extends React.Component {
       />);
     });
 
-    const defaultRoute = !Saved ? null : (
-      <Route
-        key={0}
-        path={props.match.path}
-        render={props2 => <Saved {...props2} stripes={stripes} label={props.pages[0].label} />}
-      />
-    );
-
     return (
       <Paneset nested defaultWidth="80%">
         <Pane
@@ -84,7 +76,6 @@ class Settings extends React.Component {
 
         <Switch>
           {routes}
-          {defaultRoute}
         </Switch>
       </Paneset>
     );

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -62,7 +62,7 @@ class Settings extends React.Component {
     return (
       <Paneset nested defaultWidth="80%">
         <Pane
-          defaultWidth="25%"
+          defaultWidth="fill"
           paneTitle={props.paneTitle || 'Module Settings'}
           firstMenu={(
             <Link to="/settings" className={css.settingsBackButton}>

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -31,11 +31,14 @@ class Settings extends React.Component {
   render() {
     const context = this.context;
     const props = this.props;
+    let { activeLink } = this.props;
 
     const stripes = context.stripes;
     const pages = props.pages;
 
-    let activeLink = `${props.match.path}/${pages[0].route}`;
+    if (!activeLink) {
+      activeLink = `${props.match.path}/${pages[0].route}`;
+    }
 
     const navLinks = pages.map((p) => {
       const link = `${props.match.path}/${p.route}`;
@@ -105,6 +108,7 @@ Settings.propTypes = {
   location: PropTypes.shape({
     pathname: PropTypes.string,
   }),
+  activeLink: PropTypes.string,
 };
 
 export default Settings;

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -30,7 +30,7 @@ class Settings extends React.Component {
     const props = this.props;
 
     const stripes = context.stripes;
-    const pages = _.sortBy(props.pages, ['label']);
+    const pages = props.pages;
 
     let activeLink = `${props.match.path}/${pages[0].route}`;
 

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -9,6 +9,9 @@ import Paneset from '../Paneset';
 import Pane from '../Pane';
 import NavList from '../NavList';
 import NavListSection from '../NavListSection';
+import IconButton from '../IconButton';
+
+import css from './Settings.css';
 
 class Settings extends React.Component {
   constructor(props, context) {
@@ -63,7 +66,15 @@ class Settings extends React.Component {
 
     return (
       <Paneset nested defaultWidth="80%">
-        <Pane defaultWidth="25%" paneTitle={props.paneTitle || 'Module Settings'}>
+        <Pane
+          defaultWidth="25%"
+          paneTitle={props.paneTitle || 'Module Settings'}
+          firstMenu={(
+            <Link to="/settings" className={css.settingsBackButton}>
+              <IconButton icon="left-arrow" />
+            </Link>
+          )}
+        >
           <NavList>
             <NavListSection activeLink={activeLink}>
               {navLinks}


### PR DESCRIPTION
## Purpose
The `Settings` component was unusable on narrow screens. The UX pattern was such that if you selected a module in the leftmost pane, you'd be taken directly to the first item in that module's subnav, with no way to ever access the subnav.

Groundwork for https://issues.folio.org/browse/UIEH-212

## Approach
Adjusting for a narrow screen meant several changes:
- Assuming the first link in the list is where the user wants to go means the subnav won't appear on narrow screens. The automatic selection of the first nav item has been removed.
- There's now a back button in the `firstMenu` of the pane containing the module's settings pages.
- To get around the brittle logic of `activeLink` (makes some assumptions about url structure), consumers of the `Settings` component can now pass in an `activeLink` prop.

### Bonus
We have plans for three pages in the eHoldings settings, but the right order for those is not alphabetical. The ordering of the nav list items should be up to individual modules. I removed the automatic alphabetization.

## Module adjustments
Module developers shouldn't see any breaking changes, but they should add back buttons to their individual settings pages to take advantage of the new responsiveness.

## Follow-up
The pane containing the subnav now is much wider on wider screens, because the `Paneset`' is fairly limited in its props. Ideally, `flex-grow` and `flex-shrink` would be editable when dealing with those types of layouts, not just `flex-basis`.

## Screenshots
![2018-03-27 15 16 05](https://user-images.githubusercontent.com/230597/37993406-3b0a0994-31d4-11e8-8b07-c141c459a87b.gif)