### PR TITLE
Icon: Added "status" prop used for fill color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@
 * Storybook resource added. Run `yarn storybook` to see component demos and documentation.
 * Pass a ref through to TextArea for access by a parent. Refs STSMACOM-4.
 * Add ability to pass custom filter to `<Selection>` component. Fixes STCOM-251.
+* Add ability to colour `<Icon>` using `status` prop.
 
 ## [1.9.0](https://github.com/folio-org/stripes-components/tree/v1.9.0) (2017-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.8.0...v1.9.0)

--- a/lib/Icon/Icon.css
+++ b/lib/Icon/Icon.css
@@ -21,6 +21,21 @@
 }
 
 /**
+ * Coloring
+ */
+.error {
+  fill: var(--error);
+}
+
+.warn {
+  fill: var(--warn);
+}
+
+.success {
+  fill: var(--success);
+}
+
+/**
  * Sizing
  */
 

--- a/lib/Icon/Icon.js
+++ b/lib/Icon/Icon.js
@@ -19,6 +19,11 @@ class Icon extends React.Component {
       'medium',
       'large',
     ]),
+    status: PropTypes.oneOf([
+      'error',
+      'warn',
+      'success',
+    ]),
     title: PropTypes.string,
   }
 
@@ -27,7 +32,7 @@ class Icon extends React.Component {
   }
 
   render() {
-    const { icon, color, title, iconClassName, id, size, iconRootClass } = this.props;
+    const { icon, color, title, iconClassName, id, size, status, iconRootClass } = this.props;
 
     const getRootClass = classNames(
       css.icon,
@@ -37,6 +42,12 @@ class Icon extends React.Component {
       { [css.iconSpinner]: icon === 'spinner-ellipsis' },
       // Icons that contains "left" or "right should flip on dir="rtl"
       { [css.flippable]: icon.match(/(right|left)/) },
+    );
+
+    const getSVGClass = classNames(
+      'stripes__icon',
+      iconClassName,
+      css[status]
     );
 
     const style = color ? { fill: color } : {};
@@ -55,7 +66,7 @@ class Icon extends React.Component {
         title={title}
         id={id}
       >
-        <IconSVG style={style} className={classNames('stripes__icon', iconClassName)} />
+        <IconSVG style={style} className={getSVGClass} />
       </span>
     );
   }

--- a/lib/Icon/stories/BasicUsage.js
+++ b/lib/Icon/stories/BasicUsage.js
@@ -10,14 +10,14 @@ import css from './style.css';
 
 export default () => {
   const size = select('Size', { small: 'Small', medium: 'Medium', large: 'Large' }, 'large');
-  const colour = color('Color', '#999');
+  const status = select('Status', { warn: 'Warning', error: 'Error', success: 'Success', none: 'None' }, 'none');
   const list = Object.keys(icons).map((icon, i) => (
     <li className={css.iconGridItem} key={i}>
       <div className={css.iconGridItemInner}>
         <Icon
           size={size}
           icon={icon}
-          color={colour}
+          status={status !== 'none' ? status : undefined}
         />
       </div>
       <p>{icon}</p>

--- a/lib/Icon/stories/Icon.stories.js
+++ b/lib/Icon/stories/Icon.stories.js
@@ -4,8 +4,25 @@ import withReadme from 'storybook-readme/with-readme';
 import { withKnobs } from '@storybook/addon-knobs';
 import Readme from '../readme.md';
 import stories from './index';
+import Icon from '../';
 
 storiesOf('Icon', module)
   .addDecorator(withKnobs)
   .addDecorator(withReadme(Readme))
-  .add('Basic Usage', () => <stories.BasicUsage />);
+  .add('Basic Usage', () => <stories.BasicUsage />)
+  .add('Statuses', () => (
+    <div>
+      <div>
+        <pre><strong>success</strong></pre>
+        <Icon size="large" icon="info" status="success" />
+      </div>
+      <div>
+        <pre><strong>warn</strong></pre>
+        <Icon size="large" icon="info" status="warn" />
+      </div>
+      <div>
+        <pre><strong>error</strong></pre>
+        <Icon size="large" icon="info" status="error" />
+      </div>
+    </div>
+  ));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
It's currently not possible to `fill` an `<Icon>`'s SVG without hardcoding a color in your JS and passing that as a prop. This is because we currently don't have a way of getting CSS variables into JS. 

Until we do, I added a `status` prop on Icon that satisfies the main goal, which is colouring an Icon based on our warn/error/success colours.