### PR TITLE
STCOM-314 Rename errorText and warningText props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-components
 
 ## 4.0.0 (IN PROGRESS)
+* Rename `errorText` and `warningText` props to `error` and `warning` for consistency. Fixes STCOM-314
 
 ## [3.0.0](https://github.com/folio-org/stripes-components/tree/v3.0.0)
 

--- a/lib/Checkbox/Checkbox.js
+++ b/lib/Checkbox/Checkbox.js
@@ -15,7 +15,7 @@ class Checkbox extends React.Component {
     ]),
     className: PropTypes.string,
     disabled: PropTypes.bool,
-    errorText: PropTypes.string,
+    error: PropTypes.string,
     fullWidth: PropTypes.bool,
     hover: PropTypes.bool,
     id: PropTypes.string,
@@ -32,7 +32,7 @@ class Checkbox extends React.Component {
     onChange: PropTypes.func,
     onFocus: PropTypes.func,
     value: PropTypes.string,
-    warningText: PropTypes.string,
+    warning: PropTypes.string,
   };
 
   constructor(props) {
@@ -75,13 +75,13 @@ class Checkbox extends React.Component {
 
   // Add feedback class on warning or error
   getFeedbackClasses() {
-    const { warningText, errorText } = this.props;
+    const { warning, error } = this.props;
     const classes = [];
 
     // Check if checkbox has error or warning
-    if (errorText) {
+    if (error) {
       classes.push(css.hasError);
-    } else if (warningText) {
+    } else if (warning) {
       classes.push(css.hasWarning);
     }
 
@@ -100,8 +100,8 @@ class Checkbox extends React.Component {
       return false;
     }
 
-    const error = this.props.errorText;
-    const warning = this.props.warningText;
+    const error = this.props.error;
+    const warning = this.props.warning;
 
     // Currently prefering error over warning
     return (<div className={css.checkboxFeedback}>{error || warning}</div>);
@@ -198,7 +198,7 @@ export default reduxFormField(
     onChange: input.onChange,
     onBlur: input.onBlur,
     onFocus: input.onFocus,
-    warningText: (meta.touched && meta.warning ? meta.warning : ''),
-    errorText: (meta.touched && meta.error ? meta.error : '')
+    warning: (meta.touched && meta.warning ? meta.warning : ''),
+    error: (meta.touched && meta.error ? meta.error : '')
   })
 );

--- a/lib/Checkbox/tests/Checkbox-test.js
+++ b/lib/Checkbox/tests/Checkbox-test.js
@@ -27,7 +27,7 @@ describe('Checkbox', () => {
   describe('with warning text', () => {
     beforeEach(async () => {
       await mount(
-        <Checkbox warningText="That's not a great value." />
+        <Checkbox warning="That's not a great value." />
       );
     });
 
@@ -43,7 +43,7 @@ describe('Checkbox', () => {
   describe('with error text', () => {
     beforeEach(async () => {
       await mount(
-        <Checkbox errorText="That's a bad value." />
+        <Checkbox error="That's a bad value." />
       );
     });
 

--- a/lib/ReduxFormField/readme.md
+++ b/lib/ReduxFormField/readme.md
@@ -15,8 +15,8 @@ To normalize the `input` and `meta` props injected by Redux Form:
 ```jsx
 import reduxFormField from '@folio/stripes-components/lib/ReduxFormField';
 
-function ExampleComponent({ value, onChange, warningText, errorText }) => (
-  <div>{warningText}</div>
+function ExampleComponent({ value, onChange, warning, error }) => (
+  <div>{warning}</div>
 );
 
 export default reduxFormField(
@@ -24,8 +24,8 @@ export default reduxFormField(
   ({ input, meta }) => ({
     value: input.value,
     onChange: input.onChange,
-    warningText: (meta.touched && meta.warning ? meta.warning : ''),
-    errorText: (meta.touched && meta.error ? meta.error : '')
+    warning: (meta.touched && meta.warning ? meta.warning : ''),
+    error: (meta.touched && meta.error ? meta.error : '')
   })
 );
 ```

--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -28,7 +28,7 @@ const propTypes = {
   })).isRequired,
   disabled: PropTypes.bool,
   emptyMessage: PropTypes.string,
-  errorText: PropTypes.string,
+  error: PropTypes.string,
   formatter: PropTypes.func,
   hasChanged: PropTypes.bool,
   id: PropTypes.string,
@@ -49,7 +49,7 @@ const propTypes = {
   tether: PropTypes.object,
   useValidStyle: PropTypes.bool,
   value: PropTypes.string,
-  warningText: PropTypes.string,
+  warning: PropTypes.string,
 };
 
 const defaultProps = {
@@ -601,16 +601,16 @@ class SingleSelect extends React.Component { // eslint-disable-line react/no-dep
   getControlClass() {
     let validationClasses = '';
     validationClasses = classNames(
-      { [`${formStyles.hasFeedback}`]: this.props.errorText || this.props.warningText },
-      { [`${formStyles.hasWarning}`]: this.props.warningText },
-      { [`${formStyles.hasError}`]: this.props.errorText },
+      { [`${formStyles.hasFeedback}`]: this.props.error || this.props.warning },
+      { [`${formStyles.hasWarning}`]: this.props.warning },
+      { [`${formStyles.hasError}`]: this.props.error },
       { [`${formStyles.isChanged}`]: this.props.hasChanged },
       {
         [`${formStyles.isValid}`]:
           this.props.useValidStyle &&
           this.props.isValid &&
-          !this.props.errorText &&
-          !this.props.warningText
+          !this.props.error &&
+          !this.props.warning
       },
     );
 
@@ -630,15 +630,15 @@ class SingleSelect extends React.Component { // eslint-disable-line react/no-dep
   }
 
   getWarningElement() {
-    if (this.props.warningText) {
-      return <div className={`${formStyles.feedbackWarning}`}>{this.props.warningText}</div>;
+    if (this.props.warning) {
+      return <div className={`${formStyles.feedbackWarning}`}>{this.props.warning}</div>;
     }
     return null;
   }
 
   getErrorElement() {
-    if (this.props.errorText) {
-      return <div className={`${formStyles.feedbackError}`}>{this.props.errorText}</div>;
+    if (this.props.error) {
+      return <div className={`${formStyles.feedbackError}`}>{this.props.error}</div>;
     }
     return null;
   }
@@ -705,7 +705,7 @@ class SingleSelect extends React.Component { // eslint-disable-line react/no-dep
             className={this.getControlClass()}
             ref={this.control}
             id={this.testId}
-            aria-invalid={this.props.errorText ? 'true' : 'false'}
+            aria-invalid={this.props.error ? 'true' : 'false'}
             aria-disabled={(this.props.disabled)}
             aria-owns={`sl-${this.props.id}`}
             name={this.props.name}
@@ -804,8 +804,8 @@ export default reduxFormField(
     onChange: input.onChange,
     onBlur: input.onBlur,
     onFocus: input.onFocus,
-    warningText: (meta.touched ? meta.warning : undefined),
-    errorText: (meta.touched ? meta.error : undefined),
+    warning: (meta.touched ? meta.warning : undefined),
+    error: (meta.touched ? meta.error : undefined),
     isValid: (meta.touched ? meta.valid : undefined),
     hasChanged: (meta.dirty),
   })

--- a/lib/Selection/tests/SingleSelection-test.js
+++ b/lib/Selection/tests/SingleSelection-test.js
@@ -273,12 +273,12 @@ describe('Selection, Single select', () => {
         });
       });
 
-      describe('Supplied an \'errorText\' prop', () => {
+      describe('Supplied an \'error\' prop', () => {
         beforeEach(async () => {
           await mountWithContext(
             <Selection
               dataOptions={listOptions}
-              errorText="Selection is invalid!"
+              error="Selection is invalid!"
             />
           );
         });
@@ -292,12 +292,12 @@ describe('Selection, Single select', () => {
         });
       });
 
-      describe('Supplied an \'warningText\' prop', () => {
+      describe('Supplied an \'warning\' prop', () => {
         beforeEach(async () => {
           await mountWithContext(
             <Selection
               dataOptions={listOptions}
-              warningText="You might want to choose something different!"
+              warning="You might want to choose something different!"
             />
           );
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
## Purpose
1. `<SingleSelect>` and `<Checkbox>` have props `errorText` and `warningText`.
2. `<Select>`, `<TextArea>`, and `<TextField>` call those same props `error` and `warning`.

Resolves https://issues.folio.org/browse/STCOM-314

## Approach
We decided on style 2 as the preferred.

This is technically a breaking change, but no `folio-org` projects were using the old prop naming.