### PR TITLE
Add withRef to Calendar

### DIFF
--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -489,4 +489,4 @@ class Calendar extends React.Component {
 Calendar.propTypes = propTypes;
 Calendar.defaultProps = defaultProps;
 
-export default injectIntl(Calendar);
+export default injectIntl(Calendar, { withRef: true });

--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -394,6 +394,7 @@ class Calendar extends React.Component {
         className={css.calendar}
         id={`datepicker-calendar-container-${id}`}
         ref={(r) => { this._calendarContainer = r; }}
+        data-test-calendar
       >
         <div className={css.calendarInner}>
           <table role="presentation">

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -92,6 +92,32 @@ describe('Datepicker', () => {
     });
   });
 
+  describe('the calendar picker', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <div>
+          <Datepicker />
+        </div>
+      );
+
+      await datepicker.focusInput();
+    });
+
+    it('opens on focus', () => {
+      expect(datepicker.calendar.isVisible).to.be.true;
+    });
+
+    describe('shifting the focus onBlur', () => {
+      beforeEach(async () => {
+        await datepicker.fillAndBlur('04/01/2018');
+      });
+
+      it('closes the calendar picker', () => {
+        expect(datepicker.calendar.isPresent).to.be.false;
+      });
+    });
+  });
+
   describe('coupled to redux form', () => {
     describe('selecting a date', () => {
       let dateOutput;

--- a/lib/Datepicker/tests/interactor.js
+++ b/lib/Datepicker/tests/interactor.js
@@ -1,12 +1,35 @@
 import {
   attribute,
+  blurrable,
+  clickable,
   fillable,
+  focusable,
   interactor,
+  triggerable,
   value,
 } from '@bigtest/interactor';
 
+@interactor class Calendar {}
+
 export default interactor(class DatepickerInteractor {
+  calendar = new Calendar('[data-test-calendar]');
   id = attribute('input', 'id');
   inputValue = value('input');
   fillInput = fillable('input');
+  focusInput = focusable('input');
+  blurInput = blurrable('input');
+  clickInput = clickable('input');
+  pressEnter = triggerable('input', 'keydown', {
+    bubbles: true,
+    cancelable: true,
+    keyCode: 13
+  });
+
+  fillAndBlur(date) {
+    return this
+      .clickInput()
+      .fillInput(date)
+      .pressEnter()
+      .blurInput();
+  }
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.0.26",
+  "version": "2.0.27",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
## Purpose
https://github.com/folio-org/stripes-components/pull/426 broke `Datepicker` keyboard focus behavior, and prevented dates simply typed in (vs. being clicked on in the calendar) from being validated.

### Before
![before](https://user-images.githubusercontent.com/230597/41861964-3f2bd7e8-7868-11e8-91d4-696129b31913.gif)

## Approach
`Calendar` needed to pass along its ref to `Datepicker`.

### After
![after](https://user-images.githubusercontent.com/230597/41861988-4ea2ba70-7868-11e8-9b5c-1aa5ad52e3dc.gif)

## Next Steps
The calendar picker needs some acceptance tests.
