### PR TITLE
add hidden filter config. Refs UIU-400

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * Use country-code to country-name mapping in `<AddressFieldGroup>`. Fixes STCOM-242. Available from v2.0.8.
 * MCL should use column-titles, not column keys, for the aria-label field. Fixes STCOM-246. Available from v2.0.9.
 * Allow for selecting value programmatically in Selection component. Fixes STCOM-250.
+* `<FilterGroups>` support hidden constraints. Refs UIU-500. Available from v2.0.10. 
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -37,6 +37,7 @@ FilterCheckbox.propTypes = {
 // private
 const FilterGroup = (props) => {
   const { label, groupName, names, filters, onChangeFilter: ocf, disabled } = props;
+
   return (
     <FilterControlGroup
       label={label}
@@ -111,23 +112,19 @@ export function filterState(filters) {
  * selected have no effect unless the `restrictWhenAllSelected`
  * setting is on.
  *
- * hiddenConfig contains a list of filter terms that are always in effect
- * and that are not exposed in the UI. For example, suppose a filter group
- * "species" existed and the query should *always* include humans and allow
- * the user to choose whether Ewok, Jawa, or Wookie members should also be
- * included in the search. Ewok, Jawa, and Wookie would be included in the
- * "values" array of the config element with name: "species" and Human would
- * be included in the array of the hiddenConfig element keyed by "species".
+ * config values with the attribute "hidden: true" are not exposed in the UI
+ * (i.e. no checkbox is presented in the UI) but the filter value is always
+ * applied. For example, suppose a filter group "species" existed and the
+ * query should *always* include Humans and allow the user to choose whether
+ * Ewok, Jawa, or Wookie members should also be included in the search. The
+ * values entry with the attribute `name: "human"` would also contain the
+ * attribute `hidden: true`.
  *
  * @param config array list of objects with keys label, name, cql, values[]
  * @param filters string comma-delimited list of active filters, e.g. foo.someValue,bar.otherValue
- * @param hiddenConfig object mapping config name to values[]
  *
  */
-export function filters2cql(config, filters, hiddenConfig = {}) {
-  // nothing to do if there are no filters and no hidden config values
-  if (!filters && !Object.keys(hiddenConfig).length) return undefined;
-
+export function filters2cql(config, filters) {
   const groups = {};
   const fullNames = filters.split(',');
 
@@ -144,15 +141,24 @@ export function filters2cql(config, filters, hiddenConfig = {}) {
     }
   }
 
-  // copy the hiddenConfig values into the groups object
-  for (const [key, value] of Object.entries(hiddenConfig)) {
-    if (groups[key] === undefined) {
-      groups[key] = [];
-    }
+  // pull in hidden config values which must always be applied.
+  for (const filter of config) {
+    for (const value of filter.values) {
+      if (typeof value === 'object' && value.hidden) {
+        if (groups[filter.name] === undefined) {
+          groups[filter.name] = [];
+        }
 
-    for (const option of value) {
-      groups[key].push(option.name);
+        groups[filter.name].push(value.name);
+      }
     }
+  }
+
+  // nothing to do if there are no filters.
+  // note that we can't simply bail when "filters" is empty up at the top
+  // because hidden values in config may also be present.
+  if (!filters && !Object.keys(groups).length) {
+    return undefined;
   }
 
   const conds = [];
@@ -161,15 +167,14 @@ export function filters2cql(config, filters, hiddenConfig = {}) {
     // with the same name. that *shouldn't* happen, but just in case it
     // does, only use the first one.
     const group = config.filter(g => g.name === groupName)[0];
-    const hiddenGroup = hiddenConfig[groupName] || [];
     const cqlIndex = group.cql;
 
     // values contains the selected filters
     const values = groups[groupName];
-    if (!(values.length === (group.values.length + hiddenGroup.length) && !group.restrictWhenAllSelected)) {
+    if (!(values.length === (group.values.length) && !group.restrictWhenAllSelected)) {
       const mappedValues = values.map((v) => {
         // If the field is a {name,cql} object, use the CQL.
-        const obj = [...group.values, ...hiddenGroup].filter(f => typeof f === 'object' && f.name === v);
+        const obj = group.values.filter(f => typeof f === 'object' && f.name === v);
         return (obj.length > 0) ? obj[0].cql : v;
       });
 
@@ -225,6 +230,21 @@ const FilterGroups = (props) => {
   const { config, filters, onChangeFilter: ocf, onClearFilter } = props;
   const disableNames = props.disableNames || {};
 
+  const filterGroupNames = (group) => {
+    const names = [];
+    for (const value of group.values) {
+      if (typeof value === 'object') {
+        if (!value.hidden) {
+          names.push(value.name);
+        }
+      } else {
+        names.push(value);
+      }
+    }
+
+    return names;
+  };
+
   return (
     <div>
       <AccordionSet>
@@ -247,7 +267,7 @@ const FilterGroups = (props) => {
               label={group.label}
               groupName={group.name}
               disabled={disableNames[group.name]}
-              names={group.values.map(f => ((typeof f === 'object') ? f.name : f))}
+              names={filterGroupNames(group)}
               filters={filters}
               onChangeFilter={ocf}
             />

--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -37,7 +37,6 @@ FilterCheckbox.propTypes = {
 // private
 const FilterGroup = (props) => {
   const { label, groupName, names, filters, onChangeFilter: ocf, disabled } = props;
-
   return (
     <FilterControlGroup
       label={label}
@@ -104,36 +103,76 @@ export function filterState(filters) {
 }
 
 
-// Filters come in groups. Within each group, we want to OR together
-// the filters that have been selected; and we want to AND together
-// the output of each group. Groups where no filter has been selected
-// have no effect at all. And Groups where all filters have been
-// selected have no effect unless the `restrictWhenAllSelected`
-// setting is on.
-//
-export function filters2cql(config, filters) {
-  if (!filters) return undefined;
+/**
+ * Filters come in groups. Within each group, we want to OR together
+ * the filters that have been selected; and we want to AND together
+ * the output of each group. Groups where no filter has been selected
+ * have no effect at all. And Groups where all filters have been
+ * selected have no effect unless the `restrictWhenAllSelected`
+ * setting is on.
+ *
+ * hiddenConfig contains a list of filter terms that are always in effect
+ * and that are not exposed in the UI. For example, suppose a filter group
+ * "species" existed and the query should *always* include humans and allow
+ * the user to choose whether Ewok, Jawa, or Wookie members should also be
+ * included in the search. Ewok, Jawa, and Wookie would be included in the
+ * "values" array of the config element with name: "species" and Human would
+ * be included in the array of the hiddenConfig element keyed by "species".
+ *
+ * @param config array list of objects with keys label, name, cql, values[]
+ * @param filters string comma-delimited list of active filters, e.g. foo.someValue,bar.otherValue
+ * @param hiddenConfig object mapping config name to values[]
+ *
+ */
+export function filters2cql(config, filters, hiddenConfig = {}) {
+  // nothing to do if there are no filters and no hidden config values
+  if (!filters && !Object.keys(hiddenConfig).length) return undefined;
 
   const groups = {};
   const fullNames = filters.split(',');
+
+  // restructure the "filters" argument from a string,
+  // e.g. "foo.valueOne,foo.valueTwo,bar.valueThree", to an object,
+  // e.g. { foo: [ valueOne, valueTwo ], bar: [ valueThree ]}
   for (const fullName of fullNames) {
-    const [groupName, fieldName] = fullName.split('.');
-    if (groups[groupName] === undefined) groups[groupName] = [];
-    groups[groupName].push(fieldName);
+    // Note: splitting an empty string returns an empty string,
+    // so we need to check if fullName is actually a legit filtername
+    if (fullName) {
+      const [groupName, fieldName] = fullName.split('.');
+      if (groups[groupName] === undefined) groups[groupName] = [];
+      groups[groupName].push(fieldName);
+    }
+  }
+
+  // copy the hiddenConfig values into the groups object
+  for (const [key, value] of Object.entries(hiddenConfig)) {
+    if (groups[key] === undefined) {
+      groups[key] = [];
+    }
+
+    for (const option of value) {
+      groups[key].push(option.name);
+    }
   }
 
   const conds = [];
   for (const groupName of Object.keys(groups)) {
+    // config is an array and therefore may contain multiple filters
+    // with the same name. that *shouldn't* happen, but just in case it
+    // does, only use the first one.
     const group = config.filter(g => g.name === groupName)[0];
+    const hiddenGroup = hiddenConfig[groupName] || [];
     const cqlIndex = group.cql;
 
+    // values contains the selected filters
     const values = groups[groupName];
-    if (!(values.length === group.values.length && !group.restrictWhenAllSelected)) {
+    if (!(values.length === (group.values.length + hiddenGroup.length) && !group.restrictWhenAllSelected)) {
       const mappedValues = values.map((v) => {
         // If the field is a {name,cql} object, use the CQL.
-        const obj = group.values.filter(f => typeof f === 'object' && f.name === v);
+        const obj = [...group.values, ...hiddenGroup].filter(f => typeof f === 'object' && f.name === v);
         return (obj.length > 0) ? obj[0].cql : v;
       });
+
       let joinedValues = mappedValues.map(v => `"${v}"`).join(' or ');
       if (values.length > 1) joinedValues = `(${joinedValues})`;
 

--- a/lib/FilterGroups/readme.md
+++ b/lib/FilterGroups/readme.md
@@ -27,7 +27,10 @@ const filterConfig = [
     label: 'Location',
     name: 'location',
     cql: 'location.name',
-    values: [{ name: 'Main Library', cql: 'main' }, 'Annex Library'],
+    values: [
+      { name: 'Library of Trantor', cql: 'trantor', hidden: true},
+      { name: 'Main Library', cql: 'main' },
+      'Annex Library'],
   },
 ];
 
@@ -88,12 +91,17 @@ containing two keys:
 
 * `name` -- the name used to display the filter on the page.
 * `cql` -- the value used when generating CQL queries.
+* `hidden` -- hide the value in the UI and always apply the filter
 
 In the example above, there are two filter groups, "Item Types" and
 "Location". All the values of the former are simple strings; one of
 the values of the latter is of the more complex form, using "Main
 Library" as the displayed value and just 'main' as the corresponding
-value to use in searches.
+value to use in searches. Additionally, the value with the name
+"Library of Trantor", which has the attribute `hidden: true` will
+not be exposed in the UI (i.e. there will not be a checkbox for it)
+but it will _always_ be applied to the `location` filters. Think of it
+as a hidden checkbox that is always checked.
 
 Each filter value has a "full name", made up of the group name, a
 period and the filter name itself. For example, in the configuration
@@ -188,5 +196,3 @@ The interpretation of the filters is as follows:
 
 In short, records are found if they match _any_ of the values for _all_ of
 the non-empty groups.
-
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",

--- a/util/makeQueryFunction.js
+++ b/util/makeQueryFunction.js
@@ -8,7 +8,7 @@ import { compilePathTemplate } from '@folio/stripes-connect/RESTResource/RESTRes
 //
 // For compatibility, false and true may be used for 0 and 1 respectively.
 //
-function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOnCondition, hiddenFilterConfig) {
+function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOnCondition) {
   return (queryParams, pathComponents, resourceValues, logger) => {
 
     const { qindex, filters, query, sort } = resourceValues.query || {};
@@ -45,7 +45,7 @@ function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOn
       }
     }
 
-    const filterCql = filters2cql(filterConfig, filters, hiddenFilterConfig);
+    const filterCql = filters2cql(filterConfig, filters);
     if (filterCql) {
       if (cql) {
         cql = `(${cql}) and ${filterCql}`;

--- a/util/makeQueryFunction.js
+++ b/util/makeQueryFunction.js
@@ -8,7 +8,7 @@ import { compilePathTemplate } from '@folio/stripes-connect/RESTResource/RESTRes
 //
 // For compatibility, false and true may be used for 0 and 1 respectively.
 //
-function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOnCondition) {
+function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOnCondition, hiddenFilterConfig) {
   return (queryParams, pathComponents, resourceValues, logger) => {
 
     const { qindex, filters, query, sort } = resourceValues.query || {};
@@ -45,7 +45,7 @@ function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOn
       }
     }
 
-    const filterCql = filters2cql(filterConfig, filters);
+    const filterCql = filters2cql(filterConfig, filters, hiddenFilterConfig);
     if (filterCql) {
       if (cql) {
         cql = `(${cql}) and ${filterCql}`;


### PR DESCRIPTION
Allow filters to have hidden configuration values. For example, suppose
a filter group "species" existed and the query should *always* include
humans and allow the user to choose whether Ewok, Jawa, or Wookie
members should also be included in the search. Ewok, Jawa, and Wookie
would be included in the "values" array of the config element with
name: "species" and Human would be included in the array of the
hiddenConfig element keyed by "species".

Refs [UIU-400](https://issues.folio.org/browse/UIU-400)