### PR TITLE
STCOM-284 Remove structures deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change history for stripes-components
 
-## 3.0.0 (IN PROGRESS)
+## 4.0.0 (IN PROGRESS)
+
+## [3.0.0](https://github.com/folio-org/stripes-components/tree/v3.0.0)
 
 * In `<Datepicker>`, added a new `ignoreLocalOffset` prop that ignores the tenant timezone and treats the date as UTC to display the date. Fixes UIORG-55
 * Adjust address read only view. Fixes STCOM-152.
@@ -80,6 +82,7 @@
 * Upgrade to webpack 4. Refs STCOR-175. Available from v2.1.6.
 * Correct PropTypes in `<MetaSection>`. Available from v2.1.7.
 * expose inner `<Paneset>`'s width as prop on `<EntrySelector>`. Fixes STCOM-309
+* Remove `structures` directory. [STCOM-284](https://issues.folio.org/browse/STCOM-284)
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/lib/structures/AddressFieldGroup/AddressEdit/AddressEditList.js
+++ b/lib/structures/AddressFieldGroup/AddressEdit/AddressEditList.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import AddressEditList from '../../../AddressFieldGroup/AddressEdit/AddressEditList';
-
-export default function (props) {
-  console.warn('Warning: Update path to stripes-components/lib/AddressFieldGroup/AddressEdit/AddressEditList.');
-  return (
-    <AddressEditList {...props} />
-  );
-}

--- a/lib/structures/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
+++ b/lib/structures/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import EmbeddedAddressForm from '../../../AddressFieldGroup/AddressEdit/EmbeddedAddressForm';
-
-export default function (props) {
-  console.warn('Warning: Update path to stripes-components/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm.');
-  return (
-    <EmbeddedAddressForm {...props} />
-  );
-}

--- a/lib/structures/AddressFieldGroup/AddressEdit/index.js
+++ b/lib/structures/AddressFieldGroup/AddressEdit/index.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import AddressEdit from '../../../AddressFieldGroup/AddressEdit';
-
-export default function (props) {
-  console.warn('Warning: Update path to stripes-components/lib/AddressFieldGroup/AddressEdit.');
-  return (
-    <AddressEdit {...props} />
-  );
-}

--- a/lib/structures/AddressFieldGroup/AddressList/index.js
+++ b/lib/structures/AddressFieldGroup/AddressList/index.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import AddressList from '../../../AddressFieldGroup/AddressList';
-
-export default function (props) {
-  console.warn('Warning: Update path to stripes-components/lib/AddressFieldGroup/AddressList.');
-  return (
-    <AddressList {...props} />
-  );
-}

--- a/lib/structures/AddressFieldGroup/AddressView/index.js
+++ b/lib/structures/AddressFieldGroup/AddressView/index.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import AddressView from '../../../AddressFieldGroup/AddressView';
-
-export default function (props) {
-  console.warn('Warning: Update path to stripes-components/lib/AddressFieldGroup/AddressView.');
-  return (
-    <AddressView {...props} />
-  );
-}

--- a/lib/structures/ConfirmationModal/index.js
+++ b/lib/structures/ConfirmationModal/index.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import ConfirmationModal from '../../ConfirmationModal';
-
-export default function (props) {
-  console.warn('Warning: ConfirmationModal has moved. Update path to stripes-components/lib/ConfirmationModal.');
-  return (
-    <ConfirmationModal {...props} />
-  );
-}

--- a/lib/structures/EditableList/index.js
+++ b/lib/structures/EditableList/index.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import EditableList from '../../EditableList';
-
-export default function (props) {
-  console.warn('Warning: EditableList has moved. Update path to stripes-components/lib/EditableList.');
-  return (
-    <EditableList {...props} />
-  );
-}

--- a/lib/structures/EmptyMessage/index.js
+++ b/lib/structures/EmptyMessage/index.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import EmptyMessage from '../../EmptyMessage';
-
-export default function (props) {
-  console.warn('Warning: EmptyMessage. Update path to stripes-components/lib/EmptyMessage.');
-  return (
-    <EmptyMessage {...props} />
-  );
-}

--- a/lib/structures/InfoPopover/index.js
+++ b/lib/structures/InfoPopover/index.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import InfoPopover from '../../InfoPopover';
-
-export default function (props) {
-  console.warn('Warning: InfoPopover has moved. Update path to stripes-components/lib/InfoPopover.');
-  return (
-    <InfoPopover {...props} />
-  );
-}

--- a/lib/structures/RepeatableField/index.js
+++ b/lib/structures/RepeatableField/index.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import RepeatableField from '../../RepeatableField';
-
-export default function (props) {
-  console.warn('Warning: RepeatableField has moved. Update path to stripes-components/lib/RepeatableField.');
-  return (
-    <RepeatableField {...props} />
-  );
-}

--- a/lib/structures/SearchField/index.js
+++ b/lib/structures/SearchField/index.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import SearchField from '../../SearchField';
-
-export default function (props) {
-  console.warn('Warning: SearchField has moved. Update path to stripes-components/lib/SearchField.');
-  return (
-    <SearchField {...props} />
-  );
-}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.1.8",
+  "version": "3.0.0",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
No `folio-org` repos are pointing to components previously found in `lib/structures` anymore.

Resolves https://issues.folio.org/browse/STCOM-284.

Major version bump to 3.0.0. I'll create corresponding tag too on merging.