### PR TITLE
Create tests for TextArea and Select

### DIFF
--- a/lib/Select/Select.js
+++ b/lib/Select/Select.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import css from './Select.css';
@@ -7,31 +7,31 @@ import sharedInputStylesHelper from '../sharedStyles/sharedInputStylesHelper';
 import omitProps from '../../util/omitProps';
 import Icon from '../Icon';
 
-const propTypes = {
-  dataOptions: PropTypes.arrayOf(PropTypes.object),
-  meta: PropTypes.object,
-  fullWidth: PropTypes.bool,
-  input: PropTypes.object,
-  placeholder: PropTypes.string,
-  value: PropTypes.string,
-  error: PropTypes.bool,
-  required: PropTypes.bool,
-  validationEnabled: PropTypes.bool,
-  validStylesEnabled: PropTypes.bool,
-  marginBottom0: PropTypes.bool,
-  id: PropTypes.string,
-  selectClass: PropTypes.string,
-  autoFocus: PropTypes.bool,
-};
+export default class Select extends Component {
+  static propTypes = {
+    autoFocus: PropTypes.bool,
+    dataOptions: PropTypes.arrayOf(PropTypes.object),
+    error: PropTypes.bool,
+    fullWidth: PropTypes.bool,
+    id: PropTypes.string,
+    input: PropTypes.object,
+    marginBottom0: PropTypes.bool,
+    meta: PropTypes.object,
+    placeholder: PropTypes.string,
+    required: PropTypes.bool,
+    selectClass: PropTypes.string,
+    validationEnabled: PropTypes.bool,
+    validStylesEnabled: PropTypes.bool,
+    value: PropTypes.string,
+  };
 
-const defaultProps = {
-  meta: {},
-  validationEnabled: true,
-  validStylesEnabled: false,
-  autoFocus: false,
-};
+  static defaultProps = {
+    meta: {},
+    validationEnabled: true,
+    validStylesEnabled: false,
+    autoFocus: false,
+  };
 
-class Select extends React.Component {
   getRootClass() {
     return classNames(
       css.select,
@@ -64,30 +64,50 @@ class Select extends React.Component {
   render() {
     const { input, meta: { error, warning, touched }, ...rest } = this.props;
     const { ...selectAttr } = input;
+
+    /* eslint-disable no-unused-vars */
     const {
       label,
       placeholder,
       dataOptions,
       children,
-      fullWidth, // eslint-disable-line no-unused-vars
-      marginBottom0, // eslint-disable-line no-unused-vars
-      validationEnabled, // eslint-disable-line no-unused-vars
-      validStylesEnabled, // eslint-disable-line no-unused-vars
+      fullWidth,
+      marginBottom0,
+      validationEnabled,
+      validStylesEnabled,
       ...selectCustom
     } = rest;
+    /* eslint-enable no-unused-vars */
 
     const options = [];
 
-    if (this.props.placeholder) options.push(<option value="" key="x" disabled>{placeholder}</option>);
+    if (this.props.placeholder) {
+      options.push(
+        <option value="" key="x" disabled>{placeholder}</option>
+      );
+    }
 
     if (dataOptions) {
       dataOptions.forEach((option, i) => {
-        options.push(<option value={option.value} key={option.id || `option-${i}`} disabled={option.disabled}>{option.label}</option>);
+        options.push(
+          <option
+            value={option.value}
+            key={option.id || `option-${i}`}
+            disabled={option.disabled}
+          >
+            {option.label}
+          </option>
+        );
       });
     }
 
     const component = (
-      <select autoFocus={this.props.autoFocus} className={this.getSelectClass()} {...selectAttr} {...omitProps(selectCustom, ['selectClass'])} >
+      <select
+        autoFocus={this.props.autoFocus}
+        className={this.getSelectClass()}
+        {...selectAttr}
+        {...omitProps(selectCustom, ['selectClass'])}
+      >
         {options}
         {children}
       </select>
@@ -101,7 +121,14 @@ class Select extends React.Component {
 
     return (
       <div className={this.getRootClass()}>
-        { label ? (<label htmlFor={this.props.id} className={classNames(formStyles.label, this.getLabelClass())}>{label}</label>) : '' }
+        { label ? (
+          <label
+            htmlFor={this.props.id}
+            className={classNames(formStyles.label, this.getLabelClass())}
+          >
+            {label}
+          </label>)
+        : '' }
         <div className={css.selectWrap}>
           {component}
           <Icon icon="down-triangle" iconRootClass={css.selectIcon} />
@@ -112,8 +139,3 @@ class Select extends React.Component {
     );
   }
 }
-
-Select.propTypes = propTypes;
-Select.defaultProps = defaultProps;
-
-export default Select;

--- a/lib/Select/tests/Select-test.js
+++ b/lib/Select/tests/Select-test.js
@@ -1,1 +1,159 @@
-import Select from '../Select'; // eslint-disable-line no-unused-vars
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { Field } from 'redux-form';
+import { mount, mountWithContext } from '../../../tests/helpers';
+import TestForm from '../../../tests/TestForm';
+import Select from '../Select';
+import SelectInteractor from './interactor';
+
+describe('Select', () => {
+  const select = new SelectInteractor();
+
+  beforeEach(async () => {
+    await mount(
+      <Select
+        id="test"
+        placeholder="Choose an option"
+        dataOptions={[
+          { value: 'test0', label: 'Option 0' },
+          { value: 'test1', label: 'Option 1' },
+          { value: 'test2', label: 'Option 2' }
+         ]}
+      />
+    );
+  });
+
+  it('renders a select element', () => {
+    expect(select.hasSelect).to.be.true;
+  });
+
+  it('renders no label tag by default', () => {
+    expect(select.hasLabel).to.be.false;
+  });
+
+  it('applies the id to the select', () => {
+    expect(select.id).to.equal('test');
+  });
+
+  describe('entering text', async () => {
+    beforeEach(async () => {
+      await select.selectOption('Option 1');
+    });
+
+    it('updates the value', () => {
+      expect(select.val).to.equal('test1');
+    });
+  });
+
+  describe('supplying label and id', () => {
+    beforeEach(async () => {
+      await mount(
+        <Select label="my test label" id="myTestInput" />
+      );
+    });
+
+    it('renders a label element', () => {
+      expect(select.label).to.equal('my test label');
+    });
+
+    it('with a filled htmlFor attribute', () => {
+      expect(select.labelFor).to.equal('myTestInput');
+    });
+  });
+
+  describe('using with redux-form', () => {
+    describe('inputting a value', () => {
+      beforeEach(async () => {
+        await mountWithContext(
+          <TestForm>
+            <Field
+              name="testField"
+              component={Select}
+              dataOptions={[
+                { value: 'test0', label: 'Option 0' },
+                { value: 'test1', label: 'Option 1' },
+                { value: 'test2', label: 'Option 2' }
+               ]}
+            />
+          </TestForm>
+        );
+      });
+
+      it('renders a select element', () => {
+        expect(select.hasSelect).to.be.true;
+      });
+
+      describe('changing the value', () => {
+        beforeEach(async () => {
+          await select.selectOption('Option 2')
+            .focusSelect();
+        });
+
+        it('applies a changed class', () => {
+          expect(select.hasChangedStyle).to.be.true;
+        });
+      });
+    });
+
+    describe('selecting an invalid value', () => {
+      beforeEach(async () => {
+        await mountWithContext(
+          <TestForm>
+            <Field
+              name="testField"
+              component={Select}
+              dataOptions={[
+                { value: 'test0', label: 'Option 0' },
+                { value: 'valid', label: 'Option 1' },
+                { value: 'invalid', label: 'Option 2' }
+               ]}
+              validate={value => (value === 'invalid' ? 'testField is Invalid' : undefined)}
+            />
+          </TestForm>
+        );
+      });
+
+      beforeEach(async () => {
+        await select.selectAndBlur('Option 2');
+      });
+
+      it('applies an error style', () => {
+        expect(select.hasErrorStyle).to.be.true;
+      });
+
+      it('renders an error message', () => {
+        expect(select.errorText).to.equal('testField is Invalid');
+      });
+    });
+
+    describe('selecting a valid value with validStylesEnabled', () => {
+      beforeEach(async () => {
+        await mountWithContext(
+          <TestForm>
+            <Field
+              name="testField"
+              component={Select}
+              validStylesEnabled
+              dataOptions={[
+                { value: 'test0', label: 'Option 0' },
+                { value: 'valid', label: 'Option 1' },
+                { value: 'invalid', label: 'Option 2' }
+               ]}
+              validate={value => (value === undefined ? 'testField cannot be blank' : undefined)}
+            />
+          </TestForm>
+        );
+      });
+
+      beforeEach(async () => {
+        await select.selectAndBlur('Option 1');
+      });
+
+      it('applies a valid class', () => {
+        expect(select.hasValidStyle).to.be.true;
+      });
+    });
+  });
+});

--- a/lib/Select/tests/interactor.js
+++ b/lib/Select/tests/interactor.js
@@ -1,0 +1,40 @@
+import {
+  attribute,
+  blurrable,
+  focusable,
+  hasClass,
+  interactor,
+  is,
+  isPresent,
+  selectable,
+  text,
+  value,
+} from '@bigtest/interactor';
+
+import css from '../Select.css';
+import formCss from '../../sharedStyles/form.css';
+
+export default interactor(class SelectInteractor {
+  hasSelect = isPresent('select');
+  isFocused = is('select', ':focus');
+  val = value('select');
+  selectOption = selectable('select');
+  blurSelect = blurrable('select');
+  focusSelect = focusable('select');
+  id = attribute('select', 'id');
+  labelFor = attribute('label', 'for');
+  label = text('label');
+  hasLabel = isPresent('label');
+  errorText = text(`div.${formCss.feedbackBlock}`);
+  hasWarningStyle = hasClass('select', formCss.hasWarning);
+  hasErrorStyle = hasClass('select', formCss.hasError);
+  hasChangedStyle = hasClass('select', formCss.isChanged);
+  hasValidStyle = hasClass('select', formCss.isValid);
+  hasLoadingIcon = isPresent(`.${css.loadingIcon}`);
+
+  selectAndBlur(val) {
+    return this
+      .selectOption(val)
+      .blur('select');
+  }
+});

--- a/lib/TextArea/TextArea.js
+++ b/lib/TextArea/TextArea.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import className from 'classnames';
 import css from './TextArea.css';
@@ -6,47 +6,47 @@ import omitProps from '../../util/omitProps';
 import sharedInputStylesHelper from '../sharedStyles/sharedInputStylesHelper';
 import formStyles from '../sharedStyles/form.css';
 
-const propTypes = {
-  /**
-   * Can be "type" or "number". Standard html attribute.
-   */
-  type: PropTypes.string,
-  /**
-   * Removes border.
-   */
-  noBorder: PropTypes.bool,
-  /**
-   * String of text to display.
-   */
-  value: PropTypes.string,
-  /**
-   * Event handler for text input. Required if a value is supplied.
-   */
-  onChange: PropTypes.func,
-  fullWidth: PropTypes.bool,
-  error: PropTypes.string,
-  warning: PropTypes.string,
-  input: PropTypes.object,
-  meta: PropTypes.object,
-  id: PropTypes.string,
-  required: PropTypes.bool,
-  validationEnabled: PropTypes.bool,
-  validStylesEnabled: PropTypes.bool,
-  startControl: PropTypes.element,
-  endControl: PropTypes.element,
-  marginBottom0: PropTypes.bool,
-  label: PropTypes.string,
-  inputRef: PropTypes.func,
-  autoFocus: PropTypes.bool,
-};
+export default class TextArea extends Component {
+  static propTypes = {
+    autoFocus: PropTypes.bool,
+    endControl: PropTypes.element,
+    error: PropTypes.string,
+    fullWidth: PropTypes.bool,
+    id: PropTypes.string,
+    input: PropTypes.object,
+    inputRef: PropTypes.func,
+    label: PropTypes.string,
+    marginBottom0: PropTypes.bool,
+    meta: PropTypes.object,
+    /**
+     * Removes border.
+     */
+    noBorder: PropTypes.bool,
+    /**
+     * Event handler for text input. Required if a value is supplied.
+     */
+    onChange: PropTypes.func,
+    required: PropTypes.bool,
+    startControl: PropTypes.element,
+    /**
+     * Can be "type" or "number". Standard html attribute.
+     */
+    type: PropTypes.string,
+    validationEnabled: PropTypes.bool,
+    validStylesEnabled: PropTypes.bool,
+    /**
+     * String of text to display.
+     */
+    value: PropTypes.string,
+    warning: PropTypes.string,
+  };
 
-const defaultProps = {
-  type: 'text',
-  validationEnabled: true,
-  validStylesEnabled: false,
-};
+  static defaultProps = {
+    type: 'text',
+    validationEnabled: true,
+    validStylesEnabled: false,
+  };
 
-class TextArea extends React.Component {
   getRootStyle() {
     return className(
       formStyles.inputGroup,
@@ -67,9 +67,6 @@ class TextArea extends React.Component {
   }
 
   getLabelStyle() {
-    // let labelStyle = css.textAreaLabel;
-    // labelStyle += this.props.required ? ' ' + css.required : '';
-    // return labelStyle;
     return className(
       formStyles.label,
       { [`${css.required}`]: this.props.required },
@@ -94,8 +91,20 @@ class TextArea extends React.Component {
       inputProps = null;
     }
 
-    // eslint-disable-next-line no-unused-vars
-    const { label, endControl, startControl, required, fullWidth, bottomMargin0, noBorder, inputRef, validStylesEnabled, ...inputCustom } = cleanedProps;
+    /* eslint-disable no-unused-vars */
+    const {
+      label,
+      endControl,
+      startControl,
+      required,
+      fullWidth,
+      bottomMargin0,
+      noBorder,
+      inputRef,
+      validStylesEnabled,
+      ...inputCustom
+    } = cleanedProps;
+    /* eslint-enable no-unused-vars */
 
     const component = (
       <textarea
@@ -111,25 +120,28 @@ class TextArea extends React.Component {
     let warningElement;
     let errorElement;
     if (this.props.meta) {
-      warningElement = touched && warning ? <div className={formStyles.feedbackWarning}>{warning}</div> : null;
-      errorElement = touched && error ? <div className={formStyles.feedbackError}>{error}</div> : null;
-    }
-    if (label || endControl || startControl) {
-      return (
-        <div className={this.getRootStyle()}>
-          <label htmlFor={this.props.id} className={this.getLabelStyle()}>{this.props.label}</label>
-          {component}
-          {warningElement}
-          {errorElement}
-        </div>
-      );
+      warningElement = touched && warning ?
+        <div className={formStyles.feedbackWarning}>{warning}</div> : null;
+      errorElement = touched && error ?
+        <div className={formStyles.feedbackError}>{error}</div> : null;
     }
 
-    return component;
+    const labelElement = label ?
+      <label
+        htmlFor={this.props.id}
+        className={this.getLabelStyle()}
+      >
+        {this.props.label}
+      </label>
+      : null;
+
+    return (
+      <div className={this.getRootStyle()}>
+        {labelElement}
+        {component}
+        {warningElement}
+        {errorElement}
+      </div>
+    );
   }
 }
-
-TextArea.propTypes = propTypes;
-TextArea.defaultProps = defaultProps;
-
-export default TextArea;

--- a/lib/TextArea/tests/TextArea-test.js
+++ b/lib/TextArea/tests/TextArea-test.js
@@ -1,1 +1,150 @@
-import TextArea from '../TextArea'; // eslint-disable-line no-unused-vars
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { Field } from 'redux-form';
+import { mount, mountWithContext } from '../../../tests/helpers';
+import TestForm from '../../../tests/TestForm';
+import TextArea from '../TextArea';
+import TextAreaInteractor from './interactor';
+
+describe('TextArea', () => {
+  const textArea = new TextAreaInteractor();
+
+  beforeEach(async () => {
+    await mount(
+      <TextArea id="test" />
+    );
+  });
+
+  it('renders a textarea element', () => {
+    expect(textArea.hasTextArea).to.be.true;
+  });
+
+  it('renders no label tag by default', () => {
+    expect(textArea.hasLabel).to.be.false;
+  });
+
+  it('applies the id to the textarea', () => {
+    expect(textArea.id).to.equal('test');
+  });
+
+  describe('entering text', async () => {
+    beforeEach(async () => {
+      await textArea.fillTextArea('test');
+    });
+
+    it('updates the value', () => {
+      expect(textArea.val).to.equal('test');
+    });
+  });
+
+  describe('supplying label and id', () => {
+    beforeEach(async () => {
+      await mount(
+        <TextArea label="my test label" id="myTestInput" />
+      );
+    });
+
+    it('renders a label element', () => {
+      expect(textArea.label).to.equal('my test label');
+    });
+
+    it('with a filled htmlFor attribute', () => {
+      expect(textArea.labelFor).to.equal('myTestInput');
+    });
+  });
+
+  describe('using with redux-form', () => {
+    describe('inputting a value', () => {
+      beforeEach(async () => {
+        await mountWithContext(
+          <TestForm>
+            <Field
+              name="testField"
+              component={TextArea}
+            />
+          </TestForm>
+        );
+      });
+
+      it('renders a textarea element', () => {
+        expect(textArea.hasTextArea).to.be.true;
+      });
+
+      describe('changing the value', () => {
+        beforeEach(async () => {
+          await textArea.fillTextArea('anything')
+            .focusTextArea();
+        });
+
+        it('applies a changed class', () => {
+          expect(textArea.hasChangedStyle).to.be.true;
+        });
+      });
+    });
+
+    describe('inputting an invalid value', () => {
+      beforeEach(async () => {
+        await mountWithContext(
+          <TestForm>
+            <Field
+              name="testField"
+              component={TextArea}
+              validate={value => (value === 'invalid' ? 'testField is Invalid' : undefined)}
+            />
+          </TestForm>
+        );
+      });
+
+      beforeEach(async () => {
+        await textArea.fillAndBlur('invalid');
+      });
+
+      it('applies an error style', () => {
+        expect(textArea.hasErrorStyle).to.be.true;
+      });
+
+      it('renders an error message', () => {
+        expect(textArea.errorText).to.equal('testField is Invalid');
+      });
+    });
+
+    describe('inputting an valid value with validStylesEnabled', () => {
+      beforeEach(async () => {
+        await mountWithContext(
+          <TestForm>
+            <Field
+              name="testField"
+              component={TextArea}
+              validStylesEnabled
+              validate={value => (value === undefined ? 'testField cannot be blank' : undefined)}
+            />
+          </TestForm>
+        );
+      });
+
+      beforeEach(async () => {
+        await textArea.fillAndBlur('valid');
+      });
+
+      it('applies a valid class', () => {
+        expect(textArea.hasValidStyle).to.be.true;
+      });
+
+      describe('then removing the text', () => {
+        beforeEach(async () => {
+          await textArea.fillAndBlur('');
+        });
+
+        it('applies an error style', () => {
+          expect(textArea.hasErrorStyle).to.be.true;
+        });
+
+        it('renders an error message', () => {
+          expect(textArea.errorText).to.equal('testField cannot be blank');
+        });
+      });
+    });
+  });
+});

--- a/lib/TextArea/tests/interactor.js
+++ b/lib/TextArea/tests/interactor.js
@@ -1,0 +1,40 @@
+import {
+  attribute,
+  blurrable,
+  fillable,
+  focusable,
+  hasClass,
+  interactor,
+  is,
+  isPresent,
+  text,
+  value,
+} from '@bigtest/interactor';
+
+import css from '../TextArea.css';
+import formCss from '../../sharedStyles/form.css';
+
+export default interactor(class TextAreaInteractor {
+  hasTextArea = isPresent('textarea');
+  isFocused = is('textarea', ':focus');
+  val = value('textarea');
+  fillTextArea = fillable('textarea');
+  blurTextArea = blurrable('textarea');
+  focusTextArea = focusable('textarea');
+  id = attribute('textarea', 'id');
+  labelFor = attribute('label', 'for');
+  label = text('label');
+  hasLabel = isPresent('label');
+  errorText = text(`div.${formCss.feedbackBlock}`);
+  hasWarningStyle = hasClass('textarea', formCss.hasWarning);
+  hasErrorStyle = hasClass('textarea', formCss.hasError);
+  hasChangedStyle = hasClass('textarea', formCss.isChanged);
+  hasValidStyle = hasClass('textarea', formCss.isValid);
+  hasLoadingIcon = isPresent(`.${css.loadingIcon}`);
+
+  fillAndBlur(val) {
+    return this
+      .fill('textarea', val)
+      .blur('textarea');
+  }
+});

--- a/lib/TextField/tests/interactor.js
+++ b/lib/TextField/tests/interactor.js
@@ -49,10 +49,10 @@ export default interactor(class TextFieldInteractor {
   hasClearButton = isPresent('#clearField');
   clickClearButton = clickable('#clearField');
   rendersBottomMargin0 = hasClass(rootClass, css.marginBottom0);
-  hasWarningStyle = hasClass('input', formCss.feedbackWarning);
-  hasErrorStyle = hasClass('input', formCss.feedbackError);
-  hasChangedStyle = hasClass('input', formCss.feedbackChanged);
-  hasValidStyle = hasClass('input', formCss.feedbackValid);
+  hasWarningStyle = hasClass('input', formCss.hasWarning);
+  hasErrorStyle = hasClass('input', formCss.hasError);
+  hasChangedStyle = hasClass('input', formCss.isChanged);
+  hasValidStyle = hasClass('input', formCss.isValid);
   hasLoadingIcon = isPresent(`.${css.loadingIcon}`);
 
   fillAndBlur(val) {

--- a/lib/sharedStyles/form.css
+++ b/lib/sharedStyles/form.css
@@ -77,22 +77,22 @@
     margin-bottom: 0.4rem;
   }
 
-  &.feedbackWarning {
+  &.hasWarning {
     border-color: var(--warn);
     background-color: color(var(--warn) alpha(-95%));
   }
 
-  &.feedbackError {
+  &.hasError {
     border-color: var(--error);
     background-color: color(var(--error) alpha(-95%));
   }
 
-  &.feedbackValid {
+  &.isValid {
     border-color: var(--success);
     background-color: color(var(--success) alpha(-95%));
   }
 
-  &.feedbackChanged {
+  &.isChanged {
     background-color: color(var(--primary) alpha(-80%));
   }
 }

--- a/lib/sharedStyles/sharedInputStylesHelper.js
+++ b/lib/sharedStyles/sharedInputStylesHelper.js
@@ -15,16 +15,20 @@ export default (props) => {
   // Validation classes
   let validationClasses = null;
   if (typeof props.meta !== 'undefined') {
-    const { validationEnabled, validStylesEnabled, meta: { touched, warning, error, dirty, asyncValidating, valid } } = props;
+    const {
+      validationEnabled,
+      validStylesEnabled,
+      meta: { touched, warning, error, dirty, asyncValidating, valid }
+    } = props;
     const hasError = validationEnabled && touched && error;
     const isValid = validationEnabled && validStylesEnabled && touched && !asyncValidating && valid && dirty;
     const hasWarning = validationEnabled && touched && warning;
     const hasFeedback = validationEnabled && (error || warning);
     validationClasses = classNames(
-      { [`${formStyles.feedbackChanged}`]: dirty && !hasError && !hasWarning && !isValid },
-      { [`${formStyles.feedbackWarning}`]: hasWarning },
-      { [`${formStyles.feedbackError}`]: hasError },
-      { [`${formStyles.feedbackValid}`]: isValid },
+      { [`${formStyles.isChanged}`]: dirty && !hasError && !hasWarning && !isValid },
+      { [`${formStyles.hasWarning}`]: hasWarning },
+      { [`${formStyles.hasError}`]: hasError },
+      { [`${formStyles.isValid}`]: isValid },
       { [`${formStyles.hasFeedback}`]: hasFeedback },
     );
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
## Purpose
I was trying to use `reduxFormField` with `TextField`, but since changes will be needed in `sharedInputStylesHelper.js`, I wanted to make sure all the components using the helper (`TextField`, `TextArea`, and `Select`) had test coverage first.

## Approach
Notable change: I renamed some of the classes in `sharedInputStylesHelper.js`. Since both an errored input and its error text had the class `feedbackError`, it was difficult to test that both the class got applied and that the text was present. Now the errored input will have the class `hasError` to differentiate from the feedback text.

This _will_ fail the eHoldings test suite when eHoldings updates to a newer `stripes-components`. This automated test might also fail?
  - https://github.com/folio-org/ui-testing/blob/4ae910138d3c6fb69ba64fc8cf000e543438af78/test/loan_renewal.js

## Question
How should we be considering class name changes in release management?
