### PR TITLE
Adjust clock icon for Timepicker

### DIFF
--- a/lib/Icon/icons.js
+++ b/lib/Icon/icons.js
@@ -47,4 +47,5 @@ export default {
       <div className={dotSpinner.bounce2} />
       <div className={dotSpinner.bounce3} />
     </div>),
+  'clock': ({ style, className }) => (<svg style={style} className={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 4.9c-.8 0-1.6.1-2.4.4h-.1l1.2 5.6c-.3.3-.4.7-.4 1.1 0 .9.7 1.7 1.7 1.7.3 0 .6-.1.9-.3l2.2.9.8-1.8-2.2-.9c-.1-.5-.5-.9-1-1.2l-.9-3.6h.1c2.9 0 5.2 2.4 5.2 5.2 0 2.9-2.4 5.2-5.2 5.2-2.9 0-5.2-2.4-5.2-5.2 0-1.6.7-3 1.9-4l-.8-1.8c-1.8 1.3-3 3.4-3 5.8 0 3.9 3.2 7.2 7.2 7.2s7.2-3.2 7.2-7.2c0-3.9-3.3-7.1-7.2-7.1z" /></svg>)
 };

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -524,9 +524,7 @@ class Timepicker extends React.Component { // eslint-disable-line react/no-depre
             id={`timepicker-toggle-button-${id}`}
             tabIndex="-1"
           >
-            <div style={{ width: '18px', height: '18px' }}>
-              <svg className="stripes__icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"><path d="M12 1.5c-1.2 0-2.4 0.2-3.6 0.6L8.2 2.1l1.9 8.6c-0.4 0.5-0.6 1-0.6 1.7 0 1.4 1.1 2.6 2.6 2.6 0.5 0 0.9-0.1 1.3-0.4l3.4 1.4 1.2-2.8 -3.3-1.4c-0.2-0.8-0.7-1.4-1.5-1.8L11.8 4.5C11.8 4.5 11.9 4.5 12 4.5c4.4 0 7.9 3.6 7.9 7.9 0 4.4-3.6 7.9-7.9 7.9 -4.4 0-7.9-3.6-7.9-7.9 0-2.4 1.1-4.6 2.9-6.1L5.6 3.5c-2.7 2-4.5 5.2-4.5 8.8 0 6 4.9 10.9 10.9 10.9 6 0 10.9-4.9 10.9-10.9C22.9 6.4 18 1.5 12 1.5z" /></svg>
-            </div>
+            <Icon icon="clock" />
           </Button>
         </div>
 
@@ -542,9 +540,7 @@ class Timepicker extends React.Component { // eslint-disable-line react/no-depre
           id={`timepicker-toggle-button-${id}`}
           tabIndex="-1"
         >
-          <div style={{ width: '18px', height: '18px' }}>
-            <svg className="stripes__icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"><path d="M12 1.5c-1.2 0-2.4 0.2-3.6 0.6L8.2 2.1l1.9 8.6c-0.4 0.5-0.6 1-0.6 1.7 0 1.4 1.1 2.6 2.6 2.6 0.5 0 0.9-0.1 1.3-0.4l3.4 1.4 1.2-2.8 -3.3-1.4c-0.2-0.8-0.7-1.4-1.5-1.8L11.8 4.5C11.8 4.5 11.9 4.5 12 4.5c4.4 0 7.9 3.6 7.9 7.9 0 4.4-3.6 7.9-7.9 7.9 -4.4 0-7.9-3.6-7.9-7.9 0-2.4 1.1-4.6 2.9-6.1L5.6 3.5c-2.7 2-4.5 5.2-4.5 8.8 0 6 4.9 10.9 10.9 10.9 6 0 10.9-4.9 10.9-10.9C22.9 6.4 18 1.5 12 1.5z" /></svg>
-          </div>
+          <Icon icon="clock" />
         </Button>
       );
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
The `<Timepicker>` clock icon was out of scale. Now it's the same size as the `clearX`.

### Before
<img width="717" alt="screen shot 2018-06-27 at 5 06 22 pm" src="https://user-images.githubusercontent.com/230597/42002527-44b23948-7a2d-11e8-9788-757acf13f0e9.png">

### After
<img width="717" alt="screen shot 2018-06-27 at 5 05 32 pm" src="https://user-images.githubusercontent.com/230597/42002530-47650012-7a2d-11e8-9ff9-12ce207ad377.png">
