### PR TITLE
MenuItem: Adjusted itemMeta propTypes

### DIFF
--- a/lib/MenuItem/MenuItem.js
+++ b/lib/MenuItem/MenuItem.js
@@ -8,14 +8,13 @@ const propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]),
-  itemMeta: PropTypes.object,
+  itemMeta: PropTypes.any,
   onSelectItem: PropTypes.func,
 };
 
 const MenuItem = (props) => {
   const handleItemSelect = (e) => {
-    const itemMetaData = props.itemMeta;
-    props.onSelectItem(itemMetaData, e);
+    props.onSelectItem(props.itemMeta, e);
   };
 
   const collectClickHandlers = (child) => {

--- a/lib/MenuItem/MenuItem.js
+++ b/lib/MenuItem/MenuItem.js
@@ -8,7 +8,7 @@ const propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]),
-  itemMeta: PropTypes.any,
+  itemMeta: PropTypes.any, // eslint-disable-line react/forbid-prop-types
   onSelectItem: PropTypes.func,
 };
 


### PR DESCRIPTION
All we're doing here is passing along the item's meta to the callback so we shouldn't be imposing a propType on it.