### PR TITLE
STCLI-74 Reduce build time for running tests

### DIFF
--- a/lib/Pluggable/tests/Pluggable-test.js
+++ b/lib/Pluggable/tests/Pluggable-test.js
@@ -1,1 +1,2 @@
-import Pluggable from '../Pluggable'; // eslint-disable-line no-unused-vars
+// TODO: Address 'stripes-config' dependency in Pluggable.  See STCLI-74 and STCOM-298
+// import Pluggable from '../Pluggable'; // eslint-disable-line no-unused-vars

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "node": ">=6.0.0"
   },
   "stripes": {
-    "type": "app",
+    "type": "components",
     "actionNames": [
       "selectPreviousRow",
       "selectNextRow",


### PR DESCRIPTION
As discovered in review of STCLI-74, a portion of the webpack configuration is unnecessary for running stripes-components tests in isolation. Omitting unused entry points and plugins reduces build time significantly (approx. 75% faster in my dev environment).

Stripes-CLI has been updated to apply the simplified webpack config when running tests on a module that identifies itself as "components".  See https://github.com/folio-org/stripes-cli/pull/95

This follow-up PR updates stripes.type accordingly and also comments out the unwritten test for `Pluggable`.  Excluding this test necessary as Pluggable is the only component that depends on `stripes-config`, a virtual module no longer generated due to the simplified webpack configuration.

The drawback, however, is that Pluggable is no longer reported in code coverage.  I'll leave it up to `stripes-components` authors to decide if this is an acceptable trade-off in the short-term.  Otherwise we can wait to merge until after a refactor of Pluggable / STCOM-298.
