### PR TITLE
Stcom ignore time offset refs UIORG-55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.0.0 (IN PROGRESS)
 
+* In `<Datepicker>`, added a new `ignoreLocalOffset` prop that ignores the tenant timezone and treats the date as UTC to display the date. Fixes UIORG-55
 * Adjust address read only view. Fixes STCOM-152.
 * `<FilterPaneSearch>` supports `searchableIndexes`, `selectedIndex` and `onChangeIndex` properties. Fixes STCOM-171.
 * Functions made by `makeQueryFunction` support the `qindex` parameter, which is interpreted as the name of the _only_ field to search. This allows us to support field-specific searching. Fixes STCOM-172.

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import TetherComponent from 'react-tether';
 import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import contains from 'dom-helpers/query/contains';
 import debounce from 'lodash/debounce';
 import uniqueId from 'lodash/uniqueId';
@@ -39,6 +39,7 @@ const propTypes = {
     PropTypes.string,
   ]),
   passThroughValue: PropTypes.string,
+  ignoreLocalOffset: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -96,27 +97,27 @@ class Datepicker extends React.Component {
     this.handleFieldChange = this.handleFieldChange.bind(this);
     this.datePickerIsFocused = this.datePickerIsFocused.bind(this);
     this.getPresentedValue = this.getPresentedValue.bind(this);
+    this.timezone = this.context.stripes.timezone;
 
     moment.locale(this.context.stripes.locale);
     this._dateFormat = moment.localeData()._longDateFormat.L;
 
-    // non-null presentedValue will eventually be rendered as the value of he TextField.
+    // non-null presentedValue will eventually be rendered as the value of the TextField.
     let inputValue = '';
     let presentedValue = null;
 
     // if we aren't using redux form...
-    // moment.utc used to ignore local timezones
     if (typeof this.props.input === 'undefined') {
       if (this.props.value === this.props.passThroughValue && typeof this.props.date === 'undefined') {
         presentedValue = this.props.passThroughValue;
-        inputValue = moment.utc().format(this._dateFormat);
+        inputValue = moment.tz(this.timezone).format(this._dateFormat);
       }
       // if we are using redux-form...
     } else if (this.props.input.value === this.props.passThroughValue) {
       presentedValue = this.props.passThroughValue;
-      inputValue = moment.utc().format(this._dateFormat);
+      inputValue = moment.tz(this.timezone).format(this._dateFormat);
     } else if (this.props.input.value !== '') {
-      inputValue = moment.utc(this.props.input.value).format(this._dateFormat);
+      inputValue = moment.tz(this.props.input.value, this.timezone).format(this._dateFormat);
     }
 
     this.state = {
@@ -141,9 +142,9 @@ class Datepicker extends React.Component {
         const passRE = new RegExp(`^${nextProps.input.value}`, 'i');
         if (nextProps.input.value === this.props.passThroughValue || passRE.test(this.props.passThroughValue)) {
           presentedValue = nextProps.input.value;
-          inputValue = moment.utc().format(this._dateFormat);
+          inputValue = moment.tz(this.timezone).format(this._dateFormat);
         } else {
-          inputValue = moment.utc(nextProps.input.value).format(this._dateFormat);
+          inputValue = moment.tz(nextProps.input.value, this.timezone).format(this._dateFormat);
         }
         this.setState({
           presentedValue,
@@ -158,10 +159,10 @@ class Datepicker extends React.Component {
       }
     } else if (this.props.value !== '' && this.props.date !== nextProps.date) {
       if (nextProps.value === this.props.passThroughValue && nextProps.date === 'undefined') {
-        inputValue = moment.utc().format(this._dateFormat);
+        inputValue = moment.tz(this.timezone).format(this._dateFormat);
         presentedValue = this.props.passThroughValue;
       } else {
-        inputValue = moment.utc().format(this._dateFormat);
+        inputValue = moment.tz(this.timezone).format(this._dateFormat);
       }
       this.setState({
         presentedValue,
@@ -294,7 +295,6 @@ class Datepicker extends React.Component {
         if (moment(stringDate, this._dateFormat, true).isValid()) {
           // convert date to ISO 8601 format for backend
           const standardizedDate = this.standardizeDate(stringDate);
-
           // redux-form handlers take the value rather than the event...
           this.props.input.onChange(standardizedDate);
           this.props.input.onBlur(standardizedDate);
@@ -407,13 +407,13 @@ class Datepicker extends React.Component {
       case 'ISO 8601':
       case 'ISO8601':
       case 'ISO-8601':
-        return moment(date, this._dateFormat, true).toISOString();
+        return moment.tz(date, this._dateFormat, true, this.timezone).toISOString();
       case 'RFC 2822':
       case 'RFC2822':
       case 'RFC-2822':
-        return moment(date, this._dateFormat, true).format(DATE_RFC2822);
+        return moment.tz(date, this._dateFormat, true, this.timezone).format(DATE_RFC2822);
       default:
-        return moment(date, this._dateFormat, true).format(this.props.backendDateStandard);
+        return moment.tz(date, this._dateFormat, true, this.timezone).format(this.props.backendDateStandard);
     }
   }
 

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -110,14 +110,14 @@ class Datepicker extends React.Component {
     if (typeof this.props.input === 'undefined') {
       if (this.props.value === this.props.passThroughValue && typeof this.props.date === 'undefined') {
         presentedValue = this.props.passThroughValue;
-        inputValue = moment.tz(this.timezone).format(this._dateFormat);
+        inputValue = this.props.ignoreLocalOffset ? moment.utc().format(this._dateFormat) : moment.tz(this.timezone).format(this._dateFormat);
       }
       // if we are using redux-form...
     } else if (this.props.input.value === this.props.passThroughValue) {
       presentedValue = this.props.passThroughValue;
-      inputValue = moment.tz(this.timezone).format(this._dateFormat);
+      inputValue = this.props.ignoreLocalOffset ? moment.utc().format(this._dateFormat) : moment.tz(this.timezone).format(this._dateFormat);
     } else if (this.props.input.value !== '') {
-      inputValue = moment.tz(this.props.input.value, this.timezone).format(this._dateFormat);
+      inputValue = this.props.ignoreLocalOffset ? moment.utc(this.props.input.value).format(this._dateFormat) : moment.tz(this.props.input.value, this.timezone).format(this._dateFormat);
     }
 
     this.state = {
@@ -142,9 +142,9 @@ class Datepicker extends React.Component {
         const passRE = new RegExp(`^${nextProps.input.value}`, 'i');
         if (nextProps.input.value === this.props.passThroughValue || passRE.test(this.props.passThroughValue)) {
           presentedValue = nextProps.input.value;
-          inputValue = moment.tz(this.timezone).format(this._dateFormat);
+          inputValue = this.props.ignoreLocalOffset ? moment.utc().format(this._dateFormat) : moment.tz(this.timezone).format(this._dateFormat);
         } else {
-          inputValue = moment.tz(nextProps.input.value, this.timezone).format(this._dateFormat);
+          inputValue = this.props.ignoreLocalOffset ? moment.utc(nextProps.input.value).format(this._dateFormat) : moment.tz(nextProps.input.value, this.timezone).format(this._dateFormat);
         }
         this.setState({
           presentedValue,
@@ -159,10 +159,10 @@ class Datepicker extends React.Component {
       }
     } else if (this.props.value !== '' && this.props.date !== nextProps.date) {
       if (nextProps.value === this.props.passThroughValue && nextProps.date === 'undefined') {
-        inputValue = moment.tz(this.timezone).format(this._dateFormat);
+        inputValue = this.props.ignoreLocalOffset ? moment.utc().format(this._dateFormat) : moment.tz(this.timezone).format(this._dateFormat);
         presentedValue = this.props.passThroughValue;
       } else {
-        inputValue = moment.tz(this.timezone).format(this._dateFormat);
+        inputValue = this.props.ignoreLocalOffset ? moment.utc().format(this._dateFormat) : moment.tz(this.timezone).format(this._dateFormat);
       }
       this.setState({
         presentedValue,

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -139,6 +139,7 @@ class Datepicker extends React.Component {
   componentWillReceiveProps(nextProps) {
     let inputValue;
     let presentedValue = null;
+    this.parseTimezone = nextProps.ignoreLocalOffset ? 'UTC' : this.timezone;
     if (nextProps.input) {
       if (nextProps.input.value !== '' && nextProps.input.value !== this.props.input.value) {
         const passRE = new RegExp(`^${nextProps.input.value}`, 'i');

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -105,17 +105,18 @@ class Datepicker extends React.Component {
     let presentedValue = null;
 
     // if we aren't using redux form...
+    // moment.utc used to ignore local timezones
     if (typeof this.props.input === 'undefined') {
       if (this.props.value === this.props.passThroughValue && typeof this.props.date === 'undefined') {
         presentedValue = this.props.passThroughValue;
-        inputValue = moment().format(this._dateFormat);
+        inputValue = moment.utc().format(this._dateFormat);
       }
       // if we are using redux-form...
     } else if (this.props.input.value === this.props.passThroughValue) {
       presentedValue = this.props.passThroughValue;
-      inputValue = moment().format(this._dateFormat);
+      inputValue = moment.utc().format(this._dateFormat);
     } else if (this.props.input.value !== '') {
-      inputValue = moment(this.props.input.value).format(this._dateFormat);
+      inputValue = moment.utc(this.props.input.value).format(this._dateFormat);
     }
 
     this.state = {
@@ -140,9 +141,9 @@ class Datepicker extends React.Component {
         const passRE = new RegExp(`^${nextProps.input.value}`, 'i');
         if (nextProps.input.value === this.props.passThroughValue || passRE.test(this.props.passThroughValue)) {
           presentedValue = nextProps.input.value;
-          inputValue = moment().format(this._dateFormat);
+          inputValue = moment.utc().format(this._dateFormat);
         } else {
-          inputValue = moment(nextProps.input.value).format(this._dateFormat);
+          inputValue = moment.utc(nextProps.input.value).format(this._dateFormat);
         }
         this.setState({
           presentedValue,
@@ -157,10 +158,10 @@ class Datepicker extends React.Component {
       }
     } else if (this.props.value !== '' && this.props.date !== nextProps.date) {
       if (nextProps.value === this.props.passThroughValue && nextProps.date === 'undefined') {
-        inputValue = moment().format(this._dateFormat);
+        inputValue = moment.utc().format(this._dateFormat);
         presentedValue = this.props.passThroughValue;
       } else {
-        inputValue = moment().format(this._dateFormat);
+        inputValue = moment.utc().format(this._dateFormat);
       }
       this.setState({
         presentedValue,

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -98,6 +98,7 @@ class Datepicker extends React.Component {
     this.datePickerIsFocused = this.datePickerIsFocused.bind(this);
     this.getPresentedValue = this.getPresentedValue.bind(this);
     this.timezone = this.context.stripes.timezone;
+    this.parseTimezone = this.props.ignoreLocalOffset ? 'UTC' : this.timezone;
 
     moment.locale(this.context.stripes.locale);
     this._dateFormat = moment.localeData()._longDateFormat.L;
@@ -106,18 +107,19 @@ class Datepicker extends React.Component {
     let inputValue = '';
     let presentedValue = null;
 
+
     // if we aren't using redux form...
     if (typeof this.props.input === 'undefined') {
       if (this.props.value === this.props.passThroughValue && typeof this.props.date === 'undefined') {
         presentedValue = this.props.passThroughValue;
-        inputValue = this.props.ignoreLocalOffset ? moment.utc().format(this._dateFormat) : moment.tz(this.timezone).format(this._dateFormat);
+        inputValue = moment.tz(this.parseTimezone).format(this._dateFormat);
       }
       // if we are using redux-form...
     } else if (this.props.input.value === this.props.passThroughValue) {
       presentedValue = this.props.passThroughValue;
-      inputValue = this.props.ignoreLocalOffset ? moment.utc().format(this._dateFormat) : moment.tz(this.timezone).format(this._dateFormat);
+      inputValue = moment.tz(this.parseTimezone).format(this._dateFormat);
     } else if (this.props.input.value !== '') {
-      inputValue = this.props.ignoreLocalOffset ? moment.utc(this.props.input.value).format(this._dateFormat) : moment.tz(this.props.input.value, this.timezone).format(this._dateFormat);
+      inputValue = moment.tz(this.props.input.value, this.parseTimezone).format(this._dateFormat);
     }
 
     this.state = {
@@ -142,9 +144,9 @@ class Datepicker extends React.Component {
         const passRE = new RegExp(`^${nextProps.input.value}`, 'i');
         if (nextProps.input.value === this.props.passThroughValue || passRE.test(this.props.passThroughValue)) {
           presentedValue = nextProps.input.value;
-          inputValue = this.props.ignoreLocalOffset ? moment.utc().format(this._dateFormat) : moment.tz(this.timezone).format(this._dateFormat);
+          inputValue = moment.tz(this.parseTimezone).format(this._dateFormat);
         } else {
-          inputValue = this.props.ignoreLocalOffset ? moment.utc(nextProps.input.value).format(this._dateFormat) : moment.tz(nextProps.input.value, this.timezone).format(this._dateFormat);
+          inputValue = moment.tz(nextProps.input.value, this.parseTimezone).format(this._dateFormat);
         }
         this.setState({
           presentedValue,
@@ -159,10 +161,10 @@ class Datepicker extends React.Component {
       }
     } else if (this.props.value !== '' && this.props.date !== nextProps.date) {
       if (nextProps.value === this.props.passThroughValue && nextProps.date === 'undefined') {
-        inputValue = this.props.ignoreLocalOffset ? moment.utc().format(this._dateFormat) : moment.tz(this.timezone).format(this._dateFormat);
+        inputValue = moment.tz(this.parseTimezone).format(this._dateFormat);
         presentedValue = this.props.passThroughValue;
       } else {
-        inputValue = this.props.ignoreLocalOffset ? moment.utc().format(this._dateFormat) : moment.tz(this.timezone).format(this._dateFormat);
+        inputValue = moment.tz(this.parseTimezone).format(this._dateFormat);
       }
       this.setState({
         presentedValue,

--- a/lib/Datepicker/readme.md
+++ b/lib/Datepicker/readme.md
@@ -17,6 +17,8 @@ backendDateStandard | string | parses to/from ISO 8601 standard by default befor
 id | string | id for date field - used in the "id" attribute of the text input | | false
 useFocus | bool | if set to false, component relies solely on clicking the calendar icon to toggle appearance of calendar. | true | false
 disabled | bool | if true, field will be disabled for focus or entry. | false | false
+ignoreLocalOffset | bool | if true, ignores the timezone setting and treats the date as UTC to display the date.
+| false | false. See below for more explanation
 readOnly | bool | if true, field will be readonly. 'Calendar' and 'clear' buttons will be omitted. | false | false
 value | string | date to be displayed in the textfield. In forms, this is supplied by the initialValues prop supplied to the form | "" | false
 onChange | func | Event handler to handle updates to the datefield text. | | false
@@ -46,3 +48,6 @@ Using the prop `passThroughValue` means that you expect a non-date string to be 
 ```
 <Field name="exampleDateReturned" label="Date returned" id="dateReturnDP" placeholder="Select Date" component={Datepicker} passThroughValue="Today"/>
 ```
+
+## ignoreLocalOffset
+If your date does not lean on time for validation (eg: Birthdates, that shouldn't change their value based on timezone), apply the "ignoreLocalOffset" prop to the datepicker, for it to use UTC in its produced value. For dates that lean on time (eg: expiryDate), ignore this prop.


### PR DESCRIPTION
Added in the prop `ignoreLocalOffset`. When set to true, this props helps to parse the dates passed in from the server in UTC and display dates like the birthdates constant irrespective of the tenant level timezone setting.