### PR TITLE
Fix stripes.context.locale logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 * Added fix for checkboxes/radiobuttons getting squashed together on small widhts. Fixes STCOM-260.
 * Added `autocomplete` prop to `<TextField>` that takes HTML5 string values. Fixes STCOM-289.
 * camelCase `timeZone` props
+* Fix `stripes.context.locale` logic for `<Datepicker>` and `<Timepicker>`
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -118,7 +118,7 @@ class Datepicker extends React.Component {
     if (props.locale) {
       this.locale = props.locale;
     } else if (context.stripes) {
-      this.locale = context.stripes.timezone;
+      this.locale = context.stripes.locale;
     } else {
       this.locale = 'en';
     }

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -103,7 +103,7 @@ class Timepicker extends React.Component { // eslint-disable-line react/no-depre
     if (props.locale) {
       this.locale = props.locale;
     } else if (context.stripes) {
-      this.locale = context.stripes.timezone;
+      this.locale = context.stripes.locale;
     } else {
       this.locale = 'en';
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
Didn't get caught by tests because we're not running any tests with `stripes` context.