### PR TITLE
Add @folio prefix to stripes-core peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,6 @@
     "typeface-source-sans-pro": "^0.0.44"
   },
   "peerDependencies": {
-    "stripes-core": "^2.7.0"
+    "@folio/stripes-core": "^2.7.0"
   }
 }


### PR DESCRIPTION
## Purpose
Yarn throws warnings like...
```
warning " > @folio/stripes-components@2.0.16000323" has unmet peer dependency "stripes-core@^2.7.0".
```
... even if `stripes-cli` has installed `stripes-core`.

## Approach
Update the dependency to `@folio/stripes-core`. This will need to happen in several `@folio` repos, but since they're all just nonblocking warnings, that can happen in any order/timing.