### PR TITLE
upgrade to webpack 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 * Modify makeQueryFunction to support param namespacing. Fixes STCOM-300.
 * Turn on `pointer-events: auto` for `<Modal>`. Fixes UICHKOUT-437.
 * Add link to user record in `<MetaSection>`. Fixes STCOM-305.
+* Upgrade to webpack 4. Refs STCOR-175. Available from v2.1.6.
 
 ## [2.0.0](https://github.com/folio-org/stripes-components/tree/v2.0.0) (2017-12-07)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v1.9.0...v2.0.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",
@@ -65,7 +65,7 @@
     "storybook-readme": "^3.2.0",
     "stylelint": "^8.2.0",
     "stylelint-config-standard": "^17.0.0",
-    "webpack": "^3.4.1"
+    "webpack": "^4.10.2"
   },
   "dependencies": {
     "@folio/stripes-connect": "^3.1.3",


### PR DESCRIPTION
This will bring stripes-components in sync with corresponding updates in
[stripes-core](/folio-org/stripes-core/pull/347) and [stripes-cli](/folio-org/stripes-cli/pull/88).

Refs [STCOR-175](https://issues.folio.org/browse/STCOR-175)