### PR TITLE
Change order of ModalFooter buttons

### DIFF
--- a/lib/Modal/Modal.css
+++ b/lib/Modal/Modal.css
@@ -34,9 +34,8 @@
   border-top: 1px solid var(--color-border-p2);
   padding: var(--gutter);
   display: flex;
-  justify-content: flex-end;
   align-items: center;
-  flex-wrap: wrap;
+  flex-flow: row-reverse wrap;
 }
 
 .modalLabel {

--- a/lib/ModalFooter/ModalFooter.css
+++ b/lib/ModalFooter/ModalFooter.css
@@ -6,7 +6,7 @@
   width: 100%;
 
   & + .modalFooterButton {
-    margin: var(--gutter) 0 0;
+    margin: var(--controlMarginBottom) 0 0;
   }
 
   @media (--mediumUp) {

--- a/lib/ModalFooter/ModalFooter.js
+++ b/lib/ModalFooter/ModalFooter.js
@@ -26,8 +26,8 @@ const ModalFooter = ({ primaryButton, secondaryButton }) => {
 
   return (
     <Fragment>
-      {secondaryButton ? renderButton('default', secondaryButton) : null}
       {primaryButton ? renderButton('primary', primaryButton) : null}
+      {secondaryButton ? renderButton('default', secondaryButton) : null}
     </Fragment>
   );
 };


### PR DESCRIPTION
Uses `flex-direction` to show the primary button:
- first in markup
- first on small screens
- last on wider screens

I also replaced `gutter` with `controlMarginBottom`, which reduced the vertical spacing between buttons from 15px to 12px. Fits in better with other form elements.

### Narrow screen
![localhost_9001__selectedkind modal selectedstory modalfooter addons 1 stories 1 panelright 0 addonpanel react_storybook 2freadme 2fpanel iphone 5_se](https://user-images.githubusercontent.com/230597/42850453-52a9a354-89ed-11e8-8d8e-de892f5906b2.png)

### Wider screen
<img width="468" alt="screen shot 2018-07-17 at 6 15 18 pm" src="https://user-images.githubusercontent.com/230597/42850467-63a2bcae-89ed-11e8-8dad-c02889c636e3.png">

### Wider screen, RTL
<img width="484" alt="screen shot 2018-07-17 at 6 13 05 pm" src="https://user-images.githubusercontent.com/230597/42850424-2cde0110-89ed-11e8-934c-487cd7274fdd.png">