### PR TITLE
EditableList STCOM-273: Added support for default field values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 * Pass parent's resources to EntrySelector. Fixes STCOM-262.
 * Updated current CSS variables and added new ones. Replaced in various style sheets
 * Updated checked styling of RadioButton and Checkbox. Replaced check icon with SVG in Checkbox.
+* `<EditableList>` now uses `itemTemplate` prop to define default field values.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/lib/structures/EditableList/EditableListForm.js
+++ b/lib/structures/EditableList/EditableListForm.js
@@ -53,9 +53,8 @@ const propTypes = {
    */
   visibleFields: PropTypes.arrayOf(PropTypes.string).isRequired,
   /**
-   * Object that reflects the shape of list item objects. values should be strings
-   * indicating the type: {name:'string'}
-   * This is used to create new items. If none supplied, will insert an empty object.
+   * Object where each key's value is the default value for that field.
+   * { resourceType: 'book' }
    */
   itemTemplate: PropTypes.object,
   /**
@@ -170,8 +169,7 @@ class EditableListForm extends React.Component {
 
   onAdd(fields) {
     const { itemTemplate } = this.props;
-    const item = {};
-    Object.keys(itemTemplate).forEach((key) => { item[key] = ''; });
+    const item = { ...itemTemplate };
     fields.unshift(item);
     // add field to edit-tracking in edit mode.
     this.setState((curState) => {

--- a/lib/structures/EditableList/readme.md
+++ b/lib/structures/EditableList/readme.md
@@ -39,7 +39,7 @@ onDelete | function | Callback for saving edited list items. | | no
 label | string | The text for the H3 tag in the header of the component | | no
 createButtonLabel | string | Label for the 'Add' button | `+ Add new` | no
 visibleFields | array of strings | Array of fields to render. These will also be editable. | | yes
-itemTemplate | object | Object that reflects the shape of list item objects. Values should be strings indicating the type: `{name: 'string'}` | {} | no
+itemTemplate | object | Object where each key's value is the default value for that field: `{ resourceType: 'book' }` | {} | no
 uniqueField | string | Fieldname that includes the unique identifier for the list. | `id` | yes
 actionSuppression | object | Object containing properties of list action names: `delete`, `edit` and values of sentinel functions that return booleans based on object properties. | `{ delete: () => false, edit: () => false }` | no
 actionProps | object | Object containing properties of list action names: 'delete', 'edit' and values of sentinel functions that return objects to destructure onto the action button props. | `{ delete: (item) => {return { disabled: item.item.inUse } } }`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
All fields are blank in newly created list items, there's no way to tell the component what you'd like for default values. This is especially important for uneditable fields.

`itemTemplate` wasn't being used anywhere and looks like an artifact from previous refactoring of `EditableList` according to the previous authors of this. So I made it actually do something since I liked the prop name. 😆 