### PR TITLE
change size of a small icon

### DIFF
--- a/lib/Icon/Icon.css
+++ b/lib/Icon/Icon.css
@@ -40,8 +40,9 @@
  */
 
 .small {
-  height: 16px;
-  min-width: 16px;
+  height: 14px;
+  width: 14px;
+  min-width: 14px;
 }
 
 .medium {

--- a/lib/Icon/tests/Icon-test.js
+++ b/lib/Icon/tests/Icon-test.js
@@ -20,8 +20,8 @@ describe('Icon', () => {
 
   const sizes = {
     small: {
-      width: 16,
-      height: 16,
+      width: 14,
+      height: 14,
     },
     medium: {
       width: 24,


### PR DESCRIPTION
- In order to use this Icon in ui-eholdings app, we want size "small" to be 14x14 since that matches with font size. 
- We are using this Icon component as part of an external link component, which displays an external link inline with this icon.
- Open question is whether changing this size affects other apps in a bad way, and if we want to introduce another size, possibly x-small that represents 14x14 and leave small as 16x16.