### PR TITLE
Modify makeQueryFunction to support param namespacing. Part of STCOM-300

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 * Fix issue with Selection not rendering as an overlay.
 * accessibility updates and tests added to Selection: Single Select.
 * add `focusable='false'` attribute to `<Icon>`'s rendered SVG's.
+* Modify makeQueryFunction to support param namespacing. Fixes STCOM-300.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/util/makeQueryFunction.js
+++ b/util/makeQueryFunction.js
@@ -1,6 +1,6 @@
 import { compilePathTemplate } from '@folio/stripes-connect/RESTResource/RESTResource';
-import { isString, isObject, mapKeys } from 'lodash';
 import { filters2cql } from '../lib/FilterGroups';
+import { removeNsKeys } from './nsQueryFunctions';
 
 // failOnCondition can take values:
 //      0: do not fail even if query and filters and empty
@@ -9,9 +9,11 @@ import { filters2cql } from '../lib/FilterGroups';
 //
 // For compatibility, false and true may be used for 0 and 1 respectively.
 //
-function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOnCondition, params) {
+function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOnCondition, nsParams) {
   return (queryParams, pathComponents, resourceValues, logger) => {
-    const { qindex, filters, query, sort } = resourceValues.query || {};
+    const resourceQuery = removeNsKeys(resourceValues.query, nsParams);
+    const nsQueryParams = removeNsKeys(queryParams, nsParams);
+    const { qindex, filters, query, sort } = resourceQuery || {};
 
     if ((query === undefined || query === '') &&
         (failOnCondition === 1 || failOnCondition === true)) {
@@ -21,18 +23,6 @@ function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOn
         (filters === undefined || filters === '') &&
         (failOnCondition === 2)) {
       return null;
-    }
-
-    let parsedParams = queryParams;
-
-    if (isString(params)) {
-      parsedParams = mapKeys(queryParams, (value, key) => (`${params}.${key}`));
-    }
-
-    if (isObject(params)) {
-      parsedParams = mapKeys(queryParams, (value, key) => {
-        return (params[key]) ? params[key] : key;
-      });
     }
 
     // This check should remain '$QUERY' until all uses of the $QUERY syntax have been removed from stripes modules
@@ -51,7 +41,7 @@ function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOn
         cql = `${t[0]} =\${t[1]} "${query}*"`;
       }
     } else if (query) {
-      cql = compilePathTemplate(queryTemplate, parsedParams, pathComponents, resourceValues);
+      cql = compilePathTemplate(queryTemplate, nsQueryParams, pathComponents, { query: resourceQuery });
       if (cql === null) {
         // Some part of the template requires something that we don't have.
         return null;

--- a/util/nsQueryFunctions.js
+++ b/util/nsQueryFunctions.js
@@ -7,7 +7,7 @@ export function getNsKey(key, params) {
   return (isString(params)) ? `${params}.${key}` : (params[key] || key);
 }
 
-// Adds namespace / prefix to keys for given query
+// Adds namespace / prefix to keys for given values object
 //
 // example:
 // values = { query: "test", filters: 'active', userId: 1 }, params = 'users'
@@ -18,7 +18,7 @@ export function mapNsKeys(values, params) {
   return mapKeys(values, (value, key) => getNsKey(key, params));
 }
 
-// Removes namespace / prefix from keys for given values
+// Removes namespace / prefix from keys for given values object
 //
 // example:
 // values = { "users.query" : "test", "users.filters": "active" }, params = 'users'

--- a/util/nsQueryFunctions.js
+++ b/util/nsQueryFunctions.js
@@ -4,7 +4,7 @@ const PARAM_FILTER = { filters: 1, query: 1, sort: 1, qindex: 1 };
 
 export function getNsKey(key, params) {
   if (!params || !PARAM_FILTER[key]) return key;
-  return (isString(params)) ? `${params}.${key}` : params[key];
+  return (isString(params)) ? `${params}.${key}` : (params[key] || key);
 }
 
 // Adds namespace / prefix to keys for given query

--- a/util/nsQueryFunctions.js
+++ b/util/nsQueryFunctions.js
@@ -15,8 +15,7 @@ export function getNsKey(key, params) {
 // { "users.query" : "test", "users.filters": "active", userId: 1 }
 export function mapNsKeys(values, params) {
   if (!params) return values;
-  return mapKeys(values, (value, key) =>
-    (PARAM_FILTER[key] ? getNsKey(key, params) : key));
+  return mapKeys(values, (value, key) => getNsKey(key, params));
 }
 
 // Removes namespace / prefix from keys for given values

--- a/util/nsQueryFunctions.js
+++ b/util/nsQueryFunctions.js
@@ -1,13 +1,14 @@
 import { isString, isObject, mapKeys, mapValues, transform } from 'lodash';
 
-const PARAM_FILTER = { filters: 1, query: 1, sort: 1, qindex: 1 };
+// the list of allowed parameters to which the namespace will be added
+const PARAM_WHITELIST = { filters: 1, query: 1, sort: 1, qindex: 1 };
 
 export function getNsKey(key, params) {
-  if (!params || !PARAM_FILTER[key]) return key;
+  if (!params || !PARAM_WHITELIST[key]) return key;
   return (isString(params)) ? `${params}.${key}` : (params[key] || key);
 }
 
-// Adds namespace / prefix to keys for given values object
+// Adds namespace / prefix to keys in whitelist for given values object
 //
 // example:
 // values = { query: "test", filters: 'active', userId: 1 }, params = 'users'

--- a/util/nsQueryFunctions.js
+++ b/util/nsQueryFunctions.js
@@ -1,0 +1,46 @@
+import { isString, isObject, mapKeys, mapValues, transform } from 'lodash';
+
+const PARAM_FILTER = { filters: 1, query: 1, sort: 1, qindex: 1 };
+
+export function getNsKey(key, params) {
+  if (!params || !PARAM_FILTER[key]) return key;
+  return (isString(params)) ? `${params}.${key}` : params[key];
+}
+
+// Adds namespace / prefix to keys for given query
+//
+// example:
+// values = { query: "test", filters: 'active', userId: 1 }, params = 'users'
+// result:
+// { "users.query" : "test", "users.filters": "active", userId: 1 }
+export function mapNsKeys(values, params) {
+  if (!params) return values;
+  return mapKeys(values, (value, key) =>
+    (PARAM_FILTER[key] ? getNsKey(key, params) : key));
+}
+
+// Removes namespace / prefix from keys for given values
+//
+// example:
+// values = { "users.query" : "test", "users.filters": "active" }, params = 'users'
+// result:
+// { query: "test", filters: 'active' }
+export function removeNsKeys(values, params) {
+  if (!params) return values;
+
+  if (isObject(params)) {
+    return mapValues(params, value => values[value]);
+  }
+
+  if (isString(params)) {
+    const prefix = new RegExp(`^${params}\\.`, 'i');
+    return transform(values, (result, value, key) => {
+      if (key.match(prefix)) {
+        result[key.replace(prefix, '')] = value;
+      }
+      return result;
+    }, {});
+  }
+
+  return values;
+}


### PR DESCRIPTION
The purpose of this PR is to introduce a way for namespacing params used by `makeQueryFunction`.
The implementation follows the document written by @MikeTaylor here:

https://github.com/folio-org/stripes-components/blob/master/util/parameterizing-makeQueryFunction.md

There is another PR against `stripes-smart-components` which modifies `<SearchAndSort>` component in order to set/namespace the URL query parameters: 

https://github.com/folio-org/stripes-smart-components/pull/201/files

An example of the usage of this new functionality can be found in `ui-users`:

https://github.com/folio-org/ui-users/blob/STCOM-300/Users.js#L37-L59

