### PR TITLE
STCOR-208 Use new context API: withStripes()

### DIFF
--- a/lib/AppIcon/AppIcon.js
+++ b/lib/AppIcon/AppIcon.js
@@ -9,9 +9,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { result } from 'lodash';
 import classNames from 'classnames';
+import { withStripes } from '@folio/stripes-core/src/StripesContext';
 import css from './AppIcon.css';
 
-const AppIcon = ({ size, icon, style, children, className, tag, app, iconKey }, context) => {
+const AppIcon = ({ size, icon, style, children, className, tag, app, iconKey, stripes }) => {
   /**
    * Icon from context
    *
@@ -22,7 +23,7 @@ const AppIcon = ({ size, icon, style, children, className, tag, app, iconKey }, 
    *
    */
   const iconFromMetadataContext = () => {
-    const appIcon = result(context, `stripes.metadata.${app}.icons.${iconKey}`);
+    const appIcon = result(stripes, `metadata.${app}.icons.${iconKey}`);
 
     if (appIcon && appIcon.src) {
       let src = appIcon.src;
@@ -89,12 +90,6 @@ const AppIcon = ({ size, icon, style, children, className, tag, app, iconKey }, 
   );
 };
 
-AppIcon.contextTypes = {
-  stripes: PropTypes.shape({
-    metadata: PropTypes.object,
-  }),
-};
-
 AppIcon.propTypes = {
   app: PropTypes.string,
   children: PropTypes.element,
@@ -106,6 +101,9 @@ AppIcon.propTypes = {
   }),
   iconKey: PropTypes.string,
   size: PropTypes.oneOf(['small', 'medium', 'large']),
+  stripes: PropTypes.shape({
+    metadata: PropTypes.object,
+  }),
   style: PropTypes.object,
   tag: PropTypes.string,
 };
@@ -116,4 +114,4 @@ AppIcon.defaultProps = {
   tag: 'span',
 };
 
-export default AppIcon;
+export default withStripes(AppIcon);

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -7,7 +7,7 @@ import moment from 'moment-timezone';
 import contains from 'dom-helpers/query/contains';
 import debounce from 'lodash/debounce';
 import uniqueId from 'lodash/uniqueId';
-
+import { withStripes } from '@folio/stripes-core/src/StripesContext';
 
 import injectIntl from '../InjectIntl';
 import Button from '../Button';
@@ -42,6 +42,10 @@ const propTypes = {
   required: PropTypes.bool,
   screenReaderMessage: PropTypes.string,
   showCalendar: PropTypes.bool,
+  stripes: PropTypes.shape({
+    locale: PropTypes.string,
+    timezone: PropTypes.string
+  }),
   tether: PropTypes.object,
   timeZone: PropTypes.string,
   useFocus: PropTypes.bool,
@@ -74,16 +78,9 @@ const defaultProps = {
   useFocus: true,
 };
 
-const contextTypes = {
-  stripes: PropTypes.shape({
-    locale: PropTypes.string,
-    timezone: PropTypes.string
-  }),
-};
-
 class Datepicker extends React.Component {
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
 
     this.textfield = React.createRef();
     this.picker = null;
@@ -109,8 +106,8 @@ class Datepicker extends React.Component {
     // Set time zone
     if (props.timeZone) {
       this.timeZone = props.timeZone;
-    } else if (context.stripes) {
-      this.timeZone = context.stripes.timezone;
+    } else if (props.stripes) {
+      this.timeZone = props.stripes.timezone;
     } else {
       this.timeZone = 'UTC';
     }
@@ -119,8 +116,8 @@ class Datepicker extends React.Component {
     // Set locale
     if (props.locale) {
       this.locale = props.locale;
-    } else if (context.stripes) {
-      this.locale = context.stripes.locale;
+    } else if (props.stripes) {
+      this.locale = props.stripes.locale;
     } else {
       this.locale = 'en';
     }
@@ -613,7 +610,6 @@ class Datepicker extends React.Component {
 }
 
 Datepicker.propTypes = propTypes;
-Datepicker.contextTypes = contextTypes;
 Datepicker.defaultProps = defaultProps;
 
-export default injectIntl(Datepicker);
+export default injectIntl(withStripes(Datepicker));

--- a/lib/IfInterface/IfInterface.js
+++ b/lib/IfInterface/IfInterface.js
@@ -1,18 +1,16 @@
 import PropTypes from 'prop-types';
+import { withStripes } from '@folio/stripes-core/src/StripesContext';
 
-const IfInterface = (props, context) => (
-  context.stripes.hasInterface(props.name, props.version) ? props.children : null
+const IfInterface = (props) => (
+  props.stripes.hasInterface(props.name, props.version) ? props.children : null
 );
-
-IfInterface.contextTypes = {
-  stripes: PropTypes.shape({
-    hasInterface: PropTypes.func.isRequired,
-  }).isRequired,
-};
 
 IfInterface.propTypes = {
   name: PropTypes.string.isRequired,
+  stripes: PropTypes.shape({
+    hasInterface: PropTypes.func,
+  }),
   version: PropTypes.string,
 };
 
-export default IfInterface;
+export default withStripes(IfInterface);

--- a/lib/IfPermission/IfPermission.js
+++ b/lib/IfPermission/IfPermission.js
@@ -1,13 +1,14 @@
 import PropTypes from 'prop-types';
+import { withStripes } from '@folio/stripes-core/src/StripesContext';
 
-const IfPermission = (props, context) => (
-  context.stripes.hasPerm(props.perm) ? props.children : null
+const IfPermission = (props) => (
+  props.stripes.hasPerm(props.perm) ? props.children : null
 );
 
-IfPermission.contextTypes = {
+IfPermission.propTypes = {
   stripes: PropTypes.shape({
-    hasPerm: PropTypes.func.isRequired,
-  }).isRequired,
+    hasPerm: PropTypes.func,
+  }),
 };
 
-export default IfPermission;
+export default withStripes(IfPermission);

--- a/lib/ModalFooter/ModalFooter.js
+++ b/lib/ModalFooter/ModalFooter.js
@@ -6,12 +6,12 @@
 
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import Button, { propTypes as buttonPropTypes } from '@folio/stripes-components/lib/Button/Button'; /* eslint-disable-line import/no-extraneous-dependencies */
+import Button, { propTypes as buttonPropTypes } from '@folio/stripes-components/lib/Button/Button'; // eslint-disable-line import/no-extraneous-dependencies
 
 const ModalFooter = ({ primaryButton, secondaryButton }) => {
   // Rendered buttons are identical except for the label and buttonStyle
   const renderButton = (buttonStyle, props) => {
-    const { label, ...rest } = props; /* eslint-disable-line react/prop-types */
+    const { label, ...rest } = props; // eslint-disable-line react/prop-types
     return (<Button {...rest} buttonStyle={buttonStyle} marginBottom0>{label}</Button>);
   };
 

--- a/lib/Pluggable/Pluggable.js
+++ b/lib/Pluggable/Pluggable.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { modules } from 'stripes-config'; // eslint-disable-line import/no-unresolved
+import { withStripes } from '@folio/stripes-core/src/StripesContext';
+import { modules } from 'stripes-config'; // eslint-disable-line
 
-const Pluggable = (props, context) => {
+const Pluggable = (props) => {
   const plugins = modules.plugin || [];
   let best;
 
-  const wanted = context.stripes.plugins[props.type];
+  const wanted = props.stripes.plugins[props.type];
   // "@@" is a special case of explicitly chosen "no plugin"
   if (!wanted || wanted !== '@@') {
     for (const name of Object.keys(plugins)) {
@@ -18,7 +19,7 @@ const Pluggable = (props, context) => {
     }
 
     if (best) {
-      const Child = context.stripes.connect(best.getModule());
+      const Child = props.stripes.connect(best.getModule());
       return <Child {...props} />;
     }
   }
@@ -30,18 +31,13 @@ const Pluggable = (props, context) => {
   return props.children;
 };
 
-Pluggable.contextTypes = {
-  stripes: PropTypes.shape({
-    hasPerm: PropTypes.func.isRequired,
-  }).isRequired,
-};
-
 Pluggable.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]),
+  stripes: PropTypes.object.isRequired,
   type: PropTypes.string.isRequired,
 };
 
-export default Pluggable;
+export default withStripes(Pluggable);

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -14,10 +14,9 @@ import IconButton from '../IconButton';
 import css from './Settings.css';
 
 class Settings extends React.Component {
-  constructor(props, context) {
+  constructor(props) {
     super(props);
-    this.context = context;
-    const stripes = context.stripes;
+    const stripes = props.stripes;
 
     this.sections = props.sections;
 
@@ -47,8 +46,8 @@ class Settings extends React.Component {
   }
 
   render() {
-    const { stripes } = this.context;
     const props = this.props;
+    const stripes = props.stripes;
     let { activeLink } = this.props;
 
     // links in a given section
@@ -105,13 +104,6 @@ class Settings extends React.Component {
   }
 }
 
-Settings.contextTypes = {
-  stripes: PropTypes.shape({
-    connect: PropTypes.func.isRequired,
-    hasPerm: PropTypes.func.isRequired,
-  }).isRequired,
-};
-
 Settings.propTypes = {
   activeLink: PropTypes.string,
   location: PropTypes.shape({
@@ -142,6 +134,10 @@ Settings.propTypes = {
       ).isRequired,
     }),
   ),
+  stripes: PropTypes.shape({
+    connect: PropTypes.func.isRequired,
+    hasPerm: PropTypes.func.isRequired,
+  }).isRequired,
 };
 
 export default Settings;

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -7,6 +7,7 @@ import moment from 'moment-timezone';
 import contains from 'dom-helpers/query/contains';
 import debounce from 'lodash/debounce';
 import uniqueId from 'lodash/uniqueId';
+import { withStripes } from '@folio/stripes-core/src/StripesContext';
 
 import injectIntl from '../InjectIntl';
 import Button from '../Button';
@@ -30,6 +31,10 @@ const propTypes = {
   required: PropTypes.bool,
   screenReaderMessage: PropTypes.string,
   showTimepicker: PropTypes.bool,
+  stripes: PropTypes.shape({
+    locale: PropTypes.string,
+    timezone: PropTypes.string,
+  }),
   tether: PropTypes.object,
   timeZone: PropTypes.string,
   value: PropTypes.string,
@@ -58,16 +63,9 @@ const defaultProps = {
   },
 };
 
-const contextTypes = {
-  stripes: PropTypes.shape({
-    locale: PropTypes.string,
-    timezone: PropTypes.string,
-  }),
-};
-
 class Timepicker extends React.Component { // eslint-disable-line react/no-deprecated
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
 
     this.textfield = React.createRef();
     this.picker = null;
@@ -95,8 +93,8 @@ class Timepicker extends React.Component { // eslint-disable-line react/no-depre
     // Set time zone
     if (props.timeZone) {
       this.timeZone = props.timeZone;
-    } else if (context.stripes) {
-      this.timeZone = context.stripes.timezone;
+    } else if (props.stripes) {
+      this.timeZone = props.stripes.timezone;
     } else {
       this.timeZone = 'UTC';
     }
@@ -104,8 +102,8 @@ class Timepicker extends React.Component { // eslint-disable-line react/no-depre
     // Set locale
     if (props.locale) {
       this.locale = props.locale;
-    } else if (context.stripes) {
-      this.locale = context.stripes.locale;
+    } else if (props.stripes) {
+      this.locale = props.stripes.locale;
     } else {
       this.locale = 'en';
     }
@@ -147,7 +145,7 @@ class Timepicker extends React.Component { // eslint-disable-line react/no-depre
     }
   }
 
-  componentWillReceiveProps(nextProps, nextContext) {
+  componentWillReceiveProps(nextProps) {
     let inputValue;
     let presentedValue = null;
     if (nextProps.input) { // if we're using redux-form....
@@ -183,8 +181,8 @@ class Timepicker extends React.Component { // eslint-disable-line react/no-depre
     }
 
     // adjust displayed time format for a change in locale
-    if (nextContext.stripes.locale !== this.context.stripes.locale) {
-      moment.locale(nextContext.stripes.locale);
+    if (nextProps.stripes.locale !== this.props.stripes.locale) {
+      moment.locale(nextProps.stripes.locale);
       this._timeFormat = moment.localeData()._longDateFormat.LT;
       let newTimeString = this.state.timeString;
       if (newTimeString !== '') {
@@ -636,7 +634,6 @@ class Timepicker extends React.Component { // eslint-disable-line react/no-depre
 }
 
 Timepicker.propTypes = propTypes;
-Timepicker.contextTypes = contextTypes;
 Timepicker.defaultProps = defaultProps;
 
-export default injectIntl(Timepicker);
+export default injectIntl(withStripes(Timepicker));


### PR DESCRIPTION
https://issues.folio.org/browse/STCOR-208

- This PR converts components from the legacy context API to the new context API
- `withStripes()` is a HoC to wrap components with a `StripesContext.Consumer`
- The Providers were set in https://github.com/folio-org/stripes-core/pull/330