### PR TITLE
Check `.npmrc` file into repo

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@folio:registry=https://repository.folio.org/repository/npm-folioci/


### PR DESCRIPTION
## What is this?

Since folio uses its own registry & it's not obvious that is happening we should check in an `.npmrc` file. This is so anyone that clones the repo can just `npm i` (or `yarn`) and be off to the races.

This also allows us to make config changes that everyone can just benefit from rather than asking everyone to update their global config.