### PR TITLE
Add tests for SearchField

### DIFF
--- a/lib/SearchField/SearchField.js
+++ b/lib/SearchField/SearchField.js
@@ -93,7 +93,7 @@ const SearchField = (props) => {
         id={id}
         clearFieldId={clearSearchId}
         ariaLabel={ariaLabel}
-        input={{ value: value || '' }}
+        value={value || ''}
         onChange={onChange}
         startControl={!hasSearchableIndexes ? searchIcon : null}
         inputClass={classNames(css.input, inputClass)}
@@ -102,12 +102,7 @@ const SearchField = (props) => {
         placeholder={inputPlaceholder}
         onClearField={onClear}
         hasClearIcon={typeof onClear === 'function' && loading !== true}
-        meta={
-          {
-            asyncValidating: loading,
-            active: true, // Currently needed to activate clear button
-          }
-        }
+        loading={loading}
       />
     </div>
   );

--- a/lib/SearchField/tests/SearchField-test.js
+++ b/lib/SearchField/tests/SearchField-test.js
@@ -1,1 +1,78 @@
-import SearchField from '../SearchField'; // eslint-disable-line no-unused-vars
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { mountWithContext } from '../../../tests/helpers';
+import SearchField from '../SearchField';
+import SearchFieldInteractor from './interactor';
+
+describe('SearchField', () => {
+  const searchField = new SearchFieldInteractor();
+
+  describe('rendering a SearchField', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <SearchField id="searchFieldTest" />
+      );
+    });
+
+    it('applies the supplied id prop to the input', () => {
+      expect(searchField.id).to.equal('searchFieldTest');
+    });
+  });
+
+  describe('supplying an onChange handler', () => {
+    let fieldValue = '';
+
+    beforeEach(async () => {
+      await mountWithContext(
+        <SearchField
+          onChange={(e) => { fieldValue = e.target.value; }}
+        />
+      );
+    });
+
+    describe('changing the field', () => {
+      beforeEach(async () => {
+        await searchField.fillInput('testing text');
+      });
+
+      it('should update value', () => {
+        expect(fieldValue).to.equal('testing text');
+      });
+    });
+  });
+
+  // needs Select to be independent of Redux Form to unskip
+  describe.skip('using with indexes', () => {
+    const searchableIndexes = [
+      { label: 'ID', value: 'id' },
+      { label: 'Title', value: 'title' },
+      { label: 'Identifier', value: 'identifier' },
+      { label: 'ISBN', value: 'identifier/type=isbn' },
+      { label: 'ISSN', value: 'identifier/type=issn' },
+      { label: 'Contributor', value: 'contributor' },
+      { label: 'Subject', value: 'subject' },
+      { label: 'Classification', value: 'classification' },
+      { label: 'Publisher', value: 'publisher' },
+    ];
+
+    beforeEach(async () => {
+      await mountWithContext(
+        <SearchField
+          searchableIndexes={searchableIndexes}
+        />
+      );
+    });
+
+    describe('selecting an index', () => {
+      beforeEach(async () => {
+        await searchField.selectIndex('Publisher');
+      });
+
+      it('should update the placeholder', () => {
+        expect(searchField.placeholder).to.equal('Search for publisher');
+      });
+    });
+  });
+});

--- a/lib/SearchField/tests/interactor.js
+++ b/lib/SearchField/tests/interactor.js
@@ -1,0 +1,13 @@
+import {
+  attribute,
+  fillable,
+  interactor,
+  selectable
+} from '@bigtest/interactor';
+
+export default interactor(class SearchFieldInteractor {
+  id = attribute('input', 'id');
+  fillInput = fillable('input');
+  selectIndex = selectable('select');
+  placeholder = attribute('input', 'placeholder');
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",
@@ -29,8 +29,8 @@
     ]
   },
   "devDependencies": {
-    "@bigtest/interactor": "^0.5.0",
-    "@bigtest/mocha": "^0.3.3",
+    "@bigtest/interactor": "^0.5.1",
+    "@bigtest/mocha": "^0.4.1",
     "@folio/eslint-config-stripes": "^2.0.0",
     "@folio/stripes-cli": "^1.2.0",
     "@storybook/addon-actions": "^3.2.16",


### PR DESCRIPTION
- Upgrades `@bigtest/mocha` and `@bigtest/interactor`
- The `TextField` used by `SearchField` won't try to run in "`redux-form` mode" because of the `meta` prop.
- Some tests skipped until `Select` can be more independent of `redux-form`.