### PR TITLE
Fix named exports

### DIFF
--- a/lib/Callout/index.js
+++ b/lib/Callout/index.js
@@ -1,2 +1,2 @@
 export { default } from './Callout';
-export { CalloutElement } from './CalloutElement';
+export { default as CalloutElement } from './CalloutElement';

--- a/lib/Datepicker/index.js
+++ b/lib/Datepicker/index.js
@@ -1,3 +1,2 @@
-export { Calendar } from './Calendar';
+export { default as Calendar } from './Calendar';
 export { default } from './Datepicker';
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
The webpack 4 upgrade work (https://github.com/folio-org/stripes-core/pull/347) exposed a couple of named export problems:

`"export 'Calendar' was not found in './Calendar'`
`"export 'CalloutElement' was not found in './CalloutElement'`