### PR TITLE
provide id to accordion expander buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * Updated checked styling of RadioButton and Checkbox. Replaced check icon with SVG in Checkbox.
 * `<EditableList>` now uses `itemTemplate` prop to define default field values.
 * `<EditableList>` will accept custom edit mode components using the `fieldComponents` prop. Fixes STCOM-272.
+* Provide id attribute to accordion expander buttons. Refs STCOM-276.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/lib/Accordion/headers/DefaultAccordionHeader.js
+++ b/lib/Accordion/headers/DefaultAccordionHeader.js
@@ -55,6 +55,7 @@ const DefaultAccordionHeader = (props, context) => {
             onKeyPress={handleKeyPress}
             className={css.defaultCollapseButton}
             autoFocus={props.autoFocus}
+            id={`accordion-toggle-button-${props.id}`}
           >
             <span className={css.headerInner}>
               <Icon size="medium" icon={props.open ? 'up-caret' : 'down-caret'} />

--- a/lib/Accordion/headers/FilterAccordionHeader.js
+++ b/lib/Accordion/headers/FilterAccordionHeader.js
@@ -63,6 +63,7 @@ class FilterAccordionHeader extends React.Component {
             className={classNames(css.filterSetHeader, { [css.clearButtonVisible]: clearButtonVisible })}
             role="tab"
             autoFocus={this.props.autoFocus}
+            id={`accordion-toggle-button-${this.props.id}`}
           >
             { disabled ? null : <Icon size="small" icon={`${open ? 'up' : 'down'}-caret`} /> }
             <div className={css.labelArea}>


### PR DESCRIPTION
Provide an id to the accordion expander buttons in order to make them
accessible to testing infrastructure.

Refs [STCOM-276](https://issues.folio.org/browse/STCOM-276)