### PR TITLE
Upgrade @bigtest/interactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     ]
   },
   "devDependencies": {
-    "@bigtest/interactor": "0.7.0",
+    "@bigtest/interactor": "^0.7.2",
     "@bigtest/mocha": "^0.5.0",
     "@folio/eslint-config-stripes": "^2.0.0",
     "@folio/stripes-cli": "^1.2.0",


### PR DESCRIPTION
Fixes nested scoping issue that required us to pin to `0.7.0`: https://github.com/bigtestjs/interactor/pull/39