### PR TITLE
Explicitly state mocha dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "chai": "^3.5.0",
     "eslint": "^4.8.0",
     "file-loader": "^1.1.5",
+    "mocha": "^4.0.1",
     "postcss-calc": "^6.0.1",
     "postcss-color-function": "^4.0.1",
     "postcss-custom-media": "^6.0.0",


### PR DESCRIPTION
Prevents a yarn warning that `@bigtest/mocha`'s peer dependency on `mocha` wasn't being fulfilled.