### PR TITLE
Add object to pane title ref prop type

### DIFF
--- a/lib/Pane/Pane.js
+++ b/lib/Pane/Pane.js
@@ -33,7 +33,7 @@ const propTypes = {
   paneset: PropTypes.instanceOf(Paneset),
   paneSub: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   paneTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-  paneTitleRef: PropTypes.func,
+  paneTitleRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
   subheader: PropTypes.node,
   transition: PropTypes.string,
 };

--- a/lib/PaneHeader/PaneHeader.js
+++ b/lib/PaneHeader/PaneHeader.js
@@ -31,7 +31,7 @@ class PaneHeader extends Component {
     paneSub: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.node]),
     paneTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.node]),
     paneTitleAutoFocus: PropTypes.bool,
-    paneTitleRef: PropTypes.func,
+    paneTitleRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func])
   }
 
   constructor(props) {


### PR DESCRIPTION
## Purpose

With the introduction of `React.createRef()` in React 16.3, refs are now recommended to be created using this new API.

Using this API with `Pane` or `PaneHeader` causes a propTypes warning to be thrown

## Approach

Adjusted the prop type to be one of object or function

### Learning

- https://reactjs.org/docs/refs-and-the-dom.html

### Future Work

- I went to make this change across all refs, but then noticed that some refs use `ref.bind(this)` and other refs are wrapped in a fallback function that then invokes the ref itself as a function. Instead of changing all of these refs, I made sure this pane title ref works with the new API. The other refs may require additional work besides simply changing the prop type.