### PR TITLE
Change modal widths from percentage to pixels

### DIFF
--- a/lib/Modal/Modal.css
+++ b/lib/Modal/Modal.css
@@ -88,7 +88,7 @@
  * Responsive changes
  */
 @media (--mediumUp) {
-  .modal.small {
+  .small {
     max-width: 550px;
   }
   .modal {
@@ -98,13 +98,13 @@
 }
 
 @media (--mediumUp) {
-  .modal.medium {
+  .medium {
     max-width: 750px;
   }
 }
 
 @media (--largeUp) {
-  .modal.large {
+  .large {
     max-width: 1100px;
   }
 }

--- a/lib/Modal/Modal.css
+++ b/lib/Modal/Modal.css
@@ -83,14 +83,11 @@
   background-color: rgba(0, 0, 0, 0.2);
 }
 
-
-/**
- * Responsive changes
- */
 @media (--mediumUp) {
   .small {
     max-width: 550px;
   }
+
   .modal {
     top: 100px;
     max-height: calc(100% - 115px);

--- a/lib/Modal/Modal.css
+++ b/lib/Modal/Modal.css
@@ -17,7 +17,7 @@
   top: 60px;
   background-color: #fff;
   max-height: calc(100% - 75px);
-  width: calc(100% - 30px);
+  width: calc(100% - (var(--gutter) * 2));
   overflow: hidden;
   border-radius: var(--radius);
   box-shadow: var(--shadow);

--- a/lib/Modal/Modal.css
+++ b/lib/Modal/Modal.css
@@ -14,10 +14,10 @@
   position: absolute;
   display: flex;
   flex-direction: column;
-  top: 10vh;
+  top: 60px;
   background-color: #fff;
-  max-height: 80vh;
-  width: 80vw;
+  max-height: calc(100% - 75px);
+  width: calc(100% - 30px);
   overflow: hidden;
   border-radius: var(--radius);
   box-shadow: var(--shadow);
@@ -83,18 +83,39 @@
   background-color: rgba(0, 0, 0, 0.2);
 }
 
+
+/**
+ * Responsive changes
+ */
 @media (--mediumUp) {
+  .modal.small {
+    max-width: 550px;
+  }
   .modal {
-    &.medium {
-      width: 60%;
-    }
+    top: 100px;
+    max-height: calc(100% - 115px);
+  }
+}
 
-    &.small {
-      width: 40%;
-    }
+@media (--mediumUp) {
+  .modal.medium {
+    max-width: 750px;
+  }
+}
 
-    &.large {
-      width: 90%;
-    }
+@media (--largeUp) {
+  .modal.large {
+    max-width: 1100px;
+  }
+}
+
+/**
+ * Move the modal further towards the top
+ * when the browser window is a bit smaller in height
+ */
+@media screen and (max-height: 700px) {
+  .modal {
+    top: 60px;
+    max-height: calc(100% - 75px);
   }
 }


### PR DESCRIPTION
On larger screens, the modal widths got a little out of control.

To fix this I have updated the modal to use max-width in pixels instead of percentage widths. This makes the width of the modal more predictable.

I also changed the margins on mobile devices to make sure that it fills up the space available with a margin of 15px on each side (the standard margin for the system currently).

Below is an example of a modal with the size of "small". Before it got too big on larger screens and it got a bit squashed before going to a 90vw width. Using max-width fixes this issue.

## Before
![aug-13-2018 13-20-50](https://user-images.githubusercontent.com/640976/44029032-3541827c-9efc-11e8-891c-9422fd589146.gif)

## After
![aug-13-2018 13-21-39](https://user-images.githubusercontent.com/640976/44029055-441a977a-9efc-11e8-8814-72ced3ef67ff.gif)

## Note
The new max-width values might not be the ideal ones but this can always be adjusted. Currently they are 550px on small, 750px on medium and 1100px on large.

