### PR TITLE
Added new DateTimePicker component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * `<EditableList>` will accept custom edit mode components using the `fieldComponents` prop. Fixes STCOM-272.
 * Provide id attribute to accordion expander buttons. Refs STCOM-276. Available from v2.0.17.
 * Added `enforceFocus` prop to `<Modal>`.
+* Added `<DateTimePicker>` component. Available from v2.0.18.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/lib/DateTimePicker/DateTimePicker.js
+++ b/lib/DateTimePicker/DateTimePicker.js
@@ -1,14 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Field, reduxForm } from 'redux-form';
-import { Row, Col } from '../LayoutGrid';
-import Datepicker from '../Datepicker/Datepicker';
-import Timepicker from '../Timepicker/Timepicker';
+import moment from 'moment-timezone';
+
+import DateTimePickerForm from './DateTimePickerForm';
 
 class DateTimePicker extends React.Component {
   static propTypes = {
+    stripes: PropTypes.shape({
+      timezone: PropTypes.string.isRequired,
+    }).isRequired,
     dateProps: PropTypes.object,
     timeProps: PropTypes.object,
+    onChange: PropTypes.func,
+    initialValues: PropTypes.shape({
+      date: PropTypes.string,
+      time: PropTypes.string,
+    })
   }
 
   static defaultProps = {
@@ -18,34 +25,40 @@ class DateTimePicker extends React.Component {
     timeProps: {
       label: 'Time:',
     },
+    onChange: () => {},
+    initialValues: {
+      date: new Date().toISOString(),
+      time: '12:00:00.000Z',
+    },
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.handleChange(props.initialValues);
+  }
+
+  handleChange = (values) => {
+    // Values are received in the following form: { date: "2018-10-20T00:00:00.000Z", time: "22:59:00.000Z" }
+    const date = values.date.split('T')[0];
+    const time = values.time.split(/[Z+-]/)[0];
+
+    const localDatetime = moment.tz(`${date}T${time}`, this.props.stripes.timezone);
+    const utcDatetime = localDatetime.tz('UTC').format();
+
+    this.props.onChange(utcDatetime);
   }
 
   render() {
-    const { dateProps, timeProps } = this.props;
+    const { onChange, ...rest } = this.props; // eslint-disable-line no-unused-vars
 
     return (
-      <form>
-        <Row>
-          <Col xs={12} sm={6} md={3}>
-            <Field
-              name="date"
-              component={Datepicker}
-              {...dateProps}
-            />
-          </Col>
-          <Col xs={12} sm={6} md={3}>
-            <Field
-              name="time"
-              component={Timepicker}
-              {...timeProps}
-            />
-          </Col>
-        </Row>
-      </form>
+      <DateTimePickerForm
+        onChange={this.handleChange}
+        {...rest}
+      />
     );
   }
 }
 
-export default reduxForm({
-  form: 'DateTimePicker',
-})(DateTimePicker);
+export default DateTimePicker;

--- a/lib/DateTimePicker/DateTimePicker.js
+++ b/lib/DateTimePicker/DateTimePicker.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Field, reduxForm } from 'redux-form';
+import { Row, Col } from '../LayoutGrid';
+import Datepicker from '../Datepicker/Datepicker';
+import Timepicker from '../Timepicker/Timepicker';
+
+class DateTimePicker extends React.Component {
+  static propTypes = {
+    dateProps: PropTypes.object,
+    timeProps: PropTypes.object,
+  }
+
+  static defaultProps = {
+    dateProps: {
+      label: 'Date:',
+    },
+    timeProps: {
+      label: 'Time:',
+    },
+  }
+
+  render() {
+    const { dateProps, timeProps } = this.props;
+
+    return (
+      <form>
+        <Row>
+          <Col xs={12} sm={6} md={3}>
+            <Field
+              name="date"
+              component={Datepicker}
+              {...dateProps}
+            />
+          </Col>
+          <Col xs={12} sm={6} md={3}>
+            <Field
+              name="time"
+              component={Timepicker}
+              {...timeProps}
+            />
+          </Col>
+        </Row>
+      </form>
+    );
+  }
+}
+
+export default reduxForm({
+  form: 'DateTimePicker',
+})(DateTimePicker);

--- a/lib/DateTimePicker/DateTimePickerForm.js
+++ b/lib/DateTimePicker/DateTimePickerForm.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Field, reduxForm } from 'redux-form';
+import { Row, Col } from '../LayoutGrid';
+import Datepicker from '../Datepicker/Datepicker';
+import Timepicker from '../Timepicker/Timepicker';
+
+class DateTimePicker extends React.Component {
+  static propTypes = {
+    dateProps: PropTypes.object,
+    timeProps: PropTypes.object,
+  }
+
+  render() {
+    const { dateProps, timeProps } = this.props;
+
+    return (
+      <form>
+        <Row>
+          <Col xs={12} sm={6} md={3}>
+            <Field
+              name="date"
+              component={Datepicker}
+              ignoreLocalOffset
+              {...dateProps}
+            />
+          </Col>
+          <Col xs={12} sm={6} md={3}>
+            <Field
+              name="time"
+              component={Timepicker}
+              timezone="UTC"
+              {...timeProps}
+            />
+          </Col>
+        </Row>
+      </form>
+    );
+  }
+}
+
+export default reduxForm({
+  form: 'DateTimePicker',
+})(DateTimePicker);

--- a/lib/DateTimePicker/index.js
+++ b/lib/DateTimePicker/index.js
@@ -1,0 +1,1 @@
+export { default } from './DateTimePicker';

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -24,6 +24,7 @@ const propTypes = {
   id: PropTypes.string,
   onChange: PropTypes.func,
   locale: PropTypes.string,
+  timezone: PropTypes.string,
   readOnly: PropTypes.bool,
   showTimepicker: PropTypes.bool,
   tether: PropTypes.object,
@@ -87,7 +88,7 @@ class Timepicker extends React.Component {
     this.deriveHoursFormat = this.deriveHoursFormat.bind(this);
     this.getPresentationValue = this.getPresentationValue.bind(this);
     this.getLocalTime = this.getLocalTime.bind(this);
-    this.timezone = this.context.stripes.timezone;
+    this.timezone = this.props.timezone || this.context.stripes.timezone;
     moment.locale(this.context.stripes.locale);
     this._timeFormat = moment.localeData()._longDateFormat.LT;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
Bit of a helper here that wraps the two components together.

`DateTimePickerForm` exists to manage the connected components via redux-form. It creates `Datepicker` and `Timepicker` components that ignore timezones.

Why not just roll this into one component? Because then I have to not use redux-form because passing an `onChange` to that component (from some `ui-*` code) would result in that callback being called _by redux-form_ with the separate date/time value object instead of a combined one. That kinda breaks the whole point of a DTP component since now the parent component has to do the combining/timezoning.

Instead, `DateTimePicker` creates a `DateTimePickerForm` and handles the changing values, smooshing the date/time together and applying timezone changes. 

Also: bumped stripes-components up a patch version.