### PR TITLE
Adjust ModalFooter button CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Change button relationship margins
 * Add min-height to expanded Accordion CSS
 * Added "tag"-icon to list of icons
+* Adjust <ModalFooter> button CSS
 
 ## [3.0.0](https://github.com/folio-org/stripes-components/tree/v3.0.0)
 

--- a/lib/ModalFooter/ModalFooter.css
+++ b/lib/ModalFooter/ModalFooter.css
@@ -1,20 +1,22 @@
 @import '../variables.css';
 
-.modalFooterButton {
-  flex-basis: 100%;
-  margin: 0;
+.modalFooterButtons {
+  align-items: center;
+  display: flex;
+  flex-flow: row-reverse wrap;
+  margin: calc((var(--controlMarginBottom) / 2) * -1) 0;
   width: 100%;
+}
+
+.modalFooterButton {
+  flex: 1 1 auto;
+  margin: calc(var(--controlMarginBottom) / 2) 4px;
 
   & + .modalFooterButton {
-    margin: var(--controlMarginBottom) 0 0;
+    margin: calc(var(--controlMarginBottom) / 2) 4px;
   }
 
   @media (--mediumUp) {
-    flex-basis: auto;
-    width: auto;
-
-    & + .modalFooterButton {
-      margin: 0 4px;
-    }
+    flex: 0 1 auto;
   }
 }

--- a/lib/ModalFooter/ModalFooter.js
+++ b/lib/ModalFooter/ModalFooter.js
@@ -25,10 +25,10 @@ const ModalFooter = ({ primaryButton, secondaryButton }) => {
   };
 
   return (
-    <Fragment>
+    <div className={css.modalFooterButtons}>
       {primaryButton ? renderButton('primary', primaryButton) : null}
       {secondaryButton ? renderButton('default', secondaryButton) : null}
-    </Fragment>
+    </div>
   );
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
## Purpose
`<ModalFooter>` buttons had a zone of screen widths where buttons with longer strings didn't have any space between them.

## Approach
Buttons can now be inline even below the medium breakpoint, just based on how long the button text is. I used some negative margins to improve the spacing.

## Screenshots
### Before
![before](https://user-images.githubusercontent.com/230597/43806714-bfe7f0d2-9a6a-11e8-82b6-d8eb37fd756c.gif)

### After
![after-short](https://user-images.githubusercontent.com/230597/43807472-3a8f0e62-9a6e-11e8-8423-2d8f9b364f7f.gif)

![after-long](https://user-images.githubusercontent.com/230597/43807473-3aae1992-9a6e-11e8-8957-dfd69dde107d.gif)
