### PR TITLE
New component: IconWithText

### DIFF
--- a/lib/AppIcon/tests/interactor.js
+++ b/lib/AppIcon/tests/interactor.js
@@ -8,6 +8,8 @@ import css from '../AppIcon.css';
 
 const appIconClassSelector = selectorFromClassnameString(css.appIcon);
 
-export default interactor(class AppIconInteractor {
+@interactor class AppIconInteractor {
   static defaultScope = appIconClassSelector;
-});
+}
+
+export default AppIconInteractor;

--- a/lib/AppIcon/tests/interactor.js
+++ b/lib/AppIcon/tests/interactor.js
@@ -1,0 +1,13 @@
+/**
+ * AppIcon interactor
+ */
+
+import { interactor } from '@bigtest/interactor';
+import { selectorFromClassnameString } from '../../../tests/helpers';
+import css from '../AppIcon.css';
+
+const appIconClassSelector = selectorFromClassnameString(css.appIcon);
+
+export default interactor(class AppIconInteractor {
+  static defaultScope = appIconClassSelector;
+});

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -36,6 +36,7 @@
   box-shadow: 0 0 0 18px rgba(0, 0, 0, 0);
   opacity: 1;
   font-weight: var(--text-weight-button);
+  vertical-align: top;
 
   &.slim {
     padding: 5px 2px;

--- a/lib/Icon/tests/interactor.js
+++ b/lib/Icon/tests/interactor.js
@@ -1,0 +1,13 @@
+/**
+ * Icon interactor
+ */
+
+import { interactor } from '@bigtest/interactor';
+import { selectorFromClassnameString } from '../../../tests/helpers';
+import css from '../Icon.css';
+
+const iconClassSelector = selectorFromClassnameString(css.icon);
+
+export default interactor(class IconInteractor {
+  static defaultScope = iconClassSelector;
+});

--- a/lib/IconWithText/IconWithText.css
+++ b/lib/IconWithText/IconWithText.css
@@ -9,6 +9,13 @@
 }
 
 /**
+ * Block
+ */
+.block {
+  display: flex;
+}
+
+/**
  * Padding
  */
 [dir=rtl] .paddingEnd,

--- a/lib/IconWithText/IconWithText.css
+++ b/lib/IconWithText/IconWithText.css
@@ -17,10 +17,6 @@
   font-size: inherit;
 }
 
-.icon {
-
-}
-
 /**
  * App Icon
  */
@@ -36,5 +32,5 @@
  * Regular Icon
  */
 .regularIcon {
-
+  display: relative;
 }

--- a/lib/IconWithText/IconWithText.css
+++ b/lib/IconWithText/IconWithText.css
@@ -56,10 +56,10 @@
 /* Specific for app icon */
 [dir=rtl] .iconPlacementStart .appIcon,
 .iconPlacementEnd .appIcon {
-  margin: 0 0 0 4px;
+  margin: 0 0 0 0.4em;
 }
 
 [dir=rtl] .iconPlacementEnd .appIcon,
 .iconPlacementStart .appIcon {
-  margin: 0 4px 0 0;
+  margin: 0 0.4em 0 0;
 }

--- a/lib/IconWithText/IconWithText.css
+++ b/lib/IconWithText/IconWithText.css
@@ -8,20 +8,16 @@
   vertical-align: top;
 }
 
-
-
-.text {
-  font-size: inherit;
-}
-
 /**
  * Padding
  */
-[dir=rtl] .paddingEnd, .paddingStart {
+[dir=rtl] .paddingEnd,
+.paddingStart {
   padding: 0 0 0 6px;
 }
 
-[dir=rtl] .paddingStart, .paddingEnd {
+[dir=rtl] .paddingStart,
+.paddingEnd {
   padding: 0 6px 0 0;
 }
 
@@ -36,30 +32,23 @@
  * Icon Placement
  */
 
-/* Start placement (left on ltr / right on rtl) */ 
+/* Start placement (left on ltr / right on rtl) */
 .iconPlacementStart .icon {
   order: 0;
 }
-
-  /* Specific for appIcon */
-  .iconPlacementStart .appIcon {
-    margin: 0 4px 0 0;
-  }
-
-  [dir=rtl] .iconPlacementStart .appIcon {
-    margin: 0 0 0 4px;
-  }
 
 /* End placement (right on ltr / left on rtl) */
 .iconPlacementEnd .icon {
   order: 2;
 }
 
-  /* Specific for app icon */
-  .iconPlacementEnd .appIcon {
-    margin: 0 0 0 4px;
-  }
+/* Specific for app icon */
+[dir=rtl] .iconPlacementStart .appIcon,
+.iconPlacementEnd .appIcon {
+  margin: 0 0 0 4px;
+}
 
-  [dir=rtl] .iconPlacementEnd .appIcon {
-    margin: 0 4px 0 0;
-  }
+[dir=rtl] .iconPlacementEnd .appIcon,
+.iconPlacementStart .appIcon {
+  margin: 0 4px 0 0;
+}

--- a/lib/IconWithText/IconWithText.css
+++ b/lib/IconWithText/IconWithText.css
@@ -6,26 +6,23 @@
   display: inline-flex;
   align-items: center;
   vertical-align: top;
-  padding: 0 6px 0 0;
 }
 
-[dir=rtl] .iconWithText {
-  padding: 0 0 0 6px;
-}
+
 
 .text {
   font-size: inherit;
 }
 
 /**
- * App Icon
+ * Padding
  */
-.appIcon {
-  margin-right: 4px;
+[dir=rtl] .paddingEnd, .paddingStart {
+  padding: 0 0 0 6px;
 }
 
-[dir=rtl] .appIcon {
-  margin-left: 4px;
+[dir=rtl] .paddingStart, .paddingEnd {
+  padding: 0 6px 0 0;
 }
 
 /**
@@ -34,3 +31,35 @@
 .regularIcon {
   display: relative;
 }
+
+/**
+ * Icon Placement
+ */
+
+/* Start placement (left on ltr / right on rtl) */ 
+.iconPlacementStart .icon {
+  order: 0;
+}
+
+  /* Specific for appIcon */
+  .iconPlacementStart .appIcon {
+    margin: 0 4px 0 0;
+  }
+
+  [dir=rtl] .iconPlacementStart .appIcon {
+    margin: 0 0 0 4px;
+  }
+
+/* End placement (right on ltr / left on rtl) */
+.iconPlacementEnd .icon {
+  order: 2;
+}
+
+  /* Specific for app icon */
+  .iconPlacementEnd .appIcon {
+    margin: 0 0 0 4px;
+  }
+
+  [dir=rtl] .iconPlacementEnd .appIcon {
+    margin: 0 4px 0 0;
+  }

--- a/lib/IconWithText/IconWithText.css
+++ b/lib/IconWithText/IconWithText.css
@@ -3,9 +3,38 @@
  */
 
 .iconWithText {
-  background-color: yellow;
+  display: inline-block;
+
+  padding: 0 2px;
 }
 
+/* .inner {
+  display: inline-flex;
+  align-items: center;
+} */
+
 .text {
-  background-color: blue;
+  font-size: inherit;
+}
+
+.icon {
+
+}
+
+/**
+ * App Icon
+ */
+.appIcon {
+  margin-right: 4px;
+}
+
+[dir=rtl] .appIcon {
+  margin-left: 4px;
+}
+
+/**
+ * Regular Icon
+ */
+.regularIcon {
+
 }

--- a/lib/IconWithText/IconWithText.css
+++ b/lib/IconWithText/IconWithText.css
@@ -1,0 +1,11 @@
+/**
+ * IconWithText
+ */
+
+.iconWithText {
+  background-color: yellow;
+}
+
+.text {
+  background-color: blue;
+}

--- a/lib/IconWithText/IconWithText.css
+++ b/lib/IconWithText/IconWithText.css
@@ -3,15 +3,15 @@
  */
 
 .iconWithText {
-  display: inline-block;
-
-  padding: 0 2px;
-}
-
-/* .inner {
   display: inline-flex;
   align-items: center;
-} */
+  vertical-align: top;
+  padding: 0 6px 0 0;
+}
+
+[dir=rtl] .iconWithText {
+  padding: 0 0 0 6px;
+}
 
 .text {
   font-size: inherit;

--- a/lib/IconWithText/IconWithText.css
+++ b/lib/IconWithText/IconWithText.css
@@ -29,7 +29,7 @@
 }
 
 .padding-both {
-  padding: 0 6px 0 6px;
+  padding: 0 6px;
 }
 
 /**

--- a/lib/IconWithText/IconWithText.css
+++ b/lib/IconWithText/IconWithText.css
@@ -18,14 +18,18 @@
 /**
  * Padding
  */
-[dir=rtl] .paddingEnd,
-.paddingStart {
+.padding-start,
+[dir=rtl] .padding-end {
   padding: 0 0 0 6px;
 }
 
-[dir=rtl] .paddingStart,
-.paddingEnd {
+.padding-end,
+[dir=rtl] .padding-start {
   padding: 0 6px 0 0;
+}
+
+.padding-both {
+  padding: 0 6px 0 6px;
 }
 
 /**

--- a/lib/IconWithText/IconWithText.js
+++ b/lib/IconWithText/IconWithText.js
@@ -4,17 +4,49 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import css from './IconWithText.css';
 
-const IconWithText = ({ text }) => {
+import Icon from '../Icon';
+import AppIcon from '../AppIcon';
+
+const IconWithText = ({ text, app, icon }) => {
+  const renderIcon = () => {
+    // Render AppIcon if the app key is specified
+    if (app) {
+      return (
+        <AppIcon
+          className={classnames(css.icon, css.appIcon)}
+          app={app}
+          iconKey={icon}
+          size="small"
+        />
+      );
+    // Else render regular Icon
+    } else {
+      return (
+        <Icon
+          iconRootClass={classnames(css.icon, css.regularIcon)}
+          icon={icon}
+          size="small"
+        />
+      );
+    }
+  };
+
   return (
-    <span className={css.iconWithText}>
-      <span className={css.text}>{text}</span>
-    </span>
+    <div className={css.iconWithText}>
+      <div className={css.inner}>
+        {renderIcon()}
+        <span className={css.text}>{text}</span>
+      </div>
+    </div>
   );
 };
 
 IconWithText.propTypes = {
+  app: PropTypes.string,
+  icon: PropTypes.string,
   text: PropTypes.node,
 };
 

--- a/lib/IconWithText/IconWithText.js
+++ b/lib/IconWithText/IconWithText.js
@@ -18,6 +18,7 @@ const IconWithText = ({
   iconPlacement,
   paddingStart,
   paddingEnd,
+  block,
   ...rest
 }) => {
   const renderIcon = () => {
@@ -49,6 +50,7 @@ const IconWithText = ({
     css[camelCase(`icon placement ${iconPlacement}`)],
     { [css.paddingStart]: paddingStart },
     { [css.paddingEnd]: paddingEnd },
+    { [css.block]: block },
   );
 
   return (
@@ -65,6 +67,7 @@ IconWithText.defaultProps = {
 
 IconWithText.propTypes = {
   app: PropTypes.string,
+  block: PropTypes.bool,
   className: PropTypes.string,
   icon: PropTypes.string,
   iconPlacement: PropTypes.oneOf(['start', 'end']),

--- a/lib/IconWithText/IconWithText.js
+++ b/lib/IconWithText/IconWithText.js
@@ -14,6 +14,7 @@ const IconWithText = ({
   text,
   app,
   icon,
+  id,
   className,
   iconPlacement,
   paddingStart,
@@ -54,7 +55,7 @@ const IconWithText = ({
   );
 
   return (
-    <div className={rootClasses} {...rest}>
+    <div className={rootClasses} id={id} {...rest}>
       {renderIcon()}
       <span className={css.text}>{text}</span>
     </div>
@@ -71,6 +72,7 @@ IconWithText.propTypes = {
   className: PropTypes.string,
   icon: PropTypes.string,
   iconPlacement: PropTypes.oneOf(['start', 'end']),
+  id: PropTypes.string,
   paddingEnd: PropTypes.bool,
   paddingStart: PropTypes.bool,
   text: PropTypes.node,

--- a/lib/IconWithText/IconWithText.js
+++ b/lib/IconWithText/IconWithText.js
@@ -17,8 +17,7 @@ const IconWithText = ({
   id,
   className,
   iconPlacement,
-  paddingStart,
-  paddingEnd,
+  padding,
   block,
   ...rest
 }) => {
@@ -49,8 +48,7 @@ const IconWithText = ({
     css.iconWithText,
     className,
     css[camelCase(`icon placement ${iconPlacement}`)],
-    { [css.paddingStart]: paddingStart },
-    { [css.paddingEnd]: paddingEnd },
+    { [css[`padding-${padding}`]]: padding },
     { [css.block]: block },
   );
 
@@ -73,8 +71,7 @@ IconWithText.propTypes = {
   icon: PropTypes.string,
   iconPlacement: PropTypes.oneOf(['start', 'end']),
   id: PropTypes.string,
-  paddingEnd: PropTypes.bool,
-  paddingStart: PropTypes.bool,
+  padding: PropTypes.oneOf(['start', 'end', 'both']),
   text: PropTypes.node,
 };
 

--- a/lib/IconWithText/IconWithText.js
+++ b/lib/IconWithText/IconWithText.js
@@ -6,11 +6,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import css from './IconWithText.css';
-
+import camelCase from 'lodash/camelCase';
 import Icon from '../Icon';
 import AppIcon from '../AppIcon';
 
-const IconWithText = ({ text, app, icon }) => {
+const IconWithText = ({
+  text,
+  app,
+  icon,
+  className,
+  iconPlacement,
+  paddingStart,
+  paddingEnd,
+  ...rest
+}) => {
   const renderIcon = () => {
     // Render AppIcon if the app key is specified
     if (app) {
@@ -34,17 +43,33 @@ const IconWithText = ({ text, app, icon }) => {
     }
   };
 
+  const rootClasses = classnames(
+    css.iconWithText,
+    className,
+    css[camelCase(`icon placement ${iconPlacement}`)],
+    { [css.paddingStart]: paddingStart },
+    { [css.paddingEnd]: paddingEnd },
+  );
+
   return (
-    <div className={css.iconWithText}>
+    <div className={rootClasses} {...rest}>
       {renderIcon()}
       <span className={css.text}>{text}</span>
     </div>
   );
 };
 
+IconWithText.defaultProps = {
+  iconPlacement: 'start',
+};
+
 IconWithText.propTypes = {
   app: PropTypes.string,
+  className: PropTypes.string,
   icon: PropTypes.string,
+  iconPlacement: PropTypes.oneOf(['start', 'end']),
+  paddingEnd: PropTypes.bool,
+  paddingStart: PropTypes.bool,
   text: PropTypes.node,
 };
 

--- a/lib/IconWithText/IconWithText.js
+++ b/lib/IconWithText/IconWithText.js
@@ -36,10 +36,8 @@ const IconWithText = ({ text, app, icon }) => {
 
   return (
     <div className={css.iconWithText}>
-      <div className={css.inner}>
-        {renderIcon()}
-        <span className={css.text}>{text}</span>
-      </div>
+      {renderIcon()}
+      <span className={css.text}>{text}</span>
     </div>
   );
 };

--- a/lib/IconWithText/IconWithText.js
+++ b/lib/IconWithText/IconWithText.js
@@ -5,8 +5,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import css from './IconWithText.css';
 import camelCase from 'lodash/camelCase';
+import css from './IconWithText.css';
 import Icon from '../Icon';
 import AppIcon from '../AppIcon';
 

--- a/lib/IconWithText/IconWithText.js
+++ b/lib/IconWithText/IconWithText.js
@@ -1,0 +1,21 @@
+/**
+ * IconWithText
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import css from './IconWithText.css';
+
+const IconWithText = ({ text }) => {
+  return (
+    <span className={css.iconWithText}>
+      <span className={css.text}>{text}</span>
+    </span>
+  );
+};
+
+IconWithText.propTypes = {
+  text: PropTypes.node,
+};
+
+export default IconWithText;

--- a/lib/IconWithText/examples/BasicUsage.js
+++ b/lib/IconWithText/examples/BasicUsage.js
@@ -4,16 +4,50 @@
 
 import React, { Fragment } from 'react';
 import IconWithText from '../IconWithText';
+import Headline from '../../Headline';
+import Button from '../../Button';
 
 export default () => (
   <Fragment>
+    <Headline block>Icon position "start" (default)</Headline>
     <IconWithText
       text="With regular icon"
       icon="clearX"
+      paddingEnd
     />
     <IconWithText
       text="With app icon"
       app="users"
+      paddingEnd
     />
+    <br /><br /><br />
+    <Headline block>Icon position "end"</Headline>
+    <IconWithText
+      text="With regular icon"
+      icon="clearX"
+      iconPlacement="end"
+      paddingEnd
+    />
+    <IconWithText
+      text="With app icon"
+      app="users"
+      iconPlacement="end"
+      paddingEnd
+    />
+    <br /><br /><br />
+    <Headline block>Used inside a Button</Headline>
+    <Button marginBottom0>
+      <IconWithText
+        text="Icon position 'start'"
+        icon="clearX"
+      />
+    </Button>
+    <Button marginBottom0>
+      <IconWithText
+        text="Icon position 'end'"
+        icon="clearX"
+        iconPlacement="end"
+      />
+    </Button>
   </Fragment>
 );

--- a/lib/IconWithText/examples/BasicUsage.js
+++ b/lib/IconWithText/examples/BasicUsage.js
@@ -1,0 +1,28 @@
+/**
+ * IconWithText basic usage example
+ */
+
+import React, { Fragment } from 'react';
+import IconWithText from '../IconWithText';
+
+export default () => (
+  <Fragment>
+    I need to be inline
+    <IconWithText
+      text="Hello World"
+      icon="clearX"
+    />
+    <IconWithText
+      text="Hello World"
+      app="users"
+    />
+    <IconWithText
+      text="Hello World"
+      app="users"
+    />
+    <IconWithText
+      text="Hello World"
+      icon="clearX"
+    />
+  </Fragment>
+);

--- a/lib/IconWithText/examples/BasicUsage.js
+++ b/lib/IconWithText/examples/BasicUsage.js
@@ -9,7 +9,7 @@ import Button from '../../Button';
 
 export default () => (
   <Fragment>
-    <Headline block>Icon position "start" (default)</Headline>
+    <Headline block>Icon position: start (default)</Headline>
     <IconWithText
       text="With regular icon"
       icon="clearX"
@@ -21,7 +21,7 @@ export default () => (
       paddingEnd
     />
     <br /><br /><br />
-    <Headline block>Icon position "end"</Headline>
+    <Headline block>Icon position: end</Headline>
     <IconWithText
       text="With regular icon"
       icon="clearX"

--- a/lib/IconWithText/examples/BasicUsage.js
+++ b/lib/IconWithText/examples/BasicUsage.js
@@ -49,5 +49,13 @@ export default () => (
         iconPlacement="end"
       />
     </Button>
+    <br /><br /><br />
+    <Headline block>Used inside an anchor tag</Headline>
+    <a href="https://www.google.com">
+      <IconWithText
+        text="This is a regular link"
+        icon="eye-open"
+      />
+    </a>    
   </Fragment>
 );

--- a/lib/IconWithText/examples/BasicUsage.js
+++ b/lib/IconWithText/examples/BasicUsage.js
@@ -13,12 +13,12 @@ export default () => (
     <IconWithText
       text="With regular icon"
       icon="clearX"
-      paddingEnd
+      padding="end"
     />
     <IconWithText
       text="With app icon"
       app="users"
-      paddingEnd
+      padding="both"
     />
     <br /><br /><br />
     <Headline block>Icon position: end</Headline>
@@ -26,13 +26,13 @@ export default () => (
       text="With regular icon"
       icon="clearX"
       iconPlacement="end"
-      paddingEnd
+      padding="end"
     />
     <IconWithText
       text="With app icon"
       app="users"
       iconPlacement="end"
-      paddingEnd
+      padding="end"
     />
     <br /><br /><br />
     <Headline block>Used inside a Button</Headline>

--- a/lib/IconWithText/examples/BasicUsage.js
+++ b/lib/IconWithText/examples/BasicUsage.js
@@ -56,6 +56,6 @@ export default () => (
         text="This is a regular link"
         icon="eye-open"
       />
-    </a>    
+    </a>
   </Fragment>
 );

--- a/lib/IconWithText/examples/BasicUsage.js
+++ b/lib/IconWithText/examples/BasicUsage.js
@@ -7,22 +7,13 @@ import IconWithText from '../IconWithText';
 
 export default () => (
   <Fragment>
-    I need to be inline
     <IconWithText
-      text="Hello World"
+      text="With regular icon"
       icon="clearX"
     />
     <IconWithText
-      text="Hello World"
+      text="With app icon"
       app="users"
-    />
-    <IconWithText
-      text="Hello World"
-      app="users"
-    />
-    <IconWithText
-      text="Hello World"
-      icon="clearX"
     />
   </Fragment>
 );

--- a/lib/IconWithText/examples/IconWithText.stories.js
+++ b/lib/IconWithText/examples/IconWithText.stories.js
@@ -1,0 +1,13 @@
+/**
+ * IconWithText stories
+ */
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
+import readme from '../readme.md';
+import BasicUsage from './BasicUsage';
+
+storiesOf('IconWithText', module)
+  .addDecorator(withReadme(readme))
+  .add('Basic Usage', () => <BasicUsage />);

--- a/lib/IconWithText/index.js
+++ b/lib/IconWithText/index.js
@@ -1,0 +1,1 @@
+export { default } from './IconWithText';

--- a/lib/IconWithText/readme.md
+++ b/lib/IconWithText/readme.md
@@ -1,0 +1,1 @@
+To be added..

--- a/lib/IconWithText/readme.md
+++ b/lib/IconWithText/readme.md
@@ -1,1 +1,36 @@
-To be added..
+# IconWithText
+Renders an icon with an inline label
+
+## Basic Usage
+```js
+import IconWithText from '@folio/stripes-components/lib/IconWithText';
+
+// Render a regular Icon
+<IconWithText
+    text="Bookmark"
+    icon="bookmark"
+    iconPosition="end"
+    paddingEnd
+/>
+
+// Render an AppIcon
+<IconWithText
+    text="Holdings"
+    app="inventory"
+    icon="holdings"
+    paddingStart
+/>
+```
+
+## Props
+Below are the component specific props for this component. Additional props are spread on the root element making it possible to add any additional desired prop to the root element.
+
+Name | Type | Description | Default
+-- | -- | -- | --
+app | string | Reference a Folio-app for displaying bundled icons (See [AppIcon](/?selectedKind=AppIcon) for more information) | undefined
+className | string | Add additional CSS classes to the root element | undefined
+icon | string | Determines which icon that should be rendered. If the "app"-prop is provided it will reference the "iconKey" of [AppIcon](/?selectedKind=AppIcon). If no "app"-prop is provided it will reference the available icons for the [Icon](/?selectedKind=Icon)-component. | undefined
+iconPlacement | string | Determines the position of the icon. Supports "start" and "end" | start
+paddingEnd | boolean | Adds padding in the end of the component | false
+paddingStart | boolean | Adds padding in the start of the component | false
+text | string, node | The text of the component. It's also possible to pass another component/node. | undefined

--- a/lib/IconWithText/readme.md
+++ b/lib/IconWithText/readme.md
@@ -1,5 +1,7 @@
 # IconWithText
-Renders an icon with an inline label
+Renders an icon with an inline label. 
+
+Useful for displaying icons with associated labels in a consistent way across the platform. The component can be used inside other existing components or as a standalone component.
 
 ## Basic Usage
 ```js

--- a/lib/IconWithText/readme.md
+++ b/lib/IconWithText/readme.md
@@ -12,7 +12,7 @@ import IconWithText from '@folio/stripes-components/lib/IconWithText';
     text="Bookmark"
     icon="bookmark"
     iconPosition="end"
-    paddingEnd
+    padding="both"
 />
 
 // Render an AppIcon
@@ -20,7 +20,7 @@ import IconWithText from '@folio/stripes-components/lib/IconWithText';
     text="Holdings"
     app="inventory"
     icon="holdings"
-    paddingStart
+    padding="start"
 />
 ```
 

--- a/lib/IconWithText/readme.md
+++ b/lib/IconWithText/readme.md
@@ -30,6 +30,7 @@ Below are the component specific props for this component. Additional props are 
 Name | Type | Description | Default
 -- | -- | -- | --
 app | string | Reference a Folio-app for displaying bundled icons (See [AppIcon](/?selectedKind=AppIcon) for more information) | undefined
+id | string | Add an ID to the root element | undefined
 className | string | Add additional CSS classes to the root element | undefined
 icon | string | Determines which icon that should be rendered. If the "app"-prop is provided it will reference the "iconKey" of [AppIcon](/?selectedKind=AppIcon). If no "app"-prop is provided it will reference the available icons for the [Icon](/?selectedKind=Icon)-component. | undefined
 iconPlacement | string | Determines the position of the icon. Supports "start" and "end" | start

--- a/lib/IconWithText/readme.md
+++ b/lib/IconWithText/readme.md
@@ -34,7 +34,6 @@ id | string | Add an ID to the root element | undefined
 className | string | Add additional CSS classes to the root element | undefined
 icon | string | Determines which icon that should be rendered. If the "app"-prop is provided it will reference the "iconKey" of [AppIcon](/?selectedKind=AppIcon). If no "app"-prop is provided it will reference the available icons for the [Icon](/?selectedKind=Icon)-component. | undefined
 iconPlacement | string | Determines the position of the icon. Supports "start" and "end" | start
-paddingEnd | boolean | Adds padding in the end of the component | false
-paddingStart | boolean | Adds padding in the start of the component | false
+padding | string | Adds padding on the sides of the component. Options: "start", "end" & "both" | undefined
 block | boolean | Changes display from inline-flex to flex making the component full width | false
 text | string, node | The text of the component. It's also possible to pass another component/node. | undefined

--- a/lib/IconWithText/readme.md
+++ b/lib/IconWithText/readme.md
@@ -33,4 +33,5 @@ icon | string | Determines which icon that should be rendered. If the "app"-prop
 iconPlacement | string | Determines the position of the icon. Supports "start" and "end" | start
 paddingEnd | boolean | Adds padding in the end of the component | false
 paddingStart | boolean | Adds padding in the start of the component | false
+block | boolean | Changes display from inline-flex to flex making the component full width | false
 text | string, node | The text of the component. It's also possible to pass another component/node. | undefined

--- a/lib/IconWithText/tests/IconWithText-test.js
+++ b/lib/IconWithText/tests/IconWithText-test.js
@@ -1,0 +1,31 @@
+/**
+ * IconWithText tests
+ */
+
+import React from 'react';
+
+import { it, describe, beforeEach } from '@bigtest/mocha';
+import { expect } from 'chai';
+import { mount } from '../../../tests/helpers';
+
+import IconWithText from '../IconWithText';
+import IconWithTextInteractor from './interactor';
+
+describe.only('IconWithText', () => {
+  const iconWithText = new IconWithTextInteractor();
+  const text = 'Hello World';
+  const standardIcon = 'closeX';
+
+  beforeEach(async () => {
+    await mount(
+      <IconWithText
+        text={text}
+        icon={standardIcon}
+      />
+    );
+  });
+
+  it(`Should render with a text of "${text}"`, () => {
+    expect(iconWithText.text).to.equal(text);
+  });
+});

--- a/lib/IconWithText/tests/IconWithText-test.js
+++ b/lib/IconWithText/tests/IconWithText-test.js
@@ -11,7 +11,7 @@ import { mount } from '../../../tests/helpers';
 import IconWithText from '../IconWithText';
 import IconWithTextInteractor from './interactor';
 
-describe.only('IconWithText', () => {
+describe('IconWithText', () => {
   const iconWithText = new IconWithTextInteractor();
   const text = 'Hello World';
   const standardIcon = 'closeX';

--- a/lib/IconWithText/tests/IconWithText-test.js
+++ b/lib/IconWithText/tests/IconWithText-test.js
@@ -25,7 +25,32 @@ describe.only('IconWithText', () => {
     );
   });
 
+  /**
+   * Icon and default tests
+   */
   it(`Should render with a text of "${text}"`, () => {
     expect(iconWithText.text).to.equal(text);
+  });
+
+  it('Should render an <Icon /> if a valid icon string is passed to the "icon"-prop', () => {
+    expect(iconWithText.regularIcon.isPresent).to.be.true;
+  });
+
+  /**
+   * App Icon
+   */
+  describe('Passing a string to both the "app"-prop', () => {
+    beforeEach(async () => {
+      await mount(
+        <IconWithText
+          text={text}
+          app="users"
+        />
+      );
+    });
+
+    it('Should render an <AppIcon />', () => {
+      expect(iconWithText.appIcon.isPresent).to.be.true;
+    });
   });
 });

--- a/lib/IconWithText/tests/IconWithText-test.js
+++ b/lib/IconWithText/tests/IconWithText-test.js
@@ -33,7 +33,7 @@ describe('IconWithText', () => {
   it(`Should render with an ID of "${id}"`, () => {
     expect(iconWithText.id).to.equal(id);
   });
-  
+
   it(`Should render with a text of "${text}"`, () => {
     expect(iconWithText.text).to.equal(text);
   });
@@ -51,12 +51,45 @@ describe('IconWithText', () => {
         <IconWithText
           text={text}
           app="users"
+          padding="end"
         />
       );
     });
 
     it('Should render an <AppIcon />', () => {
       expect(iconWithText.appIcon.isPresent).to.be.true;
+    });
+  });
+
+  /**
+   * Padding
+   */
+  describe('When passing a string to the padding-prop', () => {
+    it('Should have classname of "padding-start" when padding="start"', () => {
+      mount(
+        <IconWithText
+          padding="start"
+        />
+      );
+      expect(iconWithText.hasPaddingStartClass).to.be.true;
+    });
+
+    it('Should have classname of "padding-end" when padding="end"', () => {
+      mount(
+        <IconWithText
+          padding="end"
+        />
+      );
+      expect(iconWithText.hasPaddingEndClass).to.be.true;
+    });
+
+    it('Should have classname of "padding-both" when padding="both"', () => {
+      mount(
+        <IconWithText
+          padding="both"
+        />
+      );
+      expect(iconWithText.hasPaddingBothClass).to.be.true;
     });
   });
 });

--- a/lib/IconWithText/tests/IconWithText-test.js
+++ b/lib/IconWithText/tests/IconWithText-test.js
@@ -11,7 +11,7 @@ import { mount } from '../../../tests/helpers';
 import IconWithText from '../IconWithText';
 import IconWithTextInteractor from './interactor';
 
-describe('IconWithText', () => {
+describe.only('IconWithText', () => {
   const iconWithText = new IconWithTextInteractor();
   const text = 'Hello World';
   const id = 'my-test-id';
@@ -30,15 +30,15 @@ describe('IconWithText', () => {
   /**
    * Icon and default tests
    */
-  it(`Should render with an ID of "${id}"`, () => {
+  it(`Renders with an ID of "${id}"`, () => {
     expect(iconWithText.id).to.equal(id);
   });
 
-  it(`Should render with a text of "${text}"`, () => {
+  it(`Renders with a text of "${text}"`, () => {
     expect(iconWithText.text).to.equal(text);
   });
 
-  it('Should render an <Icon /> if a valid icon string is passed to the "icon"-prop', () => {
+  it('Renders an <Icon /> if a valid icon string is passed to the "icon"-prop', () => {
     expect(iconWithText.regularIcon.isPresent).to.be.true;
   });
 
@@ -56,7 +56,7 @@ describe('IconWithText', () => {
       );
     });
 
-    it('Should render an <AppIcon />', () => {
+    it('Renders an <AppIcon />', () => {
       expect(iconWithText.appIcon.isPresent).to.be.true;
     });
   });
@@ -65,7 +65,7 @@ describe('IconWithText', () => {
    * Padding
    */
   describe('When passing a string to the padding-prop', () => {
-    it('Should have classname of "padding-start" when padding="start"', () => {
+    it('Renders with a classname of "padding-start" when padding="start"', () => {
       mount(
         <IconWithText
           padding="start"
@@ -74,7 +74,7 @@ describe('IconWithText', () => {
       expect(iconWithText.hasPaddingStartClass).to.be.true;
     });
 
-    it('Should have classname of "padding-end" when padding="end"', () => {
+    it('Renders with a classname of "padding-end" when padding="end"', () => {
       mount(
         <IconWithText
           padding="end"
@@ -83,7 +83,7 @@ describe('IconWithText', () => {
       expect(iconWithText.hasPaddingEndClass).to.be.true;
     });
 
-    it('Should have classname of "padding-both" when padding="both"', () => {
+    it('Renders with a classname of "padding-both" when padding="both"', () => {
       mount(
         <IconWithText
           padding="both"

--- a/lib/IconWithText/tests/IconWithText-test.js
+++ b/lib/IconWithText/tests/IconWithText-test.js
@@ -14,6 +14,7 @@ import IconWithTextInteractor from './interactor';
 describe('IconWithText', () => {
   const iconWithText = new IconWithTextInteractor();
   const text = 'Hello World';
+  const id = 'my-test-id';
   const standardIcon = 'closeX';
 
   beforeEach(async () => {
@@ -21,6 +22,7 @@ describe('IconWithText', () => {
       <IconWithText
         text={text}
         icon={standardIcon}
+        id={id}
       />
     );
   });
@@ -28,6 +30,10 @@ describe('IconWithText', () => {
   /**
    * Icon and default tests
    */
+  it(`Should render with an ID of "${id}"`, () => {
+    expect(iconWithText.id).to.equal(id);
+  });
+  
   it(`Should render with a text of "${text}"`, () => {
     expect(iconWithText.text).to.equal(text);
   });

--- a/lib/IconWithText/tests/interactor.js
+++ b/lib/IconWithText/tests/interactor.js
@@ -2,7 +2,7 @@
  * IconWithText interactor
  */
 
-import { interactor, scoped, attribute } from '@bigtest/interactor';
+import { interactor, scoped, attribute, hasClass } from '@bigtest/interactor';
 import { selectorFromClassnameString } from '../../../tests/helpers';
 
 import IconInteractor from '../../Icon/tests/interactor';
@@ -14,6 +14,11 @@ const iconWithTextClassSelector = selectorFromClassnameString(`.${css.iconWithTe
 export default interactor(class IconWithTextInteractor {
   static defaultScope = iconWithTextClassSelector;
   id = attribute('id');
+
+  hasPaddingStartClass = hasClass(css['padding-start']);
+  hasPaddingEndClass = hasClass(css['padding-end']);
+  hasPaddingBothClass = hasClass(css['padding-both']);
+
   regularIcon = scoped(`.${css.regularIcon}`, IconInteractor);
   appIcon = scoped(`.${css.appIcon}`, AppIconInteractor);
 });

--- a/lib/IconWithText/tests/interactor.js
+++ b/lib/IconWithText/tests/interactor.js
@@ -2,13 +2,17 @@
  * IconWithText interactor
  */
 
-import { interactor } from '@bigtest/interactor';
+import { interactor, scoped } from '@bigtest/interactor';
 import { selectorFromClassnameString } from '../../../tests/helpers';
+
+import IconInteractor from '../../Icon/tests/interactor';
+import AppIconInteractor from '../../AppIcon/tests/interactor';
 import css from '../IconWithText.css';
 
 const iconWithTextClassSelector = selectorFromClassnameString(`.${css.iconWithText}`);
 
 export default interactor(class IconWithTextInteractor {
   static defaultScope = iconWithTextClassSelector;
-  // icon = scoped(`.${css.icon}`)
+  regularIcon = scoped(`.${css.regularIcon}`, IconInteractor);
+  appIcon = scoped(`.${css.appIcon}`, AppIconInteractor);
 });

--- a/lib/IconWithText/tests/interactor.js
+++ b/lib/IconWithText/tests/interactor.js
@@ -1,0 +1,14 @@
+/**
+ * IconWithText interactor
+ */
+
+import { interactor } from '@bigtest/interactor';
+import { selectorFromClassnameString } from '../../../tests/helpers';
+import css from '../IconWithText.css';
+
+const iconWithTextClassSelector = selectorFromClassnameString(`.${css.iconWithText}`);
+
+export default interactor(class IconWithTextInteractor {
+  static defaultScope = iconWithTextClassSelector;
+  // icon = scoped(`.${css.icon}`)
+});

--- a/lib/IconWithText/tests/interactor.js
+++ b/lib/IconWithText/tests/interactor.js
@@ -2,7 +2,7 @@
  * IconWithText interactor
  */
 
-import { interactor, scoped } from '@bigtest/interactor';
+import { interactor, scoped, attribute } from '@bigtest/interactor';
 import { selectorFromClassnameString } from '../../../tests/helpers';
 
 import IconInteractor from '../../Icon/tests/interactor';
@@ -13,6 +13,7 @@ const iconWithTextClassSelector = selectorFromClassnameString(`.${css.iconWithTe
 
 export default interactor(class IconWithTextInteractor {
   static defaultScope = iconWithTextClassSelector;
+  id = attribute('id');
   regularIcon = scoped(`.${css.regularIcon}`, IconInteractor);
   appIcon = scoped(`.${css.appIcon}`, AppIconInteractor);
 });

--- a/lib/IconWithText/tests/interactor.js
+++ b/lib/IconWithText/tests/interactor.js
@@ -11,7 +11,7 @@ import css from '../IconWithText.css';
 
 const iconWithTextClassSelector = selectorFromClassnameString(`.${css.iconWithText}`);
 
-export default interactor(class IconWithTextInteractor {
+@interactor class IconWithTextInteractor {
   static defaultScope = iconWithTextClassSelector;
   id = attribute('id');
 
@@ -21,4 +21,6 @@ export default interactor(class IconWithTextInteractor {
 
   regularIcon = scoped(`.${css.regularIcon}`, IconInteractor);
   appIcon = scoped(`.${css.appIcon}`, AppIconInteractor);
-});
+}
+
+export default IconWithTextInteractor;


### PR DESCRIPTION
IconWithText simply renders an icon (Icon or AppIcon — depending on which props you pass to it) with an inline label. Additional props can help ensure proper spacing and you can adjust the positioning of the icon.

This provides a consistent way of displaying inline icons with a label across the platform. It's RTL-compatible and can be used inside other existing components (such as the Button, MCL columns etc.).

The reasoning behind the creation of this component can be found in various prototypes such as the Inventory-prototype (http://ux.folio.org/prototype/en/inventory) which heavily relies on displaying icons with labels in a consistent way (properly inlined text/icon, correct spacing etc.). A future user setting for hiding labels to save space (e.g. in the MCL) is (afaik) on the drawing table which this component also could be extended for to easily allow for this.

Check out the readme [here](https://github.com/samhaeng/stripes-components/blob/7557f6b08f38e37c05ff1ab819aac9a47379e8a0/lib/IconWithText/readme.md) and a basic usage example [here](https://github.com/samhaeng/stripes-components/blob/7557f6b08f38e37c05ff1ab819aac9a47379e8a0/lib/IconWithText/examples/BasicUsage.js).

## Example
![image](https://user-images.githubusercontent.com/640976/43007317-4ba8fe2c-8c38-11e8-8980-4f5cdfce7d27.png)


## Tests
![image](https://user-images.githubusercontent.com/640976/43007488-cc80fd88-8c38-11e8-91d1-ed9458a26ad4.png)
