### PR TITLE
STCOM-268 Prefix translation strings in tests

### DIFF
--- a/tests/Harness.js
+++ b/tests/Harness.js
@@ -1,25 +1,34 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { IntlProvider } from 'react-intl';
-import translations from '../translations/en';
-
-import { reducer as formReducer} from 'redux-form';
+import { reducer as formReducer } from 'redux-form';
 import { Provider } from 'react-redux';
 import { createStore, combineReducers } from 'redux';
 
+import translations from '../translations/en';
+
 const reducers = {
-  form: formReducer
+  form: formReducer,
 };
 
 const reducer = combineReducers(reducers);
 
 const store = createStore(reducer);
 
+// mimics the StripesTranslationPlugin in @folio/stripes-core
+function prefixKeys(obj) {
+  const res = {};
+  for (const key of Object.keys(obj)) {
+    res[`stripes-components.${key}`] = obj[key];
+  }
+  return res;
+}
+
 class Harness extends React.Component {
   render() {
     return (
       <Provider store={store}>
-        <IntlProvider locale="en" key="en" messages={translations}>
+        <IntlProvider locale="en" key="en" messages={prefixKeys(translations)}>
           {this.props.children}
         </IntlProvider>
       </Provider>


### PR DESCRIPTION
## Purpose
`TextField` tests were throwing errors (but somehow not failing?) like this:
```
ERROR: '[React Intl] Missing message: "stripes-components.fieldHasError" for locale: "en"'
ERROR: '[React Intl] Cannot format message: "stripes-components.fieldHasError", using message id as fallback.'
```

Resolves https://issues.folio.org/browse/STCOM-268

## Approach
The translation strings in `stripes-components` weren't being prefixed with the string `stripes-components.` in tests.

Prefixing implementation adapted from https://github.com/folio-org/stripes-core/blob/master/webpack/stripes-translations-plugin.js