### PR TITLE
Locally scope Popover paragraph CSS

### DIFF
--- a/lib/Popover/Popover.css
+++ b/lib/Popover/Popover.css
@@ -14,16 +14,16 @@
   border-radius: var(--radius);
   box-shadow: 0 10px 30px 0 rgba(0, 0, 0, 0.24);
   outline: 0;
+
+  & p {
+    padding: 0;
+    margin: 0;
+  }
 }
 
 /* No padding on content */
 .popoverPop.noPadding {
   padding: 0;
-}
-
-p {
-  padding: 0;
-  margin: 0;
 }
 
 /* Transition */


### PR DESCRIPTION
This CSS leaked into the global scope, causing unexpected margin/padding side effects for lots of other paragraphs.