### PR TITLE
Dropdown: preventDefault when toggling dropdown

### DIFF
--- a/lib/Dropdown/Dropdown.js
+++ b/lib/Dropdown/Dropdown.js
@@ -107,7 +107,12 @@ class Dropdown extends React.Component {
     if (this.props.disabled) {
       return e && e.preventDefault();
     }
-    if (e) { e.stopPropagation(); }
+
+    if (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+
     return this.props.onToggle(e);
   }
 


### PR DESCRIPTION
When on the Edit page for a SearchAndSort record (e.g., Edit Request) that uses the `actionMenuItems` prop to add a dropdown menu, clicking the button to open the dropdown menu instead reloads the page with a query string of the edited fields.

Looks like an issue where we're stopping propagation, but not preventing the browser from doing what it wants to do. This is a quick patch, unless y'all wanted to approach the fix differently.