### PR TITLE
 Ignore artifacts directory when linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+/artifacts
+/node_modules

--- a/lib/Selection/SelectList.js
+++ b/lib/Selection/SelectList.js
@@ -179,7 +179,9 @@ class SelectList extends React.Component { // eslint-disable-line react/no-depre
         } else if (this.container.current) {
           cursored = this.container.current.querySelector(`.${css.cursor}`);
           if (cursored) {
-            if (cursored.offsetTop > ((this.optionList.current.scrollTop + this.optionList.current.offsetHeight) - 30)) {
+            if (
+              cursored.offsetTop > ((this.optionList.current.scrollTop + this.optionList.current.offsetHeight) - 30)
+            ) {
               const newScroll = cursored.offsetTop - (this.optionList.current.offsetHeight - cursored.offsetHeight);
               this.optionList.current.scrollTop = newScroll;
             } else if (cursored.offsetTop < this.optionList.current.scrollTop) {


### PR DESCRIPTION
The `/artifacts` directory created by coverage reports was being run through `eslint`, with lots of errors.