### PR TITLE
Use own translation strings instead of stripes-core

### DIFF
--- a/lib/EntrySelector/EntrySelector.js
+++ b/lib/EntrySelector/EntrySelector.js
@@ -82,7 +82,7 @@ class EntrySelector extends React.Component {
         onClick={() => this.props.onEdit(item)}
         id="clickable-edit-item"
         ariaLabel="edit"
-        title={this.props.stripes.intl.formatMessage({ id: 'stripes-core.button.edit' })}
+        title={this.props.stripes.intl.formatMessage({ id: 'stripes-components.button.edit' })}
         size="medium"
       />
     );
@@ -117,7 +117,7 @@ class EntrySelector extends React.Component {
     const LastMenu = addMenu || (
       <PaneMenu>
         <Button title={addButtonTitle} onClick={this.props.onAdd} buttonStyle="primary paneHeaderNewButton">
-          {this.props.stripes.intl.formatMessage({ id: 'stripes-core.button.new' })}
+          {this.props.stripes.intl.formatMessage({ id: 'stripes-components.button.new' })}
         </Button>
       </PaneMenu>
     );

--- a/translations/en.json
+++ b/translations/en.json
@@ -47,5 +47,7 @@
   "metaSection.source": "Source: {source}",
   "metaSection.recordCreated": "Record created: {date} {time}",
   "metaSection.recordLastUpdated": "Record last updated: {date} {time}",
-  "tableColumnCount": "Table with {count} columns"
+  "tableColumnCount": "Table with {count} columns",
+  "button.edit": "Edit",
+  "button.new": "+ New"
 }


### PR DESCRIPTION
`stripes-components` should rely solely on its own translation strings, instead of leaning on `stripes-core`'s.