### PR TITLE
Clean up injectIntl

### DIFF
--- a/lib/InjectIntl/InjectIntl.js
+++ b/lib/InjectIntl/InjectIntl.js
@@ -4,12 +4,19 @@ import { intlShape } from 'react-intl';
 
 export default function injectIntl(WrappedComponent, options = {}) {
   const { withRef = false } = options;
+  const componentName = WrappedComponent.displayName || WrappedComponent.name || 'Component';
 
   class InjectIntl extends Component {
     static WrappedComponent = WrappedComponent;
+    static displayName = `InjectIntl(${componentName})`;
 
     static propTypes = {
-      forwardedRef: PropTypes.element
+      forwardedRef: PropTypes.oneOfType([
+        PropTypes.node,
+        PropTypes.string,
+        PropTypes.func,
+        PropTypes.object
+      ])
     };
 
     static contextTypes = {
@@ -17,11 +24,16 @@ export default function injectIntl(WrappedComponent, options = {}) {
     };
 
     render() {
+      const {
+        forwardedRef,
+        ...rest
+      } = this.props;
+
       return (
         <WrappedComponent
-          {...this.props}
+          {...rest}
           intl={this.context.intl}
-          ref={withRef ? this.props.forwardedRef : null}
+          ref={withRef ? forwardedRef : null}
         />
       );
     }
@@ -29,7 +41,7 @@ export default function injectIntl(WrappedComponent, options = {}) {
 
   return forwardRef((props, ref) => {
     return (
-      <InjectIntl {...props} forwardedRef={ref} />
+      <InjectIntl forwardedRef={ref} {...props} />
     );
   });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
## Purpose
`injectIntl` needed a little more time in the oven. Follow-up to https://github.com/folio-org/stripes-components/pull/426

Being thrown:
```
ERROR: 'Warning: Failed prop type: Invalid prop `forwardedRef` of type `function` supplied to `InjectIntl`, expected a single ReactElement.
```
and
```
ERROR: 'Warning: React does not recognize the `forwardedRef` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `forwardedref` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

## Approach
- Be more permissive of `forwardedRef` prop type.
- Don't pass along `forwardedRef` to children.
- Give a `displayName` for `injectIntl`.