### PR TITLE
Update TextField to use React.createRef()

### DIFF
--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -80,9 +80,9 @@ export default class TextField extends Component {
   constructor(props) {
     super(props);
 
-    this.input = null;
-    this.startControl = null;
-    this.endControl = null;
+    this.input = React.createRef();
+    this.startControl = React.createRef();
+    this.endControl = React.createRef();
 
     this.calcPadding = this.calcPadding.bind(this);
     this.clearField = this.clearField.bind(this);
@@ -103,9 +103,9 @@ export default class TextField extends Component {
     // calculate padding only if endControl or startControl are in use.
     if (this.props.endControl || this.props.startControl) {
       requestAnimationFrame(() => {
-        if (this.input) {
+        if (this.input.current) {
           const paddingObject = this.calcPadding();
-          Object.assign(this.input.style, paddingObject);
+          Object.assign(this.input.current.style, paddingObject);
         }
       });
     }
@@ -126,16 +126,16 @@ export default class TextField extends Component {
 
     if (shouldUpdatePadding) {
       requestAnimationFrame(() => {
-        if (this.input) {
+        if (this.input.current) {
           const paddingObject = this.calcPadding();
-          Object.assign(this.input.style, paddingObject);
+          Object.assign(this.input.current.style, paddingObject);
         }
       });
     }
   }
 
   getInput() {
-    return this.input;
+    return this.input.current;
   }
 
   getInputStyle() {
@@ -155,7 +155,7 @@ export default class TextField extends Component {
   }
 
   focusInput() {
-    this.input.focus();
+    this.input.current.focus();
   }
 
   onFocus = () => {
@@ -173,7 +173,8 @@ export default class TextField extends Component {
   calcPadding() {
     let start;
     let end;
-    if (window.getComputedStyle(this.input).direction === 'rtl') {
+
+    if (this.input.current && window.getComputedStyle(this.input.current).direction === 'rtl') {
       start = 'right';
       end = 'left';
     } else {
@@ -181,10 +182,18 @@ export default class TextField extends Component {
       end = 'right';
     }
 
-    const startWidth = this.startControl.getBoundingClientRect().width + 8;
-    const endWidth = this.endControl.getBoundingClientRect().width + 8;
-
     const styleObject = {};
+    let startWidth = 0;
+    let endWidth = 0;
+
+    if (this.startControl.current) {
+      startWidth = this.startControl.current.getBoundingClientRect().width + 8;
+    }
+
+    if (this.endControl.current) {
+      endWidth = this.endControl.current.getBoundingClientRect().width + 8;
+    }
+
     styleObject[`padding-${start}`] = `${startWidth}px`;
     styleObject[`padding-${end}`] = `${endWidth}px`;
 
@@ -193,10 +202,10 @@ export default class TextField extends Component {
 
   clearField() {
     const { onClearField, input } = this.props;
-    this.input.value = '';
+    this.input.current.value = '';
     if (input) {
       const event = new Event('input', { bubbles: true });
-      this.input.dispatchEvent(event);
+      this.input.current.dispatchEvent(event);
     }
 
     // Fire callback
@@ -205,7 +214,7 @@ export default class TextField extends Component {
     }
 
     // Set focus on input again
-    setTimeout(() => { this.input.focus(); }, 5);
+    setTimeout(() => { this.input.current.focus(); }, 5);
   }
 
   render() {
@@ -266,7 +275,7 @@ export default class TextField extends Component {
 
     const component = (
       <input
-        ref={(ref) => { this.input = ref; }}
+        ref={this.input}
         className={this.getInputStyle()}
         onFocus={this.onFocus}
         onBlur={this.onBlur}
@@ -334,7 +343,7 @@ export default class TextField extends Component {
         && !this.props.meta.active
         && !this.props.meta.valid
         && !this.props.meta.asyncValidating) {
-        if (this.input && (this.input.value === '' || !this.input.value)) {
+        if (this.input.current && (this.input.current.value === '' || !this.input.current.value)) {
           validation = validationEnabled && (
             <TextFieldIcon
               iconClassName={css.errorIcon}
@@ -367,7 +376,7 @@ export default class TextField extends Component {
 
     const endControlElement = (
       <div className={css.endControls}>
-        <div className={css.controlGroup} ref={(ref) => { this.endControl = ref; }}>
+        <div className={css.controlGroup} ref={this.endControl}>
           {!this.props.readOnly && clearField}{validation}{endControl}
         </div>
       </div>
@@ -375,7 +384,7 @@ export default class TextField extends Component {
 
     const startControlElement = (
       <div className={css.startControls}>
-        <div className={css.controlGroup} ref={(ref) => { this.startControl = ref; }}>
+        <div className={css.controlGroup} ref={this.startControl}>
           {startControl}
         </div>
       </div>


### PR DESCRIPTION
## Purpose
React 16.3 introduced `React.createRef()`, a new way for working with refs: https://reactjs.org/docs/refs-and-the-dom.html

I was having trouble wrapping `TextField` with a higher-order component (in this case, `reduxFormField`, and this new ref API should solve it.

## Approach
To get the underlying DOM of the ref, use `current`.