### PR TITLE
Revert "Re-added ID for Checkbox input and htmlFor on label"

### DIFF
--- a/lib/Checkbox/Checkbox.js
+++ b/lib/Checkbox/Checkbox.js
@@ -202,9 +202,8 @@ class Checkbox extends React.Component {
 
     return (
       <div className={this.getRootStyle()}>
-        <label htmlFor={this.props.id} className={this.getLabelStyle()}>
+        <label className={this.getLabelStyle()}>
           <input
-            id={this.props.id}
             type="checkbox"
             {...inputAriaProps}
             checked={(inputChecked !== undefined && inputChecked) || (inputCustom.checked !== undefined && inputCustom.checked)}


### PR DESCRIPTION
Reverts folio-org/stripes-components#342. 

Unfortunately, we still haven't resolved the underlying issues that led to https://issues.folio.org/browse/UIU-430 (https://issues.folio.org/browse/STCOR-173 and https://issues.folio.org/browse/STRIPES-512). 