### PR TITLE
STCOM-289: Added autocomplete prop to TextField and turned it off in Datepicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 * `<AccordionSet>` works via context and sets up keyboard navigation for contained `<Accordion>`s. Fixes STCOM-213.
 * Add `timezone` prop to ``<Datepicker>`.
 * Added fix for checkboxes/radiobuttons getting squashed together on small widhts. Fixes STCOM-260.
+* Added `autocomplete` prop to `<TextField>` that takes HTML5 string values. Fixes STCOM-289.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -548,6 +548,7 @@ class Datepicker extends React.Component {
           id={this.testId}
           required={required}
           hasClearIcon={false}
+          autoComplete="off"
           autoFocus={autoFocus}
         />
       );
@@ -570,6 +571,7 @@ class Datepicker extends React.Component {
           id={this.testId}
           required={required}
           hasClearIcon={false}
+          autoComplete="off"
           autoFocus={autoFocus}
         />
       );

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -12,6 +12,7 @@ import omitProps from '../../util/omitProps';
 export default class TextField extends Component {
   static propTypes = {
     ariaLabel: PropTypes.string,
+    autoComplete: PropTypes.string,
     autoFocus: PropTypes.bool,
     clearFieldId: PropTypes.string,
     /**
@@ -273,6 +274,7 @@ export default class TextField extends Component {
         {...inputCustom}
         aria-required={required}
         aria-label={this.props.ariaLabel}
+        autoComplete={this.props.autoComplete}
         autoFocus={this.props.autoFocus}
       />
     );


### PR DESCRIPTION
This turns off the autocompletion for the Datepicker (STCOM-289) but also gives us more granularity over autofills in the future [by specifying a particular string such as `street-address`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#attr-autocomplete).

PS: I think it's pretty dumb that React makes you write `autoComplete` instead of `autocomplete` to avoid throwing an error but 🤷‍♂️.