### PR TITLE
Upgrade bigtest/interaction to bigtest/interactor

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,6 +1,6 @@
 # Testing Components
 
-Component tests can be run by navigating to your `stripes-components` folder and running 
+Component tests can be run by navigating to your `stripes-components` folder and running
 ```
 yarn test
 ```
@@ -19,9 +19,9 @@ Button
 |  |-Button-test.js
 ```
 ## Interactors
-An Interactor is a set quick values based on reading from and interaction with the rendered DOM. This employs [bigTest/interaction](https://github.com/thefrontside/bigtest/tree/master/packages/interaction) for setting up checks for event handlers, DOM attributes, classnames, etc.
+An Interactor is a set quick values based on reading from and interaction with the rendered DOM. This employs [bigtest/interactor](https://github.com/bigtestjs/interactor) for setting up checks for event handlers, DOM attributes, classnames, etc.
 See the [Button Interactor](lib/Button/tests/interactor.js) for an example.
 
 ## expect(tests).to.be.simple
-Tests are mocha style, employing [bigtest/mocha](https://github.com/thefrontside/bigtest/tree/master/packages/mocha) to test for DOM updates asynchronously without having to worry about calling `wait(###)` to hope DOM updates have happened by the time your assertion is checked.
-This requires a slighly different style to writing tests as outlined in bigtest/mocha's [documentation on writing tests](https://github.com/thefrontside/bigtest/tree/master/packages/mocha#writing-tests)
+Tests are mocha style, employing [bigtest/mocha](https://github.com/bigtestjs/mocha) to test for DOM updates asynchronously without having to worry about calling `wait(###)` to hope DOM updates have happened by the time your assertion is checked.
+This requires a slighly different style to writing tests as outlined in bigtest/mocha's [documentation on writing tests](https://github.com/bigtestjs/mocha#writing-tests)

--- a/lib/Accordion/tests/interactor.js
+++ b/lib/Accordion/tests/interactor.js
@@ -4,7 +4,7 @@ import {
   hasClass,
   property,
   text
-} from '@bigtest/interaction';
+} from '@bigtest/interactor';
 
 import css from '../Accordion.css';
 import { selectorFromClassnameString } from '../../../tests/helpers';

--- a/lib/Button/tests/interactor.js
+++ b/lib/Button/tests/interactor.js
@@ -5,7 +5,7 @@ import {
   clickable,
   hasClass,
   text,
-} from '@bigtest/interaction';
+} from '@bigtest/interactor';
 
 import css from '../Button.css';
 import { selectorFromClassnameString } from '../../../tests/helpers';

--- a/lib/IconButton/tests/interactor.js
+++ b/lib/IconButton/tests/interactor.js
@@ -3,7 +3,7 @@ import {
   attribute,
   clickable,
   is,
-} from '@bigtest/interaction';
+} from '@bigtest/interactor';
 
 import css from '../IconButton.css';
 import { selectorFromClassnameString } from '../../../tests/helpers';

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     ]
   },
   "devDependencies": {
-    "@bigtest/interaction": "^0.4.0",
+    "@bigtest/interactor": "^0.4.2",
     "@bigtest/mocha": "^0.3.3",
     "@folio/eslint-config-stripes": "^1.1.0",
     "@folio/stripes-cli": "^1.0.100056",


### PR DESCRIPTION
## Purpose
`bigtest/interaction` is now `bigtest/interactor`: https://github.com/bigtestjs/interactor
The `thefrontside/bigtest` monorepo was broken up into the `bigtestjs` org: https://github.com/bigtestjs

## Approach
There weren't any breaking API changes for `stripes-components` to move from `bigtest/interaction` is now `bigtest/interactor` (there were several for `folio-org/ui-eholdings`).