### PR TITLE
UIEH-130 Create z-index management solution

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -14,6 +14,7 @@ const postCssNesting = require('postcss-nesting');
 const postCssCustomMedia = require('postcss-custom-media');
 const postCssMediaMinMax = require('postcss-media-minmax');
 const postCssColorFunction = require('postcss-color-function');
+const postCssFunctions = require('postcss-functions');
 
 module.exports = {
   entry: [
@@ -72,6 +73,9 @@ module.exports = {
                 postCssCustomMedia(),
                 postCssMediaMinMax(),
                 postCssColorFunction(),
+                postCssFunctions({
+                  glob: path.join(path.resolve(), 'lib/sharedStyles/functions', '*.js'),
+                }),
               ],
             },
           },

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -15,5 +15,6 @@
         "compose-with"
       ],
     }],
+    "function-name-case": null
   }
 }

--- a/lib/Datepicker/Calendar.css
+++ b/lib/Datepicker/Calendar.css
@@ -5,7 +5,7 @@
   border: 1px solid #bcbcbc;
   padding: 4px;
   box-shadow: 0 4px 19px 0 rgba(0, 0, 0, 0.39);
-  z-index: 9999;
+  z-index: stripesZIndex('calendar');
 }
 
 .srOnly {

--- a/lib/Dropdown/Dropdown.css
+++ b/lib/Dropdown/Dropdown.css
@@ -15,7 +15,7 @@
 }
 
 .DropdownMenuTether {
-  z-index: 1000;
+  z-index: stripesZIndex('dropdownMenuTether');
   display: none;
   float: left;
   min-width: 90vw;

--- a/lib/DropdownMenu/DropdownMenu.css
+++ b/lib/DropdownMenu/DropdownMenu.css
@@ -4,7 +4,7 @@
   position: absolute;
   top: 100%;
   right: 0;
-  z-index: 1000;
+  z-index: stripesZIndex('dropdownMenu');
   display: none;
   float: left;
   min-width: 90vw;

--- a/lib/PaneMenu/PaneMenu.css
+++ b/lib/PaneMenu/PaneMenu.css
@@ -4,5 +4,5 @@
   display: flex;
   align-items: center;
   position: relative;
-  z-index: 2;
+  z-index: stripesZIndex('paneMenu');
 }

--- a/lib/Timepicker/TimeDropdown.css
+++ b/lib/Timepicker/TimeDropdown.css
@@ -8,7 +8,7 @@
   padding: 4px 8px;
   width: 230px;
   box-shadow: 0 4px 19px 0 rgba(0, 0, 0, 0.39);
-  z-index: 9999;
+  z-index: stripesZIndex('timepicker');
 }
 
 .center {

--- a/lib/global.css
+++ b/lib/global.css
@@ -149,3 +149,7 @@ button {
   clip-path: inset(50%);
   border: 0;
 }
+
+:global(.tether-element) {
+  z-index: stripesZIndex('tetherElement');
+}

--- a/lib/sharedStyles/functions/README.md
+++ b/lib/sharedStyles/functions/README.md
@@ -1,0 +1,27 @@
+## PostCSS functions
+
+`storybook` and `stripes-core` will scan this directory for functions that can be used in CSS.
+
+Plugin used: [`postcss-functions`](https://github.com/andyjansson/postcss-functions)
+
+Example:
+```
+// foo.js
+module.exports = function foo() {
+  return 'bar';
+};
+```
+
+```
+// MyComponent.css
+.myComponent {
+  color: foo();
+}
+```
+
+```
+// outputted CSS
+.myComponent {
+  color: 'bar';
+}
+```

--- a/lib/sharedStyles/functions/stripesZIndex.js
+++ b/lib/sharedStyles/functions/stripesZIndex.js
@@ -1,0 +1,40 @@
+/*
+  Single source-of-truth for z-indices in Stripes modules.
+  If a z-index is needed on an element, define a string here that describes it
+  and place in the appropriate order.
+
+  Layers are ordered top to bottom.
+
+  To use in CSS:
+  .myComponent {
+    z-index: stripesZIndex('myComponentLayerString');
+  }
+
+  Elements shouldn't share a layer string, because there should always be an explicit
+  z priority between two elements. Stick to one usage per string.
+
+*/
+
+module.exports = function stripesZIndex(layer) {
+  const layers = [
+    'toast',
+    'modal',
+    'tetherElement',
+    'timepicker',
+    'calendar',
+    'navDropdownMenu',
+    'dropdownMenuTether',
+    'currentAppBadge',
+    'searchFieldWrap',
+    'paneMenu',
+    'searchPreviewPane',
+    'searchFiltersPane',
+    'searchPaneVignette',
+    'searchResultsPane',
+    'navButtonBadge',
+    'navButtonInteractableIcon',
+  ];
+
+  const layerIndex = layers.indexOf(layer.replace(/^'(.*)'$/, '$1'));
+  return (layerIndex > -1) ? (layers.length - layerIndex) : '1';
+};

--- a/lib/structures/SearchField/SearchField.css
+++ b/lib/structures/SearchField/SearchField.css
@@ -15,7 +15,7 @@
   margin-bottom: -1px;
 
   &:focus {
-    z-index: 5;
+    z-index: stripesZIndex('searchFieldWrap');
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "postcss-color-function": "^4.0.1",
     "postcss-custom-media": "^6.0.0",
     "postcss-custom-properties": "^6.2.0",
+    "postcss-functions": "^3.0.0",
     "postcss-import": "^11.0.0",
     "postcss-media-minmax": "^3.0.0",
     "postcss-nesting": "^4.2.1",


### PR DESCRIPTION
## Purpose
`ui-eholdings` uses `z-index` to manage layering of its search layout. The dropdown menu from the header avatar ends up underneath the third pane: https://issues.folio.org/browse/UIEH-130

Handling `z-index` can be notoriously finicky. The solution to a problem is frequently "set it to a very high number," but with many layers happening, that can get messy real quick.

## Approach
I've used this super clever Sass way of handling z-index on several previous projects: https://www.smashingmagazine.com/2014/06/sassy-z-index-management-for-complex-layouts/

Since we don't have Sass in our toolkit, I wanted to achieve a similar setup with PostCSS. With `postcss-functions`, I was able to create a `stripesZIndex()` that works off the same idea. We define an array of layers in one place, then every time we need to define a z-index we place a new layer in the array. If there's a problem with the ordering, that can be solved from one place, instead of having to track down every z-index defined across multiple repos.

Note: `stylelint` was incorrectly throwing `function-name-case` violations with my camelCased function name, so I just turned that rule off for now.

## Risk
There's a good chance this might break an existing z-index behavior, but it will make fixes to those types of problems very easy.

## Dependencies
Requires `stripes-core` PR: https://github.com/folio-org/stripes-core/pull/257