### PR TITLE
Pluggable: use new ModulesContext

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,7 +20,8 @@
   "parser": "babel-eslint",
   "rules": {
     "import/no-extraneous-dependencies": ["error", {
-      "devDependencies": true
+      "devDependencies": true,
+      "peerDependencies": true
     }],
     "no-console": ["error", {
       "allow": ["warn", "error"]

--- a/lib/Pluggable/Pluggable.js
+++ b/lib/Pluggable/Pluggable.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStripes } from '@folio/stripes-core/src/StripesContext';
-import { modules } from 'stripes-config'; // eslint-disable-line
+import { withModules } from '@folio/stripes-core/src/components/Modules';
 
 const Pluggable = (props) => {
-  const plugins = modules.plugin || [];
+  const plugins = props.modules.plugin || [];
   let best;
 
   const wanted = props.stripes.plugins[props.type];
@@ -36,8 +36,11 @@ Pluggable.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]),
+  modules: PropTypes.shape({
+    plugins: PropTypes.array,
+  }),
   stripes: PropTypes.object.isRequired,
   type: PropTypes.string.isRequired,
 };
 
-export default withStripes(Pluggable);
+export default withStripes(withModules(Pluggable));


### PR DESCRIPTION
Don't use the `stripes-config` virtual module, use the new ModulesContext.

Yes, `Pluggable` will likely be moving somewhere else but this cleans it up for when that happens.