### PR TITLE
Pin BigTest interactor package

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     ]
   },
   "devDependencies": {
-    "@bigtest/interactor": "^0.7.0",
+    "@bigtest/interactor": "0.7.0",
     "@bigtest/mocha": "^0.5.0",
     "@folio/eslint-config-stripes": "^2.0.0",
     "@folio/stripes-cli": "^1.2.0",


### PR DESCRIPTION
https://github.com/bigtestjs/interactor/pull/37 caused some behavior changes with `Accordion` and `Datepicker` interactors.

Should fix failing tests on Jenkins.