### PR TITLE
UICHKOUT-437 Modal: Catch pointer events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@
 * accessibility updates and tests added to Selection: Single Select.
 * add `focusable='false'` attribute to `<Icon>`'s rendered SVG's.
 * Modify makeQueryFunction to support param namespacing. Fixes STCOM-300.
-* Turn on `pointer-events: all` for `<Modal>`. Fixes UICHKOUT-437.
+* Turn on `pointer-events: auto` for `<Modal>`. Fixes UICHKOUT-437.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 * accessibility updates and tests added to Selection: Single Select.
 * add `focusable='false'` attribute to `<Icon>`'s rendered SVG's.
 * Modify makeQueryFunction to support param namespacing. Fixes STCOM-300.
+* Turn on `pointer-events: all` for `<Modal>`. Fixes UICHKOUT-437.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/lib/Modal/Modal.css
+++ b/lib/Modal/Modal.css
@@ -7,6 +7,7 @@
   left: 0;
   width: 100%;
   height: 100%;
+  pointer-events: all;
 }
 
 .modal {

--- a/lib/Modal/Modal.css
+++ b/lib/Modal/Modal.css
@@ -7,7 +7,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  pointer-events: all;
+  pointer-events: auto;
 }
 
 .modal {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
#476 started rendering Modals into the `overlayContainer`, but the `overlayContainer` has `pointer-events: none` set on it so all mouse events get sent to what's _behind_ the Modal.

This PR turns pointer-events back on for Modals.