### PR TITLE
restore missing checkbox id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * Added `<ErrorBoundary>` component to stop render() error propagation.
 * Added universal interaction styles to all relevant components.
 * Various updates in relation to new universal interaction styles.
+* Restore checkbox IDs, which were erroneously removed. Available from v2.0.13.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/lib/Checkbox/Checkbox.js
+++ b/lib/Checkbox/Checkbox.js
@@ -204,6 +204,7 @@ class Checkbox extends React.Component {
       <div className={this.getRootStyle()}>
         <label className={this.getLabelStyle()}>
           <input
+            id={this.props.id}
             type="checkbox"
             {...inputAriaProps}
             checked={(inputChecked !== undefined && inputChecked) || (inputCustom.checked !== undefined && inputCustom.checked)}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
Checkbox IDs were accidentally removed in #339, and then restored #342 which _also_ restored the (broken because we don’t have unique checkbox IDs) `<label for="some-id">` attribute, which, because it was broken, was reverted in #343. 

In other words, this reverts half the reversion of the inadvertent revision. 