### PR TITLE
Fix withStripes bugs

### DIFF
--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -612,4 +612,4 @@ class Datepicker extends React.Component {
 Datepicker.propTypes = propTypes;
 Datepicker.defaultProps = defaultProps;
 
-export default injectIntl(withStripes(Datepicker));
+export default withStripes(injectIntl(Datepicker));

--- a/lib/InjectIntl/InjectIntl.js
+++ b/lib/InjectIntl/InjectIntl.js
@@ -39,9 +39,14 @@ export default function injectIntl(WrappedComponent, options = {}) {
     }
   }
 
-  return forwardRef((props, ref) => {
-    return (
-      <InjectIntl forwardedRef={ref} {...props} />
-    );
-  });
+  function forward(props, ref) {
+    return <InjectIntl forwardedRef={ref} {...props} />;
+  }
+
+  forward.displayName = componentName;
+
+  if (withRef) {
+    return forwardRef(forward);
+  }
+  return forward;
 }

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import Switch from 'react-router-dom/Switch';
 import Route from 'react-router-dom/Route';
 import Link from 'react-router-dom/Link';
-import NavListItem from '../NavListItem';
+import { withStripes } from '@folio/stripes-core/src/StripesContext';
 
+import NavListItem from '../NavListItem';
 import Paneset from '../Paneset';
 import Pane from '../Pane';
 import NavList from '../NavList';
@@ -140,4 +141,4 @@ Settings.propTypes = {
   }).isRequired,
 };
 
-export default Settings;
+export default withStripes(Settings);

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -636,4 +636,4 @@ class Timepicker extends React.Component { // eslint-disable-line react/no-depre
 Timepicker.propTypes = propTypes;
 Timepicker.defaultProps = defaultProps;
 
-export default injectIntl(withStripes(Timepicker));
+export default withStripes(injectIntl(Timepicker));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.0.27",
+  "version": "2.0.28",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
## Purpose
In a storybook context, `Datepicker` and `Timepicker` (https://github.com/folio-org/stripes-components/pull/443) wouldn't receive the `intl` context. The `intl` prop would just get eaten before it made its way down.

![screen shot 2018-06-25 at 4 36 54 pm](https://user-images.githubusercontent.com/230597/41877189-fd30458a-7895-11e8-88fc-3a9099ffeb67.png)

## Approach
Flip the order of the higher-order components.