### PR TITLE
Fix Router context in IconButton test

### DIFF
--- a/lib/IconButton/tests/IconButton-test.js
+++ b/lib/IconButton/tests/IconButton-test.js
@@ -83,7 +83,7 @@ describe('IconButton', () => {
 
     beforeEach(async () => {
       await mount(
-        <Router>
+        <Router context={{}}>
           <IconButton id="anchorId" icon="search" to={toObject} />
         </Router>
       );


### PR DESCRIPTION
## Purpose
![screen shot 2018-06-20 at 11 37 45 am](https://user-images.githubusercontent.com/230597/41672083-a0097aa4-747e-11e8-95e7-248790ba81e5.png)

## Approach
We were passing in an empty context in other `describe()` blocks, just missed one.