### PR TITLE
STCOM-305: Add link to user record in MetaSection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 * add `focusable='false'` attribute to `<Icon>`'s rendered SVG's.
 * Modify makeQueryFunction to support param namespacing. Fixes STCOM-300.
 * Turn on `pointer-events: auto` for `<Modal>`. Fixes UICHKOUT-437.
+* Add link to user record in `<MetaSection>`. Fixes STCOM-305.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/lib/MetaSection/MetaSection.js
+++ b/lib/MetaSection/MetaSection.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, intlShape } from 'react-intl';
+import { Link } from 'react-router-dom';
+import { get } from 'lodash';
 
+import { withStripes } from '@folio/stripes-core/src/StripesContext';
 import injectIntl from '../InjectIntl';
 import { Accordion } from '../Accordion';
 import MetaAccordionHeader from './MetaAccordionHeader';
@@ -9,15 +12,50 @@ import css from './MetaSection.css';
 
 const propTypes = {
   contentId: PropTypes.string,
-  createdBy: PropTypes.string,
+  createdBy: PropTypes.shape({
+    id: PropTypes.string,
+    personal: PropTypes.shape({
+      firstName: PropTypes.string,
+      lastName: PropTypes.string,
+      middleName: PropTypes.string,
+    }),
+  }),
   createdDate: PropTypes.string,
   id: PropTypes.string,
   intl: intlShape.isRequired,
-  lastUpdatedBy: PropTypes.string,
+  lastUpdatedBy: PropTypes.shape({
+    id: PropTypes.string,
+    personal: PropTypes.shape({
+      firstName: PropTypes.string,
+      lastName: PropTypes.string,
+      middleName: PropTypes.string,
+    }),
+  }),
   lastUpdatedDate: PropTypes.string,
+  stripes: PropTypes.shape({
+    hasPerm: PropTypes.func.isRequired,
+  }).isRequired,
 };
 
 class MetaSection extends React.Component {
+  renderName(user) {
+    const lastName = get(user, ['personal', 'lastName'], '');
+    const firstName = get(user, ['personal', 'firstName'], '');
+    const middleName = get(user, ['personal', 'middleName'], '');
+
+    return `${lastName}${firstName ? ', ' : ' '}${firstName} ${middleName}`;
+  }
+
+  renderUser(user) {
+    const name = this.renderName(user);
+
+    if (this.props.stripes.hasPerm('ui-users.view')) {
+      return <Link to={`/users/view/${user.id}`}>{name}</Link>;
+    } else {
+      return name;
+    }
+  }
+
   render() {
     const {
       lastUpdatedDate,
@@ -49,7 +87,7 @@ class MetaSection extends React.Component {
               <div className={css.metaSectionContentBlock}>
                 <FormattedMessage
                   id="stripes-components.metaSection.source"
-                  values={{ source: lastUpdatedBy }}
+                  values={{ source: this.renderUser(lastUpdatedBy) }}
                 />
               </div>
             }
@@ -70,7 +108,7 @@ class MetaSection extends React.Component {
                   <div className={css.metaSectionContentBlock}>
                     <FormattedMessage
                       id="stripes-components.metaSection.source"
-                      values={{ source: createdBy }}
+                      values={{ source: this.renderUser(createdBy) }}
                     />
                   </div>
                 }
@@ -85,4 +123,4 @@ class MetaSection extends React.Component {
 
 MetaSection.propTypes = propTypes;
 
-export default injectIntl(MetaSection);
+export default withStripes(injectIntl(MetaSection));

--- a/lib/MetaSection/MetaSection.js
+++ b/lib/MetaSection/MetaSection.js
@@ -12,25 +12,31 @@ import css from './MetaSection.css';
 
 const propTypes = {
   contentId: PropTypes.string,
-  createdBy: PropTypes.shape({
-    id: PropTypes.string,
-    personal: PropTypes.shape({
-      firstName: PropTypes.string,
-      lastName: PropTypes.string,
-      middleName: PropTypes.string,
+  createdBy: PropTypes.oneOf([
+    PropTypes.shape({
+      id: PropTypes.string,
+      personal: PropTypes.shape({
+        firstName: PropTypes.string,
+        lastName: PropTypes.string,
+        middleName: PropTypes.string,
+      }),
     }),
-  }),
+    PropTypes.string, // Passing a string will _not_ render a link to the user record
+  ]),
   createdDate: PropTypes.string,
   id: PropTypes.string,
   intl: intlShape.isRequired,
-  lastUpdatedBy: PropTypes.shape({
-    id: PropTypes.string,
-    personal: PropTypes.shape({
-      firstName: PropTypes.string,
-      lastName: PropTypes.string,
-      middleName: PropTypes.string,
+  lastUpdatedBy: PropTypes.oneOf([
+    PropTypes.shape({
+      id: PropTypes.string,
+      personal: PropTypes.shape({
+        firstName: PropTypes.string,
+        lastName: PropTypes.string,
+        middleName: PropTypes.string,
+      }),
     }),
-  }),
+    PropTypes.string, // Passing a string will _not_ render a link to the user record
+  ]),
   lastUpdatedDate: PropTypes.string,
   stripes: PropTypes.shape({
     hasPerm: PropTypes.func.isRequired,
@@ -47,6 +53,8 @@ class MetaSection extends React.Component {
   }
 
   renderUser(user) {
+    if (typeof user === 'string') return user;
+
     const name = this.renderName(user);
 
     if (this.props.stripes.hasPerm('ui-users.view')) {

--- a/lib/MetaSection/readme.md
+++ b/lib/MetaSection/readme.md
@@ -15,8 +15,8 @@ Simple component for displaying record metadata such as the last date/time a rec
 Name | type | description | default | required
 --- | --- | --- | --- | ---
 lastUpdatedDate | string | Latest date/time a record was modified. |  |
-lastUpdatedBy | string | Username of the last user who modified the record. |  |
+lastUpdatedBy | string/object | Name/record of the last user who modified the record. |  |
 createdDate: | string | Date/time a record was created. |  |
-createdBy: | string | Username of the user who created the record. |  |
+createdBy: | string/object | Name/record of the user who created the record. |  |
 id: | string | HTML id attribute assigned to accordion's root. |  |
 contentId: | string | HTML id attribute assigned to accordion's content |  |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
`MetaSection` can now take an Okapi user object as well as a string for the `createdBy` and `updatedBy` props. This object contains the `personal` object from which it will construct the name itself, and the user's `id` with which it will construct a `Link` to that record if the logged-in user has the appropriate permissions.