### PR TITLE
Modal: Added pass-through of enforceFocus prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 * `<EditableList>` now uses `itemTemplate` prop to define default field values.
 * `<EditableList>` will accept custom edit mode components using the `fieldComponents` prop. Fixes STCOM-272.
 * Provide id attribute to accordion expander buttons. Refs STCOM-276. Available from v2.0.17.
+* Added `enforceFocus` prop to `<Modal>`.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -38,6 +38,13 @@ const propTypes = {
   dismissible: PropTypes.bool,
   children: PropTypes.node.isRequired,
   showHeader: PropTypes.bool,
+  /**
+   * When `true` The modal will prevent focus from leaving the Modal while open.
+   *
+   * Generally this should never be set to `false` as it makes the Modal less
+   * accessible to assistive technologies, like screen readers.
+   */
+  enforceFocus: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -48,6 +55,7 @@ const defaultProps = {
   open: false,
   showHeader: true,
   size: 'medium',
+  enforceFocus: true,
 };
 
 const contextTypes = {
@@ -85,6 +93,7 @@ const Modal = (props, context) => {
       onHide={props.onClose}
       onShow={props.onOpen}
       onBackdropClick={props.closeOnBackgroundClick ? props.onClose : () => {}}
+      enforceFocus={props.enforceFocus}
     >
       <div
         className={getModalClass()}

--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -45,6 +45,8 @@ const propTypes = {
    * accessible to assistive technologies, like screen readers.
    */
   enforceFocus: PropTypes.bool,
+  /** When `true` The modal will restore focus to previously focused element once modal is hidden */
+  restoreFocus: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -56,6 +58,7 @@ const defaultProps = {
   showHeader: true,
   size: 'medium',
   enforceFocus: true,
+  restoreFocus: true,
 };
 
 const contextTypes = {
@@ -94,6 +97,7 @@ const Modal = (props, context) => {
       onShow={props.onOpen}
       onBackdropClick={props.closeOnBackgroundClick ? props.onClose : () => {}}
       enforceFocus={props.enforceFocus}
+      restoreFocus={props.restoreFocus}
     >
       <div
         className={getModalClass()}

--- a/lib/Modal/readme.md
+++ b/lib/Modal/readme.md
@@ -22,3 +22,4 @@ scope | string | Parent element for modal. Defaults to 'module' which keeps the 
 closeOnBackgroundClick | bool | Modal can be dismissed by clicking the background overlay. | false |
 dismissible | bool | If true, renders a close 'X' in the starting corner of the modal. | false |
 children | node | Content for the body of the modal. | | &#10004;
+enforceFocus | bool | If true, automatically attempts to regain focus when its children are clicked.  | true |

--- a/lib/Modal/readme.md
+++ b/lib/Modal/readme.md
@@ -23,3 +23,4 @@ closeOnBackgroundClick | bool | Modal can be dismissed by clicking the backgroun
 dismissible | bool | If true, renders a close 'X' in the starting corner of the modal. | false |
 children | node | Content for the body of the modal. | | &#10004;
 enforceFocus | bool | If true, automatically attempts to regain focus when its children are clicked.  | true |
+restoreFocus | bool | If true, the modal will restore focus to previously focused element once modal is hidden. | true |


### PR DESCRIPTION
This is needed for when you have something that should be able to take focus _inside_ a Modal. 

E.g., without this, having a `<Datepicker>` inside a Modal doesn't work at all - the clicks on the Calendar's day buttons never hit their click handler.