### PR TITLE
MCLRenderer: Added safety checks

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -242,7 +242,9 @@ class MCLRenderer extends React.Component {
     if (this.props.contentData.length > 0 && this.props.contentData.length !== prevProps.contentData.length) {
       requestAnimationFrame(() => {
         this.measureNewRows();
-        this.headerHeight = this.headerRow.offsetHeight;
+        if (this.headerRow) {
+          this.headerHeight = this.headerRow.offsetHeight;
+        }
 
         if (this.state.averageRowHeight === 0) {
           const avg = this.updateAverageHeight();
@@ -280,10 +282,9 @@ class MCLRenderer extends React.Component {
   }
 
   updateDimensions(height, data, avgHeight) {
-    let averageRowHeight = avgHeight;
-    if (!avgHeight) {
-      averageRowHeight = this.state.averageRowHeight;
-    }
+    // Base-case to avoid a catastrophic divide-by-zero during a re-render.
+    const averageRowHeight = avgHeight || this.state.averageRowHeight || 10;
+
     // if we don't have a height, then we'll just render whatever data we have...
     let newAmount;
     if (!height) {


### PR DESCRIPTION
In certain scenarios, the data provided to the MCLRenderer during the process of several re-renders can get it into some trouble without these sanity checks. For example, the amount of items to render will momentarily become NaN since we get a 0 averageRowHeight. 

This is part of the fixes for UIU-466 