### PR TITLE
folio-1035

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,3 @@
-@Library ('folio_jenkins_shared_libs@folio-1035') _
 
 buildNPM {
   publishModDescriptor = 'no'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,8 @@
+@Library ('folio_jenkins_shared_libs@folio-1035') _
 
 buildNPM {
   publishModDescriptor = 'no'
-  runLint = 'no'
-  runTest = 'no'
+  runLint = 'yes'
+  runTest = 'yes'
+  runTestOptions = '--karma.singleRun --karma.browsers=ChromeDocker'
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,17 @@
+module.exports = (config) => {
+  let configuration = {
+    browsers: ['ChromeDocker'],
+  
+    customLaunchers: {
+      ChromeDocker: {
+        base: 'Chrome',
+        flags: [
+           '--no-sandbox',
+           '--disable-web-security'
+        ]
+      }
+    }
+  };
+  config.set(configuration);
+};
+

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,7 +4,7 @@ module.exports = (config) => {
   
     customLaunchers: {
       ChromeDocker: {
-        base: 'Chrome',
+        base: 'ChromeHeadless',
         flags: [
            '--no-sandbox',
            '--disable-web-security'


### PR DESCRIPTION
- Support browser-based (i.e karma) tests in Jenkins via 'yarn test'.   Currently supported browser is Chrome.  See top-level 'karma.conf.js'.  Can be extended to support Firefox easily. 
- Publish 'yarn test' report 
- Add configurable parameter 'RunTestOptions' to Jenkinsfile to pass additional options to 'yarn test' to  specify karma parameters. 