### PR TITLE
Create TimeZone and Locale contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.0.0 (IN PROGRESS)
 
+* Create `Locale` and `TimeZone` contexts. Fixes STCOM-259.
 * In `<Datepicker>`, added a new `ignoreLocalOffset` prop that ignores the tenant timezone and treats the date as UTC to display the date. Fixes UIORG-55
 * Adjust address read only view. Fixes STCOM-152.
 * `<FilterPaneSearch>` supports `searchableIndexes`, `selectedIndex` and `onChangeIndex` properties. Fixes STCOM-171.

--- a/index.js
+++ b/index.js
@@ -12,6 +12,10 @@ export { default as TextArea } from './lib/TextArea';
 export { default as TextField } from './lib/TextField';
 export { default as Timepicker } from './lib/Timepicker';
 
+/* context providers/consumers */
+export { default as withLocale, LocaleContext } from './lib/Locale';
+export { default as withTimeZone, TimeZoneContext } from './lib/TimeZone';
+
 /* data containers */
 export { default as KeyValue } from './lib/KeyValue';
 export { default as MultiColumnList } from './lib/MultiColumnList';

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -7,6 +7,9 @@ import contains from 'dom-helpers/query/contains';
 import debounce from 'lodash/debounce';
 import uniqueId from 'lodash/uniqueId';
 
+import withLocale from '../Locale';
+import withTimeZone from '../TimeZone';
+
 import Button from '../Button';
 import TextField from '../TextField';
 import Calendar from './Calendar';
@@ -28,7 +31,6 @@ const propTypes = {
   onChange: PropTypes.func,
   useFocus: PropTypes.bool,
   hideOnChoose: PropTypes.bool,
-  locale: PropTypes.string,
   readOnly: PropTypes.bool,
   backendDateStandard: PropTypes.string,
   showCalendar: PropTypes.bool,
@@ -39,15 +41,15 @@ const propTypes = {
     PropTypes.string,
   ]),
   passThroughValue: PropTypes.string,
-  ignoreLocalOffset: PropTypes.bool,
   autoFocus: PropTypes.bool,
+  locale: PropTypes.string.isRequired,
+  timeZone: PropTypes.string.isRequired,
 };
 
 const defaultProps = {
   screenReaderMessage: '',
   hideOnChoose: true,
   useFocus: true,
-  locale: 'en',
   backendDateStandard: 'ISO8601',
   autoFocus: false,
   tether: {
@@ -67,12 +69,6 @@ const defaultProps = {
     },
     ],
   },
-};
-
-const contextTypes = {
-  stripes: PropTypes.shape({
-    locale: PropTypes.string.isRequired,
-  }).isRequired,
 };
 
 class Datepicker extends React.Component {
@@ -99,29 +95,26 @@ class Datepicker extends React.Component {
     this.handleFieldChange = this.handleFieldChange.bind(this);
     this.datePickerIsFocused = this.datePickerIsFocused.bind(this);
     this.getPresentedValue = this.getPresentedValue.bind(this);
-    this.timezone = this.context.stripes.timezone;
-    this.parseTimezone = this.props.ignoreLocalOffset ? 'UTC' : this.timezone;
 
-    moment.locale(this.context.stripes.locale);
+    moment.locale(this.props.locale);
     this._dateFormat = moment.localeData()._longDateFormat.L;
 
     // non-null presentedValue will eventually be rendered as the value of the TextField.
     let inputValue = '';
     let presentedValue = null;
 
-
     // if we aren't using redux form...
     if (typeof this.props.input === 'undefined') {
       if (this.props.value === this.props.passThroughValue && typeof this.props.date === 'undefined') {
         presentedValue = this.props.passThroughValue;
-        inputValue = moment.tz(this.parseTimezone).format(this._dateFormat);
+        inputValue = moment.tz(this.props.timeZone).format(this._dateFormat);
       }
       // if we are using redux-form...
     } else if (this.props.input.value === this.props.passThroughValue) {
       presentedValue = this.props.passThroughValue;
-      inputValue = moment.tz(this.parseTimezone).format(this._dateFormat);
+      inputValue = moment.tz(this.props.timeZone).format(this._dateFormat);
     } else if (this.props.input.value !== '') {
-      inputValue = moment.tz(this.props.input.value, this.parseTimezone).format(this._dateFormat);
+      inputValue = moment.tz(this.props.input.value, this.props.timeZone).format(this._dateFormat);
     }
 
     this.state = {
@@ -141,15 +134,15 @@ class Datepicker extends React.Component {
   componentWillReceiveProps(nextProps) {
     let inputValue;
     let presentedValue = null;
-    this.parseTimezone = nextProps.ignoreLocalOffset ? 'UTC' : this.timezone;
+
     if (nextProps.input) {
       if (nextProps.input.value !== '' && nextProps.input.value !== this.props.input.value) {
         const passRE = new RegExp(`^${nextProps.input.value}`, 'i');
         if (nextProps.input.value === this.props.passThroughValue || passRE.test(this.props.passThroughValue)) {
           presentedValue = nextProps.input.value;
-          inputValue = moment.tz(this.parseTimezone).format(this._dateFormat);
+          inputValue = moment.tz(this.props.timeZone).format(this._dateFormat);
         } else {
-          inputValue = moment.tz(nextProps.input.value, this.parseTimezone).format(this._dateFormat);
+          inputValue = moment.tz(nextProps.input.value, this.props.timeZone).format(this._dateFormat);
         }
         this.setState({
           presentedValue,
@@ -164,10 +157,10 @@ class Datepicker extends React.Component {
       }
     } else if (this.props.value !== '' && this.props.date !== nextProps.date) {
       if (nextProps.value === this.props.passThroughValue && nextProps.date === 'undefined') {
-        inputValue = moment.tz(this.parseTimezone).format(this._dateFormat);
+        inputValue = moment.tz(this.props.timeZone).format(this._dateFormat);
         presentedValue = this.props.passThroughValue;
       } else {
-        inputValue = moment.tz(this.parseTimezone).format(this._dateFormat);
+        inputValue = moment.tz(this.props.timeZone).format(this._dateFormat);
       }
       this.setState({
         presentedValue,
@@ -412,13 +405,13 @@ class Datepicker extends React.Component {
       case 'ISO 8601':
       case 'ISO8601':
       case 'ISO-8601':
-        return moment.tz(date, this._dateFormat, true, this.timezone).toISOString();
+        return moment.tz(date, this._dateFormat, true, this.props.timeZone).toISOString();
       case 'RFC 2822':
       case 'RFC2822':
       case 'RFC-2822':
-        return moment.tz(date, this._dateFormat, true, this.timezone).format(DATE_RFC2822);
+        return moment.tz(date, this._dateFormat, true, this.props.timeZone).format(DATE_RFC2822);
       default:
-        return moment.tz(date, this._dateFormat, true, this.timezone).format(this.props.backendDateStandard);
+        return moment.tz(date, this._dateFormat, true, this.props.timeZone).format(this.props.backendDateStandard);
     }
   }
 
@@ -439,7 +432,7 @@ class Datepicker extends React.Component {
       disabled,
       autoFocus,
       tether,
-
+      locale,
     } = this.props;
 
     const screenReaderFormat = this.cleanForScreenReader(this._dateFormat);
@@ -563,7 +556,7 @@ class Datepicker extends React.Component {
               ref={(ref) => { this.picker = ref; }}
               onKeyDown={this.handleKeyDown}
               onBlur={this.hideCalendar}
-              locale={this.context.stripes.locale || this.props.locale}
+              locale={locale}
               excludeDates={excludeDates}
               onNavigation={this.handleDateNavigation}
               id={this.testId}
@@ -576,7 +569,6 @@ class Datepicker extends React.Component {
 }
 
 Datepicker.propTypes = propTypes;
-Datepicker.contextTypes = contextTypes;
 Datepicker.defaultProps = defaultProps;
 
-export default Datepicker;
+export default withLocale(withTimeZone(Datepicker));

--- a/lib/Datepicker/readme.md
+++ b/lib/Datepicker/readme.md
@@ -12,23 +12,21 @@ import Datepicker from '@folio/stripes-components/lib/Datepicker';
 ### Props
 Name | type | description | default | required
 --- | --- | --- | --- | ---
-label | string | visible field label | | false
-backendDateStandard | string | parses to/from ISO 8601 standard by default before committing value. | "ISO 8601" | false
-id | string | id for date field - used in the "id" attribute of the text input | | false
-useFocus | bool | if set to false, component relies solely on clicking the calendar icon to toggle appearance of calendar. | true | false
-autoFocus | bool | If this prop is `true`, component will automatically focus on mount | | 
-disabled | bool | if true, field will be disabled for focus or entry. | false | false
-ignoreLocalOffset | bool | if true, ignores the timezone setting and treats the date as UTC to display the date.
-| false | false. See below for more explanation
-readOnly | bool | if true, field will be readonly. 'Calendar' and 'clear' buttons will be omitted. | false | false
-value | string | date to be displayed in the textfield. In forms, this is supplied by the initialValues prop supplied to the form | "" | false
-onChange | func | Event handler to handle updates to the datefield text. | | false
-screenReaderMessage | string | Additional message to be read by screenreaders when textfield is focused in addition to the label and format - which are always read. | | false
-excludeDates | array, string or Moment object | Disables supplied dates from being selected in the calendar. | | false
+`label` | string | visible field label | | false
+`backendDateStandard` | string | parses to/from ISO 8601 standard by default before committing value. | "ISO 8601" | false
+`id` | string | id for date field - used in the "id" attribute of the text input | | false
+`useFocus` | bool | if set to false, component relies solely on clicking the calendar icon to toggle appearance of calendar. | true | false
+`autoFocus` | bool | If this prop is `true`, component will automatically focus on mount | |
+`disabled` | bool | if true, field will be disabled for focus or entry. | false | false
+`readOnly` | bool | if true, field will be readonly. 'Calendar' and 'clear' buttons will be omitted. | false | false
+`value` | string | date to be displayed in the textfield. In forms, this is supplied by the initialValues prop supplied to the form | "" | false
+`onChange` | func | Event handler to handle updates to the datefield text. | | false
+`screenReaderMessage` | string | Additional message to be read by screenreaders when textfield is focused in addition to the label and format - which are always read. | | false
+`excludeDates` | array, string or Moment object | Disables supplied dates from being selected in the calendar. | | false
 `passThroughValue` | string | Can be used to set dynamic values up to the form - values should be inspected/adjusted in a handler at submission time (like a button click that calls `submit()`.) See below for usage example. |  |
-
-<!-- locale | string | locale for datepicker to use to display calendar. e.g. "de" will display calendar using the German locale | "en" | false -->
-<!-- dateFormat | string | system formatting for date. [Moment.js formats](https://momentjs.com/docs/#/displaying/format/) are supported | "MM/DD/YYYY" | false-->
+`timeZone` | string | Overrides the time zone provided by context. | "UTC", if no time zone context provider | false
+`locale` | string | Overrides the locale provided by context. | "en", if no locale context provider | false
+<!-- `dateFormat` | string | system formatting for date. [Moment.js formats](https://momentjs.com/docs/#/displaying/format/) are supported | "MM/DD/YYYY" | false-->
 
 
 ### Features
@@ -50,5 +48,5 @@ Using the prop `passThroughValue` means that you expect a non-date string to be 
 <Field name="exampleDateReturned" label="Date returned" id="dateReturnDP" placeholder="Select Date" component={Datepicker} passThroughValue="Today"/>
 ```
 
-## ignoreLocalOffset
-If your date does not lean on time for validation (eg: Birthdates, that shouldn't change their value based on timezone), apply the "ignoreLocalOffset" prop to the datepicker, for it to use UTC in its produced value. For dates that lean on time (eg: expiryDate), ignore this prop.
+## Ignore local offset
+If your date does not lean on time for validation (eg: birth dates, since those shouldn't change their value based on timezone), apply the `timeZone` prop to `UTC`. For dates that lean on time (eg: expiryDate), omit the `timeZone` prop.

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -1,0 +1,265 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { mount } from '../../../tests/helpers';
+
+import Datepicker from '../Datepicker';
+import { LocaleContext } from '../../Locale';
+import { TimeZoneContext } from '../../TimeZone';
+import DatepickerInteractor from './interactor';
+
+describe('Datepicker', () => {
+  let datepicker = new DatepickerInteractor();
+
+  beforeEach(async () => {
+    await mount(
+      <Datepicker />
+    );
+  });
+
+  it('does not have a value in the input', () => {
+    expect(datepicker.inputValue).to.equal('');
+  });
+
+  describe('with an id', () => {
+    beforeEach(async () => {
+      await mount(
+        <Datepicker id="datepicker-test" />
+      );
+    });
+
+    it('has an id on the input element', () => {
+      expect(datepicker.id).to.equal('datepicker-test');
+    });
+  });
+
+  describe('with a locale context', () => {
+    describe('selecting a date', () => {
+      let dateOutput;
+
+      beforeEach(async () => {
+        dateOutput = '';
+
+        await mount(
+          <LocaleContext.Provider value="de">
+            <Datepicker onChange={(event) => { dateOutput = event.target.value; }} />
+          </LocaleContext.Provider>
+        );
+
+        await datepicker.fillInput('04/01/2018');
+      });
+
+      it('emits an event with the date formatted as displayed', () => {
+        expect(dateOutput).to.equal('04/01/2018');
+      });
+    });
+  });
+
+  describe('with a locale prop', () => {
+    describe('selecting a date', () => {
+      let dateOutput;
+
+      beforeEach(async () => {
+        dateOutput = '';
+
+        await mount(
+          <Datepicker
+            onChange={(event) => { dateOutput = event.target.value; }}
+            locale="de"
+          />
+        );
+
+        await datepicker.fillInput('04/01/2018');
+      });
+
+      it('emits an event with the date formatted as displayed', () => {
+        expect(dateOutput).to.equal('04/01/2018');
+      });
+    });
+  });
+
+  describe('without a parent time zone context', () => {
+    describe('selecting a date', () => {
+      let dateOutput;
+
+      beforeEach(async () => {
+        dateOutput = '';
+
+        await mount(
+          <Datepicker onChange={(event) => { dateOutput = event.target.value; }} />
+        );
+
+        await datepicker.fillInput('04/01/2018');
+      });
+
+      it('emits an event with the date formatted as displayed', () => {
+        expect(dateOutput).to.equal('04/01/2018');
+      });
+    });
+
+    describe('selecting a date with timeZone prop', () => {
+      let dateOutput;
+
+      beforeEach(async () => {
+        dateOutput = '';
+
+        await mount(
+          <Datepicker
+            onChange={(event) => { dateOutput = event.target.value; }}
+            timeZone="America/Los_Angeles"
+          />
+        );
+
+        await datepicker.fillInput('04/01/2018');
+      });
+
+      it('emits an event with the date formatted as displayed', () => {
+        expect(dateOutput).to.equal('04/01/2018');
+      });
+    });
+
+    describe('coupled to redux form', () => {
+      describe('selecting a date', () => {
+        let dateOutput;
+
+        beforeEach(async () => {
+          dateOutput = '';
+
+          await mount(
+            <Datepicker
+              input={{
+                onChange: (value) => { dateOutput = value; },
+              }}
+            />
+          );
+
+          await datepicker.fillInput('04/01/2018');
+        });
+
+        it('returns an ISO 8601 datetime string at UTC', () => {
+          expect(dateOutput).to.equal('2018-04-01T00:00:00.000Z');
+        });
+      });
+
+      describe('selecting a date with timeZone prop', () => {
+        let dateOutput;
+
+        beforeEach(async () => {
+          dateOutput = '';
+
+          await mount(
+            <Datepicker
+              input={{
+                onChange: (value) => { dateOutput = value; },
+              }}
+              timeZone="America/Los_Angeles"
+            />
+          );
+
+          await datepicker.fillInput('04/01/2018');
+        });
+
+        it('returns an ISO 8601 datetime string for specific time zone', () => {
+          expect(dateOutput).to.equal('2018-04-01T07:00:00.000Z');
+        });
+      });
+    });
+  });
+
+  describe('inside a time zone context', () => {
+    describe('selecting a date', () => {
+      let dateOutput;
+
+      beforeEach(async () => {
+        dateOutput = '';
+
+        await mount(
+          <TimeZoneContext.Provider value="Australia/Sydney">
+            <Datepicker onChange={(event) => { dateOutput = event.target.value; }} />
+          </TimeZoneContext.Provider>
+        );
+
+        await datepicker.fillInput('04/01/2018');
+      });
+
+      it('emits an event with the date formatted as displayed', () => {
+        expect(dateOutput).to.equal('04/01/2018');
+      });
+    });
+
+    describe('selecting a date with timeZone prop', () => {
+      let dateOutput;
+
+      beforeEach(async () => {
+        dateOutput = '';
+
+        await mount(
+          <TimeZoneContext.Provider value="Australia/Sydney">
+            <Datepicker
+              onChange={(event) => { dateOutput = event.target.value; }}
+              timeZone="America/Los_Angeles"
+            />
+          </TimeZoneContext.Provider>
+        );
+
+        await datepicker.fillInput('04/01/2018');
+      });
+
+      it('emits an event with the date formatted as displayed', () => {
+        expect(dateOutput).to.equal('04/01/2018');
+      });
+    });
+
+    describe('coupled to redux form', () => {
+      describe('selecting a date', () => {
+        let dateOutput;
+
+        beforeEach(async () => {
+          dateOutput = '';
+
+          await mount(
+            <TimeZoneContext.Provider value="Australia/Sydney">
+              <Datepicker
+                input={{
+                  onChange: (value) => { dateOutput = value; },
+                }}
+              />
+            </TimeZoneContext.Provider>
+          );
+
+          await datepicker.fillInput('04/01/2018');
+        });
+
+        it('returns an ISO 8601 datetime string at the context time zone', () => {
+          expect(dateOutput).to.equal('2018-03-31T13:00:00.000Z');
+        });
+      });
+
+      describe('selecting a date with timeZone prop', () => {
+        let dateOutput;
+
+        beforeEach(async () => {
+          dateOutput = '';
+
+          await mount(
+            <TimeZoneContext.Provider value="Australia/Sydney">
+              <Datepicker
+                input={{
+                  onChange: (value) => { dateOutput = value; },
+                }}
+                timeZone="America/Los_Angeles"
+              />
+            </TimeZoneContext.Provider>
+          );
+
+          await datepicker.fillInput('04/01/2018');
+        });
+
+        it('returns an ISO 8601 datetime string at the prop time zone, overriding the context', () => {
+          expect(dateOutput).to.equal('2018-04-01T07:00:00.000Z');
+        });
+      });
+    });
+  });
+});

--- a/lib/Datepicker/tests/interactor.js
+++ b/lib/Datepicker/tests/interactor.js
@@ -1,0 +1,12 @@
+import {
+  attribute,
+  fillable,
+  interactor,
+  value,
+} from '@bigtest/interaction';
+
+export default interactor(class DatepickerInteractor {
+  id = attribute('input', 'id');
+  inputValue = value('input');
+  fillInput = fillable('input');
+});

--- a/lib/Locale/Locale.js
+++ b/lib/Locale/Locale.js
@@ -1,0 +1,16 @@
+import React from 'react';
+export const LocaleContext = React.createContext('en');
+
+export default function withLocale(Component) {
+  return ({ locale, ...props }) => {
+    if (locale) {
+      return (<Component locale={locale} {...props} />);
+    } else {
+      return (
+        <LocaleContext.Consumer>
+          {contextualLocale => <Component locale={contextualLocale} {...props} />}
+        </LocaleContext.Consumer>
+      );
+    }
+  };
+}

--- a/lib/Locale/index.js
+++ b/lib/Locale/index.js
@@ -1,0 +1,1 @@
+export { default, LocaleContext } from './Locale';

--- a/lib/Locale/readme.md
+++ b/lib/Locale/readme.md
@@ -1,0 +1,23 @@
+# Locale Context
+Higher-order component for consuming `locale` from a context provider.
+
+## Usage
+When using this component within the context of a `stripes-core`-powered platform, `stripes-core` creates a `<LocaleContext.Provider>`.
+
+To wrap a component in a `<LocaleContext.Consumer>`, thus sending a `locale` prop to the component:
+```
+import withLocale from '@folio/stripes-components/lib/Locale';
+
+function ExampleComponent({ locale }) => (
+  <div>{locale}</div>
+);
+
+export default withLocale(ExampleComponent)
+```
+
+For examples, see [`<Datepicker>`](../Datepicker) and [`<Timepicker>`](../Timepicker).
+
+If a component wrapped `withLocale` does not have a parent `<LocaleContext.Provider>`, it will receive the default value for the `locale` prop, `en`.
+
+### More on React context
+This is using the [context API](https://reactjs.org/docs/context.html) shipped with React 16.3.

--- a/lib/Locale/tests/Locale-test.js
+++ b/lib/Locale/tests/Locale-test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import {
+  interactor,
+  text,
+} from '@bigtest/interaction';
+
+import { mount } from '../../../tests/helpers';
+
+import withLocale, { LocaleContext } from '../../Locale';
+
+describe('Locale', () => {
+  let LocaleComponent = ({ locale }) => (
+    <div data-test-locale>{locale}</div>
+  );
+
+  let LocaleComponentInteractor = interactor(class LocaleComponentInteractor {
+    locale = text();
+  });
+  let testComponent = new LocaleComponentInteractor('[data-test-locale]');
+
+  let WrappedLocaleComponent = withLocale(LocaleComponent);
+
+  describe('without parent context', () => {
+    describe('without a locale prop', () => {
+      beforeEach(async () => {
+        await mount(<WrappedLocaleComponent />);
+      });
+
+      it('passes the default locale', () => {
+        expect(testComponent.locale).to.equal('en');
+      });
+    });
+
+    describe('with a locale prop', () => {
+      beforeEach(async () => {
+        await mount(<WrappedLocaleComponent locale="zh" />);
+      });
+
+      it('uses the prop passed in', () => {
+        expect(testComponent.locale).to.equal('zh');
+      });
+    });
+  });
+
+  describe('with parent context', () => {
+    describe('without a locale prop', () => {
+      beforeEach(async () => {
+        await mount(
+          <LocaleContext.Provider value="zh">
+            <WrappedLocaleComponent />
+          </LocaleContext.Provider>
+        );
+      });
+
+      it('passes the locale from the context', () => {
+        expect(testComponent.locale).to.equal('zh');
+      });
+    });
+
+    describe('with a locale prop', () => {
+      beforeEach(async () => {
+        await mount(
+          <LocaleContext.Provider value="zh">
+            <WrappedLocaleComponent locale="de" />
+          </LocaleContext.Provider>
+        );
+      });
+
+      it('overrides the context with the prop', () => {
+        expect(testComponent.locale).to.equal('de');
+      });
+    });
+  });
+});

--- a/lib/TimeZone/TimeZone.js
+++ b/lib/TimeZone/TimeZone.js
@@ -1,0 +1,16 @@
+import React from 'react';
+export const TimeZoneContext = React.createContext('UTC');
+
+export default function withTimeZone(Component) {
+  return ({ timeZone, ...props }) => {
+    if (timeZone) {
+      return (<Component timeZone={timeZone} {...props} />);
+    } else {
+      return (
+        <TimeZoneContext.Consumer>
+          {contextualTimeZone => <Component timeZone={contextualTimeZone} {...props} />}
+        </TimeZoneContext.Consumer>
+      );
+    }
+  };
+}

--- a/lib/TimeZone/index.js
+++ b/lib/TimeZone/index.js
@@ -1,0 +1,1 @@
+export { default, TimeZoneContext } from './TimeZone';

--- a/lib/TimeZone/readme.md
+++ b/lib/TimeZone/readme.md
@@ -1,0 +1,23 @@
+# Time Zone Context
+Higher-order component for consuming `timeZone` from a context provider.
+
+## Usage
+When using this component within the context of a `stripes-core`-powered platform, `stripes-core` creates a `<TimeZoneContext.Provider>`.
+
+To wrap a component in a `<TimeZoneContext.Consumer>`, thus sending a `timeZone` prop to the component:
+```
+import withTimeZone from '@folio/stripes-components/lib/TimeZone';
+
+function ExampleComponent({ timeZone }) => (
+  <div>{timeZone}</div>
+);
+
+export default withTimeZone(ExampleComponent)
+```
+
+For examples, see [`<Datepicker>`](../Datepicker) and [`<Timepicker>`](../Timepicker).
+
+If a component wrapped `withTimeZone` does not have a parent `<TimeZoneContext.Provider>`, it will receive the default value for the `timeZone` prop, `UTC`.
+
+### More on React context
+This is using the [context API](https://reactjs.org/docs/context.html) shipped with React 16.3.

--- a/lib/TimeZone/tests/TimeZone-test.js
+++ b/lib/TimeZone/tests/TimeZone-test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import {
+  interactor,
+  text,
+} from '@bigtest/interaction';
+
+import { mount } from '../../../tests/helpers';
+
+import withTimeZone, { TimeZoneContext } from '../../TimeZone';
+
+describe('TimeZone', () => {
+  let TimeZoneComponent = ({ timeZone }) => (
+    <div data-test-time-zone>{timeZone}</div>
+  );
+
+  let TimeZoneComponentInteractor = interactor(class TimeZoneComponentInteractor {
+    timeZone = text();
+  });
+  let testComponent = new TimeZoneComponentInteractor('[data-test-time-zone]');
+
+  let WrappedTimeZoneComponent = withTimeZone(TimeZoneComponent);
+
+  describe('without parent context', () => {
+    describe('without a timeZone prop', () => {
+      beforeEach(async () => {
+        await mount(<WrappedTimeZoneComponent />);
+      });
+
+      it('passes the default timeZone', () => {
+        expect(testComponent.timeZone).to.equal('UTC');
+      });
+    });
+
+    describe('with a timeZone prop', () => {
+      beforeEach(async () => {
+        await mount(<WrappedTimeZoneComponent timeZone="America/Los_Angeles" />);
+      });
+
+      it('uses the prop passed in', () => {
+        expect(testComponent.timeZone).to.equal('America/Los_Angeles');
+      });
+    });
+  });
+
+  describe('with parent context', () => {
+    describe('without a timeZone prop', () => {
+      beforeEach(async () => {
+        await mount(
+          <TimeZoneContext.Provider value="Australia/Sydney">
+            <WrappedTimeZoneComponent />
+          </TimeZoneContext.Provider>
+        );
+      });
+
+      it('passes the timeZone from the context', () => {
+        expect(testComponent.timeZone).to.equal('Australia/Sydney');
+      });
+    });
+
+    describe('with a timeZone prop', () => {
+      beforeEach(async () => {
+        await mount(
+          <TimeZoneContext.Provider value="Australia/Sydney">
+            <WrappedTimeZoneComponent timeZone="America/Los_Angeles" />
+          </TimeZoneContext.Provider>
+        );
+      });
+
+      it('overrides the context with the prop', () => {
+        expect(testComponent.timeZone).to.equal('America/Los_Angeles');
+      });
+    });
+  });
+});

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -6,6 +6,10 @@ import moment from 'moment-timezone';
 import contains from 'dom-helpers/query/contains';
 import debounce from 'lodash/debounce';
 import uniqueId from 'lodash/uniqueId';
+
+import withLocale from '../Locale';
+import withTimeZone from '../TimeZone';
+
 import Button from '../Button';
 import TextField from '../TextField';
 import TimeDropdown from './TimeDropdown';
@@ -22,17 +26,17 @@ const propTypes = {
   meta: PropTypes.object,
   id: PropTypes.string,
   onChange: PropTypes.func,
-  locale: PropTypes.string,
   readOnly: PropTypes.bool,
   showTimepicker: PropTypes.bool,
   tether: PropTypes.object,
   passThroughValue: PropTypes.string,
   autoFocus: PropTypes.bool,
+  locale: PropTypes.string.isRequired,
+  timeZone: PropTypes.string.isRequired,
 };
 
 const defaultProps = {
   screenReaderMessage: '',
-  locale: 'en',
   autoFocus: false,
   tether: {
     attachment: 'top center',
@@ -51,12 +55,6 @@ const defaultProps = {
     },
     ],
   },
-};
-
-const contextTypes = {
-  stripes: PropTypes.shape({
-    locale: PropTypes.string.isRequired,
-  }).isRequired,
 };
 
 class Timepicker extends React.Component {
@@ -85,8 +83,7 @@ class Timepicker extends React.Component {
     this.deriveHoursFormat = this.deriveHoursFormat.bind(this);
     this.getPresentationValue = this.getPresentationValue.bind(this);
     this.getLocalTime = this.getLocalTime.bind(this);
-    this.timezone = this.context.stripes.timezone;
-    moment.locale(this.context.stripes.locale);
+    moment.locale(this.props.locale);
     this._timeFormat = moment.localeData()._longDateFormat.LT;
 
     // inputValue will eventually be rendered as the value of he TextField.
@@ -97,16 +94,16 @@ class Timepicker extends React.Component {
       if (this.props.input.value !== '') {
         if (this.props.input.value === this.props.passThroughValue) {
           presentedValue = this.props.passThroughValue;
-          inputValue = moment.tz(this.timezone).format(this._timeFormat);
+          inputValue = moment.tz(this.props.timeZone).format(this._timeFormat);
         } else {
-          inputValue = moment.tz(this.props.input.value, this._timeFormat, this.timezone).format(this._timeFormat);
+          inputValue = moment.tz(this.props.input.value, this._timeFormat, this.props.timeZone).format(this._timeFormat);
         }
       }
     } else if (this.props.value === this.props.passThroughValue) {
       presentedValue = this.props.passThroughValue;
-      inputValue = moment.tz(this.timezone).format(this._timeFormat);
+      inputValue = moment.tz(this.props.timeZone).format(this._timeFormat);
     } else {
-      inputValue = moment(this.props.value, this._timeFormat, this.timezone).format(this._timeFormat);
+      inputValue = moment(this.props.value, this._timeFormat, this.props.timeZone).format(this._timeFormat);
     }
 
     this.state = {
@@ -124,7 +121,7 @@ class Timepicker extends React.Component {
     }
   }
 
-  componentWillReceiveProps(nextProps, nextContext) {
+  componentWillReceiveProps(nextProps) {
     let inputValue;
     let presentedValue = null;
     if (nextProps.input) { // if we're using redux-form....
@@ -132,7 +129,7 @@ class Timepicker extends React.Component {
       if (nextProps.input.value !== '' && nextProps.input.value !== this.props.input.value) {
         if (nextProps.input.value === nextProps.passThroughValue) {
           presentedValue = nextProps.passThroughValue;
-          inputValue = moment.tz(this.timezone).format(this._timeFormat);
+          inputValue = moment.tz(this.props.timeZone).format(this._timeFormat);
           this.setState({
             presentedValue,
             timeString: inputValue,
@@ -148,10 +145,10 @@ class Timepicker extends React.Component {
       }
     } else if (this.props.value !== '' && this.props.value !== nextProps.value) {
       if (nextProps.value === this.props.passThroughValue) {
-        inputValue = moment.tz(this.timezone).format(this._timeFormat);
+        inputValue = moment.tz(this.props.timeZone).format(this._timeFormat);
         presentedValue = this.props.passThroughValue;
       } else {
-        inputValue = moment.tz(this.timezone).format(this._timeFormat);
+        inputValue = moment.tz(this.props.timeZone).format(this._timeFormat);
       }
       this.setState({
         presentedValue,
@@ -160,12 +157,12 @@ class Timepicker extends React.Component {
     }
 
     // adjust displayed time format for a change in locale
-    if (nextContext.stripes.locale !== this.context.stripes.locale) {
-      moment.locale(nextContext.stripes.locale);
+    if (nextProps.locale !== this.props.locale) {
+      moment.locale(nextProps.stripes.locale);
       this._timeFormat = moment.localeData()._longDateFormat.LT;
       let newTimeString = this.state.timeString;
       if (newTimeString !== '') {
-        newTimeString = moment.tz(newTimeString, this.state.timeFormat, this.timezone).format(this._timeFormat);
+        newTimeString = moment.tz(newTimeString, this.state.timeFormat, this.props.timeZone).format(this._timeFormat);
       }
       this.setState({
         presentedValue: null,
@@ -446,7 +443,7 @@ class Timepicker extends React.Component {
   }
 
   standardizeTime(time) { // eslint-disable-line class-methods-use-this
-    const isoTime = moment.tz(time, 'HH:mm A', this.timezone).toISOString();
+    const isoTime = moment.tz(time, 'HH:mm A', this.props.timeZone).toISOString();
     const timeSplit = isoTime.split('T');
     return timeSplit[1];
   }
@@ -471,7 +468,7 @@ class Timepicker extends React.Component {
       required,
       disabled,
       tether,
-
+      locale,
     } = this.props;
 
     const screenReaderFormat = this.cleanForScreenReader(this._timeFormat);
@@ -601,7 +598,7 @@ class Timepicker extends React.Component {
             mainControl={this.textfield ? this.textfield.getInput() : undefined}
             onKeyDown={this.handleKeyDown}
             onBlur={this.hideTimepicker}
-            locale={this.context.stripes.locale || this.props.locale}
+            locale={locale}
             onNavigation={this.handleDateNavigation}
             id={this.testId}
             onClose={this.hideTimepicker}
@@ -613,7 +610,6 @@ class Timepicker extends React.Component {
 }
 
 Timepicker.propTypes = propTypes;
-Timepicker.contextTypes = contextTypes;
 Timepicker.defaultProps = defaultProps;
 
-export default Timepicker;
+export default withLocale(withTimeZone(Timepicker));

--- a/lib/Timepicker/readme.md
+++ b/lib/Timepicker/readme.md
@@ -13,9 +13,11 @@ Name | type | description | default | required
 `id` | string | Sets the `id` html attribute on the control | |
 `label` | string | If provided, will render a `<label>` tag with an `htmlFor` attribute directed at the provided `id` prop. | |
 `value` | string | Sets the value for the control. **Not necessary if using redux-form.** | |
-`onChange` | function | Callback function that will receive the control's current value and the onChange event object. `fn(e, value)` **Not necessary if using redux-form**, but it will still work if callback from a change is needed.
+`onChange` | function | Callback function that will receive the control's current value and the onChange event object. `fn(e, value)` **Not necessary if using redux-form**, but it will still work if callback from a change is needed. |  |
 `passThroughValue` | string | Can be used to set dynamic values up to the form - values should be inspected/adjusted in a handler at submission time (like a button click that calls `submit()`.) See below for usage example. |  |
 `autoFocus` | bool | If this prop is `true`, control will automatically focus on mount | |
+`timeZone` | string | Overrides the time zone provided by context. | "UTC", if no time zone context provider | false
+`locale` | string | Overrides the locale provided by context. | "en", if no locale context provider | false
 
 ## Usage in Redux-form
 Redux form will provide `input` and `meta` props to the component when it is used with a redux-form `<Field>` component. The component's value and validation are supplied through these.

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -1,0 +1,265 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { mount } from '../../../tests/helpers';
+
+import Timepicker from '../Timepicker';
+import { LocaleContext } from '../../Locale';
+import { TimeZoneContext } from '../../TimeZone';
+import TimepickerInteractor from './interactor';
+
+describe('Timepicker', () => {
+  let timepicker = new TimepickerInteractor();
+
+  beforeEach(async () => {
+    await mount(
+      <Timepicker />
+    );
+  });
+
+  it('does not have a value in the input', () => {
+    expect(timepicker.inputValue).to.equal('');
+  });
+
+  describe('with an id', () => {
+    beforeEach(async () => {
+      await mount(
+        <Timepicker id="timepicker-test" />
+      );
+    });
+
+    it('has an id on the input element', () => {
+      expect(timepicker.id).to.equal('timepicker-test');
+    });
+  });
+
+  describe('with a locale context', () => {
+    describe('selecting a time', () => {
+      let timeOutput;
+
+      beforeEach(async () => {
+        timeOutput = '';
+
+        await mount(
+          <LocaleContext.Provider value="de">
+            <Timepicker onChange={(event) => { timeOutput = event.target.value; }} />
+          </LocaleContext.Provider>
+        );
+
+        await timepicker.fillInput('05:00 PM');
+      });
+
+      it('emits an event with the time formatted as displayed', () => {
+        expect(timeOutput).to.equal('05:00 PM');
+      });
+    });
+  });
+
+  describe('with a locale prop', () => {
+    describe('selecting a time', () => {
+      let timeOutput;
+
+      beforeEach(async () => {
+        timeOutput = '';
+
+        await mount(
+          <Timepicker
+            onChange={(event) => { timeOutput = event.target.value; }}
+            locale="de"
+          />
+        );
+
+        await timepicker.fillInput('05:00 PM');
+      });
+
+      it('emits an event with the time formatted as displayed', () => {
+        expect(timeOutput).to.equal('05:00 PM');
+      });
+    });
+  });
+
+  describe('without a parent time zone context', () => {
+    describe('selecting a time', () => {
+      let timeOutput;
+
+      beforeEach(async () => {
+        timeOutput = '';
+
+        await mount(
+          <Timepicker onChange={(event) => { timeOutput = event.target.value; }} />
+        );
+
+        await timepicker.fillInput('05:00 PM');
+      });
+
+      it('emits an event with the time formatted as displayed', () => {
+        expect(timeOutput).to.equal('05:00 PM');
+      });
+    });
+
+    describe('selecting a time with timeZone prop', () => {
+      let timeOutput;
+
+      beforeEach(async () => {
+        timeOutput = '';
+
+        await mount(
+          <Timepicker
+            onChange={(event) => { timeOutput = event.target.value; }}
+            timeZone="America/Los_Angeles"
+          />
+        );
+
+        await timepicker.fillInput('05:00 PM');
+      });
+
+      it('emits an event with the time formatted as displayed', () => {
+        expect(timeOutput).to.equal('05:00 PM');
+      });
+    });
+
+    describe('coupled to redux form', () => {
+      describe('selecting a time', () => {
+        let timeOutput;
+
+        beforeEach(async () => {
+          timeOutput = '';
+
+          await mount(
+            <Timepicker
+              input={{
+                onChange: (value) => { timeOutput = value; },
+              }}
+            />
+          );
+
+          await timepicker.fillInput('05:00 PM');
+        });
+
+        it('returns an ISO 8601 time string at UTC', () => {
+          expect(timeOutput).to.equal('17:00:00.000Z');
+        });
+      });
+
+      describe('selecting a time with timeZone prop', () => {
+        let timeOutput;
+
+        beforeEach(async () => {
+          timeOutput = '';
+
+          await mount(
+            <Timepicker
+              input={{
+                onChange: (value) => { timeOutput = value; },
+              }}
+              timeZone="America/Los_Angeles"
+            />
+          );
+
+          await timepicker.fillInput('05:00 PM');
+        });
+
+        it('returns an ISO 8601 time string for specific time zone', () => {
+          expect(timeOutput).to.equal('00:00:00.000Z');
+        });
+      });
+    });
+  });
+
+  describe('inside a time zone context', () => {
+    describe('selecting a time', () => {
+      let timeOutput;
+
+      beforeEach(async () => {
+        timeOutput = '';
+
+        await mount(
+          <TimeZoneContext.Provider value="Australia/Sydney">
+            <Timepicker onChange={(event) => { timeOutput = event.target.value; }} />
+          </TimeZoneContext.Provider>
+        );
+
+        await timepicker.fillInput('05:00 PM');
+      });
+
+      it('emits an event with the time formatted as displayed', () => {
+        expect(timeOutput).to.equal('05:00 PM');
+      });
+    });
+
+    describe('selecting a time with timeZone prop', () => {
+      let timeOutput;
+
+      beforeEach(async () => {
+        timeOutput = '';
+
+        await mount(
+          <TimeZoneContext.Provider value="Australia/Sydney">
+            <Timepicker
+              onChange={(event) => { timeOutput = event.target.value; }}
+              timeZone="America/Los_Angeles"
+            />
+          </TimeZoneContext.Provider>
+        );
+
+        await timepicker.fillInput('05:00 PM');
+      });
+
+      it('emits an event with the time formatted as displayed', () => {
+        expect(timeOutput).to.equal('05:00 PM');
+      });
+    });
+
+    describe('coupled to redux form', () => {
+      describe('selecting a time', () => {
+        let timeOutput;
+
+        beforeEach(async () => {
+          timeOutput = '';
+
+          await mount(
+            <TimeZoneContext.Provider value="Australia/Sydney">
+              <Timepicker
+                input={{
+                  onChange: (value) => { timeOutput = value; },
+                }}
+              />
+            </TimeZoneContext.Provider>
+          );
+
+          await timepicker.fillInput('05:00 PM');
+        });
+
+        it('returns an ISO 8601 time string at the context time zone', () => {
+          expect(timeOutput).to.equal('07:00:00.000Z');
+        });
+      });
+
+      describe('selecting a time with timeZone prop', () => {
+        let timeOutput;
+
+        beforeEach(async () => {
+          timeOutput = '';
+
+          await mount(
+            <TimeZoneContext.Provider value="Australia/Sydney">
+              <Timepicker
+                input={{
+                  onChange: (value) => { timeOutput = value; },
+                }}
+                timeZone="America/Los_Angeles"
+              />
+            </TimeZoneContext.Provider>
+          );
+
+          await timepicker.fillInput('05:00 PM');
+        });
+
+        it('returns an ISO 8601 time string at the prop time zone, overriding the context', () => {
+          expect(timeOutput).to.equal('00:00:00.000Z');
+        });
+      });
+    });
+  });
+});

--- a/lib/Timepicker/tests/interactor.js
+++ b/lib/Timepicker/tests/interactor.js
@@ -1,0 +1,12 @@
+import {
+  attribute,
+  fillable,
+  interactor,
+  value,
+} from '@bigtest/interaction';
+
+export default interactor(class TimepickerInteractor {
+  id = attribute('input', 'id');
+  inputValue = value('input');
+  fillInput = fillable('input');
+});


### PR DESCRIPTION
## Purpose
Work for https://issues.folio.org/browse/UIORG-55 changed the behavior of `Datepicker`. Instead of emitting an ISO-8601 datetime string in the user's local time zone, it now emits the datetime at UTC.

Resulting bug in eHoldings: https://issues.folio.org/browse/STCOM-259

One of the APIs added to the `Datepicker` included `ignoreLocalOffset`: https://github.com/folio-org/stripes-components/pull/329. `ignoreLocalOffset` could easily create a race condition with the `timezone` peeled off of `stripes.context`.

All of these need tests. We should be able to more easily identify breaking changes.

## Approach
Testing context with the [new React Context API](https://reactjs.org/docs/context.html) is muuuuuch easier than before.

`Datepicker` and `Timepicker` were both tightly coupled to `locale` and `timezone` on the `stripes` context. By refactoring them to use the new Context API, we can make them both independent of `stripes-core` and significantly more testable.

`Datepicker` and `Timepicker` now simply have `locale` and `timeZone` props, that when inside of a `LocaleContext.Provider`/`TimeZoneContext.Provider`, get their value from context. The context can be overriden by the props.

I removed the `ignoreLocalOffset` prop. Instead, a `Datepicker` consumer can pass in the `timeZone` prop set to `UTC`.

### Context providers
Newly introduced: `Locale` and `TimeZone` higher-order components, that include creation of the context provider and consumer for `locale` and `timeZone`.

Modules consuming `stripes-components` can also use the consumer HOCs to receive props from context:
```
import withTimeZone from '@folio/stripes-components/lib/TimeZone';

function ExampleComponent({ timeZone }) => (
  <div>{timeZone}</div>
);

export default withTimeZone(ExampleComponent)
```

## Risk
Accessing `this.context.stripes.locale` and `this.context.stripes.timezone` should continue to work as previously, but we should find a way to deprecate those in favor of using `withLocale` and `withTimeZone`.

## Questions for later
- When in the context of a `redux-form`, `Datepicker` emits an ISO-860 string through `onChange()`, but when not in a `redux-form`, it fires an event whose `target.value` is the locale-formatted date in the input. Should those be more consistent? Should the `Datepicker` even try to reformat as ISO-860 by default?
- Should setting `moment.locale()` happen in a more global place? A lot of the date utility functions defined in `stripes-core` can go away in that case, since they're usually just wrapping `moment()`.
