### PR TITLE
Fix translations path for storybook

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -9,7 +9,7 @@ import '../lib/global.css';
 
 // Load the locale data for all your defined locales
 import { setIntlConfig, withIntl } from 'storybook-addon-intl';
-import enTranslations from '../translations/en.json';
+import enTranslations from '../translations/stripes-components/en.json';
 import { addLocaleData } from 'react-intl';
 import enLocaleData from 'react-intl/locale-data/en';
 addLocaleData(enLocaleData);


### PR DESCRIPTION
## Purpose
Storybook wasn't runnable, because the translations files moved. Follow-up to https://github.com/folio-org/stripes-components/pull/414

## Future
We should add a test to CI just to make sure storybook builds.