### PR TITLE
STCOM-304 render modal in Overlay Container

### DIFF
--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -82,7 +82,7 @@ const Modal = (props) => {
     let container;
     switch (props.scope) {
       case 'module':
-        container = document.getElementById('ModuleContainer');
+        container = document.getElementById('OverlayContainer');
         break;
       default:
         break;


### PR DESCRIPTION
`<Modal>` needs a z-index-safe place to render. `#OverlayContainer` provides that without covering the universal navigation.
## Other work -
fix styling in stripes-core so that the top nav does not appear blocked.