### PR TITLE
STCOM-256: Automatically focus textfields when editing/creating EditableList item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * `<FilterGroups>` support hidden constraints. Refs UIU-500. Available from v2.0.10.
 * Don't choke on undefined filters. Fixes UIU-470. Available from v2.0.11.
 * Fix `<ConfirmationModal>` scope. Fixes STCOM-255.
+* `<EditableList>` now autofocuses the first editable field when mounting an editable row. Fixes STCOM-256.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/lib/structures/EditableList/EditableItem.js
+++ b/lib/structures/EditableList/EditableItem.js
@@ -4,7 +4,7 @@ import ItemView from './ItemView';
 import ItemEdit from './ItemEdit';
 
 const EditableItem = props =>
-  (props.editing ? <ItemEdit {...props} /> : <ItemView {...props} />);
+  (props.editing ? <ItemEdit {...props} autoFocus /> : <ItemView {...props} />);
 
 EditableItem.propTypes = {
   editing: PropTypes.bool,

--- a/lib/structures/EditableList/ItemEdit.js
+++ b/lib/structures/EditableList/ItemEdit.js
@@ -4,7 +4,7 @@ import { Field } from 'redux-form';
 import TextField from '../../TextField';
 import css from './EditableList.css';
 
-const ItemEdit = ({ rowIndex, error, field, visibleFields, readOnlyFields, widths, cells }) => {
+const ItemEdit = ({ rowIndex, error, field, visibleFields, readOnlyFields, widths, cells, autoFocus }) => {
   const fields = visibleFields.map((name, i) => {
     if (readOnlyFields.indexOf(name) === -1) {
       return (
@@ -15,6 +15,7 @@ const ItemEdit = ({ rowIndex, error, field, visibleFields, readOnlyFields, width
             fullWidth
             marginBottom0
             placeholder={name}
+            autoFocus={autoFocus && i === 0}
           />
         </div>
       );
@@ -40,6 +41,7 @@ ItemEdit.propTypes = {
   readOnlyFields: PropTypes.arrayOf(PropTypes.string),
   widths: PropTypes.object,
   cells: PropTypes.arrayOf(PropTypes.object),
+  autoFocus: PropTypes.bool,
 };
 
 export default ItemEdit;


### PR DESCRIPTION
We're using the HTML5 `autoFocus` prop here rather than mucking around and relying on `redux-form` refs or the format of our name parameters and `focus()` hacks. Seems cleaner to me than those alternatives.