### PR TITLE
STCOM-252 Add 'autofocus' prop to form controls

### DIFF
--- a/lib/Button/Button.js
+++ b/lib/Button/Button.js
@@ -22,15 +22,19 @@ const propTypes = {
     PropTypes.arrayOf(PropTypes.node),
   ]),
   buttonRef: PropTypes.func,
+  autofocus: PropTypes.bool,
 };
 
 const defaultProps = {
   buttonStyle: 'default',
   type: 'button',
   role: 'button',
+  autofocus: false,
 };
 
 function Button(props) {
+  let controlRef;
+
   function getStyle() {
     const buttonBuiltIn = [];
     if (/\s/.test(props.buttonStyle)) {
@@ -60,9 +64,15 @@ function Button(props) {
     if (props.buttonRef) {
       props.buttonRef(ref);
     }
+    controlRef = ref;
+    if (props.autofocus) {
+      if (controlRef) {
+        controlRef.focus();
+      }
+    }
   }
 
-  const inputCustom = omitProps(props, ['buttonClass', 'buttonStyle', 'bottomMargin0', 'marginBottom0', 'paddingSide0', 'align', 'hollow', 'fullWidth', 'bsRole', 'bsClass', 'onClick', 'allowAnchorClick', 'buttonRef', 'type']);
+  const inputCustom = omitProps(props, ['buttonClass', 'autofocus', 'buttonStyle', 'bottomMargin0', 'marginBottom0', 'paddingSide0', 'align', 'hollow', 'fullWidth', 'bsRole', 'bsClass', 'onClick', 'allowAnchorClick', 'buttonRef', 'type']);
   const { children, onClick, type } = props;
 
   if (props.href) {

--- a/lib/Checkbox/Checkbox.js
+++ b/lib/Checkbox/Checkbox.js
@@ -24,10 +24,12 @@ const propTypes = {
   name: PropTypes.string,
   id: PropTypes.string,
   disabled: PropTypes.bool,
+  autofocus: PropTypes.bool,
 };
 
 const defaultProps = {
   id: `checkbox-${random(999, 99999)}`,
+  autofocus: false,
 };
 
 class Checkbox extends React.Component {
@@ -48,6 +50,9 @@ class Checkbox extends React.Component {
   }
 
   componentDidMount() {
+    if (this.props.autofocus) {
+      this.input.focus();
+    }
     // setting state after mounting can cause layout thrashing, so there's a
     // lint rule to recommend against that unless you know what you're doing.
     // Here, we're inspecting a DOM element (this.input is a ref), which won't

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -40,6 +40,7 @@ const propTypes = {
   ]),
   passThroughValue: PropTypes.string,
   ignoreLocalOffset: PropTypes.bool,
+  autofocus: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -48,6 +49,7 @@ const defaultProps = {
   useFocus: true,
   locale: 'en',
   backendDateStandard: 'ISO8601',
+  autofocus: false,
   tether: {
     attachment: 'top center',
     renderElementTo: null,
@@ -436,7 +438,7 @@ class Datepicker extends React.Component {
       excludeDates,
       disabled,
       tether,
-
+      autofocus,
     } = this.props;
 
     const screenReaderFormat = this.cleanForScreenReader(this._dateFormat);
@@ -515,6 +517,7 @@ class Datepicker extends React.Component {
           id={this.testId}
           required={required}
           hasClearIcon={false}
+          autofocus={autofocus}
         />
       );
     } else {
@@ -536,6 +539,7 @@ class Datepicker extends React.Component {
           id={this.testId}
           required={required}
           hasClearIcon={false}
+          autofocus={autofocus}
         />
       );
     }

--- a/lib/IconButton/IconButton.js
+++ b/lib/IconButton/IconButton.js
@@ -10,8 +10,18 @@ import Icon from '../Icon';
 import css from './IconButton.css';
 import Badge from '../Badge';
 
-const IconButton = ({ icon, onClick, onMouseDown, title, type, ariaLabel, id, style, className, badgeCount, iconClassName, tabIndex, badgeColor, href, size, iconSize, ...rest }) => {
+const IconButton = ({ icon, autofocus, onClick, onMouseDown, title, type, ariaLabel, id, style, className, badgeCount, iconClassName, tabIndex, badgeColor, href, size, iconSize, ...rest }) => {
   let Element = 'button';
+  let controlRef;
+
+  function setRef(ref) {
+    controlRef = ref;
+    if (autofocus) {
+      if (controlRef) {
+        controlRef.focus();
+      }
+    }
+  }
 
   let buttonProps = {
     icon,
@@ -31,12 +41,12 @@ const IconButton = ({ icon, onClick, onMouseDown, title, type, ariaLabel, id, st
    * If button is a link
    */
   if (href) {
-    buttonProps = Object.assign(buttonProps, { to: href, type: '' });
+    buttonProps = Object.assign(buttonProps, { to: href, type: '', ref: setRef });
     Element = Link;
   }
 
   return (
-    <Element {...buttonProps}>
+    <Element {...buttonProps} ref={setRef} >
       <Icon icon={icon} size={iconSize} iconClassName={iconClassName} />
       { badgeCount !== undefined && <Badge size="medium" color={badgeColor}>{badgeCount}</Badge> }
     </Element>
@@ -69,6 +79,7 @@ IconButton.propTypes = {
   id: PropTypes.string,
   tabIndex: PropTypes.string,
   style: PropTypes.object,
+  autofocus: PropTypes.bool,
 };
 
 IconButton.defaultProps = {
@@ -76,6 +87,7 @@ IconButton.defaultProps = {
   type: 'button',
   size: 'medium',
   iconSize: 'medium',
+  autofocus: false,
 };
 
 export default IconButton;

--- a/lib/Pane/Pane.js
+++ b/lib/Pane/Pane.js
@@ -19,6 +19,7 @@ const propTypes = {
     ],
   ),
   actionMenuItems: PropTypes.arrayOf(PropTypes.object),
+  actionMenuAutofocus: PropTypes.bool,
   firstMenu: PropTypes.element,
   lastMenu: PropTypes.element,
   appIcon: PropTypes.shape({

--- a/lib/PaneHeader/PaneHeader.js
+++ b/lib/PaneHeader/PaneHeader.js
@@ -16,6 +16,7 @@ export default class PaneHeader extends Component {
     firstMenu: PropTypes.element,
     lastMenu: PropTypes.element,
     actionMenuItems: PropTypes.arrayOf(PropTypes.object),
+    actionMenuAutofocus: PropTypes.bool,
     header: PropTypes.element,
     paneTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.node]),
     paneSub: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.node]),
@@ -41,10 +42,14 @@ export default class PaneHeader extends Component {
     this.getFirstContentArea = this.getFirstContentArea.bind(this);
     this.getLastContentArea = this.getLastContentArea.bind(this);
     this.setCenteredMargin = this.setCenteredMargin.bind(this);
+    this.setActionMenuRef = this.setActionMenuRef.bind(this);
   }
 
   componentDidMount() {
     this.setCenteredMargin();
+    if (this.props.actionMenuAutofocus) {
+      this.actionMenuToggle.focus();
+    }
   }
 
   /**
@@ -99,6 +104,10 @@ export default class PaneHeader extends Component {
     return {
       margin: centerMargin,
     };
+  }
+
+  setActionMenuRef(ref) {
+    this.actionMenuToggle = ref;
   }
 
   /**
@@ -158,7 +167,6 @@ export default class PaneHeader extends Component {
     /**
      * Action Menu
      */
-
     const toggleActionMenu = () => {
       this.setState({ actionMenuOpen: !actionMenuOpen });
     };
@@ -169,7 +177,7 @@ export default class PaneHeader extends Component {
         onToggle={toggleActionMenu}
         hasPadding
       >
-        <button data-role="toggle" className={css.paneHeaderCenterButton}>
+        <button data-role="toggle" className={css.paneHeaderCenterButton} ref={this.setActionMenuRef}>
           { content }
         </button>
         <DropdownMenu

--- a/lib/RadioButton/RadioButton.js
+++ b/lib/RadioButton/RadioButton.js
@@ -12,10 +12,17 @@ const propTypes = {
   id: PropTypes.string,
   label: PropTypes.string,
   error: PropTypes.bool,
+  autofocus: PropTypes.bool,
 };
 
 
 class RadioButton extends React.Component {
+  componentDidMount() {
+    if (this.props.autofocus) {
+      this.input.focus();
+    }
+  }
+
   getLabelStyle() {
     let labelStyle = css.radioLabel;
     labelStyle += this.props.error ? ` ${css.error}` : '';
@@ -39,7 +46,7 @@ class RadioButton extends React.Component {
 
     return (
       <div className={this.getRootStyle()}>
-        <input id={this.props.id} {...inputProps} className={css.input} type="radio" />
+        <input id={this.props.id} {...inputProps} className={css.input} type="radio" ref={(ref) => { this.input = ref; }} />
         <label htmlFor={this.props.id} className={this.getLabelStyle()}>{label}</label>
       </div>
     );

--- a/lib/Select/Select.js
+++ b/lib/Select/Select.js
@@ -22,6 +22,7 @@ const propTypes = {
   rounded: PropTypes.bool,
   id: PropTypes.string,
   selectClass: PropTypes.string,
+  autofocus: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -29,9 +30,16 @@ const defaultProps = {
   rounded: false,
   validationEnabled: true,
   validStylesEnabled: false,
+  autofocus: false,
 };
 
 class Select extends React.Component {
+  componentDidMount() {
+    if (this.props.autofocus) {
+      this.input.focus();
+    }
+  }
+
   getRootClass() {
     return classNames(
       css.select,
@@ -73,6 +81,7 @@ class Select extends React.Component {
       marginBottom0, // eslint-disable-line no-unused-vars
       validationEnabled, // eslint-disable-line no-unused-vars
       validStylesEnabled, // eslint-disable-line no-unused-vars
+      autofocus,  // eslint-disable-line no-unused-vars
       ...selectCustom
     } = rest;
 
@@ -87,7 +96,12 @@ class Select extends React.Component {
     }
 
     const component = (
-      <select className={this.getSelectClass()} {...selectAttr} {...omitProps(selectCustom, ['rounded', 'selectClass'])} >
+      <select
+        className={this.getSelectClass()}
+        {...selectAttr}
+        {...omitProps(selectCustom, ['rounded', 'selectClass'])}
+        ref={(ref) => { this.input = ref; }}
+      >
         {options}
         {children}
       </select>

--- a/lib/Selection/Selection.js
+++ b/lib/Selection/Selection.js
@@ -18,6 +18,7 @@ const propTypes = {
   labelIsValue: PropTypes.bool,
   formatter: PropTypes.func,
   name: PropTypes.string,
+  autofocus: PropTypes.bool,
 };
 
 const defaultProps = {

--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -36,6 +36,7 @@ const propTypes = {
   onFilter: PropTypes.func,
   formatter: PropTypes.func,
   optionAlignment: PropTypes.oneOf(['start', 'end', 'outside', 'center']),
+  autofocus: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -119,6 +120,12 @@ class SingleSelect extends React.Component {
       this.testId = this.props.id;
     } else {
       this.testId = uniqueId('stripes-selection-');
+    }
+  }
+
+  componentDidMount() {
+    if (this.props.autofocus) {
+      this.control.focus();
     }
   }
 

--- a/lib/TextArea/TextArea.js
+++ b/lib/TextArea/TextArea.js
@@ -44,6 +44,7 @@ const propTypes = {
   marginBottom0: PropTypes.bool,
   label: PropTypes.string,
   inputRef: PropTypes.func,
+  autofocus: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -54,6 +55,12 @@ const defaultProps = {
 };
 
 class TextArea extends React.Component {
+  componentDidMount() {
+    if (this.props.autofocus) {
+      this.input.focus();
+    }
+  }
+
   getRootStyle() {
     return className(
       formStyles.inputGroup,
@@ -83,6 +90,13 @@ class TextArea extends React.Component {
     );
   }
 
+  setInputRef = (ref) => {
+    if (this.props.inputRef) {
+      this.props.inputRef(ref);
+    }
+    this.input = ref;
+  }
+
   render() {
     let cleanedProps;
     let input;
@@ -102,7 +116,7 @@ class TextArea extends React.Component {
     }
 
     // eslint-disable-next-line no-unused-vars
-    const { label, endControl, startControl, rounded, required, fullWidth, bottomMargin0, noBorder, inputRef, validStylesEnabled, ...inputCustom } = cleanedProps;
+    const { label, endControl, autofocus, startControl, rounded, required, fullWidth, bottomMargin0, noBorder, inputRef, validStylesEnabled, ...inputCustom } = cleanedProps;
 
     const component = (
       <textarea
@@ -110,7 +124,7 @@ class TextArea extends React.Component {
         {...inputProps}
         {...omitProps(inputCustom, ['meta', 'validationEnabled'])}
         aria-required={required}
-        ref={cleanedProps.inputRef}
+        ref={this.setInputRef}
       />
     );
 

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -67,6 +67,7 @@ const propTypes = {
   validStylesEnabled: PropTypes.bool,
   hasClearIcon: PropTypes.bool,
   onClearField: PropTypes.func,
+  autofocus: PropTypes.func,
 };
 
 const defaultProps = {
@@ -74,6 +75,7 @@ const defaultProps = {
   validationEnabled: true,
   rounded: false,
   hasClearIcon: true,
+  autofocus: false,
 };
 
 class TextField extends React.Component {
@@ -108,6 +110,12 @@ class TextField extends React.Component {
           Object.assign(this.input.style, paddingObject);
         }
       });
+    }
+
+    if (this.props.autofocus) {
+      if (this.input) {
+        this.input.focus();
+      }
     }
   }
 
@@ -234,7 +242,7 @@ class TextField extends React.Component {
     // know the names of all the props we want to pass along, but we don't
     // know them.
     // this still feels kinda clumsy, but at least it's not broken.
-    const inputCustom = omitProps(cleanedProps, ['label', 'endControl', 'startControl', 'rounded', 'required', 'fullWidth', 'marginBottom0', 'noBorder', 'validationEnabled', 'validStylesEnabled', 'meta', 'inputClass', 'hasClearIcon', 'ariaLabel', 'onClearField', 'clearFieldId', 'focusedClass']);
+    const inputCustom = omitProps(cleanedProps, ['label', 'autofocus', 'endControl', 'startControl', 'rounded', 'required', 'fullWidth', 'marginBottom0', 'noBorder', 'validationEnabled', 'validStylesEnabled', 'meta', 'inputClass', 'hasClearIcon', 'ariaLabel', 'onClearField', 'clearFieldId', 'focusedClass']);
     const component = (
       <input
         ref={(ref) => { this.input = ref; }}

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -67,7 +67,7 @@ const propTypes = {
   validStylesEnabled: PropTypes.bool,
   hasClearIcon: PropTypes.bool,
   onClearField: PropTypes.func,
-  autofocus: PropTypes.func,
+  autofocus: PropTypes.bool,
 };
 
 const defaultProps = {

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -28,11 +28,13 @@ const propTypes = {
   tether: PropTypes.object,
   rounded: PropTypes.bool,
   passThroughValue: PropTypes.string,
+  autofocus: PropTypes.bool,
 };
 
 const defaultProps = {
   screenReaderMessage: '',
   locale: 'en',
+  autofocus: false,
   tether: {
     attachment: 'top center',
     renderElementTo: null,
@@ -470,7 +472,7 @@ class Timepicker extends React.Component {
       required,
       disabled,
       tether,
-
+      autofocus,
     } = this.props;
 
     const screenReaderFormat = this.cleanForScreenReader(this._timeFormat);
@@ -555,6 +557,7 @@ class Timepicker extends React.Component {
           aria-haspopup="true"
           aria-expanded={this.state.showTimepicker}
           rounded={this.props.rounded}
+          autofocus={autofocus}
         />
       );
     } else {
@@ -578,6 +581,7 @@ class Timepicker extends React.Component {
           aria-haspopup="true"
           aria-expanded={this.state.showTimepicker}
           rounded={this.props.rounded}
+          autofocus={autofocus}
         />
       );
     }


### PR DESCRIPTION
Focus management is a key part of accessibility and usability.  In this PR, applying the `autofocus` boolean prop to a form control will cause it to autofocus on its `componentDidMount` lifecycle method, or when a ref to the element is set.

This can be used to apply focus control to new Panes, Layers and Modals.
The components this affects:
* Button
* RadioButton
* Checkbox
* TextField
* Textarea
* Select
* Selection
* Datepicker
* Timepicker
* IconButton
* PaneHeaders (Pane action menu is autofocus-able)

