### PR TITLE
STRIPES-528 Callout: Ensure calloutContainer exists before using it

### DIFF
--- a/lib/Callout/Callout.js
+++ b/lib/Callout/Callout.js
@@ -14,9 +14,12 @@ class Callout extends React.Component {
       callouts: [],
     };
 
-    this.calloutContainer = document.getElementById('OverlayContainer');
     this.sendCallout = this.sendCallout.bind(this);
     this.removeCallout = this.removeCallout.bind(this);
+  }
+
+  updateCalloutContainer() {
+    this.calloutContainer = document.getElementById('OverlayContainer');
   }
 
   sendCallout({ type = 'success', message, timeout = 6000 }) {
@@ -42,6 +45,16 @@ class Callout extends React.Component {
   }
 
   render() {
+    // We don't want to try and create a Portal if the callout container hasn't been rendered yet,
+    // which is the case whenever the Callout Container is going to be put into the DOM at the same
+    // or later time as this Callout.
+    if (!this.calloutContainer) {
+      this.updateCalloutContainer();
+      if (!this.calloutContainer) {
+        return null;
+      }
+    }
+
     return ReactDOM.createPortal(
       <div className={css.callout}>
         <TransitionGroup className={css.calloutContainer} aria-live="polite" aria-relevant="additions">


### PR DESCRIPTION
[STRIPES-528](https://issues.folio.org/browse/STRIPES-528)

During `<Callout>`'s `render()`, it attempts to create a React Portal at `#OverlayContainer` which is rendered by `<OverlayContainer>`. However, Callout's render can be fired before OverlayContainer's, which leads to React throwing an error when it's told to create a Portal at `null`.

This PR attempts to update the Portal container as long as it's falsey, and if an update still results in a falsey value for the container, doesn't try to create the Portal.  