### PR TITLE
Adjust Accordion expand logic and CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Expose `Settings` nav pane width via `navPaneWidth` prop.
 * Rename `errorText` and `warningText` props to `error` and `warning` for consistency. Fixes STCOM-314
 * Change button relationship margins
+* Add min-height to expanded Accordion CSS
 
 ## [3.0.0](https://github.com/folio-org/stripes-components/tree/v3.0.0)
 

--- a/lib/Accordion/Accordion.css
+++ b/lib/Accordion/Accordion.css
@@ -76,6 +76,8 @@
   transition: max-height 0.25s ease;
 
   &.expanded {
+    flex: 1;
+    min-height: 0;
     max-height: none; /* max-height applied inline */
     overflow: visible;
   }

--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -170,7 +170,7 @@ class Accordion extends React.Component {
     this.expandCallback = window.requestAnimationFrame(() => {
       // update contentHeight...
       this.contentHeight = this.content.scrollHeight;
-      this.content.style.maxHeight = `${this.contentHeight}px`;
+      this.content.style.maxHeight = this.contentHeight === 0 ? 'none' : `${this.contentHeight}px`;
       window.cancelAnimationFrame(this.expandCallback);
       this.expandCallback = null;
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
Replaces https://github.com/folio-org/stripes-components/pull/520. Related to https://github.com/folio-org/ui-eholdings/pull/482.

Fixes scenarios around putting a scrollable list within an `<Accordion>`. Does not change behavior of `<Accordion>`s in storybook environment.

