### PR TITLE
Render callouts using React.Portal to overlay container.

### DIFF
--- a/lib/Callout/Callout.js
+++ b/lib/Callout/Callout.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Portal } from 'react-overlays'; // eslint-disable-line
+import ReactDOM from 'react-dom';
 import cloneDeep from 'lodash/cloneDeep';
 import uniqueId from 'lodash/uniqueId';
 import findIndex from 'lodash/findIndex';
@@ -14,6 +14,7 @@ class Callout extends React.Component {
       callouts: [],
     };
 
+    this.calloutContainer = document.getElementById('OverlayContainer');
     this.sendCallout = this.sendCallout.bind(this);
     this.removeCallout = this.removeCallout.bind(this);
   }
@@ -41,16 +42,15 @@ class Callout extends React.Component {
   }
 
   render() {
-    return (
-      <Portal container={document.body}>
-        <div className={css.callout}>
-          <TransitionGroup className={css.calloutContainer} aria-live="polite" aria-relevant="additions">
-            {this.state.callouts.map(calloutProps => (
-              <CalloutElement key={calloutProps.id} transition="slide" {...calloutProps} />
-            ))}
-          </TransitionGroup>
-        </div>
-      </Portal>
+    return ReactDOM.createPortal(
+      <div className={css.callout}>
+        <TransitionGroup className={css.calloutContainer} aria-live="polite" aria-relevant="additions">
+          {this.state.callouts.map(calloutProps => (
+            <CalloutElement key={calloutProps.id} transition="slide" {...calloutProps} />
+          ))}
+        </TransitionGroup>
+      </div>,
+      this.calloutContainer
     );
   }
 }

--- a/lib/Callout/CalloutElement.js
+++ b/lib/Callout/CalloutElement.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Transition } from 'react-transition-group';
-import Button from '../Button';
+import IconButton from '../IconButton';
 import Icon from '../Icon';
 import css from './Callout.css';
 
@@ -49,9 +49,7 @@ const CalloutElement = props => (
         <div className={getClassNamefromTransitionState(transitionState, props.type, css.calloutBase, props.transition)} >
           <Icon icon={getIconForType(props.type)} />
           <div className={css.message}>{props.message}</div>
-          <Button buttonStyle="transparent slim marginBottom0" onClick={() => props.onDismiss(props.id)}>
-            <Icon icon="closeX" color="#777" />
-          </Button>
+          <IconButton icon="closeX" onClick={() => props.onDismiss(props.id)} />
         </div>
       </div>
     )}


### PR DESCRIPTION
Callouts are 'system-level' messages, so they deserve z-index prominence that the new overlay-container div will give them.