### PR TITLE
Added jsconfig.json

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true
+  }
+}


### PR DESCRIPTION
VSCode interprets descriptors as as TypeScript feature and shows a warning that descriptors are experimental. This PR adds `jsconfig.json` file to the project to tell editors that descriptors are 👌

To learn more about jsconfig.json checkout [VSCode documentation](https://code.visualstudio.com/docs/languages/jsconfig\#_jsconfig-options). 