### PR TITLE
Change button relationship margins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.0.0 (IN PROGRESS)
 * Expose `Settings` nav pane width via `navPaneWidth` prop.
 * Rename `errorText` and `warningText` props to `error` and `warning` for consistency. Fixes STCOM-314
+* Change button relationship margins
 
 ## [3.0.0](https://github.com/folio-org/stripes-components/tree/v3.0.0)
 

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -22,9 +22,7 @@
   transition: background-color 0.25s, color 0.25s, opacity 0.07s, box-shadow 0s;
   background-color: transparent;
   border: transparent;
-  margin-left: 2px;
-  margin-right: 2px;
-  margin-bottom: var(--gutter);
+  margin: 0 0 var(--gutter);
   max-height: var(--controlHeightSmall);
   white-space: nowrap;
   line-height: 100%;
@@ -45,8 +43,8 @@
     display: block;
   }
 
-  &:first-child {
-    margin-left: 0;
+  & + .button {
+    margin-left: 4px;
   }
 
   /**
@@ -255,10 +253,11 @@
   }
 }
 
-[dir='rtl'] {
-  &.button {
-    &:first-child {
-      margin-right: 0;
+[dir="rtl"] {
+  & .button {
+    & + .button {
+      margin-left: 0;
+      margin-right: 4px;
     }
 
     &.textAlignStart {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
## Purpose
This CSS in `button.css`...
```
&:first-child {
  margin-left: 0;
}
```
... meant that any button that's a first child of its parent (even if it's by itself) would have its margin overridden.

The specific case I ran into: I wanted to put a button on the `firstMenu` of a `<PaneHeader>` with a `buttonClass` that defined some margins. 

`:first-child` was more specific than my class, so I couldn't set a left margin:

![localhost_3000_eholdings_titles_new ipad](https://user-images.githubusercontent.com/230597/43170839-ce89b836-8f6c-11e8-8473-f300448ab61f.png)


## Approach
Rely on relationships between buttons instead.

Set left and right margins of `<Button>`s to zero by default, then buttons that are next to each other get 4px between them (in both LTR and RTL languages).