### PR TITLE
Prevent buttonInner from stealing focus on click

### DIFF
--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -7,6 +7,7 @@
 .buttonInner {
   display: flex;
   align-items: center;
+  pointer-events: none;
 }
 
 .button {


### PR DESCRIPTION
Prevent buttonInner from stealing focus on click which causes interactionStyles to display improperly.