### PR TITLE
Add timezone prop to Datepicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 * Updated Accordion collapse logic to apply display:none when closed and overflow:visible when open
 * Deprecate `structures` directory. [STCOM-277](https://issues.folio.org/browse/STCOM-277)
 * `<AccordionSet>` works via context and sets up keyboard navigation for contained `<Accordion>`s. Fixes STCOM-213.
+* Add `timezone` prop to ``<Datepicker>`.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -42,13 +42,13 @@ const propTypes = {
   passThroughValue: PropTypes.string,
   ignoreLocalOffset: PropTypes.bool,
   autoFocus: PropTypes.bool,
+  timezone: PropTypes.string,
 };
 
 const defaultProps = {
   screenReaderMessage: '',
   hideOnChoose: true,
   useFocus: true,
-  locale: 'en',
   backendDateStandard: 'ISO8601',
   autoFocus: false,
   tether: {
@@ -72,8 +72,9 @@ const defaultProps = {
 
 const contextTypes = {
   stripes: PropTypes.shape({
-    locale: PropTypes.string.isRequired,
-  }).isRequired,
+    locale: PropTypes.string,
+    timezone: PropTypes.string
+  }),
   intl: intlShape,
 };
 
@@ -147,16 +148,31 @@ class Datepicker extends React.Component {
     this.handleFieldChange = this.handleFieldChange.bind(this);
     this.datePickerIsFocused = this.datePickerIsFocused.bind(this);
     this.getPresentedValue = this.getPresentedValue.bind(this);
-    this.timezone = this.context.stripes.timezone;
-    const parseTimezone = this.props.ignoreLocalOffset ? 'UTC' : this.timezone;
 
-    moment.locale(this.context.stripes.locale);
+    // Set timezone
+    if (props.timezone) {
+      this.timezone = props.timezone;
+    } else if (context.stripes) {
+      this.timezone = context.stripes.timezone;
+    } else {
+      this.timezone = 'UTC';
+    }
+    const parseTimezone = props.ignoreLocalOffset ? 'UTC' : this.timezone;
+
+    // Set locale
+    if (props.locale) {
+      this.locale = props.locale;
+    } else if (context.stripes) {
+      this.locale = context.stripes.timezone;
+    } else {
+      this.locale = 'en';
+    }
+    moment.locale(this.locale);
     this._dateFormat = moment.localeData()._longDateFormat.L;
 
     // non-null presentedValue will eventually be rendered as the value of the TextField.
     let inputValue = '';
     let presentedValue = null;
-
 
     // if we aren't using redux form...
     if (typeof this.props.input === 'undefined') {
@@ -454,7 +470,7 @@ class Datepicker extends React.Component {
       tether,
     } = this.props;
 
-    const formatMsg = this.context.stripes.intl.formatMessage;
+    const formatMsg = this.context.intl.formatMessage;
     const screenReaderFormat = this.cleanForScreenReader(this._dateFormat);
     const mergedTetherProps = Object.assign({}, Datepicker.defaultProps.tether, tether);
 
@@ -576,7 +592,7 @@ class Datepicker extends React.Component {
               ref={(ref) => { this.picker = ref; }}
               onKeyDown={this.handleKeyDown}
               onBlur={this.hideCalendar}
-              locale={this.context.stripes.locale || this.props.locale}
+              locale={this.locale}
               excludeDates={excludeDates}
               onNavigation={this.handleDateNavigation}
               id={this.testId}

--- a/lib/Datepicker/readme.md
+++ b/lib/Datepicker/readme.md
@@ -12,22 +12,23 @@ import Datepicker from '@folio/stripes-components/lib/Datepicker';
 ### Props
 Name | type | description | default | required
 --- | --- | --- | --- | ---
-label | string | visible field label | | false
-backendDateStandard | string | parses to/from ISO 8601 standard by default before committing value. | "ISO 8601" | false
-id | string | id for date field - used in the "id" attribute of the text input | | false
-useFocus | bool | if set to false, component relies solely on clicking the calendar icon to toggle appearance of calendar. | true | false
-autoFocus | bool | If this prop is `true`, component will automatically focus on mount | |
-disabled | bool | if true, field will be disabled for focus or entry. | false | false
-ignoreLocalOffset | bool | if true, ignores the timezone setting and treats the date as UTC to display the date.
+`label` | string | visible field label | | false
+`backendDateStandard` | string | parses to/from ISO 8601 standard by default before committing value. | "ISO 8601" | false
+`id` | string | id for date field - used in the "id" attribute of the text input | | false
+`useFocus` | bool | if set to false, component relies solely on clicking the calendar icon to toggle appearance of calendar. | true | false
+`autoFocus` | bool | If this prop is `true`, component will automatically focus on mount | |
+`disabled` | bool | if true, field will be disabled for focus or entry. | false | false
+`ignoreLocalOffset` | bool | if true, ignores the timezone setting and treats the date as UTC to display the date.
 | false | false. See below for more explanation
-readOnly | bool | if true, field will be readonly. 'Calendar' and 'clear' buttons will be omitted. | false | false
-value | string | date to be displayed in the textfield. In forms, this is supplied by the initialValues prop supplied to the form | "" | false
-onChange | func | Event handler to handle updates to the datefield text. | | false
-screenReaderMessage | string | Additional message to be read by screenreaders when textfield is focused in addition to the label and format - which are always read. | | false
-excludeDates | array, string or Moment object | Disables supplied dates from being selected in the calendar. | | false
+`readOnly` | bool | if true, field will be readonly. 'Calendar' and 'clear' buttons will be omitted. | false | false
+`value` | string | date to be displayed in the textfield. In forms, this is supplied by the initialValues prop supplied to the form | "" | false
+`onChange` | func | Event handler to handle updates to the datefield text. | | false
+`screenReaderMessage` | string | Additional message to be read by screenreaders when textfield is focused in addition to the label and format - which are always read. | | false
+`excludeDates` | array, string or Moment object | Disables supplied dates from being selected in the calendar. | | false
 `passThroughValue` | string | Can be used to set dynamic values up to the form - values should be inspected/adjusted in a handler at submission time (like a button click that calls `submit()`.) See below for usage example. |  |
+`timezone` | string | Overrides the time zone provided by context. | "UTC" | false
+`locale` | string | Overrides the locale provided by context. | "en" | false
 
-<!-- locale | string | locale for datepicker to use to display calendar. e.g. "de" will display calendar using the German locale | "en" | false -->
 <!-- dateFormat | string | system formatting for date. [Moment.js formats](https://momentjs.com/docs/#/displaying/format/) are supported | "MM/DD/YYYY" | false-->
 
 

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -1,1 +1,141 @@
-import Datepicker from '../Datepicker'; // eslint-disable-line no-unused-vars
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { mountWithContext } from '../../../tests/helpers';
+
+import Datepicker from '../Datepicker';
+import DatepickerInteractor from './interactor';
+
+describe('Datepicker', () => {
+  const datepicker = new DatepickerInteractor();
+
+  beforeEach(async () => {
+    await mountWithContext(
+      <Datepicker />
+    );
+  });
+
+  it('does not have a value in the input', () => {
+    expect(datepicker.inputValue).to.equal('');
+  });
+
+  describe('with an id', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <Datepicker id="datepicker-test" />
+      );
+    });
+
+    it('has an id on the input element', () => {
+      expect(datepicker.id).to.equal('datepicker-test');
+    });
+  });
+
+  describe('selecting a date', () => {
+    let dateOutput;
+
+    beforeEach(async () => {
+      dateOutput = '';
+
+      await mountWithContext(
+        <Datepicker onChange={(event) => { dateOutput = event.target.value; }} />
+      );
+
+      await datepicker.fillInput('04/01/2018');
+    });
+
+    it('emits an event with the date formatted as displayed', () => {
+      expect(dateOutput).to.equal('04/01/2018');
+    });
+  });
+
+  describe('selecting a date with locale prop', () => {
+    let dateOutput;
+
+    beforeEach(async () => {
+      dateOutput = '';
+
+      await mountWithContext(
+        <Datepicker
+          onChange={(event) => { dateOutput = event.target.value; }}
+          locale="de"
+        />
+      );
+
+      await datepicker.fillInput('04/01/2018');
+    });
+
+    it('emits an event with the date formatted as displayed', () => {
+      expect(dateOutput).to.equal('04/01/2018');
+    });
+  });
+
+  describe('selecting a date with timezone prop', () => {
+    let dateOutput;
+
+    beforeEach(async () => {
+      dateOutput = '';
+
+      await mountWithContext(
+        <Datepicker
+          onChange={(event) => { dateOutput = event.target.value; }}
+          timezone="America/Los_Angeles"
+        />
+      );
+
+      await datepicker.fillInput('04/01/2018');
+    });
+
+    it('emits an event with the date formatted as displayed', () => {
+      expect(dateOutput).to.equal('04/01/2018');
+    });
+  });
+
+  describe('coupled to redux form', () => {
+    describe('selecting a date', () => {
+      let dateOutput;
+
+      beforeEach(async () => {
+        dateOutput = '';
+
+        await mountWithContext(
+          <Datepicker
+            input={{
+              onChange: (value) => { dateOutput = value; },
+            }}
+          />
+        );
+
+        await datepicker.fillInput('04/01/2018');
+      });
+
+      it('returns an ISO 8601 datetime string at UTC', () => {
+        expect(dateOutput).to.equal('2018-04-01T00:00:00.000Z');
+      });
+    });
+
+    describe('selecting a date with timezone prop', () => {
+      let dateOutput;
+
+      beforeEach(async () => {
+        dateOutput = '';
+
+        await mountWithContext(
+          <Datepicker
+            input={{
+              onChange: (value) => { dateOutput = value; },
+            }}
+            timezone="America/Los_Angeles"
+          />
+        );
+
+        await datepicker.fillInput('04/01/2018');
+      });
+
+      it('returns an ISO 8601 datetime string for specific time zone', () => {
+        expect(dateOutput).to.equal('2018-04-01T07:00:00.000Z');
+      });
+    });
+  });
+});

--- a/lib/Datepicker/tests/interactor.js
+++ b/lib/Datepicker/tests/interactor.js
@@ -1,0 +1,12 @@
+import {
+  attribute,
+  fillable,
+  interactor,
+  value,
+} from '@bigtest/interactor';
+
+export default interactor(class DatepickerInteractor {
+  id = attribute('input', 'id');
+  inputValue = value('input');
+  fillInput = fillable('input');
+});

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -34,7 +34,6 @@ const propTypes = {
 
 const defaultProps = {
   screenReaderMessage: '',
-  locale: 'en',
   autoFocus: false,
   tether: {
     attachment: 'top center',
@@ -57,8 +56,9 @@ const defaultProps = {
 
 const contextTypes = {
   stripes: PropTypes.shape({
-    locale: PropTypes.string.isRequired,
-  }).isRequired,
+    locale: PropTypes.string,
+    timezone: PropTypes.string,
+  }),
   intl: intlShape,
 };
 
@@ -88,11 +88,28 @@ class Timepicker extends React.Component { // eslint-disable-line react/no-depre
     this.deriveHoursFormat = this.deriveHoursFormat.bind(this);
     this.getPresentationValue = this.getPresentationValue.bind(this);
     this.getLocalTime = this.getLocalTime.bind(this);
-    this.timezone = this.props.timezone || this.context.stripes.timezone;
-    moment.locale(this.context.stripes.locale);
+
+    // Set timezone
+    if (props.timezone) {
+      this.timezone = props.timezone;
+    } else if (context.stripes) {
+      this.timezone = context.stripes.timezone;
+    } else {
+      this.timezone = 'UTC';
+    }
+
+    // Set locale
+    if (props.locale) {
+      this.locale = props.locale;
+    } else if (context.stripes) {
+      this.locale = context.stripes.timezone;
+    } else {
+      this.locale = 'en';
+    }
+    moment.locale(this.locale);
     this._timeFormat = moment.localeData()._longDateFormat.LT;
 
-    // inputValue will eventually be rendered as the value of he TextField.
+    // inputValue will eventually be rendered as the value of the TextField.
     let inputValue = '';
     let presentedValue = null;
     // if we aren't using redux form...
@@ -474,7 +491,6 @@ class Timepicker extends React.Component { // eslint-disable-line react/no-depre
       required,
       disabled,
       tether,
-
     } = this.props;
     const formatMsg = this.context.intl.formatMessage;
 
@@ -605,7 +621,7 @@ class Timepicker extends React.Component { // eslint-disable-line react/no-depre
             mainControl={this.textfield ? this.textfield.getInput() : undefined}
             onKeyDown={this.handleKeyDown}
             onBlur={this.hideTimepicker}
-            locale={this.context.stripes.locale || this.props.locale}
+            locale={this.locale}
             onNavigation={this.handleDateNavigation}
             id={this.testId}
             onClose={this.hideTimepicker}

--- a/lib/Timepicker/readme.md
+++ b/lib/Timepicker/readme.md
@@ -13,9 +13,11 @@ Name | type | description | default | required
 `id` | string | Sets the `id` html attribute on the control | |
 `label` | string | If provided, will render a `<label>` tag with an `htmlFor` attribute directed at the provided `id` prop. | |
 `value` | string | Sets the value for the control. **Not necessary if using redux-form.** | |
-`onChange` | function | Callback function that will receive the control's current value and the onChange event object. `fn(e, value)` **Not necessary if using redux-form**, but it will still work if callback from a change is needed.
+`onChange` | function | Callback function that will receive the control's current value and the onChange event object. `fn(e, value)` **Not necessary if using redux-form**, but it will still work if callback from a change is needed. |  |
 `passThroughValue` | string | Can be used to set dynamic values up to the form - values should be inspected/adjusted in a handler at submission time (like a button click that calls `submit()`.) See below for usage example. |  |
 `autoFocus` | bool | If this prop is `true`, control will automatically focus on mount | |
+`timezone` | string | Overrides the time zone provided by context. | "UTC" | false
+`locale` | string | Overrides the locale provided by context. | "en" | false
 
 ## Usage in Redux-form
 Redux form will provide `input` and `meta` props to the component when it is used with a redux-form `<Field>` component. The component's value and validation are supplied through these.

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -1,1 +1,141 @@
-import Timepicker from '../Timepicker'; // eslint-disable-line no-unused-vars
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { mountWithContext } from '../../../tests/helpers';
+
+import Timepicker from '../Timepicker';
+import TimepickerInteractor from './interactor';
+
+describe('Timepicker', () => {
+  const timepicker = new TimepickerInteractor();
+
+  beforeEach(async () => {
+    await mountWithContext(
+      <Timepicker />
+    );
+  });
+
+  it('does not have a value in the input', () => {
+    expect(timepicker.inputValue).to.equal('');
+  });
+
+  describe('with an id', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <Timepicker id="timepicker-test" />
+      );
+    });
+
+    it('has an id on the input element', () => {
+      expect(timepicker.id).to.equal('timepicker-test');
+    });
+  });
+
+  describe('selecting a time', () => {
+    let timeOutput;
+
+    beforeEach(async () => {
+      timeOutput = '';
+
+      await mountWithContext(
+        <Timepicker onChange={(event) => { timeOutput = event.target.value; }} />
+      );
+
+      await timepicker.fillInput('05:00 PM');
+    });
+
+    it('emits an event with the time formatted as displayed', () => {
+      expect(timeOutput).to.equal('05:00 PM');
+    });
+  });
+
+  describe('selecting a time with locale prop', () => {
+    let timeOutput;
+
+    beforeEach(async () => {
+      timeOutput = '';
+
+      await mountWithContext(
+        <Timepicker
+          onChange={(event) => { timeOutput = event.target.value; }}
+          locale="de"
+        />
+      );
+
+      await timepicker.fillInput('05:00 PM');
+    });
+
+    it('emits an event with the time formatted as displayed', () => {
+      expect(timeOutput).to.equal('05:00 PM');
+    });
+  });
+
+  describe('selecting a time with timezone prop', () => {
+    let timeOutput;
+
+    beforeEach(async () => {
+      timeOutput = '';
+
+      await mountWithContext(
+        <Timepicker
+          onChange={(event) => { timeOutput = event.target.value; }}
+          timezone="America/Los_Angeles"
+        />
+      );
+
+      await timepicker.fillInput('05:00 PM');
+    });
+
+    it('emits an event with the time formatted as displayed', () => {
+      expect(timeOutput).to.equal('05:00 PM');
+    });
+  });
+
+  describe('coupled to redux form', () => {
+    describe('selecting a time', () => {
+      let timeOutput;
+
+      beforeEach(async () => {
+        timeOutput = '';
+
+        await mountWithContext(
+          <Timepicker
+            input={{
+              onChange: (value) => { timeOutput = value; },
+            }}
+          />
+        );
+
+        await timepicker.fillInput('05:00 PM');
+      });
+
+      it('returns an ISO 8601 time string at UTC', () => {
+        expect(timeOutput).to.equal('17:00:00.000Z');
+      });
+    });
+
+    describe('selecting a time with timezone prop', () => {
+      let timeOutput;
+
+      beforeEach(async () => {
+        timeOutput = '';
+
+        await mountWithContext(
+          <Timepicker
+            input={{
+              onChange: (value) => { timeOutput = value; },
+            }}
+            timezone="America/Los_Angeles"
+          />
+        );
+
+        await timepicker.fillInput('05:00 PM');
+      });
+
+      it('returns an ISO 8601 time string for specific time zone', () => {
+        expect(timeOutput).to.equal('00:00:00.000Z');
+      });
+    });
+  });
+});

--- a/lib/Timepicker/tests/interactor.js
+++ b/lib/Timepicker/tests/interactor.js
@@ -1,0 +1,12 @@
+import {
+  attribute,
+  fillable,
+  interactor,
+  value,
+} from '@bigtest/interactor';
+
+export default interactor(class TimepickerInteractor {
+  id = attribute('input', 'id');
+  inputValue = value('input');
+  fillInput = fillable('input');
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
## Purpose
Mimics the approach for `Timepicker` in https://github.com/folio-org/stripes-components/pull/401. Adding a `timezone` prop gets us to testability for the `Datepicker` without dealing with `stripes` context.

## Approach
Avoids using default props for `locale` and `timezone`, so the logic is more clear. When we get to the point of implementing a React 17-friendly strategy for context, we should revisit that implementation.

The most exciting part of this PR: TESTS! Datepicker and Timepicker now have minimal tests.

## Future work
`ignoreLocalOffset` is no longer really needed, but I left it in for now.