### PR TITLE
Fix Datepicker and Timepicker refs

### DIFF
--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -85,7 +85,7 @@ class Datepicker extends React.Component {
   constructor(props, context) {
     super(props, context);
 
-    this.textfield = null;
+    this.textfield = React.createRef();
     this.picker = null;
     this.container = null;
     this.srSpace = null;
@@ -326,7 +326,7 @@ class Datepicker extends React.Component {
       e.preventDefault();
 
       if (this.props.onChange) { this.props.onChange(e); }
-      this.textfield.getInput().focus();
+      this.textfield.current.getInput().focus();
 
       if (this.props.input) {
         if (moment(stringDate, this._dateFormat, true).isValid()) {
@@ -535,7 +535,7 @@ class Datepicker extends React.Component {
     if (this.props.input && this.props.meta) {
       textfield = (
         <TextField
-          ref={(ref) => { this.textfield = ref; }}
+          ref={this.textfield}
           input={input}
           value={this.getPresentedValue()}
           label={label}
@@ -560,7 +560,7 @@ class Datepicker extends React.Component {
     } else {
       textfield = (
         <TextField
-          ref={(ref) => { this.textfield = ref; }}
+          ref={this.textfield}
           label={label}
           value={this.getPresentedValue()}
           onChange={this.handleSetDate}

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -314,7 +314,7 @@ class Timepicker extends React.Component { // eslint-disable-line react/no-depre
       if (e) { e.preventDefault(); }
 
       if (this.props.onChange) { this.props.onChange(e); }
-      this.textfield.getInput().focus();
+      this.textfield.current.getInput().focus();
 
       let tString;
       if (this.deriveHoursFormat() === '12') {
@@ -434,7 +434,7 @@ class Timepicker extends React.Component { // eslint-disable-line react/no-depre
     if (this.props.input) {
       this.props.input.onChange('');
     }
-    this.textfield.getInput().focus();
+    this.textfield.current.getInput().focus();
   }
 
   cleanForScreenReader(str) {
@@ -621,7 +621,7 @@ class Timepicker extends React.Component { // eslint-disable-line react/no-depre
             selectedTime={this.state.timeString}
             timeFormat={this.state.timeFormat}
             ref={(ref) => { this.picker = ref; }}
-            mainControl={this.textfield}
+            mainControl={this.textfield.current}
             onKeyDown={this.handleKeyDown}
             onBlur={this.hideTimepicker}
             locale={this.locale}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.0.25",
+  "version": "2.0.26",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
https://github.com/folio-org/stripes-components/pull/441 unfortunately broke the `Datepicker` and the `Timepicker`. Our very minimal tests for those components were covering typing in the inputs, but not actually using the tethered pickers.

On the TODO list: write tests for the pickers.

https://github.com/folio-org/stripes-components/pull/443 introduces Storybook stories for the `Datepicker` and `Timepicker` for easier debugging in the future.