### PR TITLE
Explicitly import css variables

### DIFF
--- a/lib/Datepicker/Calendar.css
+++ b/lib/Datepicker/Calendar.css
@@ -1,3 +1,5 @@
+@import '../variables.css';
+
 .calendar {
   position: relative;
   background: #fff;

--- a/lib/FilterPaneSearch/FilterPaneSearch.css
+++ b/lib/FilterPaneSearch/FilterPaneSearch.css
@@ -1,3 +1,5 @@
+@import '../variables.css';
+
 .headerSearchContainer {
   width: 100%;
   height: 100%;

--- a/lib/LayoutBox/LayoutBox.css
+++ b/lib/LayoutBox/LayoutBox.css
@@ -1,3 +1,5 @@
+@import '../variables.css';
+
 .sectionBox {
   width: 100%;
   border-color: var(--color-border-p2);


### PR DESCRIPTION
When I tried upgrading the version of `stripes-components` used by `ui-eholdings`, I got several CSS loader errors:
```
WARNING in ./node_modules/css-loader??ref--5-1!./node_modules/postcss-loader/lib??ref--5-2!./node_modules/@folio/stripes-components/lib/Datepicker/Calendar.css
(Emitted value instead of an instance of Error) postcss-custom-properties: /Users/jeffrey/Sites/Frontside/ui-eholdings/node_modules/@folio/stripes-components/lib/Datepicker/Calendar.css:46:7: variable '--color-fill-disabled' is undefined and used without a fallback
```

Any CSS file using a variable should import the file containing the variable definition.
