### PR TITLE
Update whitespace in Datepicker placeholder

### DIFF
--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -538,7 +538,7 @@ class Datepicker extends React.Component {
           label={label}
           aria-label={ariaLabel}
           endControl={!readOnly ? endElement : null}
-          placeholder={` ${this._dateFormat}`}
+          placeholder={`${this._dateFormat}`}
           onKeyDown={!readOnly ? this.handleKeyDown : null}
           onClick={!readOnly ? this.handleFieldClick : null}
           onFocus={!readOnly ? this.handleFieldFocus : null}
@@ -563,7 +563,7 @@ class Datepicker extends React.Component {
           onChange={this.handleSetDate}
           aria-label={ariaLabel}
           endControl={!readOnly ? endElement : null}
-          placeholder={` ${this._dateFormat}`}
+          placeholder={`${this._dateFormat}`}
           onKeyDown={!readOnly ? this.handleKeyDown : null}
           onBlur={this.hideOnBlur}
           onClick={!readOnly ? this.handleFieldClick : null}

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -20,6 +20,10 @@ describe('Datepicker', () => {
     expect(datepicker.inputValue).to.equal('');
   });
 
+  it('has a placeholder in the input', () => {
+    expect(datepicker.placeholder).to.equal('MM/DD/YYYY');
+  });
+
   describe('with an id', () => {
     beforeEach(async () => {
       await mountWithContext(

--- a/lib/Datepicker/tests/interactor.js
+++ b/lib/Datepicker/tests/interactor.js
@@ -24,6 +24,7 @@ export default interactor(class DatepickerInteractor {
     cancelable: true,
     keyCode: 13
   });
+  placeholder = attribute('input', 'placeholder');
 
   fillAndBlur(date) {
     return this


### PR DESCRIPTION
`Datepicker` was the only component using `TextField` to have a whitespace character at the beginning of its placeholder (vs. `Timepicker` or `TextField` itself).

The whitespace was probably intentional originally, but now it'll match the other components.

### Before
![before](https://user-images.githubusercontent.com/230597/41934533-959c9c36-794c-11e8-96f6-a4d7681736d6.png)

### After
![after](https://user-images.githubusercontent.com/230597/41934538-98cf9cf0-794c-11e8-95f2-f861990a2757.png)


