### PR TITLE
STCOM-249 EditableList: Fixed Cancel button not resetting changed values

### DIFF
--- a/lib/structures/EditableList/EditableListForm.js
+++ b/lib/structures/EditableList/EditableListForm.js
@@ -28,6 +28,14 @@ const propTypes = {
   */
   initialValues: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
   /**
+   * Callback provided by redux-form to set the initialValues to something else.
+   */
+  initialize: PropTypes.func,
+  /**
+   * Callback provided by redux-form to set the field values to their initialValues
+   */
+  reset: PropTypes.func,
+  /**
    * Callback for saving editted list items.
    */
   onUpdate: PropTypes.func,
@@ -186,6 +194,9 @@ class EditableListForm extends React.Component {
         return newState;
       });
     }
+
+    // Reset the field values.
+    this.props.reset();
   }
 
   onSave(fields, index) {
@@ -196,7 +207,12 @@ class EditableListForm extends React.Component {
       this.props.onCreate;
     const res = callback(item);
     Promise.resolve(res).then(
-      () => this.toggleEdit(index),
+      () => {
+        // Set props.initialValues to the currently-saved field values.
+        this.props.initialize(fields.getAll());
+
+        this.toggleEdit(index);
+      },
       () => this.setError(index, 'Error on saving data'),
     );
   }


### PR DESCRIPTION
Clicking the cancel button on a form managed by `<EditableList>` does not restore the original values. It removes the editable field, but leaves the changed value in place. Navigating away then causes the "unsaved changes" prompt to appear.

This change updates `redux-form`'s `initialValues` after every successful save, and the calls `reset()` on any Cancel button press.