### PR TITLE
Refactor ModalFooter tests

### DIFF
--- a/lib/Button/tests/interactor.js
+++ b/lib/Button/tests/interactor.js
@@ -2,7 +2,8 @@ import {
   interactor,
   is,
   attribute,
-  hasClass
+  hasClass,
+  text,
 } from '@bigtest/interactor';
 
 import css from '../Button.css';
@@ -13,6 +14,7 @@ const btnClassSelector = selectorFromClassnameString(`.${css.button}`);
 
 export default interactor(class ButtonInteractor {
   static defaultScope = btnClassSelector;
+  label = text();
   id = attribute('id');
   href = attribute('href');
   isAnchor = is('a');

--- a/lib/ModalFooter/tests/ModalFooter-test.js
+++ b/lib/ModalFooter/tests/ModalFooter-test.js
@@ -11,14 +11,12 @@ import { mount } from '../../../tests/helpers';
 import ModalFooter from '../ModalFooter';
 import ModalFooterInteractor from './interactor';
 
-import buttonCss from '../../Button/Button.css';
-
-describe('ModalFooter', () => {
+describe.only('ModalFooter', () => {
   const modalFooter = new ModalFooterInteractor();
-  const primaryButtonId = 'primaryButton';
   const primaryButtonLabel = 'Primary Button';
-  const secondaryButtonId = 'secondaryButton';
+  const primaryButtonId = 'modalFooterPrimaryButton';
   const secondaryButtonLabel = 'Secondary Button';
+  const secondaryButtonId = 'modalFooterSecondaryButton';
 
   beforeEach(async () => {
     await mount(
@@ -39,24 +37,24 @@ describe('ModalFooter', () => {
    * The "primaryButton"-prop should render a primary <Button>  with the primary button style
    */
   it('renders a primary button when using the primaryButton-prop', () => {
-    const button = modalFooter.$(`#${primaryButtonId}`);
-    expect(button.className).to.include(buttonCss.primary);
+    expect(modalFooter.primaryButton.rendersPrimary).to.equal.true;
   });
 
   /**
    * The "secondaryButton"-prop should render a <Button> with the default button style
    */
   it('renders a default button when using the secondaryButton-prop', () => {
-    const button = modalFooter.$(`#${secondaryButtonId}`);
-    expect(button.className).to.include(buttonCss.default);
+    expect(modalFooter.secondaryButton.rendersDefault).to.equal.true;
   });
 
   /**
-   * Passing a label-key to either secondaryButton or primaryButton
-   * should render a button with this label
+   * Passing a label-key to either the secondaryButton- or primaryButton-prop
+   * should render a button with the label value passed
    */
-  it('renders the label when passing a label-key to any of the button props', () => {
-    const button = modalFooter.$(`#${secondaryButtonId}`);
-    expect(button.innerText.trim()).to.equal(secondaryButtonLabel);
+  it(`renders a button with a label of "${secondaryButtonLabel}"`, () => {
+    expect(modalFooter.secondaryButton.label).to.equal(secondaryButtonLabel);
+  });
+  it(`renders a button with a label of "${primaryButtonLabel}"`, () => {
+    expect(modalFooter.primaryButton.label).to.equal(primaryButtonLabel);
   });
 });

--- a/lib/ModalFooter/tests/ModalFooter-test.js
+++ b/lib/ModalFooter/tests/ModalFooter-test.js
@@ -11,7 +11,7 @@ import { mount } from '../../../tests/helpers';
 import ModalFooter from '../ModalFooter';
 import ModalFooterInteractor from './interactor';
 
-describe.only('ModalFooter', () => {
+describe('ModalFooter', () => {
   const modalFooter = new ModalFooterInteractor();
   const primaryButtonLabel = 'Primary Button';
   const primaryButtonId = 'modalFooterPrimaryButton';

--- a/lib/ModalFooter/tests/interactor.js
+++ b/lib/ModalFooter/tests/interactor.js
@@ -2,8 +2,10 @@
  * ModalFooter interactor
  */
 
-import { interactor } from '@bigtest/interactor';
+import { interactor, scoped } from '@bigtest/interactor';
+import ButtonInteractor from '../../Button/tests/interactor';
 
 export default interactor(class ModalFooterInteractor {
-
+  primaryButton = scoped('#modalFooterPrimaryButton', ButtonInteractor);
+  secondaryButton = scoped('#modalFooterSecondaryButton', ButtonInteractor);
 });


### PR DESCRIPTION
Some minor refactoring of the ModalFotoer tests. Now using the Button-interactor for buttons in the ModalFooter-interactor using the `scoped` method.

I also added "label" to the Button interactor.