### PR TITLE
Introduce responsive behavior for ModalFooter buttons

### DIFF
--- a/lib/Button/index.js
+++ b/lib/Button/index.js
@@ -1,1 +1,1 @@
-export { default } from './Button';
+export { default, propTypes } from './Button';

--- a/lib/Modal/Modal.css
+++ b/lib/Modal/Modal.css
@@ -36,6 +36,7 @@
   display: flex;
   justify-content: flex-end;
   align-items: center;
+  flex-wrap: wrap;
 }
 
 .modalLabel {
@@ -44,6 +45,7 @@
   align-items: center;
   font-weight: 600;
   min-height: 44px;
+  padding: 0 1em;
 }
 
 .modalContent {

--- a/lib/ModalFooter/ModalFooter.css
+++ b/lib/ModalFooter/ModalFooter.css
@@ -2,11 +2,11 @@
 
 .modalFooterButton {
   flex-basis: 100%;
-  margin-bottom: 0;
+  margin: 0;
   width: 100%;
 
   & + .modalFooterButton {
-    margin-top: var(--gutter);
+    margin: var(--gutter) 0 0;
   }
 
   @media (--mediumUp) {
@@ -14,7 +14,7 @@
     width: auto;
 
     & + .modalFooterButton {
-      margin-top: 0;
+      margin: 0 4px;
     }
   }
 }

--- a/lib/ModalFooter/ModalFooter.css
+++ b/lib/ModalFooter/ModalFooter.css
@@ -1,0 +1,20 @@
+@import '../variables.css';
+
+.modalFooterButton {
+  flex-basis: 100%;
+  margin-bottom: 0;
+  width: 100%;
+
+  & + .modalFooterButton {
+    margin-top: var(--gutter);
+  }
+
+  @media (--mediumUp) {
+    flex-basis: auto;
+    width: auto;
+
+    & + .modalFooterButton {
+      margin-top: 0;
+    }
+  }
+}

--- a/lib/ModalFooter/ModalFooter.js
+++ b/lib/ModalFooter/ModalFooter.js
@@ -7,12 +7,21 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Button, { propTypes as buttonPropTypes } from '../Button';
+import css from './ModalFooter.css';
 
 const ModalFooter = ({ primaryButton, secondaryButton }) => {
   // Rendered buttons are identical except for the label and buttonStyle
   const renderButton = (buttonStyle, props) => {
     const { label, ...rest } = props; // eslint-disable-line react/prop-types
-    return (<Button {...rest} buttonStyle={buttonStyle} marginBottom0>{label}</Button>);
+    return (
+      <Button
+        {...rest}
+        buttonStyle={buttonStyle}
+        buttonClass={css.modalFooterButton}
+      >
+        {label}
+      </Button>
+    );
   };
 
   return (


### PR DESCRIPTION
## Purpose
Longer button text was getting cut off by keeping the `ModalFooter` buttons inline on narrower screens / high zoom level.

Part of https://issues.folio.org/browse/UIEH-432

## Approach
Use mobile-first CSS to display the buttons as block-level until the `medium` breakpoint (641px wide).

## Screenshots
### Before, narrow screen
![localhost_9001__selectedkind modal selectedstory modalfooter full 1 addons 1 stories 1 panelright 0 addonpanel react_storybook 2freadme 2fpanel iphone 5_se 2](https://user-images.githubusercontent.com/230597/42782553-e97a2cac-890e-11e8-9ea7-a66f372aa455.png)

### After, narrow screen
![localhost_9001__selectedkind modal selectedstory modalfooter full 1 addons 1 stories 1 panelright 0 addonpanel react_storybook 2freadme 2fpanel iphone 5_se](https://user-images.githubusercontent.com/230597/42782539-e314449c-890e-11e8-8e7b-ebf4a89c6a6a.png)

### Before and after, wider screen (no change in appearance)
![localhost_9001__selectedkind modal selectedstory modalfooter full 1 addons 1 stories 1 panelright 0 addonpanel react_storybook 2freadme 2fpanel ipad](https://user-images.githubusercontent.com/230597/42782531-dc9e3424-890e-11e8-99b1-3ad30821b573.png)