### PR TITLE
MCLRenderer: i18n for aria-label

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { intlShape } from 'react-intl';
 import classnames from 'classnames';
 import isEqual from 'lodash/isEqual';
 import Icon from '../Icon';
@@ -35,7 +36,6 @@ const propTypes = {
   hotKeys: PropTypes.object,
   columnWidths: PropTypes.object,
   containerRef: PropTypes.func,
-  ariaLabel: PropTypes.string,
   rowProps: PropTypes.object,
   autosize: PropTypes.bool,
   rowMetadata: PropTypes.arrayOf(PropTypes.string),
@@ -50,6 +50,10 @@ const propTypes = {
   interactive: PropTypes.bool,
   headerRowClass: PropTypes.string,
   instanceRef: PropTypes.func,
+};
+
+const contextTypes = {
+  intl: intlShape,
 };
 
 const defaultProps = {
@@ -856,7 +860,7 @@ class MCLRenderer extends React.Component {
           tabIndex="0" // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
           id={this.props.id}
           ref={this.serveContainerRef}
-          aria-label={`${this.props.ariaLabel} with ${this.state.columns.length} columns`}
+          aria-label={this.context.intl.formatMessage({ id: 'stripes-components.tableColumnCount' }, { count: this.state.columns.length })}
           role="list"
           className={css.mclContainer}
         >
@@ -901,5 +905,6 @@ class MCLRenderer extends React.Component {
 
 MCLRenderer.propTypes = propTypes;
 MCLRenderer.defaultProps = defaultProps;
+MCLRenderer.contextTypes = contextTypes;
 
 export default MCLRenderer;

--- a/lib/Pane/Pane.css
+++ b/lib/Pane/Pane.css
@@ -1,7 +1,6 @@
 @import '../variables.css';
 
 .pane {
-  background-color: #fff;
   border-right: 1px solid var(--color-border);
   height: 100%;
   max-height: calc(100vh - 44px);

--- a/translations/en.json
+++ b/translations/en.json
@@ -46,5 +46,6 @@
   "expandSection": "Expand section",
   "metaSection.source": "Source: {source}",
   "metaSection.recordCreated": "Record created: {date} {time}",
-  "metaSection.recordLastUpdated": "Record last updated: {date} {time}"
+  "metaSection.recordLastUpdated": "Record last updated: {date} {time}",
+  "tableColumnCount": "Table with {count} columns"
 }


### PR DESCRIPTION
I observed this aria-label in the ContributerTypes EditableList: `undefined with 5 columns`

Besides a variable not being passed down, the aria-label was prone to error in translation because it inserts one display string into another. I made the label generic so the whole string can be translated.

e.g. `Table with 5 columns`

I removed the `background-color: #fff` because it was unnecessary; the background is already white.