### PR TITLE
don't choke on undefined filters. Fixes UIU-470

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,8 @@
 * Use country-code to country-name mapping in `<AddressFieldGroup>`. Fixes STCOM-242. Available from v2.0.8.
 * MCL should use column-titles, not column keys, for the aria-label field. Fixes STCOM-246. Available from v2.0.9.
 * Allow for selecting value programmatically in Selection component. Fixes STCOM-250.
-* `<FilterGroups>` support hidden constraints. Refs UIU-500. Available from v2.0.10. 
+* `<FilterGroups>` support hidden constraints. Refs UIU-500. Available from v2.0.10.
+* Don't choke on undefined filters. Fixes UIU-470. Available from v2.0.11.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -124,7 +124,7 @@ export function filterState(filters) {
  * @param filters string comma-delimited list of active filters, e.g. foo.someValue,bar.otherValue
  *
  */
-export function filters2cql(config, filters) {
+export function filters2cql(config, filters = '') {
   const groups = {};
   const fullNames = filters.split(',');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
Provide a default value for filters so that we don't ever try to call
"split" on an undefined string because, not that I'd know, but I've
heard that bad things happen when you do that.

Fixes [UIU-470](https://issues.folio.org/browse/UIU-470)