### PR TITLE
STCOM-310 Use ReduxFormField for Select and TextArea

### DIFF
--- a/lib/SearchField/SearchField.js
+++ b/lib/SearchField/SearchField.js
@@ -65,10 +65,8 @@ const SearchField = (props) => {
         dataOptions={searchableIndexes}
         selectClass={css.select}
         placeholder={searchableIndexesPlaceholder}
-        input={{
-          onChange: onChangeIndex,
-          value: selectedIndex,
-        }}
+        onChange={onChangeIndex}
+        value={selectedIndex}
       />
     );
   }

--- a/lib/SearchField/SearchField.js
+++ b/lib/SearchField/SearchField.js
@@ -60,12 +60,12 @@ const SearchField = (props) => {
   if (hasSearchableIndexes) {
     searchableIndexesDropdown = (
       <Select
+        dataOptions={searchableIndexes}
         id={`${id}-qindex`}
         marginBottom0
-        dataOptions={searchableIndexes}
-        selectClass={css.select}
-        placeholder={searchableIndexesPlaceholder}
         onChange={onChangeIndex}
+        placeholder={searchableIndexesPlaceholder}
+        selectClass={css.select}
         value={selectedIndex}
       />
     );
@@ -88,19 +88,19 @@ const SearchField = (props) => {
     <div className={rootStyles}>
       {searchableIndexesDropdown}
       <TextField
-        id={id}
-        clearFieldId={clearSearchId}
-        ariaLabel={ariaLabel}
-        value={value || ''}
-        onChange={onChange}
-        startControl={!hasSearchableIndexes ? searchIcon : null}
-        inputClass={classNames(css.input, inputClass)}
-        focusedClass={css.isFocused}
         {...rest}
-        placeholder={inputPlaceholder}
-        onClearField={onClear}
+        ariaLabel={ariaLabel}
+        clearFieldId={clearSearchId}
+        focusedClass={css.isFocused}
+        id={id}
         hasClearIcon={typeof onClear === 'function' && loading !== true}
+        inputClass={classNames(css.input, inputClass)}
         loading={loading}
+        onChange={onChange}
+        onClearField={onClear}
+        placeholder={inputPlaceholder}
+        startControl={!hasSearchableIndexes ? searchIcon : null}
+        value={value || ''}
       />
     </div>
   );

--- a/lib/SearchField/tests/SearchField-test.js
+++ b/lib/SearchField/tests/SearchField-test.js
@@ -43,8 +43,7 @@ describe('SearchField', () => {
     });
   });
 
-  // needs Select to be independent of Redux Form to unskip
-  describe.skip('using with indexes', () => {
+  describe('using with indexes', () => {
     const searchableIndexes = [
       { label: 'ID', value: 'id' },
       { label: 'Title', value: 'title' },
@@ -57,15 +56,33 @@ describe('SearchField', () => {
       { label: 'Publisher', value: 'publisher' },
     ];
 
+    class SearchFieldHarness extends React.Component {
+      constructor(props) {
+        super(props);
+
+        this.state = {
+          searchFieldIndex: 'identifier',
+        };
+      }
+
+      render() {
+        return (
+          <SearchField
+            onChangeIndex={(e) => { this.setState({ searchFieldIndex: e.target.value }); }}
+            searchableIndexes={searchableIndexes}
+            selectedIndex={this.state.searchFieldIndex}
+          />
+        );
+      }
+    }
+
     beforeEach(async () => {
       await mountWithContext(
-        <SearchField
-          searchableIndexes={searchableIndexes}
-        />
+        <SearchFieldHarness />
       );
     });
 
-    describe('selecting an index', () => {
+    describe('changing the index', () => {
       beforeEach(async () => {
         await searchField.selectIndex('Publisher');
       });

--- a/lib/Select/Select.js
+++ b/lib/Select/Select.js
@@ -1,33 +1,40 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+
+import reduxFormField from '../ReduxFormField';
 import css from './Select.css';
 import formStyles from '../sharedStyles/form.css';
 import sharedInputStylesHelper from '../sharedStyles/sharedInputStylesHelper';
 import omitProps from '../../util/omitProps';
 import Icon from '../Icon';
 
-export default class Select extends Component {
+class Select extends Component {
   static propTypes = {
     autoFocus: PropTypes.bool,
+    children: PropTypes.node,
     dataOptions: PropTypes.arrayOf(PropTypes.object),
-    error: PropTypes.bool,
+    dirty: PropTypes.bool,
+    error: PropTypes.string,
     fullWidth: PropTypes.bool,
     id: PropTypes.string,
-    input: PropTypes.object,
+    label: PropTypes.string,
+    loading: PropTypes.bool,
     marginBottom0: PropTypes.bool,
-    meta: PropTypes.object,
+    name: PropTypes.string,
     placeholder: PropTypes.string,
     required: PropTypes.bool,
     selectClass: PropTypes.string,
+    touched: PropTypes.bool,
+    valid: PropTypes.bool,
     validationEnabled: PropTypes.bool,
     validStylesEnabled: PropTypes.bool,
     value: PropTypes.string,
+    warning: PropTypes.string,
   };
 
   static defaultProps = {
     autoFocus: false,
-    meta: {},
     validationEnabled: true,
     validStylesEnabled: false,
   };
@@ -52,9 +59,7 @@ export default class Select extends Component {
       css.selectControl,
       // placeholder styling
       {
-        [`${css.placeholder}`]: this.props.input ?
-          this.props.placeholder && !this.props.input.value :
-          this.props.placeholder && !this.props.value,
+        [`${css.placeholder}`]: this.props.placeholder && !this.props.value
       }, // end placeholder
       sharedInputStylesHelper(this.props),
       this.props.selectClass,
@@ -62,21 +67,26 @@ export default class Select extends Component {
   }
 
   render() {
-    const { input, meta: { error, warning, touched }, ...rest } = this.props;
-    const { ...selectAttr } = input;
-
     /* eslint-disable no-unused-vars */
     const {
-      label,
-      placeholder,
+      autoFocus,
       dataOptions,
+      dirty,
       children,
+      error,
       fullWidth,
+      label,
+      loading,
       marginBottom0,
+      name,
+      placeholder,
+      touched,
+      valid,
       validationEnabled,
       validStylesEnabled,
+      warning,
       ...selectCustom
-    } = rest;
+    } = this.props;
     /* eslint-enable no-unused-vars */
 
     const options = [];
@@ -103,9 +113,9 @@ export default class Select extends Component {
 
     const component = (
       <select
-        autoFocus={this.props.autoFocus}
+        autoFocus={autoFocus}
         className={this.getSelectClass()}
-        {...selectAttr}
+        name={name}
         {...omitProps(selectCustom, ['selectClass'])}
       >
         {options}
@@ -113,10 +123,10 @@ export default class Select extends Component {
       </select>
     );
 
-    const errorElem = touched && error ?
+    const errorElem = error ?
       <div className={formStyles.feedbackError}>{error}</div> : null;
 
-    const warningElem = touched && warning ?
+    const warningElem = warning ?
       <div className={formStyles.feedbackWarning}>{warning}</div> : null;
 
     return (
@@ -139,3 +149,20 @@ export default class Select extends Component {
     );
   }
 }
+
+export default reduxFormField(
+  Select,
+  ({ input, meta }) => ({
+    dirty: meta.dirty,
+    error: (meta.touched && meta.error ? meta.error : ''),
+    loading: meta.asyncValidating,
+    name: input.name,
+    onBlur: input.onBlur,
+    onChange: input.onChange,
+    onFocus: input.onFocus,
+    touched: meta.touched,
+    valid: meta.valid,
+    value: input.value,
+    warning: (meta.touched && meta.warning ? meta.warning : ''),
+  })
+);

--- a/lib/Select/stories/BasicUsage.js
+++ b/lib/Select/stories/BasicUsage.js
@@ -39,29 +39,23 @@ const BasicUsage = () => (
       validStylesEnabled
       label="With valid styles"
       dataOptions={options}
-      meta={{
-        touched: true,
-        dirty: true,
-        valid: true,
-      }}
+      touched
+      dirty
+      valid
     />
     <br />
     <Select
       label="With warning styles"
       dataOptions={options}
-      meta={{
-        warning: 'Here is a warning',
-        touched: true,
-      }}
+      warning="Here is a warning"
+      touched
     />
     <br />
     <Select
       label="With error styles"
       dataOptions={options}
-      meta={{
-        error: 'Here is an error',
-        touched: true,
-      }}
+      error="Here is an error"
+      touched
     />
     <br />
     <Select

--- a/lib/Select/tests/Select-ReduxForm-test.js
+++ b/lib/Select/tests/Select-ReduxForm-test.js
@@ -1,0 +1,105 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { Field } from 'redux-form';
+import { mountWithContext } from '../../../tests/helpers';
+import TestForm from '../../../tests/TestForm';
+import Select from '../Select';
+import SelectInteractor from './interactor';
+
+describe('Select with ReduxForm', () => {
+  const select = new SelectInteractor();
+
+  describe('inputting a value', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <TestForm>
+          <Field
+            name="testField"
+            component={Select}
+            dataOptions={[
+              { value: 'test0', label: 'Option 0' },
+              { value: 'test1', label: 'Option 1' },
+              { value: 'test2', label: 'Option 2' }
+             ]}
+          />
+        </TestForm>
+      );
+    });
+
+    it('renders a select element', () => {
+      expect(select.hasSelect).to.be.true;
+    });
+
+    describe('changing the value', () => {
+      beforeEach(async () => {
+        await select.selectOption('Option 2')
+          .focusSelect();
+      });
+
+      it('applies a changed class', () => {
+        expect(select.hasChangedStyle).to.be.true;
+      });
+    });
+  });
+
+  describe('selecting an invalid value', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <TestForm>
+          <Field
+            name="testField"
+            component={Select}
+            dataOptions={[
+              { value: 'test0', label: 'Option 0' },
+              { value: 'valid', label: 'Option 1' },
+              { value: 'invalid', label: 'Option 2' }
+             ]}
+            validate={value => (value === 'invalid' ? 'testField is Invalid' : undefined)}
+          />
+        </TestForm>
+      );
+    });
+
+    beforeEach(async () => {
+      await select.selectAndBlur('Option 2');
+    });
+
+    it('applies an error style', () => {
+      expect(select.hasErrorStyle).to.be.true;
+    });
+
+    it('renders an error message', () => {
+      expect(select.errorText).to.equal('testField is Invalid');
+    });
+  });
+
+  describe('selecting a valid value with validStylesEnabled', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <TestForm>
+          <Field
+            name="testField"
+            component={Select}
+            validStylesEnabled
+            dataOptions={[
+              { value: 'test0', label: 'Option 0' },
+              { value: 'valid', label: 'Option 1' },
+              { value: 'invalid', label: 'Option 2' }
+             ]}
+            validate={value => (value === undefined ? 'testField cannot be blank' : undefined)}
+          />
+        </TestForm>
+      );
+    });
+
+    beforeEach(async () => {
+      await select.selectAndBlur('Option 1');
+    });
+
+    it('applies a valid class', () => {
+      expect(select.hasValidStyle).to.be.true;
+    });
+  });
+});

--- a/lib/Select/tests/Select-test.js
+++ b/lib/Select/tests/Select-test.js
@@ -2,39 +2,39 @@ import React from 'react';
 import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 
-import { Field } from 'redux-form';
-import { mount, mountWithContext } from '../../../tests/helpers';
-import TestForm from '../../../tests/TestForm';
+import { mount } from '../../../tests/helpers';
 import Select from '../Select';
 import SelectInteractor from './interactor';
 
 describe('Select', () => {
   const select = new SelectInteractor();
 
-  beforeEach(async () => {
-    await mount(
-      <Select
-        id="test"
-        placeholder="Choose an option"
-        dataOptions={[
-          { value: 'test0', label: 'Option 0' },
-          { value: 'test1', label: 'Option 1' },
-          { value: 'test2', label: 'Option 2' }
-         ]}
-      />
-    );
-  });
+  describe('rendering a basic Select', async () => {
+    beforeEach(async () => {
+      await mount(
+        <Select
+          id="test"
+          placeholder="Choose an option"
+          dataOptions={[
+            { value: 'test0', label: 'Option 0' },
+            { value: 'test1', label: 'Option 1' },
+            { value: 'test2', label: 'Option 2' }
+           ]}
+        />
+      );
+    });
 
-  it('renders a select element', () => {
-    expect(select.hasSelect).to.be.true;
-  });
+    it('renders a select element', () => {
+      expect(select.hasSelect).to.be.true;
+    });
 
-  it('renders no label tag by default', () => {
-    expect(select.hasLabel).to.be.false;
-  });
+    it('renders no label tag by default', () => {
+      expect(select.hasLabel).to.be.false;
+    });
 
-  it('applies the id to the select', () => {
-    expect(select.id).to.equal('test');
+    it('applies the id to the select', () => {
+      expect(select.id).to.equal('test');
+    });
   });
 
   describe('entering text', async () => {
@@ -63,97 +63,35 @@ describe('Select', () => {
     });
   });
 
-  describe('using with redux-form', () => {
-    describe('inputting a value', () => {
-      beforeEach(async () => {
-        await mountWithContext(
-          <TestForm>
-            <Field
-              name="testField"
-              component={Select}
-              dataOptions={[
-                { value: 'test0', label: 'Option 0' },
-                { value: 'test1', label: 'Option 1' },
-                { value: 'test2', label: 'Option 2' }
-               ]}
-            />
-          </TestForm>
-        );
-      });
-
-      it('renders a select element', () => {
-        expect(select.hasSelect).to.be.true;
-      });
-
-      describe('changing the value', () => {
-        beforeEach(async () => {
-          await select.selectOption('Option 2')
-            .focusSelect();
-        });
-
-        it('applies a changed class', () => {
-          expect(select.hasChangedStyle).to.be.true;
-        });
-      });
+  describe('supplying an error', () => {
+    beforeEach(async () => {
+      await mount(
+        <Select error="This is an error." />
+      );
     });
 
-    describe('selecting an invalid value', () => {
-      beforeEach(async () => {
-        await mountWithContext(
-          <TestForm>
-            <Field
-              name="testField"
-              component={Select}
-              dataOptions={[
-                { value: 'test0', label: 'Option 0' },
-                { value: 'valid', label: 'Option 1' },
-                { value: 'invalid', label: 'Option 2' }
-               ]}
-              validate={value => (value === 'invalid' ? 'testField is Invalid' : undefined)}
-            />
-          </TestForm>
-        );
-      });
-
-      beforeEach(async () => {
-        await select.selectAndBlur('Option 2');
-      });
-
-      it('applies an error style', () => {
-        expect(select.hasErrorStyle).to.be.true;
-      });
-
-      it('renders an error message', () => {
-        expect(select.errorText).to.equal('testField is Invalid');
-      });
+    it('renders an error element', () => {
+      expect(select.errorText).to.equal('This is an error.');
     });
 
-    describe('selecting a valid value with validStylesEnabled', () => {
-      beforeEach(async () => {
-        await mountWithContext(
-          <TestForm>
-            <Field
-              name="testField"
-              component={Select}
-              validStylesEnabled
-              dataOptions={[
-                { value: 'test0', label: 'Option 0' },
-                { value: 'valid', label: 'Option 1' },
-                { value: 'invalid', label: 'Option 2' }
-               ]}
-              validate={value => (value === undefined ? 'testField cannot be blank' : undefined)}
-            />
-          </TestForm>
-        );
-      });
+    it('applies an error style', () => {
+      expect(select.hasErrorStyle).to.be.true;
+    });
+  });
 
-      beforeEach(async () => {
-        await select.selectAndBlur('Option 1');
-      });
+  describe('supplying a warning', () => {
+    beforeEach(async () => {
+      await mount(
+        <Select warning="This is a warning." />
+      );
+    });
 
-      it('applies a valid class', () => {
-        expect(select.hasValidStyle).to.be.true;
-      });
+    it('renders a warning element', () => {
+      expect(select.warningText).to.equal('This is a warning.');
+    });
+
+    it('applies a warning style', () => {
+      expect(select.hasWarningStyle).to.be.true;
     });
   });
 });

--- a/lib/Select/tests/interactor.js
+++ b/lib/Select/tests/interactor.js
@@ -13,6 +13,7 @@ import {
 
 import css from '../Select.css';
 import formCss from '../../sharedStyles/form.css';
+import { selectorFromClassnameString } from '../../../tests/helpers';
 
 export default interactor(class SelectInteractor {
   hasSelect = isPresent('select');
@@ -25,7 +26,8 @@ export default interactor(class SelectInteractor {
   labelFor = attribute('label', 'for');
   label = text('label');
   hasLabel = isPresent('label');
-  errorText = text(`div.${formCss.feedbackBlock}`);
+  errorText = text(selectorFromClassnameString(`.${formCss.feedbackError}`));
+  warningText = text(selectorFromClassnameString(`.${formCss.feedbackWarning}`));
   hasWarningStyle = hasClass('select', formCss.hasWarning);
   hasErrorStyle = hasClass('select', formCss.hasError);
   hasChangedStyle = hasClass('select', formCss.isChanged);

--- a/lib/TextArea/TextArea.js
+++ b/lib/TextArea/TextArea.js
@@ -1,23 +1,26 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import className from 'classnames';
+
+import reduxFormField from '../ReduxFormField';
 import css from './TextArea.css';
 import omitProps from '../../util/omitProps';
 import sharedInputStylesHelper from '../sharedStyles/sharedInputStylesHelper';
 import formStyles from '../sharedStyles/form.css';
 
-export default class TextArea extends Component {
+class TextArea extends Component {
   static propTypes = {
     autoFocus: PropTypes.bool,
+    dirty: PropTypes.bool,
     endControl: PropTypes.element,
     error: PropTypes.string,
     fullWidth: PropTypes.bool,
     id: PropTypes.string,
-    input: PropTypes.object,
     inputRef: PropTypes.func,
     label: PropTypes.string,
+    loading: PropTypes.bool,
     marginBottom0: PropTypes.bool,
-    meta: PropTypes.object,
+    name: PropTypes.string,
     /**
      * Removes border.
      */
@@ -28,10 +31,12 @@ export default class TextArea extends Component {
     onChange: PropTypes.func,
     required: PropTypes.bool,
     startControl: PropTypes.element,
+    touched: PropTypes.bool,
     /**
      * Can be "type" or "number". Standard html attribute.
      */
     type: PropTypes.string,
+    valid: PropTypes.bool,
     validationEnabled: PropTypes.bool,
     validStylesEnabled: PropTypes.bool,
     /**
@@ -74,57 +79,44 @@ export default class TextArea extends Component {
   }
 
   render() {
-    let cleanedProps;
-    let input;
-    let error;
-    let warning;
-    let touched;
-    let rest;
-    let inputProps;
-    if (this.props.input) {
-      ({ input, meta: { error, warning, touched }, ...rest } = this.props);
-      const { ...inputAttr } = input;
-      inputProps = { ...inputAttr };
-      cleanedProps = { ...rest };
-    } else {
-      cleanedProps = this.props;
-      inputProps = null;
-    }
-
     /* eslint-disable no-unused-vars */
     const {
-      label,
+      autoFocus,
+      dirty,
       endControl,
-      startControl,
-      required,
+      error,
       fullWidth,
-      bottomMargin0,
-      noBorder,
       inputRef,
+      label,
+      loading,
+      name,
+      noBorder,
+      required,
+      startControl,
+      touched,
+      valid,
       validStylesEnabled,
+      warning,
       ...inputCustom
-    } = cleanedProps;
+    } = this.props;
     /* eslint-enable no-unused-vars */
 
     const component = (
       <textarea
-        className={this.getInputStyle()}
-        {...inputProps}
-        {...omitProps(inputCustom, ['meta', 'validationEnabled'])}
         aria-required={required}
-        ref={cleanedProps.inputRef}
-        autoFocus={this.props.autoFocus}
+        autoFocus={autoFocus}
+        className={this.getInputStyle()}
+        name={name}
+        ref={inputRef}
+        {...omitProps(inputCustom, ['validationEnabled'])}
       />
     );
 
-    let warningElement;
-    let errorElement;
-    if (this.props.meta) {
-      warningElement = touched && warning ?
-        <div className={formStyles.feedbackWarning}>{warning}</div> : null;
-      errorElement = touched && error ?
-        <div className={formStyles.feedbackError}>{error}</div> : null;
-    }
+    const warningElement = warning ?
+      <div className={formStyles.feedbackWarning}>{warning}</div> : null;
+
+    const errorElement = error ?
+      <div className={formStyles.feedbackError}>{error}</div> : null;
 
     const labelElement = label ?
       <label
@@ -145,3 +137,20 @@ export default class TextArea extends Component {
     );
   }
 }
+
+export default reduxFormField(
+  TextArea,
+  ({ input, meta }) => ({
+    dirty: meta.dirty,
+    error: (meta.touched && meta.error ? meta.error : ''),
+    loading: meta.asyncValidating,
+    name: input.name,
+    onBlur: input.onBlur,
+    onChange: input.onChange,
+    onFocus: input.onFocus,
+    touched: meta.touched,
+    valid: meta.valid,
+    value: input.value,
+    warning: (meta.touched && meta.warning ? meta.warning : ''),
+  })
+);

--- a/lib/TextArea/stories/BasicUsage.js
+++ b/lib/TextArea/stories/BasicUsage.js
@@ -21,19 +21,26 @@ const BasicUsage = () => (
     <br /><br />
     <TextArea
       validStylesEnabled
-      meta={{ touched: true, valid: true, dirty: true }}
+      touched
+      valid
+      dirty
       label="Field with validation success"
     />
     <br /><br />
     <TextArea
-      input={{ value: 'Wrong value..', onChange: () => {} }}
-      meta={{ touched: true, error: 'Here is an error message' }}
+      value="Wrong value.."
+      onChange={() => {}}
+      touched
+      error="Here is an error message"
       label="Field with a validation error"
     />
     <br /><br />
     <TextArea
-      input={{ value: 'Not entirely valid value..', onChange: () => {} }}
-      meta={{ touched: true, warning: 'Here is a warning', dirty: true }}
+      value="Not entirely valid value.."
+      onChange={() => {}}
+      touched
+      warning="Here is a warning"
+      dirty
       label="Field with validation warning"
     />
   </div>

--- a/lib/TextArea/tests/TextArea-ReduxForm-test.js
+++ b/lib/TextArea/tests/TextArea-ReduxForm-test.js
@@ -1,0 +1,104 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { Field } from 'redux-form';
+import { mountWithContext } from '../../../tests/helpers';
+import TestForm from '../../../tests/TestForm';
+import TextArea from '../TextArea';
+import TextAreaInteractor from './interactor';
+
+describe('TextArea with ReduxForm', () => {
+  const textArea = new TextAreaInteractor();
+
+  describe('inputting a value', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <TestForm>
+          <Field
+            name="testField"
+            component={TextArea}
+          />
+        </TestForm>
+      );
+    });
+
+    it('renders a textarea element', () => {
+      expect(textArea.hasTextArea).to.be.true;
+    });
+
+    describe('changing the value', () => {
+      beforeEach(async () => {
+        await textArea.fillTextArea('anything')
+          .focusTextArea();
+      });
+
+      it('applies a changed class', () => {
+        expect(textArea.hasChangedStyle).to.be.true;
+      });
+    });
+  });
+
+  describe('inputting an invalid value', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <TestForm>
+          <Field
+            name="testField"
+            component={TextArea}
+            validate={value => (value === 'invalid' ? 'testField is Invalid' : undefined)}
+          />
+        </TestForm>
+      );
+    });
+
+    beforeEach(async () => {
+      await textArea.fillAndBlur('invalid');
+    });
+
+    it('applies an error style', () => {
+      expect(textArea.hasErrorStyle).to.be.true;
+    });
+
+    it('renders an error message', () => {
+      expect(textArea.errorText).to.equal('testField is Invalid');
+    });
+  });
+
+  describe('inputting an valid value with validStylesEnabled', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <TestForm>
+          <Field
+            name="testField"
+            component={TextArea}
+            validStylesEnabled
+            validate={value => (value === undefined ? 'testField cannot be blank' : undefined)}
+          />
+        </TestForm>
+      );
+    });
+
+    beforeEach(async () => {
+      await textArea.fillAndBlur('valid');
+    });
+
+    it('applies a valid class', () => {
+      expect(textArea.hasValidStyle).to.be.true;
+    });
+
+    describe('then removing the text', () => {
+      beforeEach(async () => {
+        await textArea.fillAndBlur('');
+      });
+
+      it('applies an error style', () => {
+        expect(textArea.hasErrorStyle).to.be.true;
+      });
+
+      it('renders an error message', () => {
+        expect(textArea.errorText).to.equal('testField cannot be blank');
+      });
+    });
+  });
+});

--- a/lib/TextArea/tests/TextArea-test.js
+++ b/lib/TextArea/tests/TextArea-test.js
@@ -2,31 +2,31 @@ import React from 'react';
 import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 
-import { Field } from 'redux-form';
-import { mount, mountWithContext } from '../../../tests/helpers';
-import TestForm from '../../../tests/TestForm';
+import { mount } from '../../../tests/helpers';
 import TextArea from '../TextArea';
 import TextAreaInteractor from './interactor';
 
 describe('TextArea', () => {
   const textArea = new TextAreaInteractor();
 
-  beforeEach(async () => {
-    await mount(
-      <TextArea id="test" />
-    );
-  });
+  describe('rendering a basic TextArea', async () => {
+    beforeEach(async () => {
+      await mount(
+        <TextArea id="test" />
+      );
+    });
 
-  it('renders a textarea element', () => {
-    expect(textArea.hasTextArea).to.be.true;
-  });
+    it('renders a textarea element', () => {
+      expect(textArea.hasTextArea).to.be.true;
+    });
 
-  it('renders no label tag by default', () => {
-    expect(textArea.hasLabel).to.be.false;
-  });
+    it('renders no label tag by default', () => {
+      expect(textArea.hasLabel).to.be.false;
+    });
 
-  it('applies the id to the textarea', () => {
-    expect(textArea.id).to.equal('test');
+    it('applies the id to the textarea', () => {
+      expect(textArea.id).to.equal('test');
+    });
   });
 
   describe('entering text', async () => {
@@ -55,96 +55,35 @@ describe('TextArea', () => {
     });
   });
 
-  describe('using with redux-form', () => {
-    describe('inputting a value', () => {
-      beforeEach(async () => {
-        await mountWithContext(
-          <TestForm>
-            <Field
-              name="testField"
-              component={TextArea}
-            />
-          </TestForm>
-        );
-      });
-
-      it('renders a textarea element', () => {
-        expect(textArea.hasTextArea).to.be.true;
-      });
-
-      describe('changing the value', () => {
-        beforeEach(async () => {
-          await textArea.fillTextArea('anything')
-            .focusTextArea();
-        });
-
-        it('applies a changed class', () => {
-          expect(textArea.hasChangedStyle).to.be.true;
-        });
-      });
+  describe('supplying an error', () => {
+    beforeEach(async () => {
+      await mount(
+        <TextArea error="This is an error." />
+      );
     });
 
-    describe('inputting an invalid value', () => {
-      beforeEach(async () => {
-        await mountWithContext(
-          <TestForm>
-            <Field
-              name="testField"
-              component={TextArea}
-              validate={value => (value === 'invalid' ? 'testField is Invalid' : undefined)}
-            />
-          </TestForm>
-        );
-      });
-
-      beforeEach(async () => {
-        await textArea.fillAndBlur('invalid');
-      });
-
-      it('applies an error style', () => {
-        expect(textArea.hasErrorStyle).to.be.true;
-      });
-
-      it('renders an error message', () => {
-        expect(textArea.errorText).to.equal('testField is Invalid');
-      });
+    it('renders an error element', () => {
+      expect(textArea.errorText).to.equal('This is an error.');
     });
 
-    describe('inputting an valid value with validStylesEnabled', () => {
-      beforeEach(async () => {
-        await mountWithContext(
-          <TestForm>
-            <Field
-              name="testField"
-              component={TextArea}
-              validStylesEnabled
-              validate={value => (value === undefined ? 'testField cannot be blank' : undefined)}
-            />
-          </TestForm>
-        );
-      });
+    it('applies an error style', () => {
+      expect(textArea.hasErrorStyle).to.be.true;
+    });
+  });
 
-      beforeEach(async () => {
-        await textArea.fillAndBlur('valid');
-      });
+  describe('supplying a warning', () => {
+    beforeEach(async () => {
+      await mount(
+        <TextArea warning="This is a warning." />
+      );
+    });
 
-      it('applies a valid class', () => {
-        expect(textArea.hasValidStyle).to.be.true;
-      });
+    it('renders a warning element', () => {
+      expect(textArea.warningText).to.equal('This is a warning.');
+    });
 
-      describe('then removing the text', () => {
-        beforeEach(async () => {
-          await textArea.fillAndBlur('');
-        });
-
-        it('applies an error style', () => {
-          expect(textArea.hasErrorStyle).to.be.true;
-        });
-
-        it('renders an error message', () => {
-          expect(textArea.errorText).to.equal('testField cannot be blank');
-        });
-      });
+    it('applies a warning style', () => {
+      expect(textArea.hasWarningStyle).to.be.true;
     });
   });
 });

--- a/lib/TextArea/tests/interactor.js
+++ b/lib/TextArea/tests/interactor.js
@@ -13,6 +13,7 @@ import {
 
 import css from '../TextArea.css';
 import formCss from '../../sharedStyles/form.css';
+import { selectorFromClassnameString } from '../../../tests/helpers';
 
 export default interactor(class TextAreaInteractor {
   hasTextArea = isPresent('textarea');
@@ -25,7 +26,8 @@ export default interactor(class TextAreaInteractor {
   labelFor = attribute('label', 'for');
   label = text('label');
   hasLabel = isPresent('label');
-  errorText = text(`div.${formCss.feedbackBlock}`);
+  errorText = text(selectorFromClassnameString(`.${formCss.feedbackError}`));
+  warningText = text(selectorFromClassnameString(`.${formCss.feedbackWarning}`));
   hasWarningStyle = hasClass('textarea', formCss.hasWarning);
   hasErrorStyle = hasClass('textarea', formCss.hasError);
   hasChangedStyle = hasClass('textarea', formCss.isChanged);

--- a/lib/sharedStyles/sharedInputStylesHelper.js
+++ b/lib/sharedStyles/sharedInputStylesHelper.js
@@ -4,30 +4,28 @@
  * A shared input classes helper for adding
  * common input class names across input, textarea and select fields.
  *
- * It also adds validation classes that uses
- * the meta prop which is injected by redux-form
  */
 
 import classNames from 'classnames';
 import formStyles from './form.css';
 
-export default ({ meta, ...props }) => {
+export default (props) => {
   // Validation classes
   let validationClasses = null;
   const {
+    dirty,
+    error,
+    marginBottom0,
+    noBorder,
+    valid,
     validationEnabled,
     validStylesEnabled,
-    touched,
-    warning,
-    error,
-    dirty,
-    asyncValidating,
-    valid
-  } = { ...meta, ...props };
+    warning
+  } = props;
 
-  const hasError = validationEnabled && touched && error;
-  const isValid = validationEnabled && validStylesEnabled && touched && !asyncValidating && valid && dirty;
-  const hasWarning = validationEnabled && touched && warning;
+  const hasError = validationEnabled && error;
+  const isValid = validationEnabled && validStylesEnabled && valid;
+  const hasWarning = validationEnabled && warning;
   const hasFeedback = validationEnabled && (error || warning);
   validationClasses = classNames(
     { [`${formStyles.isChanged}`]: dirty && !hasError && !hasWarning && !isValid },
@@ -40,8 +38,8 @@ export default ({ meta, ...props }) => {
   // Other input classes
   return classNames(
     formStyles.input,
-    { [`${formStyles.noBorder}`]: props.noBorder },
-    { [`${formStyles.marginBottom0}`]: props.marginBottom0 },
+    { [`${formStyles.noBorder}`]: noBorder },
+    { [`${formStyles.marginBottom0}`]: marginBottom0 },
     validationClasses,
   );
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
## Purpose
Continue the pattern established in https://github.com/folio-org/stripes-components/pull/372.

Related to https://issues.folio.org/browse/STCOM-269
Resolves https://issues.folio.org/browse/STCOM-310

## Approach
Use the `reduxFormField()` higher-order component to simplify the logic in form field components.

With `Select` and `TextArea` using `reduxFormField()`, we can also simplify `SearchField` and the `sharedInputStylesHelper` to not know anything about `input` or `meta` props from Redux Form.

## Learning
`SearchField` needed a pattern described in https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html
