### PR TITLE
Run ESLint for entire repository

### DIFF
--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -226,7 +226,6 @@ class Accordion extends React.Component {
     }
   }
 
-  // eslint-disable-next-line class-methods-use-this
   getContentClass(open) {
     return classNames(
       css.content,
@@ -234,7 +233,6 @@ class Accordion extends React.Component {
     );
   }
 
-  // eslint-disable-next-line class-methods-use-this
   getRootClasses() {
     return classNames(
       css.accordion,

--- a/lib/AddressFieldGroup/AddressEdit/AddressEditList.js
+++ b/lib/AddressFieldGroup/AddressEdit/AddressEditList.js
@@ -3,7 +3,7 @@
 */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FieldArray } from 'redux-form'; // eslint-disable-line
+import { FieldArray } from 'redux-form';
 import { Row, Col } from '../../LayoutGrid';
 import Layout from '../../Layout';
 import EmbeddedAddressForm from './EmbeddedAddressForm';

--- a/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
+++ b/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Field } from 'redux-form'; // eslint-disable-line
+import { Field } from 'redux-form';
 import findIndex from 'lodash/findIndex';
 import cloneDeep from 'lodash/cloneDeep';
 import Button from '../../Button';

--- a/lib/AddressFieldGroup/AddressList/AddressList.js
+++ b/lib/AddressFieldGroup/AddressList/AddressList.js
@@ -99,7 +99,7 @@ const contextTypes = {
   intl: intlShape
 };
 
-class AddressList extends React.Component {
+class AddressList extends React.Component { // eslint-disable-line react/no-deprecated
   constructor(props) {
     super(props);
     this.state = {

--- a/lib/AppIcon/stories/AppIcon.stories.js
+++ b/lib/AppIcon/stories/AppIcon.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import withReadme from 'storybook-readme/with-readme'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
 import Readme from '../readme.md';
 import BasicUsage from './BasicUsage';
 

--- a/lib/Avatar/stories/Avatar.stories.js
+++ b/lib/Avatar/stories/Avatar.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import withReadme from 'storybook-readme/with-readme'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
 import readme from '../readme.md';
 import BasicUsage from './BasicUsage';
 

--- a/lib/Badge/stories/Badge.stories.js
+++ b/lib/Badge/stories/Badge.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import withReadme from 'storybook-readme/with-readme'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
 import Readme from '../readme.md';
 import BasicUsage from './BasicUsage';
 

--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -372,7 +372,7 @@ class Calendar extends React.Component {
       },
     );
 
-    let k = moment.localeData()._week.dow; // eslint-disable-line no-underscore-dangle
+    let k = moment.localeData()._week.dow;
     const daysOfWeek = [];
     while (daysOfWeek.length < 7) {
       daysOfWeek.push(<th key={k + k} className={css.weekday}>{moment().day(k).format('dd')}</th>);

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -19,7 +19,7 @@ const propTypes = {
   screenReaderMessage: PropTypes.string,
   value: PropTypes.string,
   date: PropTypes.object,
-  dateFormat: PropTypes.string, // eslint-disable-line
+  dateFormat: PropTypes.string,
   label: PropTypes.string,
   disabled: PropTypes.bool,
   required: PropTypes.bool,
@@ -177,9 +177,9 @@ class Datepicker extends React.Component {
       dateString: inputValue,
       showCalendar: this.props.showCalendar || false,
       srMessage: '',
-      parseTimezone, // eslint-disable-line react/no-unused-state
-      _dateFormat: this._dateFormat, // eslint-disable-line react/no-unused-state
-      input: this.props.input, // eslint-disable-line react/no-unused-state
+      parseTimezone,
+      _dateFormat: this._dateFormat,
+      input: this.props.input,
     };
 
     if (props.id) {
@@ -386,7 +386,7 @@ class Datepicker extends React.Component {
     }
   }
 
-  cleanForScreenReader(str) { // eslint-disable-line class-methods-use-this
+  cleanForScreenReader(str) {
     return str.replace(/Y/g, 'Y ');
   }
 

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -27,7 +27,7 @@ const propTypes = {
   /**
   * Initial form values
   */
-  initialValues: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
+  initialValues: PropTypes.object,
   /**
    * Callback provided by redux-form to set the initialValues to something else.
    */
@@ -171,7 +171,6 @@ class EditableListForm extends React.Component {
     }
   }
 
-  // eslint-disable-next-line class-methods-use-this
   buildStatusArray(items) {
     return items.map(() => ({ editing: false, error: false }));
   }

--- a/lib/EditableList/EditableListForm.js
+++ b/lib/EditableList/EditableListForm.js
@@ -133,7 +133,7 @@ const contextTypes = {
   intl: intlShape
 };
 
-class EditableListForm extends React.Component {
+class EditableListForm extends React.Component { // eslint-disable-line react/no-deprecated
   constructor(props) {
     super(props);
 

--- a/lib/EmptyMessage/stories/EmptyMessage.stories.js
+++ b/lib/EmptyMessage/stories/EmptyMessage.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import withReadme from 'storybook-readme/with-readme'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
 import readme from '../readme.md';
 import BasicUsage from './BasicUsage';
 

--- a/lib/InfoPopover/stories/InfoPopover.stories.js
+++ b/lib/InfoPopover/stories/InfoPopover.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import withReadme from 'storybook-readme/with-readme'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
 import readme from '../readme.md';
 import BasicUsage from './BasicUsage';
 

--- a/lib/Layer/Layer.js
+++ b/lib/Layer/Layer.js
@@ -26,7 +26,7 @@ const contextTypes = {
   paneset: PropTypes.instanceOf(Paneset),
 };
 
-class Layer extends React.Component {
+class Layer extends React.Component { // eslint-disable-line react/no-deprecated
   constructor(props) {
     super(props);
     this.container = null;

--- a/lib/LayoutHeader/LayoutHeader.js
+++ b/lib/LayoutHeader/LayoutHeader.js
@@ -11,7 +11,7 @@ const propTypes = {
     PropTypes.string,
     PropTypes.node,
   ]),
-  level: PropTypes.number, // eslint-disable-line
+  level: PropTypes.number,
   actions: PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string,
@@ -27,25 +27,25 @@ const defaultProps = {
   level: 3,
 };
 
-const LayoutHeader = (props) => {
-  const getHeader = () => React.createElement(`h${props.level}`, { style: { margin: 0 } }, props.title);
+const LayoutHeader = ({ title, level, actions, onDelete, noActions }) => {
+  const getHeader = () => React.createElement(`h${level}`, { style: { margin: 0 } }, title);
 
 
   const renderActions = () => {
     const renderedActions = [];
-    if (props.noActions) {
-      return [(<span key={`${props.title.toString()}-noAction`}>&nbsp;</span>)];
+    if (noActions) {
+      return [(<span key={`${title.toString()}-noAction`}>&nbsp;</span>)];
     }
 
     let actionList;
-    if (!props.actions) {
+    if (!actions) {
       actionList = [
         { title: 'Delete',
           icon: 'trashBin',
-          handler: props.onDelete },
+          handler: onDelete },
       ];
     } else {
-      actionList = props.actions;
+      actionList = actions;
     }
 
     actionList.forEach((a, i) => {

--- a/lib/List/stories/List.stories.js
+++ b/lib/List/stories/List.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import withReadme from 'storybook-readme/with-readme'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
 import Readme from '../readme.md';
 import BasicUsage from './BasicUsage';
 

--- a/lib/MetaSection/MetaAccordionHeader.js
+++ b/lib/MetaSection/MetaAccordionHeader.js
@@ -17,7 +17,7 @@ const propTypes = {
 const MetaAccordionHeader = (props) => {
   let toggleElem = null;
   let labelElem = null;
-  let iconElem = null; // eslint-disable-line
+  let iconElem = null; // eslint-disable-line no-unused-vars
   let containerElem = null;
 
   function handleHeaderClick(e) {

--- a/lib/MetaSection/MetaSection.js
+++ b/lib/MetaSection/MetaSection.js
@@ -14,8 +14,7 @@ const propTypes = {
   contentId: PropTypes.string,
 };
 
-class MetaSection extends React.Component { // eslint-disable-line
-
+class MetaSection extends React.Component {
   constructor(props, context) {
     super(props);
     this.context = context;

--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -19,12 +19,12 @@ const propTypes = {
   /** Size defaults to 60% the scope element's width.
    * "Small" can be applied for 40% and "Large" for 90%.
    */
-  size: PropTypes.oneOf(['small', 'medium', 'large']), // eslint-disable-line react/no-unused-prop-types
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
   /** Parent element for modal.
    * Defaults to 'module' which keeps the main navigation visible.
    * A value of 'root' covers the entire view.
    */
-  scope: PropTypes.oneOf([ // eslint-disable-line react/no-unused-prop-types
+  scope: PropTypes.oneOf([
     'root',
     'module',
   ]),

--- a/lib/Modal/stories/Modal.stories.js
+++ b/lib/Modal/stories/Modal.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import withReadme from 'storybook-readme/with-readme'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
 import { withKnobs } from '@storybook/addon-knobs/react';
 import Readme from '../readme.md';
 import BasicUsage from './BasicUsage';

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -72,7 +72,7 @@ const defaultProps = {
   interactive: true,
 };
 
-class MCLRenderer extends React.Component {
+class MCLRenderer extends React.Component { // eslint-disable-line react/no-deprecated
   constructor(props) {
     super(props);
 

--- a/lib/MultiColumnList/defaultRowFormatter.js
+++ b/lib/MultiColumnList/defaultRowFormatter.js
@@ -43,7 +43,7 @@ function defaultRowFormatter({ rowIndex, rowClass, cells, rowProps, labelStrings
       aria-label={labelStrings.join('...')}
       role="listitem"
       {...rowProps}
-      tabIndex="0" // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
+      tabIndex="0"
     >
       {cells}
     </Element>

--- a/lib/NavList/stories/NavList.stories.js
+++ b/lib/NavList/stories/NavList.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import withReadme from 'storybook-readme/with-readme'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
 import Readme from '../readme.md';
 import BasicUsage from './BasicUsage';
 

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -148,7 +148,7 @@ class Paneset extends React.Component {
     });
   }
 
-  transitionStart(pane) { // eslint-disable-line class-methods-use-this
+  transitionStart(pane) {
     if (pane.ref.props.transition === 'slide') {
       const styleObject = {};
       if (!Number.isNaN(parseInt(pane.ref.props.defaultWidth, 10))) {
@@ -202,7 +202,7 @@ class Paneset extends React.Component {
           dynamics.push(i);
         } else {
           staticSpace += currentPaneWidth;
-          pane.staticWidth = currentPaneWidth; // eslint-disable-line
+          pane.staticWidth = currentPaneWidth;
         }
       }
     });

--- a/lib/Popover/Popover.js
+++ b/lib/Popover/Popover.js
@@ -133,7 +133,7 @@ class Popover extends React.Component {
     return styleObject;
   }
 
-  getAlignment(targetRect, popRect, position, alignment) { // eslint-disable-line class-methods-use-this
+  getAlignment(targetRect, popRect, position, alignment) {
     let coordinate = 'left';
     let dimension = 'width';
     let a;
@@ -174,7 +174,7 @@ class Popover extends React.Component {
   }
 
   // check bounds against window...
-  checkBounds(left, top, popRect, position) { // eslint-disable-line class-methods-use-this
+  checkBounds(left, top, popRect, position) {
     const correction = { flip: false };
     if (left < 0) {
       if (position === 'start') {

--- a/lib/Popover/stories/Popover.stories.js
+++ b/lib/Popover/stories/Popover.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import withReadme from 'storybook-readme/with-readme'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
 import readme from '../readme.md';
 import BasicUsage from './BasicUsage';
 

--- a/lib/RepeatableField/RepeatableField.js
+++ b/lib/RepeatableField/RepeatableField.js
@@ -26,10 +26,6 @@ class RepeatableField extends React.Component {
 
     this.lastField = null;
 
-    this.state = {
-      length: 0, // eslint-disable-line react/no-unused-state
-    };
-
     this._added = false;
     this._arrayId = `${this.props.label}-fields`;
     this.buildComponentFromTemplate = this.buildComponentFromTemplate.bind(this);
@@ -60,7 +56,6 @@ class RepeatableField extends React.Component {
     } else {
       fields.push();
     }
-    this.setState({ length: fields.length }); // eslint-disable-line react/no-unused-state
   }
 
   handleAddField(fields) {
@@ -70,7 +65,6 @@ class RepeatableField extends React.Component {
       fields.push();
     }
     this._added = true;
-    this.setState({ length: fields.length }); // eslint-disable-line react/no-unused-state
   }
 
   render() {

--- a/lib/SRStatus/SRStatus.js
+++ b/lib/SRStatus/SRStatus.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-class SRStatus extends React.Component {
+class SRStatus extends React.Component { // eslint-disable-line react/no-deprecated
   static propTypes = {
     message: PropTypes.string,
   }

--- a/lib/SearchField/stories/SearchField.stories.js
+++ b/lib/SearchField/stories/SearchField.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
-import withReadme from 'storybook-readme/with-readme'; // eslint-disable-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
 import readme from '../readme.md';
 import BasicUsage from './BasicUsage';
 

--- a/lib/SegmentedControl/SegmentedControl.js
+++ b/lib/SegmentedControl/SegmentedControl.js
@@ -8,7 +8,7 @@ import createChainedFunction from '../../util/createChainedFunction';
 const propTypes = {
   tag: PropTypes.string,
   activeId: PropTypes.string,
-  onActivate: PropTypes.func, // eslint-disable-line
+  onActivate: PropTypes.func, // eslint-disable-line react/no-unused-prop-types
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node),

--- a/lib/Selection/SelectList.js
+++ b/lib/Selection/SelectList.js
@@ -176,7 +176,7 @@ class SelectList extends React.Component {
         } else {
           cursored = this.container.querySelector(`.${css.cursor}`);
           if (cursored) {
-            if (cursored.offsetTop > this.container.scrollTop + this.container.offsetHeight - 30) { // eslint-disable-line no-mixed-operators
+            if (cursored.offsetTop > ((this.container.scrollTop + this.container.offsetHeight) - 30)) {
               const newScroll = cursored.offsetTop - (this.container.offsetHeight - cursored.offsetHeight);
               this.container.scrollTop = newScroll;
             } else if (cursored.offsetTop < this.container.scrollTop) {

--- a/lib/Selection/SelectList.js
+++ b/lib/Selection/SelectList.js
@@ -46,7 +46,7 @@ const contextTypes = {
   intl: intlShape,
 };
 
-class SelectList extends React.Component {
+class SelectList extends React.Component { // eslint-disable-line react/no-deprecated
   constructor(props) {
     super(props);
 

--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -346,7 +346,7 @@ class SingleSelect extends React.Component {
     }
   }
 
-  getTextDirection() { // eslint-disable-line
+  getTextDirection() {
     const dir = getComputedStyle(document.body).direction;
     return dir;
   }
@@ -628,12 +628,7 @@ class SingleSelect extends React.Component {
   }
 
   render() {
-    const {
-      input, // eslint-disable-line
-      meta,  // eslint-disable-line
-      tether,
-      label,  // eslint-disable-line
-    } = this.props;
+    const { tether } = this.props;
 
     // detect smaller screen size...
     const atSmallMedia = window.matchMedia('(max-width: 800px)').matches;

--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -62,7 +62,7 @@ const defaultProps = {
   formatter: DefaultOptionFormatter,
 };
 
-class SingleSelect extends React.Component {
+class SingleSelect extends React.Component { // eslint-disable-line react/no-deprecated
   constructor(props) {
     super(props);
 

--- a/lib/TextArea/TextArea.js
+++ b/lib/TextArea/TextArea.js
@@ -10,7 +10,6 @@ const propTypes = {
   /**
    * Can be "type" or "number". Standard html attribute.
    */
-  // eslint-disable-next-line react/no-unused-prop-types
   type: PropTypes.string,
   /**
    * Removes border.
@@ -19,12 +18,10 @@ const propTypes = {
   /**
    * String of text to display.
    */
-  // eslint-disable-next-line react/no-unused-prop-types
   value: PropTypes.string,
   /**
    * Event handler for text input. Required if a value is supplied.
    */
-  // eslint-disable-next-line react/no-unused-prop-types
   onChange: PropTypes.func,
   fullWidth: PropTypes.bool,
   error: PropTypes.string,

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -18,7 +18,6 @@ export default class TextField extends Component {
     /**
      * Can be "text" or "number". Standard html attribute.
      */
-    // eslint-disable-next-line react/no-unused-prop-types
     type: PropTypes.string,
     /**
      * String of preset styles to apply to textfield. possible values: noBorder
@@ -42,7 +41,6 @@ export default class TextField extends Component {
     /**
      * Event handler for text input. Required if a value is supplied.
      */
-    // eslint-disable-next-line react/no-unused-prop-types
     onChange: PropTypes.func,
 
     /**

--- a/lib/Timepicker/TimeDropdown.js
+++ b/lib/Timepicker/TimeDropdown.js
@@ -34,7 +34,7 @@ const defaultProps = {
   minuteIncrement: 1,
 };
 
-class TimeDropdown extends React.Component {
+class TimeDropdown extends React.Component { // eslint-disable-line react/no-deprecated
   constructor(props) {
     super(props);
 

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -193,7 +193,7 @@ class Timepicker extends React.Component {
     return '24';
   }
 
-  getLocalTime(t, f) { // eslint-disable-line
+  getLocalTime(t, f) {
     if (t) {
       return moment(t).format(f);
     }
@@ -417,7 +417,7 @@ class Timepicker extends React.Component {
     this.textfield.getInput().focus();
   }
 
-  cleanForScreenReader(str) { // eslint-disable-line class-methods-use-this
+  cleanForScreenReader(str) {
     const newString = str.replace(/H/g, 'H ').replace(/m/g, 'm ').replace(/s/g, 's ');
     return newString;
   }
@@ -448,7 +448,7 @@ class Timepicker extends React.Component {
     }
   }
 
-  standardizeTime(time) { // eslint-disable-line class-methods-use-this
+  standardizeTime(time) {
     const isoTime = moment.tz(time, 'HH:mm A', this.timezone).toISOString();
     const timeSplit = isoTime.split('T');
     return timeSplit[1];

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -62,7 +62,7 @@ const contextTypes = {
   intl: intlShape,
 };
 
-class Timepicker extends React.Component {
+class Timepicker extends React.Component { // eslint-disable-line react/no-deprecated
   constructor(props, context) {
     super(props, context);
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "scripts": {
     "docgen": "react-docgen ./lib/ --pretty -e index.js -o ./docs/reactdoc.json ",
-    "lint": "eslint lib && stylelint \"lib/**/*.css\"",
-    "eslint": "eslint lib",
+    "lint": "eslint ./ && stylelint \"lib/**/*.css\"",
+    "eslint": "eslint ./",
     "stylelint": "stylelint \"lib/**/*.css\"",
     "test": "stripes test karma",
     "storybook": "start-storybook -p 9001 -c .storybook"

--- a/util/craftLayerUrl.js
+++ b/util/craftLayerUrl.js
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import queryString from 'query-string';
 
 function craftLayerUrl(mode) {
   const url = this.props.location.pathname + this.props.location.search;

--- a/util/detectElementResize.js
+++ b/util/detectElementResize.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 /**
  * Detect Element Resize.
  * https://github.com/sdecima/javascript-detect-element-resize

--- a/util/getNextFocusable.js
+++ b/util/getNextFocusable.js
@@ -5,13 +5,14 @@
 */
 
 import contains from 'dom-helpers/query/contains';
-export default function getNextFocusable(currentElement, containing = true) {
-  //add all elements we want to include in our selection
+
+export default function getNextFocusable(currentElement, containing = true) { // eslint-disable-line consistent-return
+  // add all elements we want to include in our selection
   const focusableElements = 'a:not([disabled]), button:not([disabled]), input[type=text]:not([disabled]), [tabindex]:not([disabled]):not([tabindex="-1"])';
   let focusable = Array.prototype.filter.call(document.querySelectorAll(focusableElements),
-    function (element) {
-      //check for visibility while always include the current activeElement
-      return element.offsetWidth > 0 || element.offsetHeight > 0 || element === document.activeElement
+    (element) => {
+      // check for visibility while always include the current activeElement
+      return element.offsetWidth > 0 || element.offsetHeight > 0 || element === document.activeElement;
     });
   if (!containing) {
     const outside = Array.prototype.filter.call(focusable, (element) => {

--- a/util/makeQueryFunction.js
+++ b/util/makeQueryFunction.js
@@ -1,5 +1,5 @@
-import { filters2cql } from '../lib/FilterGroups';
 import { compilePathTemplate } from '@folio/stripes-connect/RESTResource/RESTResource';
+import { filters2cql } from '../lib/FilterGroups';
 
 // failOnCondition can take values:
 //      0: do not fail even if query and filters and empty
@@ -10,7 +10,6 @@ import { compilePathTemplate } from '@folio/stripes-connect/RESTResource/RESTRes
 //
 function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOnCondition) {
   return (queryParams, pathComponents, resourceValues, logger) => {
-
     const { qindex, filters, query, sort } = resourceValues.query || {};
 
     if ((query === undefined || query === '') &&
@@ -23,19 +22,19 @@ function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOn
       return null;
     }
 
-    //This check should remain in place until all uses of the $QUERY syntax have been removed from stripes modules
-    if (queryTemplate.includes("$QUERY")) {
-      console.warn('Use of "$QUERY" in the queryTemplate is deprecated. Use the "%{query.query}" syntax instead, as found at https://github.com/folio-org/stripes-connect/blob/master/doc/api.md#text-substitution')
-      queryTemplate = queryTemplate.replace(/\$QUERY/g, '?{query}');
+    // This check should remain '$QUERY' until all uses of the $QUERY syntax have been removed from stripes modules
+    if (queryTemplate.includes('$QUERY')) {
+      console.warn('Use of "$QUERY" in the queryTemplate is deprecated. Use the "%{query.query}" syntax instead, as found at https://github.com/folio-org/stripes-connect/blob/master/doc/api.md#text-substitution');
+      queryTemplate = queryTemplate.replace(/\$QUERY/g, '?{query}'); // eslint-disable-line no-param-reassign
     }
 
-    let cql = undefined;
+    let cql;
     if (query && qindex) {
       const t = qindex.split('/', 2);
       if (t.length === 1) {
         cql = `${qindex}="${query}*"`;
       } else {
-        cql = `${t[0]} =\/${t[1]} "${query}*"`;
+        cql = `${t[0]} =\${t[1]} "${query}*"`;
       }
     } else if (query) {
       cql = compilePathTemplate(queryTemplate, queryParams, pathComponents, resourceValues);
@@ -58,7 +57,7 @@ function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOn
       const sortIndexes = sort.split(',').map((sort1) => {
         let reverse = false;
         if (sort1.startsWith('-')) {
-          sort1 = sort1.substr(1);
+          sort1 = sort1.substr(1); // eslint-disable-line no-param-reassign
           reverse = true;
         }
         let sortIndex = sortMap[sort1] || sort1;

--- a/util/transitionToParams.js
+++ b/util/transitionToParams.js
@@ -3,8 +3,9 @@ import queryString from 'query-string';
 function transitionToParams(params) {
   const location = this.props.location;
   let query = location.query;
-  if (query === undefined)
+  if (query === undefined) {
     query = queryString.parse(location.search);
+  }
 
   const allParams = Object.assign({}, query, params);
   const keys = Object.keys(allParams);


### PR DESCRIPTION
## Purpose
- In https://github.com/folio-org/stripes-components/pull/399#issuecomment-393144465 we noticed that the `query-string` dependency had not been picked up by ESLint - that's because the `util` directory was not being linted.
- The Stripes ESLint config has matured a bit, so some of the line-disabling no longer had to take place.
- Updates to `eslint-plugin-react` started throwing very chatty warnings about lifecycle hook deprecations. Those are very sensitive refactors that can take place more confidently and responsibly when those components have tests.

## Approach
- ESLint now covers the entire project, not just `lib`.
- Unnecessary line disabling removed.
- Every `eslint-disable-line` now explicitly states which rule to ignore.
- Disable the lifecycle hook warnings for now. There's already a JIRA issue for that: https://issues.folio.org/browse/STCOM-275

