### PR TITLE
Settings: Expose nav pane width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-components
 
 ## 4.0.0 (IN PROGRESS)
+* Expose `Settings` nav pane width via `navPaneWidth` prop.
 
 ## [3.0.0](https://github.com/folio-org/stripes-components/tree/v3.0.0)
 

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -83,7 +83,7 @@ class Settings extends React.Component {
     return (
       <Paneset nested defaultWidth="80%">
         <Pane
-          defaultWidth="fill"
+          defaultWidth={props.navPaneWidth}
           paneTitle={props.paneTitle || 'Module Settings'}
           firstMenu={(
             <Link to="/settings" className={css.settingsBackButton}>
@@ -113,6 +113,7 @@ Settings.propTypes = {
   match: PropTypes.shape({
     path: PropTypes.string.isRequired,
   }).isRequired,
+  navPaneWidth: PropTypes.string,
   pages: PropTypes.arrayOf(
     PropTypes.shape({
       perm: PropTypes.string,
@@ -139,6 +140,10 @@ Settings.propTypes = {
     connect: PropTypes.func.isRequired,
     hasPerm: PropTypes.func.isRequired,
   }).isRequired,
+};
+
+Settings.defaultProps = {
+  navPaneWidth: 'fill',
 };
 
 export default withStripes(Settings);

--- a/lib/Settings/Settings.js
+++ b/lib/Settings/Settings.js
@@ -143,7 +143,7 @@ Settings.propTypes = {
 };
 
 Settings.defaultProps = {
-  navPaneWidth: 'fill',
+  navPaneWidth: '30%',
 };
 
 export default withStripes(Settings);

--- a/lib/Settings/readme.md
+++ b/lib/Settings/readme.md
@@ -23,9 +23,13 @@ export default props => <Settings {...props} pages={pages} />;
 
 The following properties are supported:
 
+* `navPaneWidth`: a string indicating the width of the pane where the nav links are, e.g., `"30%"`
+* `paneTitle`: the human-readable label of the pane where the nav links are.
 * `pages`: the list of sub-pages to be linked from the settings page. Each member of the list is an object with the following members:
   * `route`: the route, relative to that of the settings page, on which the sub-page should be found.
   * `label`: the human-readable label that, when clicked on, links to the specified route.
   * `component`: the component that is rendered at the specified route.
   * `perm`: if specified, the name of a permission which the current user must have in order to access the page; if the user lacks the permission, then the link is not provided. (If omitted, then no permission check is performed for the sub-page.)
-
+* `sections`: an array of section objects. Each member of the list is an object with the following members:
+  * `label`: the human-readable label that, when clicked on, links to the specified route.
+  * `pages`: which has the same form as the `pages` prop

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
[UIORG-84](https://issues.folio.org/browse/UIORG-84) is a bit of an umbrella issue for all the scenarios where the pane sizing on Settings page is a bit off. 

PR #486 handled some of these scenarios but only solves the problem for Settings pages that use an EntrySelector. Pages that don't include the Locations pages that are specifically called out in UIORG-84, along with any page that uses `<ControlledVocab>`. 

Those three-pane pages are made cleaner by shrinking the nav pane that contains the links to a module's settings pages. I've exposed the width of that pane via `<Settings>.navPaneWidth`.

**Feedback requested about whether `navPaneWidth`'s default should be changed to something like 30% instead of keeping the same behaviour that we currently have (`fill`)**.