### PR TITLE
Fix storybook translation string prefixes

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -14,9 +14,18 @@ import { addLocaleData } from 'react-intl';
 import enLocaleData from 'react-intl/locale-data/en';
 addLocaleData(enLocaleData);
 
+// mimics the StripesTranslationPlugin in @folio/stripes-core
+function prefixKeys(obj) {
+  const res = {};
+  for (const key of Object.keys(obj)) {
+    res[`stripes-components.${key}`] = obj[key];
+  }
+  return res;
+}
+
 // Define messages
 const messages = {
-  en: enTranslations,
+  en: prefixKeys(enTranslations),
 };
 
 // Set intl configuration


### PR DESCRIPTION
## Purpose
Storybook was loading in the list of English strings like `fieldHasError`, but wasn't prefixing them like the `stripes-core` environment does.

## Approach
Copied over prefixing from the `stripes-components` test suite config so strings get registered like `stripes-components.fieldHasError`.

The `prefixKeys()` function is duplicated from the test config, but there wasn't an obvious spot to put code intended for reuse between tests and storybook (that might not even be a coupling we want to create).