### PR TITLE
STCOM-243 Fix pane title CSS ordering bug

### DIFF
--- a/lib/PaneHeader/PaneHeader.css
+++ b/lib/PaneHeader/PaneHeader.css
@@ -66,6 +66,7 @@
   font-size: inherit;
   font-weight: 600;
   align-items: center;
+  letter-spacing: 0.04em;
 }
 
 .paneTitleLabel {

--- a/lib/PaneHeader/PaneHeader.js
+++ b/lib/PaneHeader/PaneHeader.js
@@ -8,7 +8,6 @@ import { Dropdown } from '../Dropdown';
 import DropdownMenu from '../DropdownMenu';
 import NavList from '../NavList';
 import NavListSection from '../NavListSection';
-import Headline from '../Headline';
 import Icon from '../Icon';
 import AppIcon from '../AppIcon';
 
@@ -146,11 +145,11 @@ export default class PaneHeader extends Component {
     const content = (
       <div>
         { paneTitle && (
-          <Headline tag="h2" title={paneTitle} className={css.paneTitle}>
+          <h2 title={paneTitle} className={css.paneTitle}>
             { appIcon && <AppIcon size="small" app={appIcon.app} appIconKey={appIcon.key} /> }
             <span className={css.paneTitleLabel}>{paneTitle}</span>
             { paneActionMenu && <Icon icon={actionMenuOpen ? 'down-caret' : 'up-caret'} size="small" iconRootClass={css.paneActionMenuIcon} />}
-          </Headline>
+          </h2>
           )
         }
         { paneSub && (<p title={paneSub} className={css.paneSub}><span>{paneSub}</span></p>) }


### PR DESCRIPTION
## Purpose
Resolves https://issues.folio.org/browse/STCOM-243

Pane titles were occasionally getting rendered with incorrect CSS:

![folio frontside io_eholdings_searchtype titles q whales](https://user-images.githubusercontent.com/230597/38198115-1645a876-3651-11e8-99ba-416a4e15895f.png)

## Approach
The `PaneHeader` component was trying to pass some of its own styles to a `Headline` component. The order of those styles in the CSS bundle was inconsistent. The `paneTitle` CSS overrode most of what `Headline` was giving anyway, so the simplest solution was to just use a raw `<h2>`. The DOM output is identical to the previous version.