### PR TITLE
Make the `RadioButtonGroup` legend styling match other labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ atom.cson
 .DS_Store
 yarn-error.log
 artifacts
+.npmrc

--- a/lib/RadioButtonGroup/RadioButtonGroup.css
+++ b/lib/RadioButtonGroup/RadioButtonGroup.css
@@ -6,10 +6,9 @@
 
 .groupLabel {
   display: block;
-  font-size: 0.8em;
-  font-weight: bold;
-  text-transform: Uppercase;
-  color: var(--color-text-p2);
+  font-size: 14px;
+  font-weight: var(--text-weight-basis);
+  color: var(--color-text);
 
   &.required::after {
     content: '(required)';


### PR DESCRIPTION
## What is this?

The `RadioButtonGroup` legend styling should match other labels styling (like `TextField`). This was pointed out when implementing `RadioButtonGroup` in `ui-eholdings`. (https://issues.folio.org/browse/UIEH-354)

## Screenshots 

**Before**
![image](https://user-images.githubusercontent.com/2072894/40854568-8799c1c2-6597-11e8-8e91-af6ceaee6beb.png)

**After**
![image](https://user-images.githubusercontent.com/2072894/40854704-e3244472-6597-11e8-93dd-7d4f4f137bfb.png)
