### PR TITLE
Added 'storybook-build' to scripts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ atom.cson
 yarn-error.log
 artifacts
 .npmrc
+.out

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "eslint": "eslint ./",
     "stylelint": "stylelint \"lib/**/*.css\"",
     "test": "stripes test karma",
-    "storybook": "start-storybook -p 9001 -c .storybook"
+    "storybook": "start-storybook -p 9001 -c .storybook",
+    "storybook-build": "build-storybook -c .storybook -o .out"
   },
   "engines": {
     "node": ">=6.0.0"


### PR DESCRIPTION
 The command makes it easy to generate a static storybook site.

Simply run `yarn run storybook-build` to generate a static site.

I use it when uploading updated versions of the storybook to http://ux.folio.org/storybook-draft.