### PR TITLE
ErrorBoundary: Specify more precise proptypes

### DIFF
--- a/lib/ErrorBoundary/ErrorBoundary.js
+++ b/lib/ErrorBoundary/ErrorBoundary.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 class ErrorBoundary extends React.Component {
   static propTypes = {
-    children: PropTypes.object,
+    children: PropTypes.node,
   };
 
   constructor(props) {


### PR DESCRIPTION
`children` can be an array of objects, so use the more precise `node` prop type.