### PR TITLE
Minor MetaSection updates

### DIFF
--- a/lib/MetaSection/MetaSection.css
+++ b/lib/MetaSection/MetaSection.css
@@ -7,12 +7,17 @@
 }
 
 .metaSectionContent {
-  padding: 3px 26px;
+  margin-top: -6px;
+  padding: 0 0 4px 27px;
   color: var(--color-text);
 }
 
 .metaSectionContentBlock {
-  margin: 4px 0;
+  margin: 2px 0;
+}
+
+.metaSectionGroup {
+  margin-top: 10px;
 }
 
 .headerWrapper {

--- a/lib/MetaSection/MetaSection.js
+++ b/lib/MetaSection/MetaSection.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 import { Accordion } from '../Accordion';
 import MetaAccordionHeader from './MetaAccordionHeader';
 import css from './MetaSection.css';
@@ -40,7 +41,7 @@ class MetaSection extends React.Component { // eslint-disable-line
           contentId={this.props.contentId}
           label={
             <div>
-              Record last updated:
+              <FormattedMessage id="stripes-components.metaSection.recordLastUpdated" />:
               &nbsp;
               <span className={css.metaHeaderValue}>
                 {this.formatDate(lastUpdatedDate)}
@@ -53,27 +54,31 @@ class MetaSection extends React.Component { // eslint-disable-line
           <div className={css.metaSectionContent}>
             {lastUpdatedBy &&
               <div className={css.metaSectionContentBlock}>
-                Source:
+                <FormattedMessage id="stripes-components.metaSection.source" />:
                 &nbsp;
                 <span>{lastUpdatedBy}</span>
               </div>
             }
-            {createdDate &&
-              <div className={css.metaSectionContentBlock}>
-                Record created:
-                &nbsp;
-                {this.formatDate(createdDate)}
-                &nbsp;
-                {this.formatTime(createdDate)}
+            { (createdDate || createdBy) && (
+              <div className={css.metaSectionGroup}>
+                {createdDate &&
+                  <div className={css.metaSectionContentBlock}>
+                    <FormattedMessage id="stripes-components.metaSection.recordCreated" />:
+                    &nbsp;
+                    {this.formatDate(createdDate)}
+                    &nbsp;
+                    {this.formatTime(createdDate)}
+                  </div>
+                }
+                {createdBy &&
+                  <div className={css.metaSectionContentBlock}>
+                    <FormattedMessage id="stripes-components.metaSection.source" />:
+                    &nbsp;
+                    <span>{createdBy}</span>
+                  </div>
+                }
               </div>
-            }
-            {createdBy &&
-              <div className={css.metaSectionContentBlock}>
-                Source:
-                &nbsp;
-                <span>{createdBy}</span>
-              </div>
-            }
+            )}
           </div>
         </Accordion>
       </div>

--- a/translations/en.json
+++ b/translations/en.json
@@ -43,5 +43,8 @@
   "removeSelection": "Remove selection",
   "addSelection": "Add selection",
   "collapseSection": "Collapse section",
-  "expandSection": "Expand section"
+  "expandSection": "Expand section",
+  "metaSection.source": "Source",
+  "metaSection.recordCreated": "Record created",
+  "metaSection.recordLastUpdated": "Record last updated"
 }


### PR DESCRIPTION
Adjusted spacing in MetaSection and added translations for strings.

Added a "metaSectionGroup" CSS class to apply spacing between related groups of meta data to achieve a better visual overview of the informaiton displayed.

**Before**
![image](https://user-images.githubusercontent.com/640976/40659925-f004ab4a-634f-11e8-85a4-c1ac30541124.png)

**After**
![image](https://user-images.githubusercontent.com/640976/40659967-082f4af4-6350-11e8-80c2-ae84726d7de1.png)
