### PR TITLE
Add linting overrides for tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,14 @@
     "mount":true
   },
   "extends": "@folio/eslint-config-stripes",
+  "overrides": [
+    {
+      "files": ["lib/**/tests/*"],
+      "rules": {
+        "no-unused-expressions": "off"
+      }
+    }
+  ],
   "parser": "babel-eslint",
   "rules": {
     "import/no-extraneous-dependencies": ["error", {

--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,8 @@
     {
       "files": ["lib/**/tests/*"],
       "rules": {
-        "no-unused-expressions": "off"
+        "no-unused-expressions": "off",
+        "func-names": "off"
       }
     }
   ],

--- a/lib/Accordion/tests/Accordion-test.js
+++ b/lib/Accordion/tests/Accordion-test.js
@@ -8,7 +8,7 @@ import Accordion from '../Accordion';
 import AccordionInteractor from './interactor';
 
 describe('Accordion', () => {
-  let accordion = new AccordionInteractor();
+  const accordion = new AccordionInteractor();
 
   beforeEach(async () => {
     await mount(
@@ -94,7 +94,7 @@ describe('Accordion', () => {
     beforeEach(async () => {
       await mount(
         <Accordion label="test" id="accordion-test">
-          <div style={{ height: 100 }}/>
+          <div style={{ height: 100 }} />
         </Accordion>
       );
     });

--- a/lib/TextField/tests/TextField-test.js
+++ b/lib/TextField/tests/TextField-test.js
@@ -1,0 +1,126 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { mount } from '../../../tests/helpers';
+
+import TextField from '../TextField';
+import TextFieldHarness from './TextFieldHarness';
+
+import TextFieldInteractor from './interactor';
+
+describe('TextField', () => {
+  const textfield = new TextFieldInteractor();
+
+  beforeEach(async () => {
+    await mount(
+      <TextField id="tfTest" />
+    );
+  });
+
+  it('renders an input type="text" by default', () => {
+    expect(textfield.isInput).to.be.true;
+    expect(textfield.type).to.equal('text');
+  });
+
+  it('renders no label tag by default', () => {
+    expect(textfield.labelRendered).to.be.false;
+  });
+
+  it('applies the supplied id prop to the input', () => {
+    expect(textfield.id).to.equal('tfTest');
+  });
+
+  describe('entering text into the field', async () => {
+    beforeEach(async () => {
+      await textfield.fillInput('test');
+    });
+
+    it('updates the value', () => {
+      expect(textfield.val).to.equal('test');
+    });
+  });
+
+  describe('Supplying label and id props', () => {
+    beforeEach(async () => {
+      await mount(
+        <TextField label="my test label" id="myTestInput" />
+      );
+    });
+
+    it('renders a proper label element', () => {
+      expect(textfield.labelRendered).to.be.true;
+      expect(textfield.label).to.equal('my test label');
+    });
+
+    it('with a filled htmlFor attribute', () => {
+      expect(textfield.labelFor).to.equal('myTestInput');
+    });
+  });
+
+  describe('supplying an endControl', () => {
+    beforeEach(async () => {
+      await mount(
+        <TextField endControl={<span>testEnd</span>} />
+      );
+    });
+
+    it('renders the supplied element in the end-control container', () => {
+      expect(textfield.endControl).to.be.true;
+    });
+
+    it('applies appropriate padding to the input', () => {
+      expect(parseFloat(textfield.inputComputed.paddingRight)).to.be.above(parseFloat(textfield.inputComputed.paddingLeft));
+    });
+  });
+
+  describe('supplying a startControl', () => {
+    beforeEach(async () => {
+      await mount(
+        <TextField startControl={<span>testStart</span>} />
+      );
+    });
+
+    it('renders the supplied element in the start-control container', () => {
+      expect(textfield.startControl).to.be.true;
+    });
+
+    it('applies appropriate padding to the input', () => {
+      expect(parseFloat(textfield.inputComputed.paddingLeft)).to.be.above(parseFloat(textfield.inputComputed.paddingRight));
+    });
+  });
+
+  describe('supplying a value prop with readOnly', () => {
+    beforeEach(async () => {
+      await mount(
+        <TextField value="test value prop" readOnly />
+      );
+    });
+
+    it('displays a value in the textfield', () => {
+      expect(textfield.val).to.equal('test value prop');
+    });
+
+    it('sets the readonly attribute', () => {
+      expect(textfield.inputReadOnly).to.equal('');
+    });
+  });
+
+  describe('supplying an onChange handler', () => {
+    beforeEach(async () => {
+      await mount(
+        <TextFieldHarness />
+      );
+    });
+
+    describe('changing the field', () => {
+      beforeEach(async () => {
+        await textfield.fillInput('testing text');
+      });
+
+      it('should update value', () => {
+        expect(textfield.val).to.equal('testing text');
+      });
+    });
+  });
+});

--- a/lib/TextField/tests/TextFieldHarness.js
+++ b/lib/TextField/tests/TextFieldHarness.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import TextField from '../TextField';
+
+class TextFieldHarness extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      fieldVal: 'test text',
+    };
+  }
+
+  render() {
+    return (
+      <TextField
+        value={this.state.fieldVal}
+        onChange={(e) => { this.setState({ fieldVal: e.target.value }); }}
+      />
+    );
+  }
+}
+
+export default TextFieldHarness;

--- a/lib/TextField/tests/interactor.js
+++ b/lib/TextField/tests/interactor.js
@@ -1,0 +1,45 @@
+import {
+  computed,
+  interactor,
+  find,
+  is,
+  isPresent,
+  attribute,
+  value,
+  fillable,
+  hasClass,
+  text,
+} from '@bigtest/interactor';
+
+import css from '../TextField.css';
+import formCss from '../../sharedStyles/form.css';
+
+// import { selectorFromClassnameString } from '../../../tests/helpers';
+
+const inputClass = `.${formCss.input}`;
+const labelClass = `.${formCss.label}`;
+const rootClass = `.${css.textField}`;
+
+function computedStyle(selector) {
+  return computed(function () {
+    return getComputedStyle(this.$(selector));
+  });
+}
+
+export default interactor(class TextFieldInteractor {
+  isInput = is('input', inputClass);
+  val = value(inputClass);
+  fillInput = fillable(inputClass);
+  id = attribute(inputClass, 'id');
+  type = attribute(inputClass, 'type');
+  labelFor = attribute(labelClass, 'for');
+  label = text(labelClass);
+  labelRendered = isPresent('label');
+  endControl = isPresent(`.${css.endControls} span`)
+  ecWidth= find(`.${css.endControls}`).offsetWidth;
+  startControl = isPresent(`.${css.startControls} span`);
+  scWidth= find(`.${css.startControls}`).offsetWidth;
+  inputComputed = computedStyle(inputClass);
+  inputReadOnly = attribute(inputClass, 'readonly');
+  rendersBottomMargin0 = hasClass(rootClass, css.marginBottom0)
+});

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import '../lib/global.css';
+
 function getCleanTestingRoot() {
   let $root = document.getElementById('root');
 


### PR DESCRIPTION
Tests get written a bit differently from typical JS code - especially chai assertions.
Adding some rules overrides to not be so noisy when we're trying to write tests.