### PR TITLE
STCOM-199 MCL, Do not consider 0-length cell values for column measurement

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -656,8 +656,9 @@ class MCLRenderer extends React.Component {
           } else {
             charLength = row[colName].toString().length;
           }
-
-          charLengthArray.push(charLength);
+          if (charLength > 0) {
+            charLengthArray.push(charLength);
+          }
         });
         // getAverage width..
         let sum = 0;


### PR DESCRIPTION
If a table has a column with many empty cells, it may make conditions a bit cramped for any cells that do have content. This can lead to odd breakage in titles and a general lack of real-estate use.

### Before
![column-with-averaged-0s](https://user-images.githubusercontent.com/20704067/38953183-8a12d700-4313-11e8-8b84-3bcbe6a5dac5.PNG)

### After
![0-lengths-discarded](https://user-images.githubusercontent.com/20704067/38953191-909d7620-4313-11e8-9d98-947c79e21e97.JPG)
