### PR TITLE
Expand TextField tests

### DIFF
--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { intlShape } from 'react-intl';
 import uniqueId from 'lodash/uniqueId';
 import classNames from 'classnames';
@@ -9,78 +9,78 @@ import formStyles from '../sharedStyles/form.css';
 import sharedInputStylesHelper from '../sharedStyles/sharedInputStylesHelper';
 import omitProps from '../../util/omitProps';
 
-const contextTypes = {
-  intl: intlShape
-};
+export default class TextField extends Component {
+  static contextTypes = {
+    intl: intlShape
+  };
 
-const propTypes = {
-  /**
-   * Can be "text" or "number". Standard html attribute.
-   */
-  // eslint-disable-next-line react/no-unused-prop-types
-  type: PropTypes.string,
-  /**
-   * String of preset styles to apply to textfield. possible values: noBorder
-   */
-  inputStyle: PropTypes.string,
-  /**
-   * Control or Icon to display at the start of the textfield.
-   */
-  startControl: PropTypes.element,
-  /**
-   * Control or Icon to display at the end of the textfield.
-   */
-  endControl: PropTypes.element,
-  /**
-   * String of text to display.
-   */
-  value: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-  ]),
-  /**
-   * Event handler for text input. Required if a value is supplied.
-   */
-  // eslint-disable-next-line react/no-unused-prop-types
-  onChange: PropTypes.func,
+  static propTypes = {
+    /**
+     * Can be "text" or "number". Standard html attribute.
+     */
+    // eslint-disable-next-line react/no-unused-prop-types
+    type: PropTypes.string,
+    /**
+     * String of preset styles to apply to textfield. possible values: noBorder
+     */
+    inputStyle: PropTypes.string,
+    /**
+     * Control or Icon to display at the start of the textfield.
+     */
+    startControl: PropTypes.element,
+    /**
+     * Control or Icon to display at the end of the textfield.
+     */
+    endControl: PropTypes.element,
+    /**
+     * String of text to display.
+     */
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]),
+    /**
+     * Event handler for text input. Required if a value is supplied.
+     */
+    // eslint-disable-next-line react/no-unused-prop-types
+    onChange: PropTypes.func,
 
-  /**
-   * Render textfield as readonly, disable clear action.
-   */
-  readOnly: PropTypes.bool,
+    /**
+     * Render textfield as readonly, disable clear action.
+     */
+    readOnly: PropTypes.bool,
 
-  /**
-   * Apply CSS class on wrapper element on focus
-   */
-  focusedClass: PropTypes.string,
+    /**
+     * Apply CSS class on wrapper element on focus
+     */
+    focusedClass: PropTypes.string,
 
-  inputClass: PropTypes.string,
-  error: PropTypes.string,
-  warning: PropTypes.string,
-  id: PropTypes.string,
-  meta: PropTypes.object,
-  input: PropTypes.object,
-  noBorder: PropTypes.bool,
-  marginBottom0: PropTypes.bool,
-  fullWidth: PropTypes.bool,
-  label: PropTypes.string,
-  ariaLabel: PropTypes.string,
-  clearFieldId: PropTypes.string,
-  required: PropTypes.bool,
-  validationEnabled: PropTypes.bool,
-  validStylesEnabled: PropTypes.bool,
-  hasClearIcon: PropTypes.bool,
-  onClearField: PropTypes.func,
-  autoFocus: PropTypes.bool
-};
+    inputClass: PropTypes.string,
+    error: PropTypes.string,
+    warning: PropTypes.string,
+    id: PropTypes.string,
+    meta: PropTypes.object,
+    input: PropTypes.object,
+    noBorder: PropTypes.bool,
+    marginBottom0: PropTypes.bool,
+    fullWidth: PropTypes.bool,
+    label: PropTypes.string,
+    ariaLabel: PropTypes.string,
+    clearFieldId: PropTypes.string,
+    required: PropTypes.bool,
+    validationEnabled: PropTypes.bool,
+    validStylesEnabled: PropTypes.bool,
+    hasClearIcon: PropTypes.bool,
+    onClearField: PropTypes.func,
+    autoFocus: PropTypes.bool
+  };
 
-const defaultProps = {
-  type: 'text',
-  validationEnabled: true,
-  hasClearIcon: true,
-};
+  static defaultProps = {
+    type: 'text',
+    validationEnabled: true,
+    hasClearIcon: true,
+  };
 
-class TextField extends React.Component {
   constructor(props) {
     super(props);
 
@@ -117,7 +117,8 @@ class TextField extends React.Component {
 
   componentDidUpdate(prevProps) {
     let shouldUpdatePadding = false;
-    if (prevProps.endControl !== this.props.endControl || prevProps.startControl !== this.props.startControl) {
+    if (prevProps.endControl !== this.props.endControl
+      || prevProps.startControl !== this.props.startControl) {
       shouldUpdatePadding = true;
     }
 
@@ -167,7 +168,7 @@ class TextField extends React.Component {
     });
   }
 
-  onBlur= () => {
+  onBlur = () => {
     this.setState({
       focused: false,
     });
@@ -231,7 +232,13 @@ class TextField extends React.Component {
       inputProps = null;
     }
 
-    const { label, endControl, startControl, required, clearFieldId } = cleanedProps;
+    const {
+      label,
+      endControl,
+      startControl,
+      required,
+      clearFieldId
+    } = cleanedProps;
 
     // Use omitProps here instead of separateComponentProps because
     // redux-form needs the abililty to directly manage the props it passes
@@ -239,7 +246,28 @@ class TextField extends React.Component {
     // know the names of all the props we want to pass along, but we don't
     // know them.
     // this still feels kinda clumsy, but at least it's not broken.
-    const inputCustom = omitProps(cleanedProps, ['label', 'endControl', 'startControl', 'required', 'fullWidth', 'marginBottom0', 'noBorder', 'validationEnabled', 'meta', 'inputClass', 'hasClearIcon', 'ariaLabel', 'onClearField', 'clearFieldId', 'validStylesEnabled', 'focusedClass']);
+    const inputCustom = omitProps(
+      cleanedProps,
+      [
+        'label',
+        'endControl',
+        'startControl',
+        'required',
+        'fullWidth',
+        'marginBottom0',
+        'noBorder',
+        'validationEnabled',
+        'meta',
+        'inputClass',
+        'hasClearIcon',
+        'ariaLabel',
+        'onClearField',
+        'clearFieldId',
+        'validStylesEnabled',
+        'focusedClass'
+      ]
+    );
+
     const component = (
       <input
         ref={(ref) => { this.input = ref; }}
@@ -258,40 +286,114 @@ class TextField extends React.Component {
     let clearField = null;
 
     if (this.props.meta) {
-      if (this.props.hasClearIcon && this.props.meta.active && !this.props.meta.asyncValidating && this.props.input && this.props.input.value !== '') {
-        clearField = <TextFieldIcon title={formatMsg({ id: 'stripes-components.clearThisField' })} onMouseDown={this.clearField} tabIndex="-1" icon="clearX" id={clearFieldId || `clickable-${this.testId}-clear-field`} />;
+      if (this.props.hasClearIcon
+        && this.props.meta.active
+        && !this.props.meta.asyncValidating
+        && this.props.input
+        && this.props.input.value !== '') {
+        clearField = (
+          <TextFieldIcon
+            ariaLabel={formatMsg({ id: 'stripes-components.clearThisField' })}
+            onClick={this.clearField}
+            tabIndex="-1"
+            icon="clearX"
+            id={clearFieldId || `clickable-${this.testId}-clear-field`}
+          />
+        );
       }
 
       if (validationEnabled && this.props.meta.asyncValidating) {
-        validation = <TextFieldIcon iconClassName={css.successIcon} title={formatMsg({ id: 'stripes-components.validatingInProcess' })} iconSize="small" icon="spinner-ellipsis" />;
+        validation = (
+          <TextFieldIcon
+            iconClassName={css.successIcon}
+            ariaLabel={formatMsg({ id: 'stripes-components.validatingInProcess' })}
+            iconSize="small"
+            icon="spinner-ellipsis"
+          />
+        );
       }
 
       // If validStylesEnabled is enabled we add some styling if the field is valid
       // This is disabled by default because it's primarily used when something is
       // getting validated on the server - e.g. checking for an email or similar.
-      if (this.props.validStylesEnabled && validationEnabled && this.props.meta.touched && this.props.meta.dirty && !this.props.meta.active && this.props.meta.valid && !this.props.meta.asyncValidating) {
-        validation = <TextFieldIcon iconClassName={css.successIcon} title={formatMsg({ id: 'stripes-components.fieldIsValid' })} icon="validation-check" id={`icon-${this.testId}-validation-success`} />;
+      if (this.props.validStylesEnabled
+        && validationEnabled
+        && this.props.meta.touched
+        && this.props.meta.dirty
+        && !this.props.meta.active
+        && this.props.meta.valid
+        && !this.props.meta.asyncValidating) {
+        validation = (
+          <TextFieldIcon
+            iconClassName={css.successIcon}
+            ariaLabel={formatMsg({ id: 'stripes-components.fieldIsValid' })}
+            icon="validation-check"
+            id={`icon-${this.testId}-validation-success`}
+          />
+        );
       }
 
-      if (this.props.meta.touched && !this.props.meta.active && !this.props.meta.valid && !this.props.meta.asyncValidating) {
+      if (this.props.meta.touched
+        && !this.props.meta.active
+        && !this.props.meta.valid
+        && !this.props.meta.asyncValidating) {
         if (this.input && (this.input.value === '' || !this.input.value)) {
-          validation = validationEnabled && <TextFieldIcon iconClassName={css.errorIcon} title={formatMsg({ id: 'stripes-components.fieldHasError' })} icon="validation-error" id={`icon-${this.testId}-validation-error`} />;
+          validation = validationEnabled && (
+            <TextFieldIcon
+              iconClassName={css.errorIcon}
+              ariaLabel={formatMsg({ id: 'stripes-components.fieldHasError' })}
+              icon="validation-error"
+              id={`icon-${this.testId}-validation-error`}
+            />
+          );
         } else {
-          validation = validationEnabled && <TextFieldIcon title={formatMsg({ id: 'stripes-components.fieldHasError' })} onClick={this.clearField} iconClassName={css.errorIcon} icon="validation-error" id={`icon-${this.testId}-validation-error`} />;
-          clearField = this.props.hasClearIcon && <TextFieldIcon title={formatMsg({ id: 'stripes-components.clearThisField' })} onClick={this.clearField} icon="clearX" id={clearFieldId || `clickable-${this.testId}-clear-field`} />;
+          validation = validationEnabled && (
+            <TextFieldIcon
+              ariaLabel={formatMsg({ id: 'stripes-components.fieldHasError' })}
+              onClick={this.clearField}
+              iconClassName={css.errorIcon}
+              icon="validation-error"
+              id={`icon-${this.testId}-validation-error`}
+            />
+          );
+          clearField = this.props.hasClearIcon && (
+            <TextFieldIcon
+              ariaLabel={formatMsg({ id: 'stripes-components.clearThisField' })}
+              onClick={this.clearField}
+              icon="clearX"
+              id={clearFieldId || `clickable-${this.testId}-clear-field`}
+            />
+          );
         }
       }
     }
 
-    const endControlElement = <div className={css.endControls}><div className={css.controlGroup} ref={(ref) => { this.endControl = ref; }}>{!this.props.readOnly && clearField}{validation}{endControl}</div></div>;
-    const startControlElement = <div className={css.startControls}><div className={css.controlGroup} ref={(ref) => { this.startControl = ref; }}>{startControl}</div></div>;
+    const endControlElement = (
+      <div className={css.endControls}>
+        <div className={css.controlGroup} ref={(ref) => { this.endControl = ref; }}>
+          {!this.props.readOnly && clearField}{validation}{endControl}
+        </div>
+      </div>
+    );
+
+    const startControlElement = (
+      <div className={css.startControls}>
+        <div className={css.controlGroup} ref={(ref) => { this.startControl = ref; }}>
+          {startControl}
+        </div>
+      </div>
+    );
 
     let warningElement;
     let errorElement;
     if (this.props.meta) {
       const { error, warning, touched } = this.props.meta;
-      warningElement = touched && warning ? <div className={formStyles.feedbackWarning}>{warning}</div> : null;
-      errorElement = touched && error ? <div className={formStyles.feedbackError}>{error}</div> : null;
+      warningElement = touched && warning ? (
+        <div className={formStyles.feedbackWarning}>{warning}</div>
+      ) : null;
+      errorElement = touched && error ? (
+        <div className={formStyles.feedbackError}>{error}</div>
+      ) : null;
     }
 
     const wrapperStyles = classNames(
@@ -301,7 +403,14 @@ class TextField extends React.Component {
 
     return (
       <div className={wrapperStyles}>
-        { label && <label htmlFor={this.props.id} className={formStyles.label}>{label}</label> }
+        { label && (
+          <label
+            htmlFor={this.props.id}
+            className={formStyles.label}
+          >
+              {label}
+          </label>
+        )}
         <div className={formStyles.inputGroup}>
           {startControlElement}
           {component}
@@ -313,9 +422,3 @@ class TextField extends React.Component {
     );
   }
 }
-
-TextField.propTypes = propTypes;
-TextField.defaultProps = defaultProps;
-TextField.contextTypes = contextTypes;
-
-export default TextField;

--- a/lib/TextField/tests/TextField-test.js
+++ b/lib/TextField/tests/TextField-test.js
@@ -126,41 +126,95 @@ describe('TextField', () => {
     });
   });
 
-  describe('Using width redux-form', () => {
-    beforeEach(async () => {
-      await mountWithContext(
-        <TestForm>
-          <Field name="testField" component={TextField} clearFieldId="clearField" />
-        </TestForm>
-      );
-    });
-
-    it('should render the textField normally', () => {
-      expect(textfield.isInput).to.be.true;
-      expect(textfield.type).to.equal('text');
-    });
-
-    describe('given an invalid value', () => {
+  describe('using with redux-form', () => {
+    describe('inputting a value', () => {
       beforeEach(async () => {
-        await textfield.fillBlurInvalid;
+        await mountWithContext(
+          <TestForm>
+            <Field
+              name="testField"
+              component={TextField}
+              clearFieldId="clearField"
+            />
+          </TestForm>
+        );
+      });
+
+      it('should render the TextField normally', () => {
+        expect(textfield.isInput).to.be.true;
+        expect(textfield.type).to.equal('text');
+      });
+
+      describe('changing the value', () => {
+        beforeEach(async () => {
+          await textfield.fillInput('anything')
+            .focusInput();
+        });
+
+        it('applies a changed class', () => {
+          expect(textfield.hasChangedStyle).to.be.true;
+        });
+
+        it('renders a clear button', () => {
+          expect(textfield.hasClearButton).to.be.true;
+        });
+
+        describe('clicking the clear button', () => {
+          beforeEach(async () => {
+            await textfield
+              .clickClearButton()
+              .blurInput();
+          });
+
+          it('clears the field', () => {
+            expect(textfield.val).to.equal('');
+          });
+        });
+      });
+    });
+
+    describe('inputting an invalid value', () => {
+      beforeEach(async () => {
+        await mountWithContext(
+          <TestForm>
+            <Field
+              name="testField"
+              component={TextField}
+              validate={value => (value === 'invalid' ? 'testField is Invalid' : undefined)}
+            />
+          </TestForm>
+        );
+      });
+
+      beforeEach(async () => {
+        await textfield.fillAndBlur('invalid');
       });
 
       it('renders an error message', () => {
         expect(textfield.inputError).to.be.true;
       });
+    });
 
-      it('and also renders a clear button', () => {
-        expect(textfield.hasClearButton).to.be.true;
+    describe('inputting an valid value with validStylesEnabled', () => {
+      beforeEach(async () => {
+        await mountWithContext(
+          <TestForm>
+            <Field
+              name="testField"
+              component={TextField}
+              validStylesEnabled
+              validate={value => (value === 'invalid' ? 'testField is Invalid' : undefined)}
+            />
+          </TestForm>
+        );
       });
 
-      describe('clicking the clear button', () => {
-        beforeEach(async () => {
-          await textfield.clickClearButton();
-        });
+      beforeEach(async () => {
+        await textfield.fillAndBlur('valid');
+      });
 
-        it('clears the field', () => {
-          expect(textfield.val).to.equal('');
-        });
+      it('applies a valid class', () => {
+        expect(textfield.hasValidStyle).to.be.true;
       });
     });
   });

--- a/lib/TextField/tests/interactor.js
+++ b/lib/TextField/tests/interactor.js
@@ -1,16 +1,17 @@
 import {
+  attribute,
+  blurrable,
+  clickable,
   computed,
-  Interactor,
-  interactor,
+  fillable,
   find,
+  focusable,
+  hasClass,
+  interactor,
   is,
   isPresent,
-  attribute,
-  value,
-  fillable,
-  clickable,
-  hasClass,
   text,
+  value,
 } from '@bigtest/interactor';
 
 import css from '../TextField.css';
@@ -29,33 +30,35 @@ function computedStyle(selector) {
   });
 }
 
-class CustomInteractor extends Interactor {
-  fillAndBlur(val) {
-    return this
-      .fill(inputClass, val)
-      .blur(inputClass);
-  }
-}
-
 export default interactor(class TextFieldInteractor {
   isInput = is('input', inputClass);
   val = value(inputClass);
   fillInput = fillable(inputClass);
+  blurInput = blurrable(inputClass);
+  focusInput = focusable(inputClass);
   id = attribute(inputClass, 'id');
   type = attribute(inputClass, 'type');
   labelFor = attribute(labelClass, 'for');
   label = text(labelClass);
   labelRendered = isPresent('label');
   endControl = isPresent(`.${css.endControls} span`)
-  ecWidth= find(`.${css.endControls}`).offsetWidth;
+  endControlsWidth= find(`.${css.endControls}`).offsetWidth;
   startControl = isPresent(`.${css.startControls} span`);
-  scWidth= find(`.${css.startControls}`).offsetWidth;
+  startControlsWidth= find(`.${css.startControls}`).offsetWidth;
   inputComputed = computedStyle(inputClass);
   inputReadOnly = attribute(inputClass, 'readonly');
-  fillBlurInvalid = new CustomInteractor().fillAndBlur('invalid');
-  fillBlurValid = new CustomInteractor().fillAndBlur('valid');
   inputError = isPresent(errorClass);
   hasClearButton = isPresent('#clearField');
   clickClearButton = clickable('#clearField');
-  rendersBottomMargin0 = hasClass(rootClass, css.marginBottom0)
+  rendersBottomMargin0 = hasClass(rootClass, css.marginBottom0);
+  hasWarningStyle = hasClass('input', formCss.feedbackWarning);
+  hasErrorStyle = hasClass('input', formCss.feedbackError);
+  hasChangedStyle = hasClass('input', formCss.feedbackChanged);
+  hasValidStyle = hasClass('input', formCss.feedbackValid);
+
+  fillAndBlur(val) {
+    return this
+      .fill(inputClass, val)
+      .blur(inputClass);
+  }
 });

--- a/tests/TestForm.js
+++ b/tests/TestForm.js
@@ -8,15 +8,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
 
-function validate(values) {
-  const errors = {};
-
-  if (values.testField === 'invalid') {
-    errors.testField = 'testField is Invalid';
-  }
-  return errors;
-}
-
 class TestForm extends React.Component {
   static propTypes = {
     children: PropTypes.node
@@ -28,6 +19,5 @@ class TestForm extends React.Component {
 }
 
 export default reduxForm({
-  form: 'formsDemo',
-  validate
+  form: 'formsDemo'
 })(TestForm);


### PR DESCRIPTION
I'm interested in using the `reduxFormField` HoC with `TextField`, but it needed some more tests before that significant of a refactor.

## Highlights
- `onMouseDown` for the input clear button is now an `onClick`- there wasn't really a good reason for it to be a mouse-specific event, and most assistive technology will appropriately deal with `onClick`
- `title`s are now `ariaLabel`
- I made `tests/TestForm.js` more generic for future reuse; instead I leaned on field-level Redux Form validation.
- I made a more generic `fillAndBlur()` on the `TextField` interactor
- I did some minor reformats to the component: `contextTypes`/`propTypes`/`defaultProps` are all now static on the class (reads a lot nicer), and I split particularly long lines into multiple lines

## Next steps
- Start using `reduxFormField` - will need more props
- More accessibility optimizations
- I have a strong suspicion all the JS used to determine the rendering of `startControl` and `endControl` can be refactored to be simply CSS