### PR TITLE
Replace alerts with Storybook actions

### DIFF
--- a/lib/ConfirmationModal/examples/ConfirmationModalExample.js
+++ b/lib/ConfirmationModal/examples/ConfirmationModalExample.js
@@ -3,6 +3,7 @@
  */
 
 import React from 'react';
+import { action } from '@storybook/addon-actions';
 import ConfirmationModal from '../../ConfirmationModal';
 
 export default () => (
@@ -11,8 +12,8 @@ export default () => (
     id="simple-confirmation-modal"
     heading="Please confirm this action"
     message="Here's a detailed message that explains what happens if you confirm this action."
-    onConfirm={() => alert('Confirmed') /* eslint-disable-line */}
-    onCancel={() => alert('Cancelled') /* eslint-disable-line */}
+    onConfirm={action('Confirmed')}
+    onCancel={action('Cancelled')}
     cancelLabel="No, I will not confirm"
     confirmLabel="Okay, I will confirm this"
   />

--- a/lib/ConfirmationModal/readme.md
+++ b/lib/ConfirmationModal/readme.md
@@ -1,6 +1,6 @@
 # ConfirmationModal
 
-A basic confirmation modal with props to support a heading (required) and brief message along with customizeable 'cancel' and 'submit' action labeling.
+A basic confirmation modal with props to support a heading (required) and brief message along with customizable 'cancel' and 'submit' action labeling.
 
 ## Basic usage
 
@@ -20,7 +20,6 @@ hideConfirm() {
 }
 
 handleSubmit() {
-  alert('submitting!');
   this.hideConfirm();
 }
 

--- a/lib/Modal/stories/BasicUsage.js
+++ b/lib/Modal/stories/BasicUsage.js
@@ -4,6 +4,7 @@
 
 import React, { Fragment } from 'react';
 import { text, boolean, select } from '@storybook/addon-knobs/react';
+import { action } from '@storybook/addon-actions';
 import Modal from '../Modal';
 import Button from '../../Button';
 
@@ -32,7 +33,7 @@ export default () => {
       label={label}
       size={size}
       showHeader={showHeader}
-      onClose={() => alert('onClose callback')} // eslint-disable-line no-alert
+      onClose={action('onClose callback')}
       footer={footer}
     >
       Modal Content

--- a/lib/ModalFooter/examples/ModalFooterExample.js
+++ b/lib/ModalFooter/examples/ModalFooterExample.js
@@ -4,6 +4,7 @@
 
 /* eslint-disable */
 import React from 'react';
+import { action } from '@storybook/addon-actions';
 import ModalFooter from '../ModalFooter';
 import Button from '../../Button';
 import Modal from '../../Modal';
@@ -13,11 +14,11 @@ export default () => {
     <ModalFooter
       primaryButton={{
         label: 'Save',
-        onClick: () => alert('You clicked save'),
+        onClick: action('You clicked save')
       }}
       secondaryButton={{
         label: 'Cancel',
-        onClick: () => alert('You clicked cancel'),
+        onClick: action('You clicked cancel')
       }}
     />
   );


### PR DESCRIPTION
These popped up in SonarCloud "Security" reports: https://sonarcloud.io/component_measures?id=folio-org%3Astripes-components&metric=security_rating

Uses Storybook actions instead of `alert()`: https://github.com/storybooks/storybook/tree/release/3.4/addons/actions