### PR TITLE
STCOM-275: Dropdown: Refactor away componentWillUpdate

### DIFF
--- a/lib/Dropdown/Dropdown.js
+++ b/lib/Dropdown/Dropdown.js
@@ -54,22 +54,12 @@ class Dropdown extends React.Component {
     super(props);
     this.handleToggle = this.handleToggle.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
-    this._focusInDropdown = false;
-  }
-
-  componentWillUpdate(nextProps) {
-    if (!nextProps.open && this.props.open) {
-      this._focusInDropdown = this._menu.node ? this._menu.node.contains(document.activeElement) : false;
-    }
   }
 
   componentDidUpdate(prevProps) {
-    const { open } = this.props;
-    const prevOpen = prevProps.open;
-
-    if (!open && prevOpen) {
-      if (this._focusInDropdown) {
-        this._focusInDropdown = false;
+    // If the dropdown was just closed and the dropdown menu had focus, focus on the dropdown toggle button
+    if (!this.props.open && prevProps.open) {
+      if (this._menu && this._menu.node.contains(document.activeElement)) {
         this.focus();
       }
     }

--- a/lib/Dropdown/Dropdown.js
+++ b/lib/Dropdown/Dropdown.js
@@ -59,7 +59,7 @@ class Dropdown extends React.Component {
   componentDidUpdate(prevProps) {
     // If the dropdown was just closed and the dropdown menu had focus, focus on the dropdown toggle button
     if (!this.props.open && prevProps.open) {
-      if (this._menu && this._menu.node.contains(document.activeElement)) {
+      if (this._menu && this._menu.node && this._menu.node.contains(document.activeElement)) {
         this.focus();
       }
     }


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-275

`_focusInDropdown` was equal to `this._menu.node.contains(document.activeElement)`, and its state is the same before and after render, so I moved it to after.