### PR TITLE
Allow number for Select value prop

### DIFF
--- a/lib/Select/Select.js
+++ b/lib/Select/Select.js
@@ -29,7 +29,7 @@ class Select extends Component {
     valid: PropTypes.bool,
     validationEnabled: PropTypes.bool,
     validStylesEnabled: PropTypes.bool,
-    value: PropTypes.string,
+    value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     warning: PropTypes.string,
   };
 


### PR DESCRIPTION
eHoldings uses a `<Select>` with Redux Form to add identifiers to a title:
```
<Field
  name={`${identifier}.flattenedType`}
  type="text"
  component={Select}
  autoFocus={Object.keys(allFields.get(index)).length === 0}
  label="Type"
  dataOptions={[
    { value: '0', label: 'ISSN (Online)' },
    { value: '1', label: 'ISSN (Print)' },
    { value: '2', label: 'ISBN (Online)' },
    { value: '3', label: 'ISBN (Print)' }
  ]}
/>
```

That fails the `<Select>` `propType` validation because the values eventually get parsed as numbers, not strings.

It seems like it'd be a common use case to have a numerical ID as the value for a `<Select>`.