### PR TITLE
Minor pane header sub fix

### DIFF
--- a/lib/PaneHeader/PaneHeader.css
+++ b/lib/PaneHeader/PaneHeader.css
@@ -80,6 +80,7 @@
 .paneSub {
   color: var(--color-text-p2);
   font-size: 11px;
+  line-height: 1.2;
 }
 
 /* Last content area */


### PR DESCRIPTION
Added line-height of 1.2 to pane header sub to avoid letters that go below the text baseline (g, j, p, q) to be cropped off.