### PR TITLE
Add tests to Datepicker components

### DIFF
--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -102,7 +102,7 @@ class Calendar extends React.Component {
       date: inputDate,
       month,
       year,
-      calendar: getCalendar(year, month),
+      calendar: getCalendar(year, month)
     };
 
     this.handleDayClick = this.handleDayClick.bind(this);
@@ -121,7 +121,7 @@ class Calendar extends React.Component {
     // When the selected date has changed, update the state with it
     let stateUpdate;
     if (nextProps.selectedDate !== prevState.selectedDate) {
-      const moDate = moment(nextProps.selectedDate, prevState.dateFormat, true);
+      const moDate = moment(nextProps.selectedDate, nextProps.dateFormat, true);
       if (moDate.isValid()) {
         if (moDate !== prevState.date) {
           // const moDate = moment(nextProps.selectedDate);
@@ -440,7 +440,7 @@ class Calendar extends React.Component {
                 </td>
                 <td colSpan="3">
                   <span className={css.selectedMonth} data-test-calendar-header>
-                    {moment().month(this.state.month).format('MMMM')} {this.state.year}
+                    {this.state.cursorDate.format('MMMM YYYY')}
                   </span>
                 </td>
                 <td>

--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -54,11 +54,7 @@ function getCalendar(year, month) {
 const propTypes = {
   buttonFocus: PropTypes.func,
   dateFormat: PropTypes.string,
-  excludeDates: PropTypes.oneOfType([
-    PropTypes.array,
-    PropTypes.object,
-    PropTypes.string,
-  ]),
+  excluded: PropTypes.func,
   id: PropTypes.string,
   intl: intlShape.isRequired,
   locale: PropTypes.string,
@@ -72,6 +68,7 @@ const defaultProps = {
   dateFormat: 'MM DD YYYY',
   locale: 'en',
   onSetDate: () => null,
+  excluded: () => false
 };
 
 class Calendar extends React.Component {
@@ -111,7 +108,6 @@ class Calendar extends React.Component {
     this.previousMonth = this.previousMonth.bind(this);
     this.nextYear = this.nextYear.bind(this);
     this.previousYear = this.previousYear.bind(this);
-    this.checkExcluded = this.checkExcluded.bind(this);
     this.isDateSelected = this.isDateSelected.bind(this);
     this.updateCursorDate = this.updateCursorDate.bind(this);
     this.getDOMContainer = this.getDOMContainer.bind(this);
@@ -263,42 +259,6 @@ class Calendar extends React.Component {
     this.props.onSetDate(e, day, day.format(this.props.dateFormat));
   }
 
-  checkExcluded(date) {
-    let excluded = false;
-    if (!this.props.excludeDates) {
-      return false;
-    }
-
-    const ex = this.props.excludeDates;
-    switch (typeof (ex)) {
-      case 'string':
-        if (date.isSame(moment(ex), 'day')) {
-          return true;
-        }
-        break;
-      case 'object':
-        if (moment.isMoment(ex)) {
-          if (date.isSame(ex, 'day')) {
-            return true;
-          }
-        } else { // excluded is an array...
-          ex.forEach((exd) => {
-            if (moment.isMoment(exd)) {
-              if (date.isSame(exd, 'day')) {
-                excluded = true;
-              }
-            } else if (date.isSame(moment(exd), 'day')) {
-              excluded = true;
-            }
-          });
-        }
-        break;
-      default:
-        return false;
-    }
-    return excluded;
-  }
-
   isDateSelected(day) {
     if (this.props.selectedDate) {
       return day.format(this.props.dateFormat) ===
@@ -330,7 +290,7 @@ class Calendar extends React.Component {
             const isToday = day.isSame(moment(), 'day');
             const isSelected = this.isDateSelected(day);
             const isCursored = day.isSame(this.state.cursorDate, 'day');
-            const isExcluded = this.checkExcluded(day);
+            const isExcluded = this.props.excluded(day);
             let dayClasses = css.dayButton;
 
             if (!isCurrentMonth) {
@@ -355,7 +315,6 @@ class Calendar extends React.Component {
             return (
               <td key={day.format('D-MM')} >
                 <DayButton
-                  data-test-calendar-day={classnames({ isMuted: !isCurrentMonth, isToday, isSelected, isCursored, isExcluded })}
                   data-test-date={titleFormattedDay}
                   onFocus={this.props.buttonFocus}
                   className={dayClasses}

--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -16,6 +16,7 @@ import DayButton from './DayButton';
 import Icon from '../Icon';
 
 import css from './Calendar.css';
+import classnames from 'classnames';
 
 const moment = extendMoment(Moment);
 
@@ -354,6 +355,7 @@ class Calendar extends React.Component {
             return (
               <td key={day.format('D-MM')} >
                 <DayButton
+                  data-test-calendar-day={classnames({ isMuted: !isCurrentMonth, isToday, isSelected, isCursored, isExcluded })}
                   onFocus={this.props.buttonFocus}
                   className={dayClasses}
                   title={intl.formatMessage(

--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -402,6 +402,7 @@ class Calendar extends React.Component {
               <tr>
                 <td>
                   <button
+                    data-test-calendar-previous-year
                     id={`datepicker-previous-year-button-${id}`}
                     className={css.nav}
                     type="button"
@@ -418,6 +419,7 @@ class Calendar extends React.Component {
                 </td>
                 <td>
                   <button
+                    data-test-calendar-previous-month
                     id={`datepicker-previous-month-button-${id}`}
                     href="#"
                     className={css.nav}
@@ -434,12 +436,13 @@ class Calendar extends React.Component {
                   </button>
                 </td>
                 <td colSpan="3">
-                  <span className={css.selectedMonth}>
+                  <span className={css.selectedMonth} data-test-calendar-header>
                     {moment().month(this.state.month).format('MMMM')} {this.state.year}
                   </span>
                 </td>
                 <td>
                   <button
+                    data-test-calendar-next-month
                     href="#"
                     id={`datepicker-next-month-button-${id}`}
                     className={css.nav}
@@ -457,6 +460,7 @@ class Calendar extends React.Component {
                 </td>
                 <td>
                   <button
+                    data-test-calendar-next-year
                     href="#"
                     id={`datepicker-next-year-button-${id}`}
                     className={css.nav}

--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -54,7 +54,7 @@ function getCalendar(year, month) {
 const propTypes = {
   buttonFocus: PropTypes.func,
   dateFormat: PropTypes.string,
-  excluded: PropTypes.func,
+  exclude: PropTypes.func,
   id: PropTypes.string,
   intl: intlShape.isRequired,
   locale: PropTypes.string,
@@ -68,7 +68,7 @@ const defaultProps = {
   dateFormat: 'MM DD YYYY',
   locale: 'en',
   onSetDate: () => null,
-  excluded: () => false
+  exclude: () => false
 };
 
 class Calendar extends React.Component {
@@ -290,7 +290,7 @@ class Calendar extends React.Component {
             const isToday = day.isSame(moment(), 'day');
             const isSelected = this.isDateSelected(day);
             const isCursored = day.isSame(this.state.cursorDate, 'day');
-            const isExcluded = this.props.excluded(day);
+            const isExcluded = this.props.exclude(day);
             let dayClasses = css.dayButton;
 
             if (!isCurrentMonth) {

--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -356,6 +356,7 @@ class Calendar extends React.Component {
               <td key={day.format('D-MM')} >
                 <DayButton
                   data-test-calendar-day={classnames({ isMuted: !isCurrentMonth, isToday, isSelected, isCursored, isExcluded })}
+                  data-test-date={titleFormattedDay}
                   onFocus={this.props.buttonFocus}
                   className={dayClasses}
                   title={intl.formatMessage(

--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -20,6 +20,8 @@ import classnames from 'classnames';
 
 const moment = extendMoment(Moment);
 
+const noop = () => {};
+
 function getCalendar(year, month) {
   const startDate = moment([year, month]);
   const firstDay = moment(startDate).startOf('month');
@@ -273,6 +275,15 @@ class Calendar extends React.Component {
     return false;
   }
 
+  keyDownOnExcluded = e => {
+    // when keydown is pressed on excluded event
+    // we only want to prevent selection (ie enter key press)
+    // all other keypresses should contrinue to allow navigation
+    if (e.keyCode !== 13) {
+      this.props.onKeyDown(e);
+    }
+  }
+
   render() {
     const { id, intl } = this.props;
 
@@ -324,8 +335,9 @@ class Calendar extends React.Component {
                   )}
                   onDayClick={this.handleDayClick}
                   day={day}
-                  onKeyDown={this.props.onKeyDown}
+                  onKeyDown={isExcluded ? this.keyDownOnExcluded : this.props.onKeyDown}
                   onBlur={this.props.onBlur}
+                  disabled={isExcluded}
                   id={`datepicker-choose-date-button-${day.format('D')}-${id}`}
                 >
                   {day.format('D')}

--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -16,11 +16,8 @@ import DayButton from './DayButton';
 import Icon from '../Icon';
 
 import css from './Calendar.css';
-import classnames from 'classnames';
 
 const moment = extendMoment(Moment);
-
-const noop = () => {};
 
 function getCalendar(year, month) {
   const startDate = moment([year, month]);

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -22,11 +22,7 @@ const propTypes = {
   date: PropTypes.object,
   dateFormat: PropTypes.string,
   disabled: PropTypes.bool,
-  excludeDates: PropTypes.oneOfType([
-    PropTypes.array,
-    PropTypes.object,
-    PropTypes.string,
-  ]),
+  exclude: PropTypes.func,
   hideOnChoose: PropTypes.bool,
   id: PropTypes.string,
   ignoreLocalOffset: PropTypes.bool,
@@ -449,7 +445,7 @@ class Datepicker extends React.Component {
     if (/2822/.test(backendDateStandard)) {
       return parsed.format(DATE_RFC2822);
     }
-    
+
     return parsed.format(this.props.backendDateStandard);
   }
 
@@ -466,7 +462,7 @@ class Datepicker extends React.Component {
       screenReaderMessage,
       label, id, readOnly,
       required,
-      excludeDates,
+      exclude,
       disabled,
       autoFocus,
       tether,
@@ -590,7 +586,7 @@ class Datepicker extends React.Component {
               onKeyDown={this.handleKeyDown}
               onBlur={this.hideCalendar}
               locale={this.locale}
-              excludeDates={excludeDates}
+              exclude={exclude}
               onNavigation={this.handleDateNavigation}
               id={this.testId}
             />

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { intlShape } from 'react-intl';
 import PropTypes from 'prop-types';
+import { deprecated } from 'prop-types-extra';
 import TetherComponent from 'react-tether';
 import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
 import moment from 'moment-timezone';
@@ -8,7 +9,6 @@ import contains from 'dom-helpers/query/contains';
 import debounce from 'lodash/debounce';
 import uniqueId from 'lodash/uniqueId';
 import { withStripes } from '@folio/stripes-core/src/StripesContext';
-import deprecated from 'deprecated-prop-type';
 
 import injectIntl from '../InjectIntl';
 import Button from '../Button';
@@ -28,7 +28,7 @@ const propTypes = {
     PropTypes.array,
     PropTypes.object,
     PropTypes.string,
-  ]), 'Use `exclude` property instead.'),
+  ]), 'Use `exclude` property instead'),
   hideOnChoose: PropTypes.bool,
   id: PropTypes.string,
   ignoreLocalOffset: PropTypes.bool,
@@ -75,6 +75,16 @@ const defaultProps = {
     ],
   },
   useFocus: true,
+};
+
+const isSameDay = (a, b) => {
+  if (moment.isMoment(a) && moment.isMoment(b)) {
+    return a.isSame(b, 'day');
+  }
+  if (moment.isMoment(a) && typeof b === 'string') {
+    return a.isSame(moment(b), 'day');
+  }
+  return false;
 };
 
 class Datepicker extends React.Component {
@@ -399,6 +409,22 @@ class Datepicker extends React.Component {
     }
   }
 
+  deprecatedExcludeDates = date => {
+    const { excludeDates } = this.props;
+
+    if (Array.isArray(excludeDates)) {
+      return excludeDates.reduce((shouldExclude, excluded) => {
+        if (shouldExclude) {
+          return true;
+        } else {
+          return isSameDay(date, excluded);
+        }
+      }, false);
+    }
+
+    return isSameDay(date, excludeDates);
+  }
+
   cleanForScreenReader(str) {
     return str.replace(/Y/g, 'Y ');
   }
@@ -456,7 +482,7 @@ class Datepicker extends React.Component {
   }
 
   renderCalendar() {
-    const { exclude } = this.props;
+    const { excludeDates, exclude } = this.props;
 
     return (
       <RootCloseWrapper onRootClose={this.handleRootClose} >
@@ -468,7 +494,7 @@ class Datepicker extends React.Component {
           onKeyDown={this.handleKeyDown}
           onBlur={this.hideCalendar}
           locale={this.locale}
-          exclude={exclude}
+          exclude={excludeDates ? this.deprecatedExcludeDates : exclude}
           id={this.testId}
         />
       </RootCloseWrapper>

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -8,6 +8,7 @@ import contains from 'dom-helpers/query/contains';
 import debounce from 'lodash/debounce';
 import uniqueId from 'lodash/uniqueId';
 import { withStripes } from '@folio/stripes-core/src/StripesContext';
+import deprecated from 'deprecated-prop-type';
 
 import injectIntl from '../InjectIntl';
 import Button from '../Button';
@@ -23,6 +24,11 @@ const propTypes = {
   dateFormat: PropTypes.string,
   disabled: PropTypes.bool,
   exclude: PropTypes.func,
+  excludeDates: deprecated(PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string,
+  ]), 'Use `exclude` property instead.'),
   hideOnChoose: PropTypes.bool,
   id: PropTypes.string,
   ignoreLocalOffset: PropTypes.bool,
@@ -567,7 +573,7 @@ class Datepicker extends React.Component {
 
   render() {
     return (
-      <TetherComponent {...defaultProps.tether} {...this.props.tether }>
+      <TetherComponent {...defaultProps.tether} {...this.props.tether}>
         <div style={{ position: 'relative', width: '100%' }} ref={(ref) => { this.container = ref; }}>
           <div
             aria-live="assertive"

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -439,18 +439,18 @@ class Datepicker extends React.Component {
 
   standardizeDate(date) {
     const DATE_RFC2822 = 'ddd, MM MMM YYYY HH:mm:ss ZZ';
-    switch (this.props.backendDateStandard) {
-      case 'ISO 8601':
-      case 'ISO8601':
-      case 'ISO-8601':
-        return moment.tz(date, this._dateFormat, true, this.timeZone).toISOString();
-      case 'RFC 2822':
-      case 'RFC2822':
-      case 'RFC-2822':
-        return moment.tz(date, this._dateFormat, true, this.timeZone).format(DATE_RFC2822);
-      default:
-        return moment.tz(date, this._dateFormat, true, this.timeZone).format(this.props.backendDateStandard);
+    const { backendDateStandard } = this.props;
+    const parsed = moment.tz(date, this._dateFormat, true, this.timeZone);
+    
+    if (/8601/.test(backendDateStandard)) {
+      return parsed.toISOString();
     }
+
+    if (/2822/.test(backendDateStandard)) {
+      return parsed.format(DATE_RFC2822);
+    }
+    
+    return parsed.format(this.props.backendDateStandard);
   }
 
   getPresentedValue() {

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -111,14 +111,15 @@ class Datepicker extends React.Component {
     }
     const parseTimeZone = props.ignoreLocalOffset ? 'UTC' : this.timeZone;
 
-    // Set locale
-    if (props.locale) {
-      this.locale = props.locale;
-    } else {
-      this.locale = props.intl.locale;
-    }
+    this.locale = props.locale || props.intl.locale;
+
     moment.locale(this.locale);
-    this._dateFormat = moment.localeData()._longDateFormat.L;
+    
+    if (this.props.dateFormat) {
+      this._dateFormat = this.props.dateFormat;
+    } else {
+      this._dateFormat = moment.localeData()._longDateFormat.L;
+    }
 
     // non-null presentedValue will eventually be rendered as the value of the TextField.
     let inputValue = '';
@@ -135,7 +136,9 @@ class Datepicker extends React.Component {
       presentedValue = this.props.passThroughValue;
       inputValue = moment.tz(parseTimeZone).format(this._dateFormat);
     } else if (this.props.input.value !== '') {
-      inputValue = moment.tz(this.props.input.value, parseTimeZone).format(this._dateFormat);
+      inputValue = moment(this.props.input.value, this._dateFormat)
+        .tz(parseTimeZone)
+        .format(this._dateFormat);
     }
 
     this.state = {

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -326,7 +326,7 @@ class Datepicker extends React.Component {
       e.preventDefault();
 
       if (this.props.onChange) { this.props.onChange(e); }
-      // this.textfield.current.getInput().focus();
+      this.textfield.current.getInput().focus();
 
       if (this.props.input) {
         if (moment(stringDate, this._dateFormat, true).isValid()) {

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -202,7 +202,7 @@ class Datepicker extends React.Component {
   }
 
   handleFieldFocus() {
-    if (this.props.useFocus) {
+    if (this.props.useFocus && !this.props.disabled) {
       this.showCalendar();
     }
   }

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -329,7 +329,9 @@ class Datepicker extends React.Component {
           const standardizedDate = this.standardizeDate(stringDate);
           // redux-form handlers take the value rather than the event...
           this.props.input.onChange(standardizedDate);
-          this.props.input.onBlur(standardizedDate);
+          if (this.props.input.onBlur) {
+            this.props.input.onBlur(standardizedDate);
+          }
         }
       }
       if (this.props.hideOnChoose) {

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -483,11 +483,11 @@ class Datepicker extends React.Component {
       );
     }
 
-    let endElement;
-    if (this.state.dateString !== '') {
-      endElement = (
-        <div style={{ display: 'flex' }}>
+    const endElement = (
+      <div style={{ display: 'flex' }}>
+        { this.state.dateString !== '' && (
           <Button
+            data-test-clear
             key="clearButton"
             buttonStyle="fieldControl"
             onClick={this.clearDate}
@@ -497,22 +497,7 @@ class Datepicker extends React.Component {
           >
             <Icon icon="clearX" />
           </Button>
-          <Button
-            key="calendarButton"
-            buttonStyle="fieldControl"
-            onClick={this.toggleCalendar}
-            onKeyDown={this.handleKeyDown}
-            aria-label={intl.formatMessage({ id: 'stripes-components.showOrHideDatepicker' })}
-            id={`datepicker-toggle-calendar-button-${id}`}
-            tabIndex="-1"
-          >
-            <Icon icon="calendar" />
-          </Button>
-        </div>
-
-      );
-    } else {
-      endElement = (
+        )}
         <Button
           key="calendarButton"
           buttonStyle="fieldControl"
@@ -524,8 +509,8 @@ class Datepicker extends React.Component {
         >
           <Icon icon="calendar" />
         </Button>
-      );
-    }
+      </div>
+    );
 
     let textfield;
     if (this.props.input && this.props.meta) {

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -372,7 +372,9 @@ class Datepicker extends React.Component {
           const standardizedDate = this.standardizeDate(e.target.value);
 
           // redux-form handlers take the value rather than the event...
-          this.props.input.onChange(standardizedDate);
+          if (this.props.input.onChange) {
+            this.props.input.onChange(standardizedDate);
+          }
         }
       }
       if (this.props.onSetDate) { this.props.onSetDate(); }
@@ -386,7 +388,7 @@ class Datepicker extends React.Component {
       const ptREx = new RegExp(`^${e.target.value}`, 'i');
       if (ptREx.test(this.props.passThroughValue)) {
         if (this.props.onChange) { this.props.onChange(e); }
-        if (this.props.input) {
+        if (this.props.input.onChange) {
           this.props.input.onChange(e.target.value);
         }
         this.setState({
@@ -404,7 +406,7 @@ class Datepicker extends React.Component {
       dateString: '',
     });
     if (this.props.onChange) { this.props.onChange(e); }
-    if (this.props.input) {
+    if (this.props.input.onChange) {
       this.props.input.onChange('');
     }
   }
@@ -450,7 +452,7 @@ class Datepicker extends React.Component {
 
   hideOnBlur = (e) => {
     if (this.datePickerIsFocused()) {
-      if (this.props.input) {
+      if (this.props.input.onBlur) {
         this.props.input.onBlur(e);
       }
       this.hideCalendar();
@@ -520,7 +522,7 @@ class Datepicker extends React.Component {
           </Button>
         )}
         <Button
-          key="calendarButton"
+          data-test-calendar-button
           buttonStyle="fieldControl"
           onClick={this.toggleCalendar}
           onKeyDown={this.handleKeyDown}

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -31,7 +31,7 @@ const propTypes = {
   ]), 'Use `exclude` property instead'),
   hideOnChoose: PropTypes.bool,
   id: PropTypes.string,
-  ignoreLocalOffset: PropTypes.bool,
+  ignoreLocalOffset: deprecated(PropTypes.bool, 'Use timeZone="UTC" instead'),
   input: PropTypes.object,
   intl: intlShape.isRequired,
   label: PropTypes.string,

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -54,7 +54,6 @@ const defaultProps = {
   screenReaderMessage: '',
   tether: {
     attachment: 'top center',
-    renderElementTo: null,
     targetAttachment: 'bottom center',
     optimizations: {
       gpu: false,
@@ -73,29 +72,17 @@ const defaultProps = {
 };
 
 class Datepicker extends React.Component {
+  static propTypes = propTypes;
+  static defaultProps = defaultProps;
+
   constructor(props) {
     super(props);
 
-    this.textfield = React.createRef();
     this.picker = null;
     this.container = null;
     this.srSpace = null;
 
-    this.handleSetDate = this.handleSetDate.bind(this);
-    this.handleFieldFocus = this.handleFieldFocus.bind(this);
-    this.handleKeyDown = this.handleKeyDown.bind(this);
-    this.clearDate = this.clearDate.bind(this);
-    this.showCalendar = this.showCalendar.bind(this);
-    this.handleFieldClick = this.handleFieldClick.bind(this);
-    this.hideCalendar = this.hideCalendar.bind(this);
     this.dbhideCalendar = debounce(this.hideCalendar, 10);
-    this.toggleCalendar = this.toggleCalendar.bind(this);
-    this.handleRootClose = this.handleRootClose.bind(this);
-    this.hideOnBlur = this.hideOnBlur.bind(this);
-    this.standardizeDate = this.standardizeDate.bind(this);
-    this.handleFieldChange = this.handleFieldChange.bind(this);
-    this.datePickerIsFocused = this.datePickerIsFocused.bind(this);
-    this.getPresentedValue = this.getPresentedValue.bind(this);
 
     // Set time zone
     if (props.timeZone) {
@@ -110,7 +97,7 @@ class Datepicker extends React.Component {
     this.locale = props.locale || props.intl.locale;
 
     moment.locale(this.locale);
-    
+
     if (this.props.dateFormat) {
       this._dateFormat = this.props.dateFormat;
     } else {
@@ -200,13 +187,15 @@ class Datepicker extends React.Component {
     return null;
   }
 
-  handleFieldFocus() {
+  textfield = React.createRef();
+
+  handleFieldFocus = () => {
     if (this.props.useFocus && !this.props.disabled) {
       this.showCalendar();
     }
   }
 
-  handleFieldClick() {
+  handleFieldClick = () => {
     if (this.props.useFocus) {
       if (!this.state.showCalendar) {
         this.showCalendar();
@@ -214,7 +203,7 @@ class Datepicker extends React.Component {
     }
   }
 
-  handleRootClose(e) {
+  handleRootClose = (e) => {
     // used by <RootCloseWrapper> to determine whether or not it should hide the picker.
     // it should determine that the element that's focused is outside of the datepicker's containing div and
     // the calendar widget (this.picker).
@@ -225,26 +214,26 @@ class Datepicker extends React.Component {
     }
   }
 
-  showCalendar() {
+  showCalendar = () => {
     this.setState({
       showCalendar: true,
     });
   }
 
-  hideCalendar() {
+  hideCalendar = () => {
     this.setState({
       showCalendar: false,
     });
   }
 
-  toggleCalendar() {
+  toggleCalendar = () => {
     const current = this.state.showCalendar;
     this.setState({
       showCalendar: !current,
     });
   }
 
-  handleKeyDown(e) {
+  handleKeyDown = (e) => {
     if (this.picker) {
       const curDate = this.picker.getCursorDate();
       const formattedDate = curDate.format(this._dateFormat);
@@ -316,19 +305,21 @@ class Datepicker extends React.Component {
     }
   }
 
-  handleSetDate(e, date, stringDate) {
+  handleSetDate = (e, date, stringDate) => {
     if (e.type === 'click' || e.type === 'keydown') {
       e.preventDefault();
 
       if (this.props.onChange) { this.props.onChange(e); }
-      this.textfield.current.getInput().focus();
+      // this.textfield.current.getInput().focus();
 
       if (this.props.input) {
         if (moment(stringDate, this._dateFormat, true).isValid()) {
           // convert date to ISO 8601 format for backend
           const standardizedDate = this.standardizeDate(stringDate);
           // redux-form handlers take the value rather than the event...
-          this.props.input.onChange(standardizedDate);
+          if (this.props.input.onChange) {
+            this.props.input.onChange(standardizedDate);
+          }
           if (this.props.input.onBlur) {
             this.props.input.onBlur(standardizedDate);
           }
@@ -372,7 +363,7 @@ class Datepicker extends React.Component {
     }
   }
 
-  handleFieldChange(e) {
+  handleFieldChange = (e) => {
     if (e.target.value === '') {
       this.clearDate();
     } else {
@@ -391,7 +382,7 @@ class Datepicker extends React.Component {
     }
   }
 
-  clearDate(e) {
+  clearDate = (e) => {
     this.setState({
       presentedValue: null,
       dateString: '',
@@ -425,7 +416,7 @@ class Datepicker extends React.Component {
     return false;
   }
 
-  hideOnBlur(e) {
+  hideOnBlur = (e) => {
     if (this.datePickerIsFocused()) {
       if (this.props.input) {
         this.props.input.onBlur(e);
@@ -439,7 +430,7 @@ class Datepicker extends React.Component {
     const DATE_RFC2822 = 'ddd, MM MMM YYYY HH:mm:ss ZZ';
     const { backendDateStandard } = this.props;
     const parsed = moment.tz(date, this._dateFormat, true, this.timeZone);
-    
+
     if (/8601/.test(backendDateStandard)) {
       return parsed.toISOString();
     }
@@ -458,33 +449,30 @@ class Datepicker extends React.Component {
     return this.state.dateString;
   }
 
-  render() {
-    const {
-      input,
-      screenReaderMessage,
-      label, id, readOnly,
-      required,
-      exclude,
-      disabled,
-      autoFocus,
-      tether,
-      intl
-    } = this.props;
+  renderCalendar() {
+    const { exclude } = this.props;
 
-    const screenReaderFormat = this.cleanForScreenReader(this._dateFormat);
-    const mergedTetherProps = Object.assign({}, Datepicker.defaultProps.tether, tether);
+    return (
+      <RootCloseWrapper onRootClose={this.handleRootClose} >
+        <Calendar
+          onSetDate={this.handleSetDate}
+          selectedDate={this.state.dateString}
+          dateFormat={this._dateFormat}
+          ref={(ref) => { this.picker = ref; }}
+          onKeyDown={this.handleKeyDown}
+          onBlur={this.hideCalendar}
+          locale={this.locale}
+          exclude={exclude}
+          id={this.testId}
+        />
+      </RootCloseWrapper>
+    );
+  }
 
-    let ariaLabel;
-    if (readOnly) {
-      ariaLabel = `${label}`;
-    } else {
-      ariaLabel = intl.formatMessage(
-        { id: 'stripes-components.screenReaderLabel' },
-        { label, screenReaderFormat, screenReaderMessage }
-      );
-    }
+  renderEndElement() {
+    const { intl } = this.props;
 
-    const endElement = (
+    return (
       <div style={{ display: 'flex' }}>
         { this.state.dateString !== '' && (
           <Button
@@ -493,7 +481,7 @@ class Datepicker extends React.Component {
             buttonStyle="fieldControl"
             onClick={this.clearDate}
             aria-label={intl.formatMessage({ id: 'stripes-components.clearFieldValue' })}
-            id={`datepicker-clear-button-${id}`}
+            id={`datepicker-clear-button-${this.testId}`}
             tabIndex="-1"
           >
             <Icon icon="clearX" />
@@ -505,67 +493,81 @@ class Datepicker extends React.Component {
           onClick={this.toggleCalendar}
           onKeyDown={this.handleKeyDown}
           aria-label={intl.formatMessage({ id: 'stripes-components.showOrHideDatepicker' })}
-          id={`datepicker-toggle-calendar-button-${id}`}
+          id={`datepicker-toggle-calendar-button-${this.testId}`}
           tabIndex="-1"
         >
           <Icon icon="calendar" />
         </Button>
       </div>
     );
+  }
 
-    let textfield;
-    if (this.props.input && this.props.meta) {
-      textfield = (
-        <TextField
-          ref={this.textfield}
-          input={input}
-          value={this.getPresentedValue()}
-          label={label}
-          aria-label={ariaLabel}
-          endControl={!readOnly ? endElement : null}
-          placeholder={`${this._dateFormat}`}
-          onKeyDown={!readOnly ? this.handleKeyDown : null}
-          onClick={!readOnly ? this.handleFieldClick : null}
-          onFocus={!readOnly ? this.handleFieldFocus : null}
-          onBlur={this.hideOnBlur}
-          meta={this.props.meta}
-          onChange={this.handleFieldChange}
-          readOnly={readOnly}
-          disabled={disabled}
-          id={this.testId}
-          required={required}
-          hasClearIcon={false}
-          autoComplete="off"
-          autoFocus={autoFocus}
-        />
-      );
+  renderInput() {
+    const {
+      input,
+      screenReaderMessage,
+      label,
+      readOnly,
+      required,
+      disabled,
+      autoFocus,
+      intl
+    } = this.props;
+
+    const screenReaderFormat = this.cleanForScreenReader(this._dateFormat);
+
+    let ariaLabel;
+    if (readOnly) {
+      ariaLabel = `${label}`;
     } else {
-      textfield = (
-        <TextField
-          ref={this.textfield}
-          label={label}
-          value={this.getPresentedValue()}
-          onChange={this.handleSetDate}
-          aria-label={ariaLabel}
-          endControl={!readOnly ? endElement : null}
-          placeholder={`${this._dateFormat}`}
-          onKeyDown={!readOnly ? this.handleKeyDown : null}
-          onBlur={this.hideOnBlur}
-          onClick={!readOnly ? this.handleFieldClick : null}
-          onFocus={!readOnly ? this.handleFieldFocus : null}
-          readOnly={readOnly}
-          disabled={disabled}
-          id={this.testId}
-          required={required}
-          hasClearIcon={false}
-          autoComplete="off"
-          autoFocus={autoFocus}
-        />
+      ariaLabel = intl.formatMessage(
+        { id: 'stripes-components.screenReaderLabel' },
+        { label, screenReaderFormat, screenReaderMessage }
       );
     }
 
+    let textfieldProps = {
+      label,
+      readOnly,
+      disabled,
+      required,
+      autoFocus,
+      'id': this.testId,
+      'ref': this.textfield,
+      'onChange': this.handleSetDate,
+      'value': this.getPresentedValue(),
+      'aria-label': ariaLabel,
+      'placeholder': `${this._dateFormat}`,
+      'onBlur': this.hideOnBlur,
+      'hasClearIcon': false,
+      'autoComplete': 'off',
+    };
+
+    if (!readOnly) {
+      textfieldProps = {
+        ...textfieldProps,
+        endControl: this.renderEndElement(),
+        onKeyDown: this.handleKeyDown,
+        onClick: this.handleFieldClick,
+        onFocus: this.handleFieldFocus
+      };
+    }
+
+    if (this.props.input && this.props.meta) {
+      textfieldProps = {
+        ...textfieldProps,
+        meta: this.props.meta,
+        input,
+        onChange: this.handleFieldChange
+      };
+    }
+
+    return <TextField {...textfieldProps} />;
+  }
+
+  render() {
     return (
-      <TetherComponent {...mergedTetherProps}>
+      <TetherComponent {...defaultProps.tether} {...this.props.tether }>
         <div style={{ position: 'relative', width: '100%' }} ref={(ref) => { this.container = ref; }}>
           <div
             aria-live="assertive"
@@ -575,31 +577,12 @@ class Datepicker extends React.Component {
           >
             <div>{this.state.srMessage}</div>
           </div>
-          {textfield}
+          {this.renderInput()}
         </div>
-
-        {this.state.showCalendar &&
-          <RootCloseWrapper onRootClose={this.handleRootClose} >
-            <Calendar
-              onSetDate={this.handleSetDate}
-              selectedDate={this.state.dateString}
-              dateFormat={this._dateFormat}
-              ref={(ref) => { this.picker = ref; }}
-              onKeyDown={this.handleKeyDown}
-              onBlur={this.hideCalendar}
-              locale={this.locale}
-              exclude={exclude}
-              onNavigation={this.handleDateNavigation}
-              id={this.testId}
-            />
-          </RootCloseWrapper>
-        }
+        {this.state.showCalendar && this.renderCalendar()}
       </TetherComponent>
     );
   }
 }
-
-Datepicker.propTypes = propTypes;
-Datepicker.defaultProps = defaultProps;
 
 export default withStripes(injectIntl(Datepicker));

--- a/lib/Datepicker/DayButton.js
+++ b/lib/Datepicker/DayButton.js
@@ -22,7 +22,6 @@ const DayButton = (props) => {
 
   return (
     <button
-      data-test-calendar-day
       onClick={handleClick}
       tabIndex="-1"
       type="button"

--- a/lib/Datepicker/DayButton.js
+++ b/lib/Datepicker/DayButton.js
@@ -22,6 +22,7 @@ const DayButton = (props) => {
 
   return (
     <button
+      data-test-calendar-day
       onClick={handleClick}
       tabIndex="-1"
       type="button"

--- a/lib/Datepicker/tests/Datepicker-Redux-test.js
+++ b/lib/Datepicker/tests/Datepicker-Redux-test.js
@@ -3,6 +3,7 @@ import propTypes from 'prop-types';
 import { describe, beforeEach, afterEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 import mock from 'jest-mock';
+import moment from 'moment';
 
 import { mountWithContext } from '../../../tests/helpers';
 
@@ -43,12 +44,32 @@ describe('Datepicker with Redux Form integration', () => {
     });
   });
 
+  describe('clear button', () => {
+    let onChange;
+    beforeEach(async () => {
+      onChange = mock.fn();
+      await mountWithContext(
+        <Datepicker input={{
+            onChange,
+            value: '04/01/2018'
+          }}
+        />
+      );
+
+      await datepicker.clearButton.click();
+    });
+    it('makes input value empty', () => {
+      expect(datepicker.inputValue).to.equal('');
+    });
+    it('called onChange with empty value', () => {
+      expect(onChange.mock.calls[0][0]).to.equal('');
+    });
+  });
+
   describe('Calendar', () => {
     beforeEach(async () => {
       await mountWithContext(
-        <div>
-          <Datepicker input={{ value: '04/01/2018' }} />
-        </div>
+        <Datepicker input={{ value: '04/01/2018' }} />
       );
 
       await datepicker.focusInput();
@@ -368,35 +389,66 @@ describe('Datepicker with Redux Form integration', () => {
   describe('excludeDates prop', () => {
     let error;
 
-    beforeEach(async () => {
-      error = console.error;
-      console.error = mock.fn();
-
-      await mountWithContext(
-        <Datepicker
-          input={{ value: '04/05/2018' }}
-          excludeDates="04/01/2018"
-        />
-      );
-
-      await datepicker.clickInput();
+    describe('string value', () => {
+      beforeEach(async () => {
+        error = console.error;
+        console.error = mock.fn();
+  
+        await mountWithContext(
+          <Datepicker
+            input={{ value: '04/05/2018' }}
+            excludeDates="04/01/2018"
+          />
+        );
+  
+        await datepicker.clickInput();
+      });
+  
+      afterEach(() => { console.error = error; });
+  
+      it('logs a deprecation warning', () => {
+        expect(console.error.mock.calls.length).to.equal(1);
+        expect(console.error.mock.calls[0][0]).to.have.string('The prop `excludeDates` of `Datepicker` is deprecated.');
+      });
+  
+      it('excludes the passed in date', () => {
+        expect(datepicker.calendar.excludedDates).to.deep.equal(
+          ['04/01/2018']
+        );
+      });
+  
+      it('makes excluded days disabled', () => {
+        expect(datepicker.calendar.days(0).disabled).to.be.true;
+      });
     });
 
-    afterEach(() => { console.error = error; });
+    describe('multiple dates', () => {
+      beforeEach(async () => {
+        error = console.error;
+        console.error = mock.fn();
 
-    it('logs a deprecation warning', () => {
-      expect(console.error.mock.calls.length).to.equal(1);
-      expect(console.error.mock.calls[0][0]).to.have.string('The prop `excludeDates` of `Datepicker` is deprecated.');
-    });
+        await mountWithContext(
+          <Datepicker
+            input={{ value: '04/05/2018' }}
+            excludeDates={['04/01/2018', moment('04/03/2018', 'MM/DD/YYYY')]}
+          />
+        );
 
-    it('excludes the passed in date', () => {
-      expect(datepicker.calendar.excludedDates).to.deep.equal(
-        ['04/01/2018']
-      );
-    });
+        await datepicker.clickInput();
+      });
 
-    it('makes excluded days disabled', () => {
-      expect(datepicker.calendar.days(0).disabled).to.be.true;
+      afterEach(() => { console.error = error; });
+
+      it('excludes multipe dates', () => {
+        expect(datepicker.calendar.excludedDates).to.deep.equal(
+          ['04/01/2018', '04/03/2018']
+        );
+      });
+
+      it('makes excluded days disabled', () => {
+        expect(datepicker.calendar.days(0).disabled).to.be.true;
+        expect(datepicker.calendar.days(2).disabled).to.be.true;
+      });
     });
   });
 

--- a/lib/Datepicker/tests/Datepicker-Redux-test.js
+++ b/lib/Datepicker/tests/Datepicker-Redux-test.js
@@ -254,6 +254,31 @@ describe('Datepicker with Redux Form integration', () => {
     });
   });
 
+  describe('input selection position', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <div>
+          <Datepicker input={{ value: '04/03/2018' }} />
+        </div>
+      );
+
+      await datepicker.clickInput();
+
+      // await datepicker.inputSelectionRange(10);
+    });
+
+    it('selection start is at the end of the input text', () => {
+      expect(datepicker.inputSelectionStart).to.equal(10);
+    });
+
+    // describe('navigating with keyboard in the calendar', () => {
+    //   beforeEach(async () => datepicker.calendar.cursor.pressLeft());
+    //   it('does not change the position of the cursor', () => {
+    //     expect(datepicker.inputSelectionStart).to.equal(10);
+    //   });
+    // });
+  });
+
   describe('dateFormat prop', () => {
     beforeEach(async () => {
       await mountWithContext(
@@ -382,7 +407,6 @@ describe('Datepicker with Redux Form integration', () => {
     });
 
     describe('multiple dates', () => {
-
       beforeEach(async () => {
         await mountWithContext(
           <Datepicker

--- a/lib/Datepicker/tests/Datepicker-Redux-test.js
+++ b/lib/Datepicker/tests/Datepicker-Redux-test.js
@@ -8,7 +8,7 @@ import { mountWithContext } from '../../../tests/helpers';
 import Datepicker from '../Datepicker';
 import DatepickerInteractor from './interactor';
 
-describe.only('Datepicker with Redux Form integration', () => {
+describe('Datepicker with Redux Form integration', () => {
   const datepicker = new DatepickerInteractor();
 
   describe('disabled prop', () => {
@@ -21,11 +21,11 @@ describe.only('Datepicker with Redux Form integration', () => {
 
       await mountWithContext(
         <Datepicker
+          disabled
           input={{
-          value: '04/01/2018',
-          disabled: true,
-          onChange,
-          onBlur
+            value: '04/01/2018',
+            onChange,
+            onBlur
           }}
         />
       );
@@ -35,16 +35,8 @@ describe.only('Datepicker with Redux Form integration', () => {
       expect(datepicker.inputValue).to.be.equal('04/01/2018');
     });
 
-    describe('changing input value', () => {
-      beforeEach(() => datepicker.fillAndBlur('04/03/2018'));
-
-      it('did not call onChange', () => {
-        expect(onChange.mock.calls.length).to.be.equal(0);
-      });
-
-      it('did not call onBlur', () => {
-        expect(onBlur.mock.calls.length).to.be.equal(0);
-      });
+    it('has disabled input', () => {
+      expect(datepicker.disabled).to.be.true;
     });
 
     describe('choosing a date from calendar', () => {

--- a/lib/Datepicker/tests/Datepicker-Redux-test.js
+++ b/lib/Datepicker/tests/Datepicker-Redux-test.js
@@ -23,16 +23,15 @@ describe('Datepicker with Redux Form integration', () => {
   const datepicker = new DatepickerInteractor();
 
   describe('onChange', () => {
-    let dateOutput;
+    let onChange;
 
     beforeEach(async () => {
-      dateOutput = '';
+      onChange = mock.fn();
 
       await mountWithContext(
         <Datepicker
-          input={{
-            onChange: (value) => { dateOutput = value; },
-          }}
+          input={{ onChange }}
+          meta={{}}
         />
       );
 
@@ -40,7 +39,17 @@ describe('Datepicker with Redux Form integration', () => {
     });
 
     it('returns an ISO 8601 datetime string at UTC', () => {
-      expect(dateOutput).to.equal('2018-04-01T00:00:00.000Z');
+      expect(onChange.mock.calls[0][0]).to.equal('2018-04-01T00:00:00.000Z');
+    });
+
+    describe('clearing the input', () => {
+      beforeEach(async () => datepicker.fillInput(''));
+      it('called onChange', () => {
+        expect(onChange.mock.calls.length).to.equal(2);
+      });
+      it('sends empty value to onChange', () => {
+        expect(onChange.mock.calls[1][0]).to.equal('');
+      });
     });
   });
 
@@ -49,10 +58,12 @@ describe('Datepicker with Redux Form integration', () => {
     beforeEach(async () => {
       onChange = mock.fn();
       await mountWithContext(
-        <Datepicker input={{
+        <Datepicker
+          input={{
             onChange,
             value: '04/01/2018'
           }}
+          meta={{}}
         />
       );
 
@@ -273,6 +284,14 @@ describe('Datepicker with Redux Form integration', () => {
         expect(datepicker.calendar.cursor.date).to.equal('04/01/2019');
       });
     });
+
+    describe('press escape to close', () => {
+      beforeEach(async () => datepicker.calendar.cursor.pressEscape());
+
+      it('closes the calendar', () => {
+        expect(datepicker.calendar.isPresent).to.be.false;
+      });
+    });
   });
 
   describe('dateFormat prop', () => {
@@ -393,30 +412,30 @@ describe('Datepicker with Redux Form integration', () => {
       beforeEach(async () => {
         error = console.error;
         console.error = mock.fn();
-  
+
         await mountWithContext(
           <Datepicker
             input={{ value: '04/05/2018' }}
             excludeDates="04/01/2018"
           />
         );
-  
+
         await datepicker.clickInput();
       });
-  
+
       afterEach(() => { console.error = error; });
-  
+
       it('logs a deprecation warning', () => {
         expect(console.error.mock.calls.length).to.equal(1);
         expect(console.error.mock.calls[0][0]).to.have.string('The prop `excludeDates` of `Datepicker` is deprecated.');
       });
-  
+
       it('excludes the passed in date', () => {
         expect(datepicker.calendar.excludedDates).to.deep.equal(
           ['04/01/2018']
         );
       });
-  
+
       it('makes excluded days disabled', () => {
         expect(datepicker.calendar.days(0).disabled).to.be.true;
       });

--- a/lib/Datepicker/tests/Datepicker-Redux-test.js
+++ b/lib/Datepicker/tests/Datepicker-Redux-test.js
@@ -1,46 +1,17 @@
 import React from 'react';
 import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
+import mock from 'jest-mock';
 
 import { mountWithContext } from '../../../tests/helpers';
 
 import Datepicker from '../Datepicker';
 import DatepickerInteractor from './interactor';
 
-/*
- * Commonly used props:
- *  - [] backendDateStandard
- *  - [] timeZone
- *  - [] dateFormat
- *  - [] intl
- *  - [] locale
- *  - [] excludeDates
- *
- * HTML Attributes
- *  - [] value
- *  - [x] disabled
- *  - [x] label
- *  - [x] id
- *  - [x] required
- *  - [x] onChange
- *  - [] readOnly
- *
- * Redux Integration
- *  - input
- *    - [x] value
- *    - [x] onChange
- *  - meta
- *
- * Possible Deprecation
- *  - [?] passThroughValue - when value matches specified value, just pass the value through
- *  - stripes
- *  - [] ignoreLocalOffset
- */
-
 describe('Datepicker with Redux Form integration', () => {
   const datepicker = new DatepickerInteractor();
 
-  describe('selecting a date', () => {
+  describe('onChange', () => {
     let dateOutput;
 
     beforeEach(async () => {
@@ -294,24 +265,6 @@ describe('Datepicker with Redux Form integration', () => {
       it('changed cursor to April 1, 2019', () => {
         expect(datepicker.calendar.cursor.date).to.equal('04/01/2019');
       });
-    });
-  });
-
-  describe('onChange', () => {
-    let dateOutput;
-
-    beforeEach(async () => {
-      dateOutput = '';
-
-      await mountWithContext(
-        <Datepicker input={{ onChange: date => { dateOutput = date; } }} />
-      );
-
-      await datepicker.fillInput('04/01/2018');
-    });
-
-    it('emits an event with the date formatted as displayed', () => {
-      expect(dateOutput).to.equal('2018-04-01T00:00:00.000Z');
     });
   });
 

--- a/lib/Datepicker/tests/Datepicker-Redux-test.js
+++ b/lib/Datepicker/tests/Datepicker-Redux-test.js
@@ -382,7 +382,7 @@ describe('Datepicker with Redux Form integration', () => {
 
       await datepicker.clickInput();
     });
-    
+
     afterEach(() => { console.error = error; });
 
     it('logs a deprecation warning', () => {

--- a/lib/Datepicker/tests/Datepicker-Redux-test.js
+++ b/lib/Datepicker/tests/Datepicker-Redux-test.js
@@ -410,8 +410,6 @@ describe('Datepicker with Redux Form integration', () => {
       await mountWithContext(
         <Datepicker ignoreLocalOffset />
       );
-
-      await datepicker.clickInput();
     });
 
     afterEach(() => { console.error = error; });

--- a/lib/Datepicker/tests/Datepicker-Redux-test.js
+++ b/lib/Datepicker/tests/Datepicker-Redux-test.js
@@ -264,8 +264,7 @@ describe('Datepicker with Redux Form integration', () => {
             dateFormat="YYYY-DD-MM"
             input={{
                 value,
-                onChange: date => update({ value: date }),
-                onBlur: () => {}
+                onChange: date => update({ value: date })
               }}
           />)}
         </State>
@@ -398,6 +397,28 @@ describe('Datepicker with Redux Form integration', () => {
 
     it('makes excluded days disabled', () => {
       expect(datepicker.calendar.days(0).disabled).to.be.true;
+    });
+  });
+
+  describe('ignoreLocalOffset deprecation', () => {
+    let error;
+
+    beforeEach(async () => {
+      error = console.error;
+      console.error = mock.fn();
+
+      await mountWithContext(
+        <Datepicker ignoreLocalOffset />
+      );
+
+      await datepicker.clickInput();
+    });
+
+    afterEach(() => { console.error = error; });
+
+    it('logs warning when used', () => {
+      expect(console.error.mock.calls.length).to.equal(1);
+      expect(console.error.mock.calls[0][0]).to.have.string('The prop `ignoreLocalOffset` of `Datepicker` is deprecated.');
     });
   });
 

--- a/lib/Datepicker/tests/Datepicker-Redux-test.js
+++ b/lib/Datepicker/tests/Datepicker-Redux-test.js
@@ -273,7 +273,7 @@ describe('Datepicker with Redux Form integration', () => {
       );
     });
 
-    it('changes the placeholder to specified format', () => {
+    it('placeholder is YYYY-DD-MM', () => {
       expect(datepicker.placeholder).to.equal('YYYY-DD-MM');
     });
 
@@ -314,6 +314,56 @@ describe('Datepicker with Redux Form integration', () => {
 
     it('returns an ISO 8601 datetime string for specific time zone', () => {
       expect(dateOutput).to.equal('2018-04-01T07:00:00.000Z');
+    });
+  });
+
+  describe('backendDateStandard prop', () => {
+    describe('RFC2822', () => {
+      let onChange;
+  
+      beforeEach(async () => {
+        onChange = mock.fn();
+  
+        await mountWithContext(
+          <Datepicker
+            backendDateStandard="RFC2822"
+            input={{
+              onChange
+            }}
+            timeZone="America/Los_Angeles"
+          />
+        );
+  
+        await datepicker.fillInput('04/01/2018');
+      });
+  
+      it('returns an RFC2822 datetime string for specific time zone', () => {
+        expect(onChange.mock.calls[0][0]).to.equal('Sun, 04 Apr 2018 00:00:00 -0700');
+      });
+    });
+
+    describe('arbitrary format', () => {
+      let onChange;
+  
+      beforeEach(async () => {
+        onChange = mock.fn();
+  
+        await mountWithContext(
+          <Datepicker
+            backendDateStandard="YYYY"
+            input={{
+              onChange
+            }}
+            timeZone="America/Los_Angeles"
+          />
+        );
+  
+        await datepicker.fillInput('04/01/2018');
+      });
+  
+      it('returns an RFC2822 datetime string for specific time zone', () => {
+        expect(onChange.mock.calls[0][0]).to.equal('2018');
+      });
     });
   });
 });

--- a/lib/Datepicker/tests/Datepicker-Redux-test.js
+++ b/lib/Datepicker/tests/Datepicker-Redux-test.js
@@ -254,31 +254,6 @@ describe('Datepicker with Redux Form integration', () => {
     });
   });
 
-  describe('input selection position', () => {
-    beforeEach(async () => {
-      await mountWithContext(
-        <div>
-          <Datepicker input={{ value: '04/03/2018' }} />
-        </div>
-      );
-
-      await datepicker.clickInput();
-
-      // await datepicker.inputSelectionRange(10);
-    });
-
-    it('selection start is at the end of the input text', () => {
-      expect(datepicker.inputSelectionStart).to.equal(10);
-    });
-
-    // describe('navigating with keyboard in the calendar', () => {
-    //   beforeEach(async () => datepicker.calendar.cursor.pressLeft());
-    //   it('does not change the position of the cursor', () => {
-    //     expect(datepicker.inputSelectionStart).to.equal(10);
-    //   });
-    // });
-  });
-
   describe('dateFormat prop', () => {
     beforeEach(async () => {
       await mountWithContext(

--- a/lib/Datepicker/tests/Datepicker-Redux-test.js
+++ b/lib/Datepicker/tests/Datepicker-Redux-test.js
@@ -255,7 +255,6 @@ describe('Datepicker with Redux Form integration', () => {
   });
 
   describe('dateFormat prop', () => {
-
     beforeEach(async () => {
       await mountWithContext(
         <State
@@ -320,10 +319,10 @@ describe('Datepicker with Redux Form integration', () => {
   describe('backendDateStandard prop', () => {
     describe('RFC2822', () => {
       let onChange;
-  
+
       beforeEach(async () => {
         onChange = mock.fn();
-  
+
         await mountWithContext(
           <Datepicker
             backendDateStandard="RFC2822"
@@ -333,10 +332,10 @@ describe('Datepicker with Redux Form integration', () => {
             timeZone="America/Los_Angeles"
           />
         );
-  
+
         await datepicker.fillInput('04/01/2018');
       });
-  
+
       it('returns an RFC2822 datetime string for specific time zone', () => {
         expect(onChange.mock.calls[0][0]).to.equal('Sun, 04 Apr 2018 00:00:00 -0700');
       });
@@ -344,10 +343,10 @@ describe('Datepicker with Redux Form integration', () => {
 
     describe('arbitrary format', () => {
       let onChange;
-  
+
       beforeEach(async () => {
         onChange = mock.fn();
-  
+
         await mountWithContext(
           <Datepicker
             backendDateStandard="YYYY"
@@ -357,12 +356,53 @@ describe('Datepicker with Redux Form integration', () => {
             timeZone="America/Los_Angeles"
           />
         );
-  
+
         await datepicker.fillInput('04/01/2018');
       });
-  
+
       it('returns an RFC2822 datetime string for specific time zone', () => {
         expect(onChange.mock.calls[0][0]).to.equal('2018');
+      });
+    });
+  });
+
+  describe('exclude prop', () => {
+    describe('by default no day is excluded', () => {
+      beforeEach(async () => {
+        await mountWithContext(
+          <Datepicker input={{ value: '04/01/2018' }} />
+        );
+
+        await datepicker.clickInput();
+      });
+
+      it('has no excluded days', () => {
+        expect(datepicker.calendar.excludedDates).to.deep.equal([]);
+      });
+    });
+
+    describe('multiple dates', () => {
+      let exclude;
+
+      beforeEach(async () => {
+        exclude = mock.fn(date => {
+          return ['04/01/2018', '04/03/2018'].includes(date.format('MM/DD/YYYY'));
+        });
+
+        await mountWithContext(
+          <Datepicker
+            input={{ value: '04/01/2018' }}
+            exclude={exclude}
+          />
+        );
+
+        await datepicker.clickInput();
+      });
+
+      it('excludes multipe dates', () => {
+        expect(datepicker.calendar.excludedDates).to.deep.equal(
+          ['04/01/2018', '04/03/2018']
+        );
       });
     });
   });

--- a/lib/Datepicker/tests/Datepicker-Redux-test.js
+++ b/lib/Datepicker/tests/Datepicker-Redux-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import propTypes from 'prop-types';
 import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 import mock from 'jest-mock';
@@ -7,6 +8,15 @@ import { mountWithContext } from '../../../tests/helpers';
 
 import Datepicker from '../Datepicker';
 import DatepickerInteractor from './interactor';
+
+const { assign } = Object;
+
+class State extends React.PureComponent {
+  static propTypes = { children: propTypes.func }
+  state = this.props;
+  update = state => this.setState(assign({}, this.state, state));
+  render = () => this.props.children(this.state, this.update);
+}
 
 describe('Datepicker with Redux Form integration', () => {
   const datepicker = new DatepickerInteractor();
@@ -32,30 +42,6 @@ describe('Datepicker with Redux Form integration', () => {
       expect(dateOutput).to.equal('2018-04-01T00:00:00.000Z');
     });
   });
-
-  describe('selecting a date with timeZone prop', () => {
-    let dateOutput;
-
-    beforeEach(async () => {
-      dateOutput = '';
-
-      await mountWithContext(
-        <Datepicker
-          input={{
-            onChange: (value) => { dateOutput = value; },
-          }}
-          timeZone="America/Los_Angeles"
-        />
-      );
-
-      await datepicker.fillInput('04/01/2018');
-    });
-
-    it('returns an ISO 8601 datetime string for specific time zone', () => {
-      expect(dateOutput).to.equal('2018-04-01T07:00:00.000Z');
-    });
-  });
-
 
   describe('Calendar', () => {
     beforeEach(async () => {
@@ -268,10 +254,66 @@ describe('Datepicker with Redux Form integration', () => {
     });
   });
 
-  describe.skip('clear button', () => {
-    beforeEach(async () => mountWithContext(<Datepicker />));
-    it('does not show clear button', () => {
-      expect(datepicker.clearButton.isVisible).to.be.false;
+  describe('dateFormat prop', () => {
+
+    beforeEach(async () => {
+      await mountWithContext(
+        <State
+          value="2018-18-04"
+        >
+          {({ value }, update) => (<Datepicker
+            dateFormat="YYYY-DD-MM"
+            input={{
+                value,
+                onChange: date => update({ value: date }),
+                onBlur: () => {}
+              }}
+          />)}
+        </State>
+      );
+    });
+
+    it('changes the placeholder to specified format', () => {
+      expect(datepicker.placeholder).to.equal('YYYY-DD-MM');
+    });
+
+    describe('day selected in calendar', () => {
+      beforeEach(async () => datepicker.clickInput());
+
+      it('has April 18 2018 selected', () => {
+        expect(datepicker.calendar.selected.date).to.equal('2018-18-04');
+      });
+    });
+
+    describe('fill in a new date', () => {
+      beforeEach(async () => datepicker.clickInput().fillInput('2016-10-02'));
+
+      it('has February 10, 2016 selected', () => {
+        expect(datepicker.calendar.selected.date).to.equal('2016-10-02');
+      });
+    });
+  });
+
+  describe('selecting a date with timeZone prop', () => {
+    let dateOutput;
+
+    beforeEach(async () => {
+      dateOutput = '';
+
+      await mountWithContext(
+        <Datepicker
+          input={{
+            onChange: (value) => { dateOutput = value; },
+          }}
+          timeZone="America/Los_Angeles"
+        />
+      );
+
+      await datepicker.fillInput('04/01/2018');
+    });
+
+    it('returns an ISO 8601 datetime string for specific time zone', () => {
+      expect(dateOutput).to.equal('2018-04-01T07:00:00.000Z');
     });
   });
 });

--- a/lib/Datepicker/tests/Datepicker-Redux-test.js
+++ b/lib/Datepicker/tests/Datepicker-Redux-test.js
@@ -382,17 +382,12 @@ describe('Datepicker with Redux Form integration', () => {
     });
 
     describe('multiple dates', () => {
-      let exclude;
 
       beforeEach(async () => {
-        exclude = mock.fn(date => {
-          return ['04/01/2018', '04/03/2018'].includes(date.format('MM/DD/YYYY'));
-        });
-
         await mountWithContext(
           <Datepicker
-            input={{ value: '04/01/2018' }}
-            exclude={exclude}
+            input={{ value: '04/05/2018' }}
+            exclude={date => ['04/01/2018', '04/03/2018'].includes(date.format('MM/DD/YYYY'))}
           />
         );
 
@@ -403,6 +398,50 @@ describe('Datepicker with Redux Form integration', () => {
         expect(datepicker.calendar.excludedDates).to.deep.equal(
           ['04/01/2018', '04/03/2018']
         );
+      });
+
+      it('makes excluded days disabled', () => {
+        expect(datepicker.calendar.days(0).disabled).to.be.true;
+        expect(datepicker.calendar.days(2).disabled).to.be.true;
+      });
+    });
+
+    describe('selecting excluded date', () => {
+      let onChange;
+
+
+      beforeEach(async () => {
+        onChange = mock.fn();
+
+        await mountWithContext(
+          <Datepicker
+            input={{ value: '04/03/2018', onChange }}
+            exclude={date => date.format('MM/DD/YYYY') === '04/03/2018'}
+          />
+        );
+
+        await datepicker.clickInput();
+      });
+
+      describe('click to select', () => {
+        beforeEach(async () => datepicker.calendar.days(2).click());
+        it('did not call onChange', () => {
+          expect(onChange.mock.calls.length).to.equal(0);
+        });
+      });
+
+      describe('pressing enter', () => {
+        beforeEach(async () => datepicker.calendar.days(2).pressEnter());
+        it('did not call onChange', () => {
+          expect(onChange.mock.calls.length).to.equal(0);
+        });
+      });
+
+      describe('navigation on exluded date', () => {
+        beforeEach(async () => datepicker.calendar.cursor.pressLeft());
+        it('changed cursor to April 2, 2018', () => {
+          expect(datepicker.calendar.cursor.date).to.equal('04/02/2018');
+        });
       });
     });
   });

--- a/lib/Datepicker/tests/Datepicker-Redux-test.js
+++ b/lib/Datepicker/tests/Datepicker-Redux-test.js
@@ -1,0 +1,343 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+import jest from 'jest-mock';
+
+import { mountWithContext } from '../../../tests/helpers';
+
+import Datepicker from '../Datepicker';
+import DatepickerInteractor from './interactor';
+
+describe.only('Datepicker with Redux Form integration', () => {
+  const datepicker = new DatepickerInteractor();
+
+  describe('disabled prop', () => {
+    let onChange;
+    let onBlur;
+
+    beforeEach(async () => {
+      onChange = jest.fn();
+      onBlur = jest.fn();
+
+      await mountWithContext(
+        <Datepicker
+          input={{
+          value: '04/01/2018',
+          disabled: true,
+          onChange,
+          onBlur
+          }}
+        />
+      );
+    });
+
+    it('shows value in the input field', () => {
+      expect(datepicker.inputValue).to.be.equal('04/01/2018');
+    });
+
+    describe('changing input value', () => {
+      beforeEach(() => datepicker.fillAndBlur('04/03/2018'));
+
+      it('did not call onChange', () => {
+        expect(onChange.mock.calls.length).to.be.equal(0);
+      });
+
+      it('did not call onBlur', () => {
+        expect(onBlur.mock.calls.length).to.be.equal(0);
+      });
+    });
+
+    describe('choosing a date from calendar', () => {
+      beforeEach(async () => datepicker.clickInput().focusInput());
+      it('did not open the calendar', () => {
+        expect(datepicker.calendar.isPresent).to.be.false;
+      });
+
+      it('did not call onChange', () => {
+        expect(onChange.mock.calls.length).to.be.equal(0);
+      });
+
+      it('did not call onBlur', () => {
+        expect(onBlur.mock.calls.length).to.be.equal(0);
+      });
+    });
+  });
+
+  describe('selecting a date', () => {
+    let dateOutput;
+
+    beforeEach(async () => {
+      dateOutput = '';
+
+      await mountWithContext(
+        <Datepicker
+          input={{
+            onChange: (value) => { dateOutput = value; },
+          }}
+        />
+      );
+
+      await datepicker.fillInput('04/01/2018');
+    });
+
+    it('returns an ISO 8601 datetime string at UTC', () => {
+      expect(dateOutput).to.equal('2018-04-01T00:00:00.000Z');
+    });
+  });
+
+  describe('selecting a date with timeZone prop', () => {
+    let dateOutput;
+
+    beforeEach(async () => {
+      dateOutput = '';
+
+      await mountWithContext(
+        <Datepicker
+          input={{
+            onChange: (value) => { dateOutput = value; },
+          }}
+          timeZone="America/Los_Angeles"
+        />
+      );
+
+      await datepicker.fillInput('04/01/2018');
+    });
+
+    it('returns an ISO 8601 datetime string for specific time zone', () => {
+      expect(dateOutput).to.equal('2018-04-01T07:00:00.000Z');
+    });
+  });
+
+
+  describe('Calendar', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <div>
+          <Datepicker input={{ value: '04/01/2018' }} />
+        </div>
+      );
+
+      await datepicker.focusInput();
+    });
+
+    it('has April 2018 in calendar header', () => {
+      expect(datepicker.calendar.header).to.equal('April 2018');
+    });
+
+    it('shows days from April 2018', () => {
+      expect(datepicker.calendar.text).to.deep.equal([
+        '1', '2', '3', '4', '5', '6', '7',
+        '8', '9', '10', '11', '12', '13', '14',
+        '15', '16', '17', '18', '19', '20', '21',
+        '22', '23', '24', '25', '26', '27', '28',
+        '29', '30', '_1_', '_2_', '_3_', '_4_', '_5_'
+      ]);
+    });
+
+    it('has April 1st as selected', () => {
+      expect(datepicker.calendar.selected.text).to.equal('1');
+    });
+
+    describe('going to previous month', () => {
+      beforeEach(async () => datepicker.calendar.previousMonth());
+
+      it('changed calendar header to March 2018', () => {
+        expect(datepicker.calendar.header).to.equal('March 2018');
+      });
+
+      it('shows days from March 2018', () => {
+        expect(datepicker.calendar.text).to.deep.equal([
+          '_25_', '_26_', '_27_', '_28_', '1', '2', '3',
+          '4', '5', '6', '7', '8', '9', '10',
+          '11', '12', '13', '14', '15', '16', '17',
+          '18', '19', '20', '21', '22', '23', '24',
+          '25', '26', '27', '28', '29', '30', '31'
+        ]);
+      });
+
+      it('does not have a selected day', () => {
+        expect(datepicker.calendar.selected).to.be.undefined;
+      });
+    });
+
+    describe('going to next month', () => {
+      beforeEach(async () => datepicker.calendar.nextMonth());
+
+      it('changed calendar header to May 2018', () => {
+        expect(datepicker.calendar.header).to.equal('May 2018');
+      });
+
+      it('shows days from May 2018', () => {
+        expect(datepicker.calendar.text).to.deep.equal([
+          '_29_', '_30_', '1', '2', '3', '4', '5',
+          '6', '7', '8', '9', '10', '11', '12',
+          '13', '14', '15', '16', '17', '18', '19',
+          '20', '21', '22', '23', '24', '25', '26',
+          '27', '28', '29', '30', '31', '_1_', '_2_'
+        ]);
+      });
+
+      it('does not have a selected day', () => {
+        expect(datepicker.calendar.selected).to.be.undefined;
+      });
+    });
+
+    describe('going to previous year', () => {
+      beforeEach(async () => datepicker.calendar.previousYear());
+
+      it('changed calendar header to April 2017', () => {
+        expect(datepicker.calendar.header).to.equal('April 2017');
+      });
+
+      it('shows days from April 2017', () => {
+        expect(datepicker.calendar.text).to.deep.equal([
+          '_26_', '_27_', '_28_', '_29_', '_30_', '_31_', '1',
+          '2', '3', '4', '5', '6', '7', '8',
+          '9', '10', '11', '12', '13', '14', '15',
+          '16', '17', '18', '19', '20', '21', '22',
+          '23', '24', '25', '26', '27', '28', '29',
+          '30', '_1_', '_2_', '_3_', '_4_', '_5_', '_6_'
+        ]);
+      });
+
+      it('does not have a selected day', () => {
+        expect(datepicker.calendar.selected).to.be.undefined;
+      });
+    });
+
+    describe('going to next year', () => {
+      beforeEach(async () => datepicker.calendar.nextYear());
+
+      it('changed calendar header to April 2019', () => {
+        expect(datepicker.calendar.header).to.equal('April 2019');
+      });
+
+      it('shows days from April 2019', () => {
+        expect(datepicker.calendar.text).to.deep.equal([
+          '_31_', '1', '2', '3', '4', '5', '6',
+          '7', '8', '9', '10', '11', '12', '13',
+          '14', '15', '16', '17', '18', '19', '20',
+          '21', '22', '23', '24', '25', '26', '27',
+          '28', '29', '30', '_1_', '_2_', '_3_', '_4_'
+        ]);
+      });
+
+      it('does not have a selected day', () => {
+        expect(datepicker.calendar.selected).to.be.undefined;
+      });
+    });
+
+    it('has cursor on April 1, 2018', () => {
+      expect(datepicker.calendar.cursor.date).to.equal('04/01/2018');
+    });
+
+    describe('press up', () => {
+      beforeEach(async () => datepicker.calendar.cursor.pressUp());
+
+      it('takes user to previous month', () => {
+        expect(datepicker.calendar.header).to.equal('March 2018');
+      });
+
+      it('changed cursor to March 25, 2018', () => {
+        expect(datepicker.calendar.cursor.date).to.equal('03/25/2018');
+      });
+    });
+
+    describe('press down', () => {
+      beforeEach(async () => datepicker.calendar.cursor.pressDown());
+
+      it('changed cursor to April 8, 2018', () => {
+        expect(datepicker.calendar.cursor.date).to.equal('04/08/2018');
+      });
+    });
+
+    describe('press left', () => {
+      beforeEach(async () => datepicker.calendar.cursor.pressLeft());
+
+      it('takes user to previous month', () => {
+        expect(datepicker.calendar.header).to.equal('March 2018');
+      });
+
+      it('changed cursor to March 31, 2018', () => {
+        expect(datepicker.calendar.cursor.date).to.equal('03/31/2018');
+      });
+    });
+
+    describe('press right', () => {
+      beforeEach(async () => datepicker.calendar.cursor.pressRight());
+
+      it('changed cursor to April 2, 2018', () => {
+        expect(datepicker.calendar.cursor.date).to.equal('04/02/2018');
+      });
+    });
+
+    describe('press page up', () => {
+      beforeEach(async () => datepicker.calendar.cursor.pressPageUp());
+
+      it('takes user to previous month', () => {
+        expect(datepicker.calendar.header).to.equal('March 2018');
+      });
+
+      it('changed cursor to March 1, 2018', () => {
+        expect(datepicker.calendar.cursor.date).to.equal('03/01/2018');
+      });
+    });
+
+    describe('press page down', () => {
+      beforeEach(async () => datepicker.calendar.cursor.pressPageDown());
+
+      it('takes user to next month', () => {
+        expect(datepicker.calendar.header).to.equal('May 2018');
+      });
+
+      it('changed cursor to May 1, 2018', () => {
+        expect(datepicker.calendar.cursor.date).to.equal('05/01/2018');
+      });
+    });
+
+    describe('press alt + page up', () => {
+      beforeEach(async () => datepicker.calendar.cursor.altPageUp());
+
+      it('takes user to previous year', () => {
+        expect(datepicker.calendar.header).to.equal('April 2017');
+      });
+
+      it('changed cursor to April 1, 2017', () => {
+        expect(datepicker.calendar.cursor.date).to.equal('04/01/2017');
+      });
+    });
+
+    describe('press alt + page down', () => {
+      beforeEach(async () => datepicker.calendar.cursor.altPageDown());
+
+      it('takes user to next year', () => {
+        expect(datepicker.calendar.header).to.equal('April 2019');
+      });
+
+      it('changed cursor to April 1, 2019', () => {
+        expect(datepicker.calendar.cursor.date).to.equal('04/01/2019');
+      });
+    });
+  });
+
+  describe.skip('clear button', () => {
+    beforeEach(async () => mountWithContext(<Datepicker />));
+    it('does not show clear button', () => {
+      expect(datepicker.clearButton.isVisible).to.be.false;
+    });
+  });
+
+  describe('required', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <Datepicker input={{ required: true, onBlur: () => {}, onChange: () => {} }} />
+      );
+
+      await datepicker.clickInput().fillAndBlur();
+    });
+
+    it('shows that fields is required', () => {
+      
+    });
+  });
+});

--- a/lib/Datepicker/tests/Datepicker-Redux-test.js
+++ b/lib/Datepicker/tests/Datepicker-Redux-test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
-import jest from 'jest-mock';
 
 import { mountWithContext } from '../../../tests/helpers';
 
@@ -18,16 +17,18 @@ import DatepickerInteractor from './interactor';
  *  - [] excludeDates
  *
  * HTML Attributes
+ *  - [] value
  *  - [x] disabled
  *  - [x] label
  *  - [x] id
- *  - [] onChange
+ *  - [x] required
+ *  - [x] onChange
  *  - [] readOnly
- *  - [] required
  *
  * Redux Integration
  *  - input
  *    - [x] value
+ *    - [x] onChange
  *  - meta
  *
  * Possible Deprecation
@@ -296,22 +297,28 @@ describe('Datepicker with Redux Form integration', () => {
     });
   });
 
+  describe('onChange', () => {
+    let dateOutput;
+
+    beforeEach(async () => {
+      dateOutput = '';
+
+      await mountWithContext(
+        <Datepicker input={{ onChange: date => { dateOutput = date; } }} />
+      );
+
+      await datepicker.fillInput('04/01/2018');
+    });
+
+    it('emits an event with the date formatted as displayed', () => {
+      expect(dateOutput).to.equal('2018-04-01T00:00:00.000Z');
+    });
+  });
+
   describe.skip('clear button', () => {
     beforeEach(async () => mountWithContext(<Datepicker />));
     it('does not show clear button', () => {
       expect(datepicker.clearButton.isVisible).to.be.false;
-    });
-  });
-
-  describe('required', () => {
-    beforeEach(async () => {
-      await mountWithContext(
-        <Datepicker label="Pick a date" required />
-      );
-    });
-
-    it('adds required attribute to input field', () => {
-      expect(datepicker.required).to.be.true;
     });
   });
 });

--- a/lib/Datepicker/tests/Datepicker-Redux-test.js
+++ b/lib/Datepicker/tests/Datepicker-Redux-test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import { describe, beforeEach, it } from '@bigtest/mocha';
+import { describe, beforeEach, afterEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 import mock from 'jest-mock';
 
@@ -363,6 +363,41 @@ describe('Datepicker with Redux Form integration', () => {
       it('returns an RFC2822 datetime string for specific time zone', () => {
         expect(onChange.mock.calls[0][0]).to.equal('2018');
       });
+    });
+  });
+
+  describe('excludeDates prop', () => {
+    let error;
+
+    beforeEach(async () => {
+      error = console.error;
+      console.error = mock.fn();
+
+      await mountWithContext(
+        <Datepicker
+          input={{ value: '04/05/2018' }}
+          excludeDates="04/01/2018"
+        />
+      );
+
+      await datepicker.clickInput();
+    });
+    
+    afterEach(() => { console.error = error; });
+
+    it('logs a deprecation warning', () => {
+      expect(console.error.mock.calls.length).to.equal(1);
+      expect(console.error.mock.calls[0][0]).to.have.string('The prop `excludeDates` of `Datepicker` is deprecated.');
+    });
+
+    it('excludes the passed in date', () => {
+      expect(datepicker.calendar.excludedDates).to.deep.equal(
+        ['04/01/2018']
+      );
+    });
+
+    it('makes excluded days disabled', () => {
+      expect(datepicker.calendar.days(0).disabled).to.be.true;
     });
   });
 

--- a/lib/Datepicker/tests/Datepicker-Redux-test.js
+++ b/lib/Datepicker/tests/Datepicker-Redux-test.js
@@ -8,52 +8,36 @@ import { mountWithContext } from '../../../tests/helpers';
 import Datepicker from '../Datepicker';
 import DatepickerInteractor from './interactor';
 
+/*
+ * Commonly used props:
+ *  - [] backendDateStandard
+ *  - [] timeZone
+ *  - [] dateFormat
+ *  - [] intl
+ *  - [] locale
+ *  - [] excludeDates
+ *
+ * HTML Attributes
+ *  - [x] disabled
+ *  - [x] label
+ *  - [x] id
+ *  - [] onChange
+ *  - [] readOnly
+ *  - [] required
+ *
+ * Redux Integration
+ *  - input
+ *    - [x] value
+ *  - meta
+ *
+ * Possible Deprecation
+ *  - [?] passThroughValue - when value matches specified value, just pass the value through
+ *  - stripes
+ *  - [] ignoreLocalOffset
+ */
+
 describe('Datepicker with Redux Form integration', () => {
   const datepicker = new DatepickerInteractor();
-
-  describe('disabled prop', () => {
-    let onChange;
-    let onBlur;
-
-    beforeEach(async () => {
-      onChange = jest.fn();
-      onBlur = jest.fn();
-
-      await mountWithContext(
-        <Datepicker
-          disabled
-          input={{
-            value: '04/01/2018',
-            onChange,
-            onBlur
-          }}
-        />
-      );
-    });
-
-    it('shows value in the input field', () => {
-      expect(datepicker.inputValue).to.be.equal('04/01/2018');
-    });
-
-    it('has disabled input', () => {
-      expect(datepicker.disabled).to.be.true;
-    });
-
-    describe('choosing a date from calendar', () => {
-      beforeEach(async () => datepicker.clickInput().focusInput());
-      it('did not open the calendar', () => {
-        expect(datepicker.calendar.isPresent).to.be.false;
-      });
-
-      it('did not call onChange', () => {
-        expect(onChange.mock.calls.length).to.be.equal(0);
-      });
-
-      it('did not call onBlur', () => {
-        expect(onBlur.mock.calls.length).to.be.equal(0);
-      });
-    });
-  });
 
   describe('selecting a date', () => {
     let dateOutput;
@@ -322,14 +306,12 @@ describe('Datepicker with Redux Form integration', () => {
   describe('required', () => {
     beforeEach(async () => {
       await mountWithContext(
-        <Datepicker input={{ required: true, onBlur: () => {}, onChange: () => {} }} />
+        <Datepicker label="Pick a date" required />
       );
-
-      await datepicker.clickInput().fillAndBlur();
     });
 
-    it('shows that fields is required', () => {
-      
+    it('adds * to the label', () => {
+      expect(datepicker.labelText).to.equal('Pick a date*');
     });
   });
 });

--- a/lib/Datepicker/tests/Datepicker-Redux-test.js
+++ b/lib/Datepicker/tests/Datepicker-Redux-test.js
@@ -310,8 +310,8 @@ describe('Datepicker with Redux Form integration', () => {
       );
     });
 
-    it('adds * to the label', () => {
-      expect(datepicker.labelText).to.equal('Pick a date*');
+    it('adds required attribute to input field', () => {
+      expect(datepicker.required).to.be.true;
     });
   });
 });

--- a/lib/Datepicker/tests/Datepicker-Redux-test.js
+++ b/lib/Datepicker/tests/Datepicker-Redux-test.js
@@ -4,6 +4,8 @@ import { describe, beforeEach, afterEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 import mock from 'jest-mock';
 import moment from 'moment';
+import { Field } from 'redux-form';
+import TestForm from '../../../tests/TestForm';
 
 import { mountWithContext } from '../../../tests/helpers';
 
@@ -29,17 +31,20 @@ describe('Datepicker with Redux Form integration', () => {
       onChange = mock.fn();
 
       await mountWithContext(
-        <Datepicker
-          input={{ onChange }}
-          meta={{}}
-        />
+        <TestForm>
+          <Field
+            name="calendar"
+            component={Datepicker}
+            onChange={onChange}
+          />
+        </TestForm>
       );
 
       await datepicker.fillInput('04/01/2018');
     });
 
     it('returns an ISO 8601 datetime string at UTC', () => {
-      expect(onChange.mock.calls[0][0]).to.equal('2018-04-01T00:00:00.000Z');
+      expect(onChange.mock.calls[0][1]).to.equal('2018-04-01T00:00:00.000Z');
     });
 
     describe('clearing the input', () => {
@@ -48,7 +53,7 @@ describe('Datepicker with Redux Form integration', () => {
         expect(onChange.mock.calls.length).to.equal(2);
       });
       it('sends empty value to onChange', () => {
-        expect(onChange.mock.calls[1][0]).to.equal('');
+        expect(onChange.mock.calls[1][1]).to.equal('');
       });
     });
   });
@@ -58,13 +63,13 @@ describe('Datepicker with Redux Form integration', () => {
     beforeEach(async () => {
       onChange = mock.fn();
       await mountWithContext(
-        <Datepicker
-          input={{
-            onChange,
-            value: '04/01/2018'
-          }}
-          meta={{}}
-        />
+        <TestForm initialValues={{ calendar: '04/01/2018' }}>
+          <Field
+            name="calendar"
+            component={Datepicker}
+            onChange={onChange}
+          />
+        </TestForm>
       );
 
       await datepicker.clearButton.click();
@@ -73,14 +78,16 @@ describe('Datepicker with Redux Form integration', () => {
       expect(datepicker.inputValue).to.equal('');
     });
     it('called onChange with empty value', () => {
-      expect(onChange.mock.calls[0][0]).to.equal('');
+      expect(onChange.mock.calls[0][1]).to.equal('');
     });
   });
 
   describe('Calendar', () => {
     beforeEach(async () => {
       await mountWithContext(
-        <Datepicker input={{ value: '04/01/2018' }} />
+        <TestForm initialValues={{ calendar: '04/01/2018' }}>
+          <Field name="calendar" component={Datepicker} />
+        </TestForm>
       );
 
       await datepicker.focusInput();
@@ -297,17 +304,13 @@ describe('Datepicker with Redux Form integration', () => {
   describe('dateFormat prop', () => {
     beforeEach(async () => {
       await mountWithContext(
-        <State
-          value="2018-18-04"
-        >
-          {({ value }, update) => (<Datepicker
+        <TestForm initialValues={{ calendar: '2018-18-04' }}>
+          <Field
+            name="calendar"
             dateFormat="YYYY-DD-MM"
-            input={{
-                value,
-                onChange: date => update({ value: date })
-              }}
-          />)}
-        </State>
+            component={Datepicker}
+          />
+        </TestForm>
       );
     });
 
@@ -333,25 +336,28 @@ describe('Datepicker with Redux Form integration', () => {
   });
 
   describe('selecting a date with timeZone prop', () => {
-    let dateOutput;
+    let onChange;
 
     beforeEach(async () => {
-      dateOutput = '';
+      onChange = mock.fn();
 
       await mountWithContext(
-        <Datepicker
-          input={{
-            onChange: (value) => { dateOutput = value; },
-          }}
-          timeZone="America/Los_Angeles"
-        />
+        <TestForm>
+          <Field
+            name="calendar"
+            component={Datepicker}
+            onChange={onChange}
+            timeZone="America/Los_Angeles"
+
+          />
+        </TestForm>
       );
 
       await datepicker.fillInput('04/01/2018');
     });
 
     it('returns an ISO 8601 datetime string for specific time zone', () => {
-      expect(dateOutput).to.equal('2018-04-01T07:00:00.000Z');
+      expect(onChange.mock.calls[0][1]).to.equal('2018-04-01T07:00:00.000Z');
     });
   });
 
@@ -363,20 +369,23 @@ describe('Datepicker with Redux Form integration', () => {
         onChange = mock.fn();
 
         await mountWithContext(
-          <Datepicker
-            backendDateStandard="RFC2822"
-            input={{
-              onChange
-            }}
-            timeZone="America/Los_Angeles"
-          />
+          <TestForm>
+            <Field
+              name="calendar"
+              backendDateStandard="RFC2822"
+              component={Datepicker}
+              onChange={onChange}
+              timeZone="America/Los_Angeles"
+
+            />
+          </TestForm>
         );
 
         await datepicker.fillInput('04/01/2018');
       });
 
       it('returns an RFC2822 datetime string for specific time zone', () => {
-        expect(onChange.mock.calls[0][0]).to.equal('Sun, 04 Apr 2018 00:00:00 -0700');
+        expect(onChange.mock.calls[0][1]).to.equal('Sun, 04 Apr 2018 00:00:00 -0700');
       });
     });
 
@@ -387,20 +396,22 @@ describe('Datepicker with Redux Form integration', () => {
         onChange = mock.fn();
 
         await mountWithContext(
-          <Datepicker
-            backendDateStandard="YYYY"
-            input={{
-              onChange
-            }}
-            timeZone="America/Los_Angeles"
-          />
+          <TestForm>
+            <Field
+              name="calendar"
+              backendDateStandard="YYYY"
+              component={Datepicker}
+              onChange={onChange}
+              timeZone="America/Los_Angeles"
+            />
+          </TestForm>
         );
 
         await datepicker.fillInput('04/01/2018');
       });
 
       it('returns an RFC2822 datetime string for specific time zone', () => {
-        expect(onChange.mock.calls[0][0]).to.equal('2018');
+        expect(onChange.mock.calls[0][1]).to.equal('2018');
       });
     });
   });
@@ -414,10 +425,13 @@ describe('Datepicker with Redux Form integration', () => {
         console.error = mock.fn();
 
         await mountWithContext(
-          <Datepicker
-            input={{ value: '04/05/2018' }}
-            excludeDates="04/01/2018"
-          />
+          <TestForm initialValues={{ calendar: '04/05/2018' }}>
+            <Field
+              name="calendar"
+              component={Datepicker}
+              excludeDates="04/01/2018"
+            />
+          </TestForm>
         );
 
         await datepicker.clickInput();
@@ -447,10 +461,13 @@ describe('Datepicker with Redux Form integration', () => {
         console.error = mock.fn();
 
         await mountWithContext(
-          <Datepicker
-            input={{ value: '04/05/2018' }}
-            excludeDates={['04/01/2018', moment('04/03/2018', 'MM/DD/YYYY')]}
-          />
+          <TestForm initialValues={{ calendar: '04/05/2018' }}>
+            <Field
+              name="calendar"
+              component={Datepicker}
+              excludeDates={['04/01/2018', moment('04/03/2018', 'MM/DD/YYYY')]}
+            />
+          </TestForm>
         );
 
         await datepicker.clickInput();
@@ -495,7 +512,12 @@ describe('Datepicker with Redux Form integration', () => {
     describe('by default no day is excluded', () => {
       beforeEach(async () => {
         await mountWithContext(
-          <Datepicker input={{ value: '04/01/2018' }} />
+          <TestForm initialValues={{ calendar: '04/01/2018' }}>
+            <Field
+              name="calendar"
+              component={Datepicker}
+            />
+          </TestForm>
         );
 
         await datepicker.clickInput();
@@ -509,10 +531,13 @@ describe('Datepicker with Redux Form integration', () => {
     describe('multiple dates', () => {
       beforeEach(async () => {
         await mountWithContext(
-          <Datepicker
-            input={{ value: '04/05/2018' }}
-            exclude={date => ['04/01/2018', '04/03/2018'].includes(date.format('MM/DD/YYYY'))}
-          />
+          <TestForm initialValues={{ calendar: '04/05/2018' }}>
+            <Field
+              name="calendar"
+              component={Datepicker}
+              exclude={date => ['04/01/2018', '04/03/2018'].includes(date.format('MM/DD/YYYY'))}
+            />
+          </TestForm>
         );
 
         await datepicker.clickInput();
@@ -538,10 +563,14 @@ describe('Datepicker with Redux Form integration', () => {
         onChange = mock.fn();
 
         await mountWithContext(
-          <Datepicker
-            input={{ value: '04/03/2018', onChange }}
-            exclude={date => date.format('MM/DD/YYYY') === '04/03/2018'}
-          />
+          <TestForm initialValues={{ calendar: '04/03/2018' }}>
+            <Field
+              name="calendar"
+              component={Datepicker}
+              onChange={onChange}
+              exclude={date => date.format('MM/DD/YYYY') === '04/03/2018'}
+            />
+          </TestForm>
         );
 
         await datepicker.clickInput();

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -111,7 +111,7 @@ describe('Datepicker', () => {
       expect(onChange.mock.calls[0][0].value).to.equal('2018-04-01T07:00:00.000Z');
     });
   });
-  
+
   describe('selecting a date with locale prop', () => {
     let dateOutput;
 

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -328,6 +328,54 @@ describe.only('Datepicker', () => {
         });
       });
 
+      describe('press page up', () => {
+        beforeEach(async () => datepicker.calendar.cursor.pressPageUp());
+
+        it('takes user to previous month', () => {
+          expect(datepicker.calendar.header).to.equal('March 2018');
+        });
+
+        it('changed cursor to March 1, 2018', () => {
+          expect(datepicker.calendar.cursor.date).to.equal("03/01/2018");
+        });
+      });
+
+      describe('press page down', () => {
+        beforeEach(async () => datepicker.calendar.cursor.pressPageDown());
+
+        it('takes user to next month', () => {
+          expect(datepicker.calendar.header).to.equal('May 2018');
+        });
+
+        it('changed cursor to May 1, 2018', () => {
+          expect(datepicker.calendar.cursor.date).to.equal("05/01/2018");
+        });
+      });
+
+      describe('press alt + page up', () => {
+        beforeEach(async () => datepicker.calendar.cursor.altPageUp());
+
+        it('takes user to previous year', () => {
+          expect(datepicker.calendar.header).to.equal('April 2017');
+        });
+
+        it('changed cursor to April 1, 2017', () => {
+          expect(datepicker.calendar.cursor.date).to.equal("04/01/2017");
+        });
+      });
+
+      describe('press alt + page down', () => {
+        beforeEach(async () => datepicker.calendar.cursor.altPageDown());
+
+        it('takes user to next year', () => {
+          expect(datepicker.calendar.header).to.equal('April 2019');
+        });
+
+        it('changed cursor to April 1, 2019', () => {
+          expect(datepicker.calendar.cursor.date).to.equal("04/01/2019");
+        });
+      });
+
     });
 
   });

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
+import jest from 'jest-mock';
 
 import { mountWithContext } from '../../../tests/helpers';
 
@@ -16,7 +17,7 @@ import DatepickerInteractor from './interactor';
  *  - dateFormat
  *  - intl
  *  - locale
- * 
+ *
  * HTML Attributes
  *  - label
  *  - disabled
@@ -25,19 +26,19 @@ import DatepickerInteractor from './interactor';
  *  - readOnly
  *  - required
  *  - value
- * 
+ *
  * Redux Integration
  *  - input
  *  - meta
- * 
+ *
  * Possible Deprecation
  *  - stripes
  *  - passThroughValue - when value matches specified value, just pass the value through
- * 
+ *
  * Unused Configurations
  * - useFocus (set to true, so it's always active although never passed)
  * - thether (has defaults but never used)
- * - screenReaderMessage 
+ * - screenReaderMessage
  * - hideOnChoose (default true)
  * - onSetDate
  * - showCalendar
@@ -52,11 +53,11 @@ describe.only('Datepicker', () => {
         <Datepicker />
       );
     });
-  
+
     it('does not have a value in the input', () => {
       expect(datepicker.inputValue).to.equal('');
     });
-  
+
     it('has a placeholder in the input', () => {
       expect(datepicker.placeholder).to.equal('MM/DD/YYYY');
     });
@@ -134,8 +135,73 @@ describe.only('Datepicker', () => {
     });
   });
 
-  describe('the calendar picker', () => {
+  describe.skip('clear button', () => {
+    describe('without value', () => {
+      beforeEach(async () => mountWithContext(<Datepicker />));
+      it('does not show clear button', () => {
+        expect(datepicker.clearButton.isVisible).to.be.false;
+      });
+    });
+  });
 
+  describe.only('passThroughValue prop', () => {
+    let onBlur;
+    let onChange;
+
+    beforeEach(async () => {
+      onBlur = jest.fn();
+      onChange = jest.fn();
+
+      await mountWithContext(
+        <Datepicker
+          passThroughValue="yesterday"
+          input={{
+            value: 'yesterday',
+            onBlur,
+            onChange
+          }}
+        />
+      );
+    });
+
+    it('has yesterday is in input field', () => {
+      expect(datepicker.inputValue).to.equal('yesterday');
+    });
+
+    describe.skip('blur the input field', () => {
+      beforeEach(async () => datepicker.focusInput());
+
+      it('does not have any day selected', () => {
+        expect(datepicker.calendar.selected).to.be.undefined;
+      });
+    });
+
+    describe.skip('clearing and typing in yesterday', () => {
+      beforeEach(async () => {
+        await datepicker.fillAndBlur('04/01/2018');
+        await datepicker.fillAndBlur('yesterday');
+      });
+
+      it('called onBlur twice', () => {
+        expect(onBlur.mock.calls.length).to.be.equal(2);
+      });
+
+      it('sends yesterday to onBlur', () => {
+        expect(onBlur.mock.calls[1]).to.be.equal('yesterday');
+      });
+
+      it('called onChange twice', () => {
+        expect(onChange.mock.calls.length).to.be.equal(2);
+      });
+
+      it('sends yesterday to onChange', () => {
+        expect(onChange.mock.calls[1]).to.be.equal('yesterday');
+      });
+    });
+
+  });
+
+  describe('the calendar picker', () => {
     describe('without value', () => {
       beforeEach(async () => {
         await mountWithContext(
@@ -143,25 +209,27 @@ describe.only('Datepicker', () => {
             <Datepicker />
           </div>
         );
-  
-        await datepicker.focusInput();
       });
-  
-      it('opens on focus', () => {
-        expect(datepicker.calendar.isVisible).to.be.true;
+
+      it('is closed', () => {
+        expect(datepicker.calendar.isPresent).to.be.false;
       });
-  
-      it('shows days', () => {
-        expect(datepicker.calendar.days().length).to.equal(35);
-      });
-  
-      describe('shifting the focus onBlur', () => {
-        beforeEach(async () => {
-          await datepicker.fillAndBlur('04/01/2018');
+
+      describe('focus', () => {
+        beforeEach(async () => datepicker.focusInput());
+
+        it('opens on focus', () => {
+          expect(datepicker.calendar.isVisible).to.be.true;
         });
-  
-        it('closes the calendar picker', () => {
-          expect(datepicker.calendar.isPresent).to.be.false;
+
+        describe('shifting the focus onBlur', () => {
+          beforeEach(async () => {
+            await datepicker.fillAndBlur('04/01/2018');
+          });
+
+          it('closes the calendar picker', () => {
+            expect(datepicker.calendar.isPresent).to.be.false;
+          });
         });
       });
     });
@@ -173,7 +241,7 @@ describe.only('Datepicker', () => {
             <Datepicker input={{ value: '04/01/2018' }} />
           </div>
         );
-  
+
         await datepicker.focusInput();
       });
 
@@ -192,12 +260,12 @@ describe.only('Datepicker', () => {
       });
 
       it('has April 1st as selected', () => {
-        expect(datepicker.calendar.selected.text).to.equal("1");
+        expect(datepicker.calendar.selected.text).to.equal('1');
       });
 
       describe('going to previous month', () => {
         beforeEach(async () => datepicker.calendar.previousMonth());
-  
+
         it('changed calendar header to March 2018', () => {
           expect(datepicker.calendar.header).to.equal('March 2018');
         });
@@ -219,7 +287,7 @@ describe.only('Datepicker', () => {
 
       describe('going to next month', () => {
         beforeEach(async () => datepicker.calendar.nextMonth());
-  
+
         it('changed calendar header to May 2018', () => {
           expect(datepicker.calendar.header).to.equal('May 2018');
         });
@@ -229,7 +297,7 @@ describe.only('Datepicker', () => {
             '_29_', '_30_', '1', '2', '3', '4', '5',
             '6', '7', '8', '9', '10', '11', '12',
             '13', '14', '15', '16', '17', '18', '19',
-            '20', '21', '22', '23', '24', '25', '26', 
+            '20', '21', '22', '23', '24', '25', '26',
             '27', '28', '29', '30', '31', '_1_', '_2_'
           ]);
         });
@@ -241,7 +309,7 @@ describe.only('Datepicker', () => {
 
       describe('going to previous year', () => {
         beforeEach(async () => datepicker.calendar.previousYear());
-  
+
         it('changed calendar header to April 2017', () => {
           expect(datepicker.calendar.header).to.equal('April 2017');
         });
@@ -264,7 +332,7 @@ describe.only('Datepicker', () => {
 
       describe('going to next year', () => {
         beforeEach(async () => datepicker.calendar.nextYear());
-  
+
         it('changed calendar header to April 2019', () => {
           expect(datepicker.calendar.header).to.equal('April 2019');
         });
@@ -283,11 +351,11 @@ describe.only('Datepicker', () => {
           expect(datepicker.calendar.selected).to.be.undefined;
         });
       });
-      
+
       it('has cursor on April 1, 2018', () => {
-        expect(datepicker.calendar.cursor.date).to.equal("04/01/2018");
+        expect(datepicker.calendar.cursor.date).to.equal('04/01/2018');
       });
-      
+
       describe('press up', () => {
         beforeEach(async () => datepicker.calendar.cursor.pressUp());
 
@@ -296,7 +364,7 @@ describe.only('Datepicker', () => {
         });
 
         it('changed cursor to March 25, 2018', () => {
-          expect(datepicker.calendar.cursor.date).to.equal("03/25/2018");
+          expect(datepicker.calendar.cursor.date).to.equal('03/25/2018');
         });
       });
 
@@ -304,7 +372,7 @@ describe.only('Datepicker', () => {
         beforeEach(async () => datepicker.calendar.cursor.pressDown());
 
         it('changed cursor to April 8, 2018', () => {
-          expect(datepicker.calendar.cursor.date).to.equal("04/08/2018");
+          expect(datepicker.calendar.cursor.date).to.equal('04/08/2018');
         });
       });
 
@@ -316,7 +384,7 @@ describe.only('Datepicker', () => {
         });
 
         it('changed cursor to March 31, 2018', () => {
-          expect(datepicker.calendar.cursor.date).to.equal("03/31/2018");
+          expect(datepicker.calendar.cursor.date).to.equal('03/31/2018');
         });
       });
 
@@ -324,7 +392,7 @@ describe.only('Datepicker', () => {
         beforeEach(async () => datepicker.calendar.cursor.pressRight());
 
         it('changed cursor to April 2, 2018', () => {
-          expect(datepicker.calendar.cursor.date).to.equal("04/02/2018");
+          expect(datepicker.calendar.cursor.date).to.equal('04/02/2018');
         });
       });
 
@@ -336,7 +404,7 @@ describe.only('Datepicker', () => {
         });
 
         it('changed cursor to March 1, 2018', () => {
-          expect(datepicker.calendar.cursor.date).to.equal("03/01/2018");
+          expect(datepicker.calendar.cursor.date).to.equal('03/01/2018');
         });
       });
 
@@ -348,7 +416,7 @@ describe.only('Datepicker', () => {
         });
 
         it('changed cursor to May 1, 2018', () => {
-          expect(datepicker.calendar.cursor.date).to.equal("05/01/2018");
+          expect(datepicker.calendar.cursor.date).to.equal('05/01/2018');
         });
       });
 
@@ -360,7 +428,7 @@ describe.only('Datepicker', () => {
         });
 
         it('changed cursor to April 1, 2017', () => {
-          expect(datepicker.calendar.cursor.date).to.equal("04/01/2017");
+          expect(datepicker.calendar.cursor.date).to.equal('04/01/2017');
         });
       });
 
@@ -372,12 +440,10 @@ describe.only('Datepicker', () => {
         });
 
         it('changed cursor to April 1, 2019', () => {
-          expect(datepicker.calendar.cursor.date).to.equal("04/01/2019");
+          expect(datepicker.calendar.cursor.date).to.equal('04/01/2019');
         });
       });
-
     });
-
   });
 
   describe('coupled to redux form', () => {

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -10,30 +10,30 @@ import DatepickerInteractor from './interactor';
 
 /**
  * Commonly used props:
- *  - backendDateStandard
- *  - ignoreLocalOffset
- *  - required
- *  - timeZone
- *  - dateFormat
- *  - intl
- *  - locale
+ *  - [] backendDateStandard
+ *  - [] timeZone
+ *  - [] dateFormat
+ *  - [] intl
+ *  - [] locale
+ *  - [] excludeDates
  *
  * HTML Attributes
- *  - label
- *  - disabled
- *  - id
- *  - onChange
- *  - readOnly
- *  - required
- *  - value
+ *  - [?] disabled
+ *  - [] label
+ *  - [] value
+ *  - [] id
+ *  - [] onChange
+ *  - [] readOnly
+ *  - [] required
  *
  * Redux Integration
  *  - input
  *  - meta
  *
  * Possible Deprecation
+ *  - [?] passThroughValue - when value matches specified value, just pass the value through
  *  - stripes
- *  - passThroughValue - when value matches specified value, just pass the value through
+ *  - [] ignoreLocalOffset
  *
  * Unused Configurations
  * - useFocus (set to true, so it's always active although never passed)
@@ -42,9 +42,32 @@ import DatepickerInteractor from './interactor';
  * - hideOnChoose (default true)
  * - onSetDate
  * - showCalendar
+ *
+ * Tests
+ *  - require to make sure asterisc shows up
+ *  - if I input does it emit onChange event
+ *  - Click on event does it change the event
+ *  - Navigation tests
+ *  - render with id
+
+ *  - click and nothing inputted does calendar show up
+ *  - Warning & error outside of redux
+ *
+ * Things Datepicker should do according to John
+ * - uses a standard text input - value can be typed as well as picked using the calendar
+ * - picker disappears with a click outside or blur of the input
+ * - presents in localized format (based on locale to determine input and output)
+ * - custom format can be applied
+ * - excluded dates
+ * - a11y - screen reader compatibility (announces actions, selections, values)
+ * - a11y - keyboard navigation of dates
+ * - accepts colors from a stripes theme/works with stripes-components postcss workflow/css-modules
+ * - supports some version of the “passThroughValue” to keep repetitious entries to a minimum. Use-case: checkin - applying today’s date to multiple items within a check-in.  (would have to discuss alternatives with UX design staff)
+ * - validation styles/classes in-line with other stripes-components
+ * - Optional: outputs date in iso format (output value) (redux: format for input, normalize for output) (assumption is that all folio apps use full ISO, eholdings does not because of ebsco)
  */
 
-describe.only('Datepicker', () => {
+describe('Datepicker', () => {
   const datepicker = new DatepickerInteractor();
 
   describe('render', () => {
@@ -135,16 +158,7 @@ describe.only('Datepicker', () => {
     });
   });
 
-  describe.skip('clear button', () => {
-    describe('without value', () => {
-      beforeEach(async () => mountWithContext(<Datepicker />));
-      it('does not show clear button', () => {
-        expect(datepicker.clearButton.isVisible).to.be.false;
-      });
-    });
-  });
-
-  describe.only('passThroughValue prop', () => {
+  describe('passThroughValue', () => {
     let onBlur;
     let onChange;
 
@@ -198,297 +212,36 @@ describe.only('Datepicker', () => {
         expect(onChange.mock.calls[1]).to.be.equal('yesterday');
       });
     });
-
   });
 
   describe('the calendar picker', () => {
-    describe('without value', () => {
-      beforeEach(async () => {
-        await mountWithContext(
-          <div>
-            <Datepicker />
-          </div>
-        );
-      });
-
-      it('is closed', () => {
-        expect(datepicker.calendar.isPresent).to.be.false;
-      });
-
-      describe('focus', () => {
-        beforeEach(async () => datepicker.focusInput());
-
-        it('opens on focus', () => {
-          expect(datepicker.calendar.isVisible).to.be.true;
-        });
-
-        describe('shifting the focus onBlur', () => {
-          beforeEach(async () => {
-            await datepicker.fillAndBlur('04/01/2018');
-          });
-
-          it('closes the calendar picker', () => {
-            expect(datepicker.calendar.isPresent).to.be.false;
-          });
-        });
-      });
+    beforeEach(async () => {
+      await mountWithContext(
+        <div>
+          <Datepicker />
+        </div>
+      );
     });
 
-    describe('with value', () => {
-      beforeEach(async () => {
-        await mountWithContext(
-          <div>
-            <Datepicker input={{ value: '04/01/2018' }} />
-          </div>
-        );
-
-        await datepicker.focusInput();
-      });
-
-      it('has April 2018 in calendar header', () => {
-        expect(datepicker.calendar.header).to.equal('April 2018');
-      });
-
-      it('shows days from April 2018', () => {
-        expect(datepicker.calendar.text).to.deep.equal([
-          '1', '2', '3', '4', '5', '6', '7',
-          '8', '9', '10', '11', '12', '13', '14',
-          '15', '16', '17', '18', '19', '20', '21',
-          '22', '23', '24', '25', '26', '27', '28',
-          '29', '30', '_1_', '_2_', '_3_', '_4_', '_5_'
-        ]);
-      });
-
-      it('has April 1st as selected', () => {
-        expect(datepicker.calendar.selected.text).to.equal('1');
-      });
-
-      describe('going to previous month', () => {
-        beforeEach(async () => datepicker.calendar.previousMonth());
-
-        it('changed calendar header to March 2018', () => {
-          expect(datepicker.calendar.header).to.equal('March 2018');
-        });
-
-        it('shows days from March 2018', () => {
-          expect(datepicker.calendar.text).to.deep.equal([
-            '_25_', '_26_', '_27_', '_28_', '1', '2', '3',
-            '4', '5', '6', '7', '8', '9', '10',
-            '11', '12', '13', '14', '15', '16', '17',
-            '18', '19', '20', '21', '22', '23', '24',
-            '25', '26', '27', '28', '29', '30', '31'
-          ]);
-        });
-
-        it('does not have a selected day', () => {
-          expect(datepicker.calendar.selected).to.be.undefined;
-        });
-      });
-
-      describe('going to next month', () => {
-        beforeEach(async () => datepicker.calendar.nextMonth());
-
-        it('changed calendar header to May 2018', () => {
-          expect(datepicker.calendar.header).to.equal('May 2018');
-        });
-
-        it('shows days from May 2018', () => {
-          expect(datepicker.calendar.text).to.deep.equal([
-            '_29_', '_30_', '1', '2', '3', '4', '5',
-            '6', '7', '8', '9', '10', '11', '12',
-            '13', '14', '15', '16', '17', '18', '19',
-            '20', '21', '22', '23', '24', '25', '26',
-            '27', '28', '29', '30', '31', '_1_', '_2_'
-          ]);
-        });
-
-        it('does not have a selected day', () => {
-          expect(datepicker.calendar.selected).to.be.undefined;
-        });
-      });
-
-      describe('going to previous year', () => {
-        beforeEach(async () => datepicker.calendar.previousYear());
-
-        it('changed calendar header to April 2017', () => {
-          expect(datepicker.calendar.header).to.equal('April 2017');
-        });
-
-        it('shows days from April 2017', () => {
-          expect(datepicker.calendar.text).to.deep.equal([
-            '_26_', '_27_', '_28_', '_29_', '_30_', '_31_', '1',
-            '2', '3', '4', '5', '6', '7', '8',
-            '9', '10', '11', '12', '13', '14', '15',
-            '16', '17', '18', '19', '20', '21', '22',
-            '23', '24', '25', '26', '27', '28', '29',
-            '30', '_1_', '_2_', '_3_', '_4_', '_5_', '_6_'
-          ]);
-        });
-
-        it('does not have a selected day', () => {
-          expect(datepicker.calendar.selected).to.be.undefined;
-        });
-      });
-
-      describe('going to next year', () => {
-        beforeEach(async () => datepicker.calendar.nextYear());
-
-        it('changed calendar header to April 2019', () => {
-          expect(datepicker.calendar.header).to.equal('April 2019');
-        });
-
-        it('shows days from April 2019', () => {
-          expect(datepicker.calendar.text).to.deep.equal([
-            '_31_', '1', '2', '3', '4', '5', '6',
-            '7', '8', '9', '10', '11', '12', '13',
-            '14', '15', '16', '17', '18', '19', '20',
-            '21', '22', '23', '24', '25', '26', '27',
-            '28', '29', '30', '_1_', '_2_', '_3_', '_4_'
-          ]);
-        });
-
-        it('does not have a selected day', () => {
-          expect(datepicker.calendar.selected).to.be.undefined;
-        });
-      });
-
-      it('has cursor on April 1, 2018', () => {
-        expect(datepicker.calendar.cursor.date).to.equal('04/01/2018');
-      });
-
-      describe('press up', () => {
-        beforeEach(async () => datepicker.calendar.cursor.pressUp());
-
-        it('takes user to previous month', () => {
-          expect(datepicker.calendar.header).to.equal('March 2018');
-        });
-
-        it('changed cursor to March 25, 2018', () => {
-          expect(datepicker.calendar.cursor.date).to.equal('03/25/2018');
-        });
-      });
-
-      describe('press down', () => {
-        beforeEach(async () => datepicker.calendar.cursor.pressDown());
-
-        it('changed cursor to April 8, 2018', () => {
-          expect(datepicker.calendar.cursor.date).to.equal('04/08/2018');
-        });
-      });
-
-      describe('press left', () => {
-        beforeEach(async () => datepicker.calendar.cursor.pressLeft());
-
-        it('takes user to previous month', () => {
-          expect(datepicker.calendar.header).to.equal('March 2018');
-        });
-
-        it('changed cursor to March 31, 2018', () => {
-          expect(datepicker.calendar.cursor.date).to.equal('03/31/2018');
-        });
-      });
-
-      describe('press right', () => {
-        beforeEach(async () => datepicker.calendar.cursor.pressRight());
-
-        it('changed cursor to April 2, 2018', () => {
-          expect(datepicker.calendar.cursor.date).to.equal('04/02/2018');
-        });
-      });
-
-      describe('press page up', () => {
-        beforeEach(async () => datepicker.calendar.cursor.pressPageUp());
-
-        it('takes user to previous month', () => {
-          expect(datepicker.calendar.header).to.equal('March 2018');
-        });
-
-        it('changed cursor to March 1, 2018', () => {
-          expect(datepicker.calendar.cursor.date).to.equal('03/01/2018');
-        });
-      });
-
-      describe('press page down', () => {
-        beforeEach(async () => datepicker.calendar.cursor.pressPageDown());
-
-        it('takes user to next month', () => {
-          expect(datepicker.calendar.header).to.equal('May 2018');
-        });
-
-        it('changed cursor to May 1, 2018', () => {
-          expect(datepicker.calendar.cursor.date).to.equal('05/01/2018');
-        });
-      });
-
-      describe('press alt + page up', () => {
-        beforeEach(async () => datepicker.calendar.cursor.altPageUp());
-
-        it('takes user to previous year', () => {
-          expect(datepicker.calendar.header).to.equal('April 2017');
-        });
-
-        it('changed cursor to April 1, 2017', () => {
-          expect(datepicker.calendar.cursor.date).to.equal('04/01/2017');
-        });
-      });
-
-      describe('press alt + page down', () => {
-        beforeEach(async () => datepicker.calendar.cursor.altPageDown());
-
-        it('takes user to next year', () => {
-          expect(datepicker.calendar.header).to.equal('April 2019');
-        });
-
-        it('changed cursor to April 1, 2019', () => {
-          expect(datepicker.calendar.cursor.date).to.equal('04/01/2019');
-        });
-      });
-    });
-  });
-
-  describe('coupled to redux form', () => {
-    describe('selecting a date', () => {
-      let dateOutput;
-
-      beforeEach(async () => {
-        dateOutput = '';
-
-        await mountWithContext(
-          <Datepicker
-            input={{
-              onChange: (value) => { dateOutput = value; },
-            }}
-          />
-        );
-
-        await datepicker.fillInput('04/01/2018');
-      });
-
-      it('returns an ISO 8601 datetime string at UTC', () => {
-        expect(dateOutput).to.equal('2018-04-01T00:00:00.000Z');
-      });
+    it('is closed', () => {
+      expect(datepicker.calendar.isPresent).to.be.false;
     });
 
-    describe('selecting a date with timeZone prop', () => {
-      let dateOutput;
+    describe('focus', () => {
+      beforeEach(async () => datepicker.focusInput());
 
-      beforeEach(async () => {
-        dateOutput = '';
-
-        await mountWithContext(
-          <Datepicker
-            input={{
-              onChange: (value) => { dateOutput = value; },
-            }}
-            timeZone="America/Los_Angeles"
-          />
-        );
-
-        await datepicker.fillInput('04/01/2018');
+      it('opens on focus', () => {
+        expect(datepicker.calendar.isVisible).to.be.true;
       });
 
-      it('returns an ISO 8601 datetime string for specific time zone', () => {
-        expect(dateOutput).to.equal('2018-04-01T07:00:00.000Z');
+      describe('shifting the focus onBlur', () => {
+        beforeEach(async () => {
+          await datepicker.fillAndBlur('04/01/2018');
+        });
+
+        it('closes the calendar picker', () => {
+          expect(datepicker.calendar.isPresent).to.be.false;
+        });
       });
     });
   });

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -87,31 +87,6 @@ describe('Datepicker', () => {
     });
   });
 
-  describe.skip('selecting a date with timeZone prop', () => {
-    let onChange;
-
-    beforeEach(async () => {
-      onChange = mock.fn();
-
-      await mountWithContext(
-        <Datepicker
-          onChange={onChange}
-          timeZone="America/Los_Angeles"
-        />
-      );
-
-      await datepicker.fillInput('04/01/2018');
-    });
-
-    it('called onChange once', () => {
-      expect(onChange.mock.calls.length).to.equal(1);
-    })
-
-    it('returns an ISO 8601 datetime string for specific time zone', () => {
-      expect(onChange.mock.calls[0][0].value).to.equal('2018-04-01T07:00:00.000Z');
-    });
-  });
-
   describe('selecting a date with locale prop', () => {
     let dateOutput;
 

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -1,71 +1,12 @@
 import React from 'react';
 import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
-import jest from 'jest-mock';
+import mock from 'jest-mock';
 
 import { mountWithContext } from '../../../tests/helpers';
 
 import Datepicker from '../Datepicker';
-import DatepickerInteractor from './interactor';
-
-/**
- * Commonly used props:
- *  - [] backendDateStandard
- *  - [] timeZone
- *  - [] dateFormat
- *  - [] intl
- *  - [] locale
- *  - [] excludeDates
- *
- * HTML Attributes
- *  - [?] disabled
- *  - [] label
- *  - [] value
- *  - [] id
- *  - [] onChange
- *  - [] readOnly
- *  - [] required
- *
- * Redux Integration
- *  - input
- *  - meta
- *
- * Possible Deprecation
- *  - [?] passThroughValue - when value matches specified value, just pass the value through
- *  - stripes
- *  - [] ignoreLocalOffset
- *
- * Unused Configurations
- * - useFocus (set to true, so it's always active although never passed)
- * - thether (has defaults but never used)
- * - screenReaderMessage
- * - hideOnChoose (default true)
- * - onSetDate
- * - showCalendar
- *
- * Tests
- *  - require to make sure asterisc shows up
- *  - if I input does it emit onChange event
- *  - Click on event does it change the event
- *  - Navigation tests
- *  - render with id
-
- *  - click and nothing inputted does calendar show up
- *  - Warning & error outside of redux
- *
- * Things Datepicker should do according to John
- * - uses a standard text input - value can be typed as well as picked using the calendar
- * - picker disappears with a click outside or blur of the input
- * - presents in localized format (based on locale to determine input and output)
- * - custom format can be applied
- * - excluded dates
- * - a11y - screen reader compatibility (announces actions, selections, values)
- * - a11y - keyboard navigation of dates
- * - accepts colors from a stripes theme/works with stripes-components postcss workflow/css-modules
- * - supports some version of the “passThroughValue” to keep repetitious entries to a minimum. Use-case: checkin - applying today’s date to multiple items within a check-in.  (would have to discuss alternatives with UX design staff)
- * - validation styles/classes in-line with other stripes-components
- * - Optional: outputs date in iso format (output value) (redux: format for input, normalize for output) (assumption is that all folio apps use full ISO, eholdings does not because of ebsco)
- */
+import DatepickerInteractor from './interactor'; 
 
 describe('Datepicker', () => {
   const datepicker = new DatepickerInteractor();
@@ -146,6 +87,31 @@ describe('Datepicker', () => {
     });
   });
 
+  describe.skip('selecting a date with timeZone prop', () => {
+    let onChange;
+
+    beforeEach(async () => {
+      onChange = mock.fn();
+
+      await mountWithContext(
+        <Datepicker
+          onChange={onChange}
+          timeZone="America/Los_Angeles"
+        />
+      );
+
+      await datepicker.fillInput('04/01/2018');
+    });
+
+    it('called onChange once', () => {
+      expect(onChange.mock.calls.length).to.equal(1);
+    })
+
+    it('returns an ISO 8601 datetime string for specific time zone', () => {
+      expect(onChange.mock.calls[0][0].value).to.equal('2018-04-01T07:00:00.000Z');
+    });
+  });
+  
   describe('selecting a date with locale prop', () => {
     let dateOutput;
 
@@ -193,8 +159,8 @@ describe('Datepicker', () => {
     let onBlur;
 
     beforeEach(async () => {
-      onChange = jest.fn();
-      onBlur = jest.fn();
+      onChange = mock.fn();
+      onBlur = mock.fn();
 
       await mountWithContext(
         <Datepicker
@@ -234,8 +200,8 @@ describe('Datepicker', () => {
     let onChange;
 
     beforeEach(async () => {
-      onBlur = jest.fn();
-      onChange = jest.fn();
+      onBlur = mock.fn();
+      onChange = mock.fn();
 
       await mountWithContext(
         <Datepicker
@@ -326,6 +292,13 @@ describe('Datepicker', () => {
 
     it('adds required attribute to input field', () => {
       expect(datepicker.required).to.be.true;
+    });
+  });
+
+  describe.skip('clear button', () => {
+    beforeEach(async () => mountWithContext(<Datepicker />));
+    it('does not show clear button', () => {
+      expect(datepicker.clearButton.isVisible).to.be.false;
     });
   });
 });

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -298,4 +298,16 @@ describe('Datepicker', () => {
       });
     });
   });
+
+  describe('required', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <Datepicker label="Pick a date" required />
+      );
+    });
+
+    it('adds required attribute to input field', () => {
+      expect(datepicker.required).to.be.true;
+    });
+  });
 });

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -98,6 +98,18 @@ describe('Datepicker', () => {
     });
   });
 
+  describe('label prop', () => {
+    beforeEach(async () => mountWithContext(
+      <Datepicker
+        label="Pick a date"
+      />
+    ));
+
+    it('shows the label', () => {
+      expect(datepicker.labelText).to.equal('Pick a date');
+    });
+  });
+
   describe('selecting a date', () => {
     let dateOutput;
 
@@ -155,6 +167,47 @@ describe('Datepicker', () => {
 
     it('emits an event with the date formatted as displayed', () => {
       expect(dateOutput).to.equal('04/01/2018');
+    });
+  });
+
+  describe('disabled prop', () => {
+    let onChange;
+    let onBlur;
+
+    beforeEach(async () => {
+      onChange = jest.fn();
+      onBlur = jest.fn();
+
+      await mountWithContext(
+        <Datepicker
+          disabled
+          onChange={onChange}
+          onBlur={onBlur}
+        />
+      );
+    });
+
+    it('shows value in the input field', () => {
+      expect(datepicker.inputValue).to.be.equal('');
+    });
+
+    it('has disabled input', () => {
+      expect(datepicker.disabled).to.be.true;
+    });
+
+    describe('choosing a date from calendar', () => {
+      beforeEach(async () => datepicker.clickInput().focusInput());
+      it('did not open the calendar', () => {
+        expect(datepicker.calendar.isPresent).to.be.false;
+      });
+
+      it('did not call onChange', () => {
+        expect(onChange.mock.calls.length).to.be.equal(0);
+      });
+
+      it('did not call onBlur', () => {
+        expect(onBlur.mock.calls.length).to.be.equal(0);
+      });
     });
   });
 

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -7,21 +7,59 @@ import { mountWithContext } from '../../../tests/helpers';
 import Datepicker from '../Datepicker';
 import DatepickerInteractor from './interactor';
 
-describe('Datepicker', () => {
+/**
+ * Commonly used props:
+ *  - backendDateStandard
+ *  - ignoreLocalOffset
+ *  - required
+ *  - timeZone
+ *  - dateFormat
+ *  - intl
+ *  - locale
+ * 
+ * HTML Attributes
+ *  - label
+ *  - disabled
+ *  - id
+ *  - onChange
+ *  - readOnly
+ *  - required
+ *  - value
+ * 
+ * Redux Integration
+ *  - input
+ *  - meta
+ * 
+ * Possible Deprecation
+ *  - stripes
+ *  - passThroughValue - when value matches specified value, just pass the value through
+ * 
+ * Unused Configurations
+ * - useFocus (set to true, so it's always active although never passed)
+ * - thether (has defaults but never used)
+ * - screenReaderMessage 
+ * - hideOnChoose (default true)
+ * - onSetDate
+ * - showCalendar
+ */
+
+describe.only('Datepicker', () => {
   const datepicker = new DatepickerInteractor();
 
-  beforeEach(async () => {
-    await mountWithContext(
-      <Datepicker />
-    );
-  });
-
-  it('does not have a value in the input', () => {
-    expect(datepicker.inputValue).to.equal('');
-  });
-
-  it('has a placeholder in the input', () => {
-    expect(datepicker.placeholder).to.equal('MM/DD/YYYY');
+  describe('render', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <Datepicker />
+      );
+    });
+  
+    it('does not have a value in the input', () => {
+      expect(datepicker.inputValue).to.equal('');
+    });
+  
+    it('has a placeholder in the input', () => {
+      expect(datepicker.placeholder).to.equal('MM/DD/YYYY');
+    });
   });
 
   describe('with an id', () => {
@@ -97,29 +135,137 @@ describe('Datepicker', () => {
   });
 
   describe('the calendar picker', () => {
-    beforeEach(async () => {
-      await mountWithContext(
-        <div>
-          <Datepicker />
-        </div>
-      );
 
-      await datepicker.focusInput();
-    });
-
-    it('opens on focus', () => {
-      expect(datepicker.calendar.isVisible).to.be.true;
-    });
-
-    describe('shifting the focus onBlur', () => {
+    describe('without value', () => {
       beforeEach(async () => {
-        await datepicker.fillAndBlur('04/01/2018');
+        await mountWithContext(
+          <div>
+            <Datepicker />
+          </div>
+        );
+  
+        await datepicker.focusInput();
       });
-
-      it('closes the calendar picker', () => {
-        expect(datepicker.calendar.isPresent).to.be.false;
+  
+      it('opens on focus', () => {
+        expect(datepicker.calendar.isVisible).to.be.true;
+      });
+  
+      it('shows days', () => {
+        expect(datepicker.calendar.days().length).to.equal(35);
+      });
+  
+      describe('shifting the focus onBlur', () => {
+        beforeEach(async () => {
+          await datepicker.fillAndBlur('04/01/2018');
+        });
+  
+        it('closes the calendar picker', () => {
+          expect(datepicker.calendar.isPresent).to.be.false;
+        });
       });
     });
+
+    describe('with value', () => {
+      beforeEach(async () => {
+        await mountWithContext(
+          <div>
+            <Datepicker input={{ value: '04/01/2018' }} />
+          </div>
+        );
+  
+        await datepicker.focusInput();
+      });
+
+      it('has April 2018 in calendar header', () => {
+        expect(datepicker.calendar.header).to.equal('April 2018');
+      });
+
+      it('shows days from April 2018', () => {
+        expect(datepicker.calendar.text).to.deep.equal([
+          '1', '2', '3', '4', '5', '6', '7',
+          '8', '9', '10', '11', '12', '13', '14',
+          '15', '16', '17', '18', '19', '20', '21',
+          '22', '23', '24', '25', '26', '27', '28',
+          '29', '30', '1', '2', '3', '4', '5'
+        ]);
+      });
+
+      describe('going to previous month', () => {
+        beforeEach(async () => datepicker.calendar.previousMonth());
+  
+        it('changed calendar header to March 2018', () => {
+          expect(datepicker.calendar.header).to.equal('March 2018');
+        });
+
+        it('shows days from March 2018', () => {
+          expect(datepicker.calendar.text).to.deep.equal([
+            '25', '26', '27', '28', '1', '2', '3',
+            '4', '5', '6', '7', '8', '9', '10',
+            '11', '12', '13', '14', '15', '16', '17',
+            '18', '19', '20', '21', '22', '23', '24',
+            '25', '26', '27', '28', '29', '30', '31'
+          ]);
+        });
+      });
+
+      describe('going to next month', () => {
+        beforeEach(async () => datepicker.calendar.nextMonth());
+  
+        it('changed calendar header to May 2018', () => {
+          expect(datepicker.calendar.header).to.equal('May 2018');
+        });
+
+        it('shows days from May 2018', () => {
+          expect(datepicker.calendar.text).to.deep.equal([
+            '29', '30', '1', '2', '3', '4', '5',
+            '6', '7', '8', '9', '10', '11', '12',
+            '13', '14', '15', '16', '17', '18', '19',
+            '20', '21', '22', '23', '24', '25', '26', 
+            '27', '28', '29', '30', '31', '1', '2'
+          ]);
+        });
+      });
+
+      describe('going to previous year', () => {
+        beforeEach(async () => datepicker.calendar.previousYear());
+  
+        it('changed calendar header to April 2017', () => {
+          expect(datepicker.calendar.header).to.equal('April 2017');
+        });
+
+        it('shows days from April 2017', () => {
+          expect(datepicker.calendar.text).to.deep.equal([
+            '26', '27', '28', '29', '30', '31', '1',
+            '2', '3', '4', '5', '6', '7', '8',
+            '9', '10', '11', '12', '13', '14', '15',
+            '16', '17', '18', '19', '20', '21', '22',
+            '23', '24', '25', '26', '27', '28', '29',
+            '30', '1', '2', '3', '4', '5', '6'
+          ]);
+        });
+      });
+
+      describe('going to next year', () => {
+        beforeEach(async () => datepicker.calendar.nextYear());
+  
+        it('changed calendar header to April 2019', () => {
+          expect(datepicker.calendar.header).to.equal('April 2019');
+        });
+
+        it('shows days from April 2019', () => {
+          expect(datepicker.calendar.text).to.deep.equal([
+            '31', '1', '2', '3', '4', '5', '6',
+            '7', '8', '9', '10', '11', '12', '13',
+            '14', '15', '16', '17', '18', '19', '20',
+            '21', '22', '23', '24', '25', '26', '27',
+            '28', '29', '30', '1', '2', '3', '4'
+          ]);
+        });
+      });
+
+    });
+
   });
 
   describe('coupled to redux form', () => {

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -98,7 +98,7 @@ describe('Datepicker', () => {
     });
   });
 
-  describe('label prop', () => {
+  describe('label', () => {
     beforeEach(async () => mountWithContext(
       <Datepicker
         label="Pick a date"
@@ -107,6 +107,24 @@ describe('Datepicker', () => {
 
     it('shows the label', () => {
       expect(datepicker.labelText).to.equal('Pick a date');
+    });
+  });
+
+  describe('readOnly', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <Datepicker readOnly />
+      );
+
+      await datepicker.focusInput();
+    });
+
+    it('is not disabled', () => {
+      expect(datepicker.disabled).to.be.false;
+    });
+
+    it('it did not open the calendar', () => {
+      expect(datepicker.calendar.isPresent).to.be.false;
     });
   });
 

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -247,6 +247,30 @@ describe('Datepicker', () => {
     });
   });
 
+  describe('press enter opens the calendar', () => {
+    beforeEach(async () => {
+      await mountWithContext(<Datepicker />);
+
+      await datepicker.pressEnter();
+    });
+
+    it('is opened the calendar', () => {
+      expect(datepicker.calendar.isPresent).to.be.true;
+    });
+  });
+
+  describe('clicking on calendar button', () => {
+    beforeEach(async () => {
+      await mountWithContext(<Datepicker />);
+
+      await datepicker.calendarButton.click();
+    });
+
+    it('opened the calendar', () => {
+      expect(datepicker.calendar.isPresent).to.be.true;
+    });
+  });
+
   describe('the calendar picker', () => {
     beforeEach(async () => {
       await mountWithContext(
@@ -275,6 +299,13 @@ describe('Datepicker', () => {
         });
       });
 
+      describe('pressing escape while calendar open', () => {
+        beforeEach(async () => datepicker.pressTab());
+        it('closes the calendar picker', () => {
+          expect(datepicker.calendar.isPresent).to.be.false;
+        });
+      });
+
       describe('shifting the focus onBlur', () => {
         beforeEach(async () => {
           await datepicker.fillAndBlur('04/01/2018');
@@ -296,13 +327,6 @@ describe('Datepicker', () => {
 
     it('adds required attribute to input field', () => {
       expect(datepicker.required).to.be.true;
-    });
-  });
-
-  describe.skip('clear button', () => {
-    beforeEach(async () => mountWithContext(<Datepicker />));
-    it('does not show clear button', () => {
-      expect(datepicker.clearButton.isVisible).to.be.false;
     });
   });
 });

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -187,8 +187,12 @@ describe.only('Datepicker', () => {
           '8', '9', '10', '11', '12', '13', '14',
           '15', '16', '17', '18', '19', '20', '21',
           '22', '23', '24', '25', '26', '27', '28',
-          '29', '30', '1', '2', '3', '4', '5'
+          '29', '30', '_1_', '_2_', '_3_', '_4_', '_5_'
         ]);
+      });
+
+      it('has April 1st as selected', () => {
+        expect(datepicker.calendar.selected.text).to.equal("1");
       });
 
       describe('going to previous month', () => {
@@ -200,12 +204,16 @@ describe.only('Datepicker', () => {
 
         it('shows days from March 2018', () => {
           expect(datepicker.calendar.text).to.deep.equal([
-            '25', '26', '27', '28', '1', '2', '3',
+            '_25_', '_26_', '_27_', '_28_', '1', '2', '3',
             '4', '5', '6', '7', '8', '9', '10',
             '11', '12', '13', '14', '15', '16', '17',
             '18', '19', '20', '21', '22', '23', '24',
             '25', '26', '27', '28', '29', '30', '31'
           ]);
+        });
+
+        it('does not have a selected day', () => {
+          expect(datepicker.calendar.selected).to.be.undefined;
         });
       });
 
@@ -218,12 +226,16 @@ describe.only('Datepicker', () => {
 
         it('shows days from May 2018', () => {
           expect(datepicker.calendar.text).to.deep.equal([
-            '29', '30', '1', '2', '3', '4', '5',
+            '_29_', '_30_', '1', '2', '3', '4', '5',
             '6', '7', '8', '9', '10', '11', '12',
             '13', '14', '15', '16', '17', '18', '19',
             '20', '21', '22', '23', '24', '25', '26', 
-            '27', '28', '29', '30', '31', '1', '2'
+            '27', '28', '29', '30', '31', '_1_', '_2_'
           ]);
+        });
+
+        it('does not have a selected day', () => {
+          expect(datepicker.calendar.selected).to.be.undefined;
         });
       });
 
@@ -236,13 +248,17 @@ describe.only('Datepicker', () => {
 
         it('shows days from April 2017', () => {
           expect(datepicker.calendar.text).to.deep.equal([
-            '26', '27', '28', '29', '30', '31', '1',
+            '_26_', '_27_', '_28_', '_29_', '_30_', '_31_', '1',
             '2', '3', '4', '5', '6', '7', '8',
             '9', '10', '11', '12', '13', '14', '15',
             '16', '17', '18', '19', '20', '21', '22',
             '23', '24', '25', '26', '27', '28', '29',
-            '30', '1', '2', '3', '4', '5', '6'
+            '30', '_1_', '_2_', '_3_', '_4_', '_5_', '_6_'
           ]);
+        });
+
+        it('does not have a selected day', () => {
+          expect(datepicker.calendar.selected).to.be.undefined;
         });
       });
 
@@ -255,12 +271,16 @@ describe.only('Datepicker', () => {
 
         it('shows days from April 2019', () => {
           expect(datepicker.calendar.text).to.deep.equal([
-            '31', '1', '2', '3', '4', '5', '6',
+            '_31_', '1', '2', '3', '4', '5', '6',
             '7', '8', '9', '10', '11', '12', '13',
             '14', '15', '16', '17', '18', '19', '20',
             '21', '22', '23', '24', '25', '26', '27',
-            '28', '29', '30', '1', '2', '3', '4'
+            '28', '29', '30', '_1_', '_2_', '_3_', '_4_'
           ]);
+        });
+
+        it('does not have a selected day', () => {
+          expect(datepicker.calendar.selected).to.be.undefined;
         });
       });
 

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -283,6 +283,50 @@ describe.only('Datepicker', () => {
           expect(datepicker.calendar.selected).to.be.undefined;
         });
       });
+      
+      it('has cursor on April 1, 2018', () => {
+        expect(datepicker.calendar.cursor.date).to.equal("04/01/2018");
+      });
+      
+      describe('press up', () => {
+        beforeEach(async () => datepicker.calendar.cursor.pressUp());
+
+        it('takes user to previous month', () => {
+          expect(datepicker.calendar.header).to.equal('March 2018');
+        });
+
+        it('changed cursor to March 25, 2018', () => {
+          expect(datepicker.calendar.cursor.date).to.equal("03/25/2018");
+        });
+      });
+
+      describe('press down', () => {
+        beforeEach(async () => datepicker.calendar.cursor.pressDown());
+
+        it('changed cursor to April 8, 2018', () => {
+          expect(datepicker.calendar.cursor.date).to.equal("04/08/2018");
+        });
+      });
+
+      describe('press left', () => {
+        beforeEach(async () => datepicker.calendar.cursor.pressLeft());
+
+        it('takes user to previous month', () => {
+          expect(datepicker.calendar.header).to.equal('March 2018');
+        });
+
+        it('changed cursor to March 31, 2018', () => {
+          expect(datepicker.calendar.cursor.date).to.equal("03/31/2018");
+        });
+      });
+
+      describe('press right', () => {
+        beforeEach(async () => datepicker.calendar.cursor.pressRight());
+
+        it('changed cursor to April 2, 2018', () => {
+          expect(datepicker.calendar.cursor.date).to.equal("04/02/2018");
+        });
+      });
 
     });
 

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -129,6 +129,27 @@ describe('Datepicker', () => {
     });
   });
 
+  describe('selecting a date with stripes.timezone prop', () => {
+    let dateOutput;
+
+    beforeEach(async () => {
+      dateOutput = '';
+
+      await mountWithContext(
+        <Datepicker
+          onChange={(event) => { dateOutput = event.target.value; }}
+          stripes={{ timezone: 'America/Los_Angeles' }}
+        />
+      );
+
+      await datepicker.fillInput('04/01/2018');
+    });
+
+    it('emits an event with the date formatted as displayed', () => {
+      expect(dateOutput).to.equal('04/01/2018');
+    });
+  });
+
   describe('disabled prop', () => {
     let onChange;
     let onBlur;
@@ -231,6 +252,7 @@ describe('Datepicker', () => {
       await mountWithContext(
         <div>
           <Datepicker />
+          <div id="anywhere-else" />
         </div>
       );
     });
@@ -244,6 +266,13 @@ describe('Datepicker', () => {
 
       it('opens on focus', () => {
         expect(datepicker.calendar.isVisible).to.be.true;
+      });
+
+      describe('clicking outside of calendar', () => {
+        beforeEach(() => document.getElementById('anywhere-else').click());
+        it('closes the calendar picker', () => {
+          expect(datepicker.calendar.isPresent).to.be.false;
+        });
       });
 
       describe('shifting the focus onBlur', () => {

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -6,7 +6,7 @@ import mock from 'jest-mock';
 import { mountWithContext } from '../../../tests/helpers';
 
 import Datepicker from '../Datepicker';
-import DatepickerInteractor from './interactor'; 
+import DatepickerInteractor from './interactor';
 
 describe('Datepicker', () => {
   const datepicker = new DatepickerInteractor();

--- a/lib/Datepicker/tests/interactor.js
+++ b/lib/Datepicker/tests/interactor.js
@@ -12,6 +12,8 @@ import {
 } from '@bigtest/interactor';
 
 @interactor class Day {
+  date = attribute('data-test-date');
+  title = attribute('title');
   state = attribute('data-test-calendar-day');
 
   get isMuted() {
@@ -33,6 +35,30 @@ import {
   get isExcluded() {
     return this.state.indexOf('isExcluded') !== -1;
   }
+
+  pressUp = triggerable('keydown', {
+    bubbles: true,
+    cancelable: true,
+    keyCode: 38
+  });
+
+  pressDown = triggerable('keydown', {
+    bubbles: true,
+    cancelable: true,
+    keyCode: 40
+  });
+
+  pressLeft = triggerable('keydown', {
+    bubbles: true,
+    cancelable: true,
+    keyCode: 37
+  });
+
+  pressRight = triggerable('keydown', {
+    bubbles: true,
+    cancelable: true,
+    keyCode: 39
+  });
 }
 
 @interactor class Calendar {
@@ -57,7 +83,7 @@ import {
     return this.days().find(day => day.isSelected);
   }
 
-  get cursored() {
+  get cursor() {
     return this.days().find(day => day.isCursored);
   }
 }
@@ -70,11 +96,13 @@ export default interactor(class DatepickerInteractor {
   focusInput = focusable('input');
   blurInput = blurrable('input');
   clickInput = clickable('input');
+
   pressEnter = triggerable('input', 'keydown', {
     bubbles: true,
     cancelable: true,
     keyCode: 13
   });
+
   placeholder = attribute('input', 'placeholder');
 
   fillAndBlur(date) {

--- a/lib/Datepicker/tests/interactor.js
+++ b/lib/Datepicker/tests/interactor.js
@@ -128,6 +128,7 @@ export default interactor(class DatepickerInteractor {
   disabled = property('input', 'disabled')
   labelText = text('label');
   required = property('input', 'required');
+  placeholder = attribute('input', 'placeholder');
 
   pressEnter = triggerable('input', 'keydown', {
     bubbles: true,
@@ -135,7 +136,6 @@ export default interactor(class DatepickerInteractor {
     keyCode: 13
   });
 
-  placeholder = property('input', 'placeholder');
 
   fillAndBlur(date) {
     return this

--- a/lib/Datepicker/tests/interactor.js
+++ b/lib/Datepicker/tests/interactor.js
@@ -19,6 +19,8 @@ import css from '../Calendar.css';
 @interactor class Day {
   title = attribute('title');
   date = attribute('data-test-date');
+  disabled = property('disabled');
+  click = clickable();
 
   isMuted = hasClass(css.muted);
   isSelected = hasClass(css.selected);
@@ -74,6 +76,12 @@ import css from '../Calendar.css';
     cancelable: true,
     keyCode: 34,
     altKey: true
+  });
+
+  pressEnter = triggerable('keydown', {
+    bubbles: true,
+    cancelable: true,
+    keyCode: 13
   });
 }
 

--- a/lib/Datepicker/tests/interactor.js
+++ b/lib/Datepicker/tests/interactor.js
@@ -9,7 +9,8 @@ import {
   value,
   collection,
   text,
-  scoped
+  scoped,
+  property
 } from '@bigtest/interactor';
 
 @interactor class Day {
@@ -124,6 +125,7 @@ export default interactor(class DatepickerInteractor {
   blurInput = blurrable('input');
   clickInput = clickable('input');
   clearButton = scoped('[data-test-clear]');
+  disabled = property('input', 'disabled')
 
   pressEnter = triggerable('input', 'keydown', {
     bubbles: true,
@@ -139,5 +141,10 @@ export default interactor(class DatepickerInteractor {
       .fillInput(date)
       .pressEnter()
       .blurInput();
+  }
+
+  fillNoEnterBlur(date) {
+    return this
+      .clickInput();
   }
 });

--- a/lib/Datepicker/tests/interactor.js
+++ b/lib/Datepicker/tests/interactor.js
@@ -16,26 +16,6 @@ import {
   title = attribute('title');
   state = attribute('data-test-calendar-day');
 
-  get isMuted() {
-    return this.state.indexOf('isMuted') !== -1;
-  }
-
-  get isSelected() {
-    return this.state.indexOf('isSelected') !== -1;
-  }
-
-  get isCursored() {
-    return this.state.indexOf('isCursored') !== -1;
-  }
-
-  get isToday() {
-    return this.state.indexOf('isToday') !== -1;
-  }
-
-  get isExcluded() {
-    return this.state.indexOf('isExcluded') !== -1;
-  }
-
   pressUp = triggerable('keydown', {
     bubbles: true,
     cancelable: true,
@@ -59,6 +39,52 @@ import {
     cancelable: true,
     keyCode: 39
   });
+
+  pressPageUp = triggerable('keydown', {
+    bubbles: true,
+    cancelable: true,
+    keyCode: 33
+  });
+
+  pressPageDown = triggerable('keydown', {
+    bubbles: true,
+    cancelable: true,
+    keyCode: 34
+  });
+
+  altPageUp = triggerable('keydown', {
+    bubbles: true,
+    cancelable: true,
+    keyCode: 33,
+    altKey: true
+  });
+
+  altPageDown = triggerable('keydown', {
+    bubbles: true,
+    cancelable: true,
+    keyCode: 34,
+    altKey: true
+  });
+
+  get isMuted() {
+    return this.state.indexOf('isMuted') !== -1;
+  }
+
+  get isSelected() {
+    return this.state.indexOf('isSelected') !== -1;
+  }
+
+  get isCursored() {
+    return this.state.indexOf('isCursored') !== -1;
+  }
+
+  get isToday() {
+    return this.state.indexOf('isToday') !== -1;
+  }
+
+  get isExcluded() {
+    return this.state.indexOf('isExcluded') !== -1;
+  }
 }
 
 @interactor class Calendar {

--- a/lib/Datepicker/tests/interactor.js
+++ b/lib/Datepicker/tests/interactor.js
@@ -141,6 +141,7 @@ export default interactor(class DatepickerInteractor {
   blurInput = blurrable('input');
   clickInput = clickable('input');
   clearButton = scoped('[data-test-clear]');
+  calendarButton = scoped('[data-test-calendar-button]');
   disabled = property('input', 'disabled')
   labelText = text('label');
   required = property('input', 'required');
@@ -152,6 +153,18 @@ export default interactor(class DatepickerInteractor {
     bubbles: true,
     cancelable: true,
     keyCode: 13
+  });
+
+  pressTab = triggerable('input', 'keydown', {
+    bubbles: true,
+    cancelable: true,
+    keyCode: 9
+  });
+
+  pressEscape = triggerable('input', 'keydown', {
+    bubbles: true,
+    cancelable: true,
+    keyCode: 27
   });
 
   press1 = triggerable('input', 'keydown', {

--- a/lib/Datepicker/tests/interactor.js
+++ b/lib/Datepicker/tests/interactor.js
@@ -150,8 +150,4 @@ export default interactor(class DatepickerInteractor {
       .pressEnter()
       .blurInput();
   }
-
-  enterOne() {
-    return this.clickInput().press1();
-  }
 });

--- a/lib/Datepicker/tests/interactor.js
+++ b/lib/Datepicker/tests/interactor.js
@@ -11,10 +11,26 @@ import {
   text,
   scoped,
   property,
-  hasClass
+  hasClass,
+  action
 } from '@bigtest/interactor';
 
 import css from '../Calendar.css';
+
+/**
+ * Set the selection range on an element. Equivalent to calling
+ * inputElement.setSelectionRange(selectionStart, selectionEnd)
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange
+ *
+ * @param {*} selector
+ * @param {Number} start
+ * @param {Number} end
+ */
+function selectable(selector = null) {
+  return action(function (start = 0, end = start) {
+    return this.$(selector).setSelectionRange(start, end);
+  });
+}
 
 @interactor class Day {
   title = attribute('title');
@@ -129,6 +145,8 @@ export default interactor(class DatepickerInteractor {
   labelText = text('label');
   required = property('input', 'required');
   placeholder = attribute('input', 'placeholder');
+  inputSelectionStart = property('input', 'selectionStart');
+  inputSelectionRange = selectable('input');
 
   pressEnter = triggerable('input', 'keydown', {
     bubbles: true,

--- a/lib/Datepicker/tests/interactor.js
+++ b/lib/Datepicker/tests/interactor.js
@@ -136,6 +136,12 @@ export default interactor(class DatepickerInteractor {
     keyCode: 13
   });
 
+  press1 = triggerable('input', 'keydown', {
+    bubbles: true,
+    cancelable: true,
+    keyCode: 1
+  });
+
 
   fillAndBlur(date) {
     return this
@@ -143,5 +149,9 @@ export default interactor(class DatepickerInteractor {
       .fillInput(date)
       .pressEnter()
       .blurInput();
+  }
+
+  enterOne() {
+    return this.clickInput().press1();
   }
 });

--- a/lib/Datepicker/tests/interactor.js
+++ b/lib/Datepicker/tests/interactor.js
@@ -8,7 +8,8 @@ import {
   triggerable,
   value,
   collection,
-  text
+  text,
+  scoped
 } from '@bigtest/interactor';
 
 @interactor class Day {
@@ -122,6 +123,7 @@ export default interactor(class DatepickerInteractor {
   focusInput = focusable('input');
   blurInput = blurrable('input');
   clickInput = clickable('input');
+  clearButton = scoped('[data-test-clear]');
 
   pressEnter = triggerable('input', 'keydown', {
     bubbles: true,

--- a/lib/Datepicker/tests/interactor.js
+++ b/lib/Datepicker/tests/interactor.js
@@ -126,7 +126,8 @@ export default interactor(class DatepickerInteractor {
   clickInput = clickable('input');
   clearButton = scoped('[data-test-clear]');
   disabled = property('input', 'disabled')
-  labelText = text('label')
+  labelText = text('label');
+  required = property('input', 'required');
 
   pressEnter = triggerable('input', 'keydown', {
     bubbles: true,
@@ -134,7 +135,7 @@ export default interactor(class DatepickerInteractor {
     keyCode: 13
   });
 
-  placeholder = attribute('input', 'placeholder');
+  placeholder = property('input', 'placeholder');
 
   fillAndBlur(date) {
     return this

--- a/lib/Datepicker/tests/interactor.js
+++ b/lib/Datepicker/tests/interactor.js
@@ -7,9 +7,26 @@ import {
   interactor,
   triggerable,
   value,
+  collection,
+  text
 } from '@bigtest/interactor';
 
-@interactor class Calendar {}
+@interactor class Day {
+
+}
+
+@interactor class Calendar {
+  days = collection('[data-test-calendar-day]', Day);
+  header = text('[data-test-calendar-header]');
+  previousMonth = clickable('[data-test-calendar-previous-month]');
+  nextMonth = clickable('[data-test-calendar-next-month]');
+  previousYear = clickable('[data-test-calendar-previous-year]');
+  nextYear = clickable('[data-test-calendar-next-year]');
+  
+  get text() {
+    return this.days().map(day => day.text);
+  }
+}
 
 export default interactor(class DatepickerInteractor {
   calendar = new Calendar('[data-test-calendar]');

--- a/lib/Datepicker/tests/interactor.js
+++ b/lib/Datepicker/tests/interactor.js
@@ -99,6 +99,12 @@ function selectable(selector = null) {
     cancelable: true,
     keyCode: 13
   });
+
+  pressEscape = triggerable('keydown', {
+    bubbles: true,
+    cancelable: true,
+    keyCode: 27
+  });
 }
 
 @interactor class Calendar {

--- a/lib/Datepicker/tests/interactor.js
+++ b/lib/Datepicker/tests/interactor.js
@@ -95,6 +95,10 @@ import css from '../Calendar.css';
     });
   }
 
+  get excludedDates() {
+    return this.days().filter(day => day.isExcluded).map(day => day.date);
+  }
+
   get selected() {
     return this.days().find(day => day.isSelected);
   }

--- a/lib/Datepicker/tests/interactor.js
+++ b/lib/Datepicker/tests/interactor.js
@@ -10,13 +10,21 @@ import {
   collection,
   text,
   scoped,
-  property
+  property,
+  hasClass
 } from '@bigtest/interactor';
 
+import css from '../Calendar.css';
+
 @interactor class Day {
-  date = attribute('data-test-date');
   title = attribute('title');
-  state = attribute('data-test-calendar-day');
+  date = attribute('data-test-date');
+
+  isMuted = hasClass(css.muted);
+  isSelected = hasClass(css.selected);
+  isCursor = hasClass(css.cursor);
+  isToday = hasClass(css.today);
+  isExcluded = hasClass(css.excluded);
 
   pressUp = triggerable('keydown', {
     bubbles: true,
@@ -67,30 +75,10 @@ import {
     keyCode: 34,
     altKey: true
   });
-
-  get isMuted() {
-    return this.state.indexOf('isMuted') !== -1;
-  }
-
-  get isSelected() {
-    return this.state.indexOf('isSelected') !== -1;
-  }
-
-  get isCursored() {
-    return this.state.indexOf('isCursored') !== -1;
-  }
-
-  get isToday() {
-    return this.state.indexOf('isToday') !== -1;
-  }
-
-  get isExcluded() {
-    return this.state.indexOf('isExcluded') !== -1;
-  }
 }
 
 @interactor class Calendar {
-  days = collection('[data-test-calendar-day]', Day);
+  days = collection(`.${css.dayButton}`, Day);
   header = text('[data-test-calendar-header]');
   previousMonth = clickable('[data-test-calendar-previous-month]');
   nextMonth = clickable('[data-test-calendar-next-month]');
@@ -112,7 +100,7 @@ import {
   }
 
   get cursor() {
-    return this.days().find(day => day.isCursored);
+    return this.days().find(day => day.isCursor);
   }
 }
 
@@ -141,7 +129,6 @@ export default interactor(class DatepickerInteractor {
     cancelable: true,
     keyCode: 1
   });
-
 
   fillAndBlur(date) {
     return this

--- a/lib/Datepicker/tests/interactor.js
+++ b/lib/Datepicker/tests/interactor.js
@@ -12,7 +12,27 @@ import {
 } from '@bigtest/interactor';
 
 @interactor class Day {
+  state = attribute('data-test-calendar-day');
 
+  get isMuted() {
+    return this.state.indexOf('isMuted') !== -1;
+  }
+
+  get isSelected() {
+    return this.state.indexOf('isSelected') !== -1;
+  }
+
+  get isCursored() {
+    return this.state.indexOf('isCursored') !== -1;
+  }
+
+  get isToday() {
+    return this.state.indexOf('isToday') !== -1;
+  }
+
+  get isExcluded() {
+    return this.state.indexOf('isExcluded') !== -1;
+  }
 }
 
 @interactor class Calendar {
@@ -22,9 +42,23 @@ import {
   nextMonth = clickable('[data-test-calendar-next-month]');
   previousYear = clickable('[data-test-calendar-previous-year]');
   nextYear = clickable('[data-test-calendar-next-year]');
-  
+
   get text() {
-    return this.days().map(day => day.text);
+    return this.days().map(day => {
+      if (day.isMuted) {
+        return `_${day.text}_`;
+      } else {
+        return day.text;
+      }
+    });
+  }
+
+  get selected() {
+    return this.days().find(day => day.isSelected);
+  }
+
+  get cursored() {
+    return this.days().find(day => day.isCursored);
   }
 }
 

--- a/lib/Datepicker/tests/interactor.js
+++ b/lib/Datepicker/tests/interactor.js
@@ -126,6 +126,7 @@ export default interactor(class DatepickerInteractor {
   clickInput = clickable('input');
   clearButton = scoped('[data-test-clear]');
   disabled = property('input', 'disabled')
+  labelText = text('label')
 
   pressEnter = triggerable('input', 'keydown', {
     bubbles: true,
@@ -141,10 +142,5 @@ export default interactor(class DatepickerInteractor {
       .fillInput(date)
       .pressEnter()
       .blurInput();
-  }
-
-  fillNoEnterBlur(date) {
-    return this
-      .clickInput();
   }
 });

--- a/lib/TextField/stories/BasicUsage.js
+++ b/lib/TextField/stories/BasicUsage.js
@@ -5,14 +5,22 @@
 import React from 'react';
 import TextField from '../TextField';
 import Icon from '../../Icon';
+import Button from '../../Button';
 
 const BasicUsage = () => (
   <div>
     <TextField
       label="Field with label"
       placeholder="Placeholder Text"
-      required
     />
+    <form>
+      <TextField
+        label="Required field"
+        placeholder="Placeholder Text"
+        required
+      />
+      <Button type="submit">Submit</Button>
+    </form>
     <br />
     <TextField
       value="This field can't be changed"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
   },
   "dependencies": {
     "8": "0.0.1",
-    "deprecated-prop-type": "1.0.0",
     "@folio/stripes-connect": "^3.1.3",
     "@folio/stripes-form": "^0.8.2",
     "@folio/stripes-react-hotkeys": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "chai": "^3.5.0",
     "eslint": "^4.8.0",
     "file-loader": "^1.1.5",
+    "jest-mock": "23.2.0",
     "mocha": "^4.0.1",
     "postcss-calc": "^6.0.1",
     "postcss-color-function": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   },
   "dependencies": {
     "8": "0.0.1",
+    "deprecated-prop-type": "1.0.0-beta1",
     "@folio/stripes-connect": "^3.1.3",
     "@folio/stripes-form": "^0.8.2",
     "@folio/stripes-react-hotkeys": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "8": "0.0.1",
-    "deprecated-prop-type": "1.0.0-beta1",
+    "deprecated-prop-type": "1.0.0",
     "@folio/stripes-connect": "^3.1.3",
     "@folio/stripes-form": "^0.8.2",
     "@folio/stripes-react-hotkeys": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "webpack": "^4.10.2"
   },
   "dependencies": {
+    "8": "0.0.1",
     "@folio/stripes-connect": "^3.1.3",
     "@folio/stripes-form": "^0.8.2",
     "@folio/stripes-react-hotkeys": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "webpack": "^4.10.2"
   },
   "dependencies": {
-    "8": "0.0.1",
     "@folio/stripes-connect": "^3.1.3",
     "@folio/stripes-form": "^0.8.2",
     "@folio/stripes-react-hotkeys": "^1.0.0",


### PR DESCRIPTION
## Purpose

The goal of this PR is to increase confidence in the Datepicker/Calendar/DayButton components by writing tests for them. 

## Approach

I gathered required requirements about this component from @JohnC-80 and @cherewaty. 

**Features that Datepicker should support**
- uses a standard text input - value can be typed as well as picked using the calendar
- picker disappears with a click outside or blur of the input
- presents in localized format (based on locale to determine input and output)
- custom format can be applied
- excluded dates
- a11y - screen reader compatibility (announces actions, selections, values)
- a11y - keyboard navigation of dates
- accepts colors from a stripes theme/works with stripes-components postcss workflow/css-modules
- supports some version of the “passThroughValue” to keep repetitious entries to a minimum. Use-case: checkin - applying today’s date to multiple items within a check-in.  (would have to discuss alternatives with UX design staff)
- validation styles/classes in-line with other stripes-components
- Optional: outputs date in iso format (output value) (redux: format for input, normalize for output) (assumption is that all folio apps use full ISO, eholdings does not because of ebsco)
 
Then I created a list of all props that this component accepts and went through and ensured that all props either have tests or are marked as deprecated. Here is a list of all props that have been covered by the tests.

**Commonly used props**
- [x] intl
- [x] backendDateStandard
- [x] timeZone
- [x] dateFormat
- [x] locale

**HTML Attributes**
- [x] value
- [x] disabled
- [x] label
- [x] id
- [x] required
- [x] onChange
- [x] readOnly

**Deprecated**
- [x] excludeDates
- [x] ignoreLocalOffset

**Not Deprecated in this PR (but probably should)**
- [x] passThroughValue - when value matches specified value, just pass the value through

## Learning

- [x] Create an issue of accessibility issues in this component - [STCOM-315](https://issues.folio.org/browse/STCOM-315)
- [x] `prop-types-extra` package has [deprecated](https://www.npmjs.com/package/prop-types-extra#deprecatedvalidator-reason) prop type.
- [x] we might want to consider using [react-dates](http://airbnb.io/react-dates/?selectedKind=DateRangePicker%20%28DRP%29&selectedStory=default&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel) instead of fixing this component or writing something from scratch using [downshift](https://github.com/paypal/downshift)

## Screenshots

<img width="966" alt="screen shot 2018-07-18 at 9 19 59 pm" src="https://user-images.githubusercontent.com/74687/42915988-dd8c84ee-8ad0-11e8-8d0c-1170e1d3bb08.png">