### PR TITLE
Fix paths for ModalFooter story CSS

### DIFF
--- a/lib/ModalFooter/examples/ModalFooterExample.js
+++ b/lib/ModalFooter/examples/ModalFooterExample.js
@@ -4,9 +4,9 @@
 
 /* eslint-disable */
 import React from 'react';
-import ModalFooter from '@folio/stripes-components/lib/ModalFooter';
-import Button from '@folio/stripes-components/lib/Button';
-import Modal from '@folio/stripes-components/lib/Modal';
+import ModalFooter from '../ModalFooter';
+import Button from '../../Button';
+import Modal from '../../Modal';
 
 export default () => {
   const footer = (


### PR DESCRIPTION
## Purpose
Live reload wasn't working for the CSS on the `ModalFooter` story. It's because there was an un-relative path that resolved to the `@folio/stripes-components` found in `node_modules`.

## Approach
Stick to relative paths in Storybook stories.
