### PR TITLE
Camel case timeZone props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 * Add `timezone` prop to ``<Datepicker>`.
 * Added fix for checkboxes/radiobuttons getting squashed together on small widhts. Fixes STCOM-260.
 * Added `autocomplete` prop to `<TextField>` that takes HTML5 string values. Fixes STCOM-289.
+* camelCase `timeZone` props
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -40,7 +40,7 @@ const propTypes = {
   screenReaderMessage: PropTypes.string,
   showCalendar: PropTypes.bool,
   tether: PropTypes.object,
-  timezone: PropTypes.string,
+  timeZone: PropTypes.string,
   useFocus: PropTypes.bool,
   value: PropTypes.string,
 };
@@ -104,15 +104,15 @@ class Datepicker extends React.Component {
     this.datePickerIsFocused = this.datePickerIsFocused.bind(this);
     this.getPresentedValue = this.getPresentedValue.bind(this);
 
-    // Set timezone
-    if (props.timezone) {
-      this.timezone = props.timezone;
+    // Set time zone
+    if (props.timeZone) {
+      this.timeZone = props.timeZone;
     } else if (context.stripes) {
-      this.timezone = context.stripes.timezone;
+      this.timeZone = context.stripes.timezone;
     } else {
-      this.timezone = 'UTC';
+      this.timeZone = 'UTC';
     }
-    const parseTimezone = props.ignoreLocalOffset ? 'UTC' : this.timezone;
+    const parseTimeZone = props.ignoreLocalOffset ? 'UTC' : this.timeZone;
 
     // Set locale
     if (props.locale) {
@@ -133,14 +133,14 @@ class Datepicker extends React.Component {
     if (typeof this.props.input === 'undefined') {
       if (this.props.value === this.props.passThroughValue && typeof this.props.date === 'undefined') {
         presentedValue = this.props.passThroughValue;
-        inputValue = moment.tz(parseTimezone).format(this._dateFormat);
+        inputValue = moment.tz(parseTimeZone).format(this._dateFormat);
       }
       // if we are using redux-form...
     } else if (this.props.input.value === this.props.passThroughValue) {
       presentedValue = this.props.passThroughValue;
-      inputValue = moment.tz(parseTimezone).format(this._dateFormat);
+      inputValue = moment.tz(parseTimeZone).format(this._dateFormat);
     } else if (this.props.input.value !== '') {
-      inputValue = moment.tz(this.props.input.value, parseTimezone).format(this._dateFormat);
+      inputValue = moment.tz(this.props.input.value, parseTimeZone).format(this._dateFormat);
     }
 
     this.state = {
@@ -148,7 +148,7 @@ class Datepicker extends React.Component {
       dateString: inputValue,
       showCalendar: this.props.showCalendar || false,
       srMessage: '',
-      parseTimezone,
+      parseTimeZone,
       _dateFormat: this._dateFormat,
       input: this.props.input,
     };
@@ -170,9 +170,9 @@ class Datepicker extends React.Component {
         const passRE = new RegExp(`^${nextProps.input.value}`, 'i');
         if (nextProps.input.value === prevState.passThroughValue || passRE.test(prevState.passThroughValue)) {
           presentedValue = nextProps.input.value;
-          inputValue = moment.tz(prevState.parseTimezone).format(_dateFormat);
+          inputValue = moment.tz(prevState.parseTimeZone).format(_dateFormat);
         } else {
-          inputValue = moment.tz(nextProps.input.value, prevState.parseTimezone).format(_dateFormat);
+          inputValue = moment.tz(nextProps.input.value, prevState.parseTimeZone).format(_dateFormat);
         }
         return {
           presentedValue,
@@ -191,10 +191,10 @@ class Datepicker extends React.Component {
       }
     } else if (prevState.value !== '' && prevState.date !== nextProps.date) {
       if (nextProps.value === this.props.passThroughValue && nextProps.date === 'undefined') {
-        inputValue = moment.tz(prevState.parseTimezone).format(_dateFormat);
+        inputValue = moment.tz(prevState.parseTimeZone).format(_dateFormat);
         presentedValue = this.props.passThroughValue;
       } else {
-        inputValue = moment.tz(prevState.parseTimezone).format(_dateFormat);
+        inputValue = moment.tz(prevState.parseTimeZone).format(_dateFormat);
       }
       return {
         presentedValue,
@@ -442,13 +442,13 @@ class Datepicker extends React.Component {
       case 'ISO 8601':
       case 'ISO8601':
       case 'ISO-8601':
-        return moment.tz(date, this._dateFormat, true, this.timezone).toISOString();
+        return moment.tz(date, this._dateFormat, true, this.timeZone).toISOString();
       case 'RFC 2822':
       case 'RFC2822':
       case 'RFC-2822':
-        return moment.tz(date, this._dateFormat, true, this.timezone).format(DATE_RFC2822);
+        return moment.tz(date, this._dateFormat, true, this.timeZone).format(DATE_RFC2822);
       default:
-        return moment.tz(date, this._dateFormat, true, this.timezone).format(this.props.backendDateStandard);
+        return moment.tz(date, this._dateFormat, true, this.timeZone).format(this.props.backendDateStandard);
     }
   }
 

--- a/lib/Datepicker/readme.md
+++ b/lib/Datepicker/readme.md
@@ -18,7 +18,7 @@ Name | type | description | default | required
 `useFocus` | bool | if set to false, component relies solely on clicking the calendar icon to toggle appearance of calendar. | true | false
 `autoFocus` | bool | If this prop is `true`, component will automatically focus on mount | |
 `disabled` | bool | if true, field will be disabled for focus or entry. | false | false
-`ignoreLocalOffset` | bool | if true, ignores the timezone setting and treats the date as UTC to display the date.
+`ignoreLocalOffset` | bool | if true, ignores the time zone setting and treats the date as UTC to display the date.
 | false | false. See below for more explanation
 `readOnly` | bool | if true, field will be readonly. 'Calendar' and 'clear' buttons will be omitted. | false | false
 `value` | string | date to be displayed in the textfield. In forms, this is supplied by the initialValues prop supplied to the form | "" | false
@@ -26,7 +26,7 @@ Name | type | description | default | required
 `screenReaderMessage` | string | Additional message to be read by screenreaders when textfield is focused in addition to the label and format - which are always read. | | false
 `excludeDates` | array, string or Moment object | Disables supplied dates from being selected in the calendar. | | false
 `passThroughValue` | string | Can be used to set dynamic values up to the form - values should be inspected/adjusted in a handler at submission time (like a button click that calls `submit()`.) See below for usage example. |  |
-`timezone` | string | Overrides the time zone provided by context. | "UTC" | false
+`timeZone` | string | Overrides the time zone provided by context. | "UTC" | false
 `locale` | string | Overrides the locale provided by context. | "en" | false
 
 <!-- dateFormat | string | system formatting for date. [Moment.js formats](https://momentjs.com/docs/#/displaying/format/) are supported | "MM/DD/YYYY" | false-->
@@ -52,4 +52,4 @@ Using the prop `passThroughValue` means that you expect a non-date string to be 
 ```
 
 ## ignoreLocalOffset
-If your date does not lean on time for validation (eg: Birthdates, that shouldn't change their value based on timezone), apply the "ignoreLocalOffset" prop to the datepicker, for it to use UTC in its produced value. For dates that lean on time (eg: expiryDate), ignore this prop.
+If your date does not lean on time for validation (eg: Birthdates, that shouldn't change their value based on time zone), apply the "ignoreLocalOffset" prop to the datepicker, for it to use UTC in its produced value. For dates that lean on time (eg: expiryDate), ignore this prop.

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -71,7 +71,7 @@ describe('Datepicker', () => {
     });
   });
 
-  describe('selecting a date with timezone prop', () => {
+  describe('selecting a date with timeZone prop', () => {
     let dateOutput;
 
     beforeEach(async () => {
@@ -80,7 +80,7 @@ describe('Datepicker', () => {
       await mountWithContext(
         <Datepicker
           onChange={(event) => { dateOutput = event.target.value; }}
-          timezone="America/Los_Angeles"
+          timeZone="America/Los_Angeles"
         />
       );
 
@@ -115,7 +115,7 @@ describe('Datepicker', () => {
       });
     });
 
-    describe('selecting a date with timezone prop', () => {
+    describe('selecting a date with timeZone prop', () => {
       let dateOutput;
 
       beforeEach(async () => {
@@ -126,7 +126,7 @@ describe('Datepicker', () => {
             input={{
               onChange: (value) => { dateOutput = value; },
             }}
-            timezone="America/Los_Angeles"
+            timeZone="America/Los_Angeles"
           />
         );
 

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -28,7 +28,7 @@ const propTypes = {
   screenReaderMessage: PropTypes.string,
   showTimepicker: PropTypes.bool,
   tether: PropTypes.object,
-  timezone: PropTypes.string,
+  timeZone: PropTypes.string,
   value: PropTypes.string,
 };
 
@@ -90,13 +90,13 @@ class Timepicker extends React.Component { // eslint-disable-line react/no-depre
     this.getPresentationValue = this.getPresentationValue.bind(this);
     this.getLocalTime = this.getLocalTime.bind(this);
 
-    // Set timezone
-    if (props.timezone) {
-      this.timezone = props.timezone;
+    // Set time zone
+    if (props.timeZone) {
+      this.timeZone = props.timeZone;
     } else if (context.stripes) {
-      this.timezone = context.stripes.timezone;
+      this.timeZone = context.stripes.timezone;
     } else {
-      this.timezone = 'UTC';
+      this.timeZone = 'UTC';
     }
 
     // Set locale
@@ -118,16 +118,16 @@ class Timepicker extends React.Component { // eslint-disable-line react/no-depre
       if (this.props.input.value !== '') {
         if (this.props.input.value === this.props.passThroughValue) {
           presentedValue = this.props.passThroughValue;
-          inputValue = moment.tz(this.timezone).format(this._timeFormat);
+          inputValue = moment.tz(this.timeZone).format(this._timeFormat);
         } else {
-          inputValue = moment.tz(this.props.input.value, this._timeFormat, this.timezone).format(this._timeFormat);
+          inputValue = moment.tz(this.props.input.value, this._timeFormat, this.timeZone).format(this._timeFormat);
         }
       }
     } else if (this.props.value === this.props.passThroughValue) {
       presentedValue = this.props.passThroughValue;
-      inputValue = moment.tz(this.timezone).format(this._timeFormat);
+      inputValue = moment.tz(this.timeZone).format(this._timeFormat);
     } else {
-      inputValue = moment(this.props.value, this._timeFormat, this.timezone).format(this._timeFormat);
+      inputValue = moment(this.props.value, this._timeFormat, this.timeZone).format(this._timeFormat);
     }
 
     this.state = {
@@ -153,7 +153,7 @@ class Timepicker extends React.Component { // eslint-disable-line react/no-depre
       if (nextProps.input.value !== '' && nextProps.input.value !== this.props.input.value) {
         if (nextProps.input.value === nextProps.passThroughValue) {
           presentedValue = nextProps.passThroughValue;
-          inputValue = moment.tz(this.timezone).format(this._timeFormat);
+          inputValue = moment.tz(this.timeZone).format(this._timeFormat);
           this.setState({
             presentedValue,
             timeString: inputValue,
@@ -169,10 +169,10 @@ class Timepicker extends React.Component { // eslint-disable-line react/no-depre
       }
     } else if (this.props.value !== '' && this.props.value !== nextProps.value) {
       if (nextProps.value === this.props.passThroughValue) {
-        inputValue = moment.tz(this.timezone).format(this._timeFormat);
+        inputValue = moment.tz(this.timeZone).format(this._timeFormat);
         presentedValue = this.props.passThroughValue;
       } else {
-        inputValue = moment.tz(this.timezone).format(this._timeFormat);
+        inputValue = moment.tz(this.timeZone).format(this._timeFormat);
       }
       this.setState({
         presentedValue,
@@ -186,7 +186,7 @@ class Timepicker extends React.Component { // eslint-disable-line react/no-depre
       this._timeFormat = moment.localeData()._longDateFormat.LT;
       let newTimeString = this.state.timeString;
       if (newTimeString !== '') {
-        newTimeString = moment.tz(newTimeString, this.state.timeFormat, this.timezone).format(this._timeFormat);
+        newTimeString = moment.tz(newTimeString, this.state.timeFormat, this.timeZone).format(this._timeFormat);
       }
       this.setState({
         presentedValue: null,
@@ -467,7 +467,7 @@ class Timepicker extends React.Component { // eslint-disable-line react/no-depre
   }
 
   standardizeTime(time) {
-    const isoTime = moment.tz(time, 'HH:mm A', this.timezone).toISOString();
+    const isoTime = moment.tz(time, 'HH:mm A', this.timeZone).toISOString();
     const timeSplit = isoTime.split('T');
     return timeSplit[1];
   }

--- a/lib/Timepicker/readme.md
+++ b/lib/Timepicker/readme.md
@@ -16,7 +16,7 @@ Name | type | description | default | required
 `onChange` | function | Callback function that will receive the control's current value and the onChange event object. `fn(e, value)` **Not necessary if using redux-form**, but it will still work if callback from a change is needed. |  |
 `passThroughValue` | string | Can be used to set dynamic values up to the form - values should be inspected/adjusted in a handler at submission time (like a button click that calls `submit()`.) See below for usage example. |  |
 `autoFocus` | bool | If this prop is `true`, control will automatically focus on mount | |
-`timezone` | string | Overrides the time zone provided by context. | "UTC" | false
+`timeZone` | string | Overrides the time zone provided by context. | "UTC" | false
 `locale` | string | Overrides the locale provided by context. | "en" | false
 
 ## Usage in Redux-form

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -71,7 +71,7 @@ describe('Timepicker', () => {
     });
   });
 
-  describe('selecting a time with timezone prop', () => {
+  describe('selecting a time with timeZone prop', () => {
     let timeOutput;
 
     beforeEach(async () => {
@@ -80,7 +80,7 @@ describe('Timepicker', () => {
       await mountWithContext(
         <Timepicker
           onChange={(event) => { timeOutput = event.target.value; }}
-          timezone="America/Los_Angeles"
+          timeZone="America/Los_Angeles"
         />
       );
 
@@ -115,7 +115,7 @@ describe('Timepicker', () => {
       });
     });
 
-    describe('selecting a time with timezone prop', () => {
+    describe('selecting a time with timeZone prop', () => {
       let timeOutput;
 
       beforeEach(async () => {
@@ -126,7 +126,7 @@ describe('Timepicker', () => {
             input={{
               onChange: (value) => { timeOutput = value; },
             }}
-            timezone="America/Los_Angeles"
+            timeZone="America/Los_Angeles"
           />
         );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.0.21",
+  "version": "2.0.22",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
## Purpose
`timezone` was consistent with `this.context.stripes` and `moment`, but not with `react-intl`'s API or any other props in `stripes-components`.

## Approach
camelCase it.

The `DueDatePickerForm` in `stripes-smart-components` is the only use I know of that will break.