### PR TITLE
Add extra check for component in EmbeddedAddressForm

### DIFF
--- a/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
+++ b/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
@@ -130,7 +130,7 @@ class EmbeddedAddressForm extends React.Component {
 
       let field;
       if (Object.prototype.hasOwnProperty.call(mergedFieldComponents, fieldName)) {
-        if (typeof (mergedFieldComponents[fieldName]) === 'object') {
+        if (typeof (mergedFieldComponents[fieldName]) === 'object' && mergedFieldComponents[fieldName].component) {
           if (fieldName === 'addressType') {
             const list = omitUsedOptions(
               mergedFieldComponents[fieldName].props.dataOptions,


### PR DESCRIPTION
Some recent changes around `forward_ref` caused `mergedFieldComponents[fieldName`] to return object instead of a react function:

````js
{ $$typeof: Symbol(react.forward_ref), render: ƒ}
````

which caused tests fo fail. This PR just adds extra check for the component. We should probably refactor it a bit more but for now I just want to get the tests to pass again. 