### PR TITLE
Update IconButton test for react-router 4.3

### DIFF
--- a/lib/IconButton/tests/IconButton-test.js
+++ b/lib/IconButton/tests/IconButton-test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
-import { HashRouter as Router } from 'react-router-dom';
+import { StaticRouter as Router } from 'react-router-dom';
 
 import { mount } from '../../../tests/helpers';
 
@@ -14,7 +14,7 @@ describe('IconButton', () => {
 
   beforeEach(async () => {
     await mount(
-      <Router>
+      <Router context={{}}>
         <IconButton id="testId" icon="search" onClick={() => { ibClicked = true; }} />
       </Router>
     );
@@ -43,8 +43,8 @@ describe('IconButton', () => {
   describe('When passed an href prop', () => {
     beforeEach(async () => {
       await mount(
-        <Router>
-          <IconButton id="anchorId" icon="search" href="#" />
+        <Router context={{}}>
+          <IconButton id="anchorId" icon="search" href="/testPath" />
         </Router>
       );
     });
@@ -54,15 +54,15 @@ describe('IconButton', () => {
     });
 
     it('properly renders the href attribute', () => {
-      expect(iconButton.href).to.equal('#/#');
+      expect(iconButton.href).to.equal('/testPath');
     });
   });
 
   describe('When passed an to prop (string)', () => {
     beforeEach(async () => {
       await mount(
-        <Router>
-          <IconButton id="anchorId" icon="search" to="#" />
+        <Router context={{}}>
+          <IconButton id="anchorId" icon="search" to="/testPath" />
         </Router>
       );
     });
@@ -72,7 +72,7 @@ describe('IconButton', () => {
     });
 
     it('properly renders the href attribute', () => {
-      expect(iconButton.href).to.match(/#$/);
+      expect(iconButton.href).to.equal('/testPath');
     });
   });
 


### PR DESCRIPTION
## Purpose
`react-router` 4.3.x introduced a change to the way `Link`s construct: https://github.com/ReactTraining/react-router/pull/5489

## Approach
Use the `StaticRouter` to test instead of `HashRouter`.