### PR TITLE
Remove create-react-class from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "@folio/stripes-form": "^0.8.2",
     "@folio/stripes-react-hotkeys": "^1.0.0",
     "classnames": "^2.2.5",
-    "create-react-class": "^15.5.3",
     "dom-helpers": "^3.2.1",
     "lodash": "^4.17.4",
     "moment": "^2.17.1",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "moment": "^2.17.1",
     "moment-range": "^3.0.3",
     "moment-timezone": "^0.5.14",
-    "mousetrap": "^1.6.1",
     "normalize.css": "^7.0.0",
     "prop-types": "^15.5.10",
     "prop-types-extra": "^1.0.1",


### PR DESCRIPTION
## Purpose
`create-react-class` was added as a dependency in https://github.com/folio-org/stripes-components/commit/93c421f2e357e676d2ae7fe8525ae0bf3eb44055

## Approach
`@folio/stripes-react-hotkeys` declares a dependency on `create-react-class`, and `@folio/stripes-components` has no other dependency on `create-react-class`. Therefore it doesn't need to be declared as a dependency of `@folio/stripes-components`.