### PR TITLE
Create minimum rendering test for <Selection>

### DIFF
--- a/lib/Selection/tests/Selection-test.js
+++ b/lib/Selection/tests/Selection-test.js
@@ -1,1 +1,34 @@
-import Selection from '../Selection'; // eslint-disable-line no-unused-vars
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+import { Field } from 'redux-form';
+
+import { mountWithContext } from '../../../tests/helpers';
+import TestForm from '../../../tests/TestForm';
+
+import Selection from '../Selection';
+import SelectionInteractor from './interactor';
+
+describe('Selection', () => {
+  const selection = new SelectionInteractor();
+
+  describe('coupled to redux-form', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <TestForm>
+          <Field
+            name="testField"
+            component={Selection}
+            dataOptions={[
+              { value: 'test', label: 'Hello World' }
+            ]}
+          />
+        </TestForm>
+      );
+    });
+
+    it('renders the control', () => {
+      expect(selection.controlPresent).to.be.true;
+    });
+  });
+});

--- a/lib/Selection/tests/interactor.js
+++ b/lib/Selection/tests/interactor.js
@@ -1,0 +1,9 @@
+import {
+  interactor,
+  isPresent
+} from '@bigtest/interactor';
+import css from '../Selection.css';
+
+export default interactor(class SelectionInteractor {
+  controlPresent = isPresent(`.${css.SelectionControlContainer}`);
+});


### PR DESCRIPTION
## Purpose
`<Selection>` is one of the most complex components in the library. We can get a big coverage win simply by rendering it, even if we're not testing any of its functionality yet.

## Result
Raises overall lines covered in `stripes-components` 3.57 percentage points.