### PR TITLE
Adding <Selection> example + minor changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add min-height to expanded Accordion CSS
 * Added "tag"-icon to list of icons
 * Adjust <ModalFooter> button CSS
+* Added example for <Selection>
 
 ## [3.0.0](https://github.com/folio-org/stripes-components/tree/v3.0.0)
 

--- a/lib/Button/stories/Button.stories.js
+++ b/lib/Button/stories/Button.stories.js
@@ -4,6 +4,5 @@ import readme from '../readme.md';
 import stories from './index';
 
 storiesOf('Button', module)
-  .add('General', withReadme(readme.general, stories.general))
-  .add('Styles', withReadme(readme.styles, stories.styles))
-  .add('Sizes', withReadme(readme.sizes, stories.sizes));
+  .add('Basic Usage', withReadme(readme, stories.general))
+  .add('Styles', withReadme(readme, stories.styles));

--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -594,7 +594,7 @@ class SingleSelect extends React.Component { // eslint-disable-line react/no-dep
       return null;
     }
     return (
-      <label className={css.label} htmlFor={this.testId} id={`sl-label-${this.testId}`}>{label}</label>
+      <label className={formStyles.label} htmlFor={this.testId} id={`sl-label-${this.testId}`}>{label}</label>
     );
   }
 

--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -712,6 +712,7 @@ class SingleSelect extends React.Component { // eslint-disable-line react/no-dep
             onFocus={this.props.onFocus}
             onBlur={this.handleControlBlur}
             autoFocus={this.props.autoFocus}
+            disabled={this.props.disabled}
           >
             <div className={css.singleValue} id={renderedSelectionId}>
               {this.renderSelectedOption() || this.props.placeholder}

--- a/lib/Selection/stories/BasicUsage.js
+++ b/lib/Selection/stories/BasicUsage.js
@@ -3,7 +3,7 @@
  */
 
 import React from 'react';
-import Selection from '@folio/stripes-components/lib/Selection';
+import Selection from '../Selection';
 
 // the dataOptions prop takes an array of objects with 'label' and 'value' keys
 const countriesOptions = [

--- a/lib/Selection/stories/BasicUsage.js
+++ b/lib/Selection/stories/BasicUsage.js
@@ -26,5 +26,13 @@ export default () => (
       placeholder="Select country"
       dataOptions={countriesOptions}
     />
+    <Selection
+      name="SelectionCountryDisabled"
+      label="Country (disabled)"
+      id="countrySelectDisabled"
+      placeholder="Select country"
+      dataOptions={countriesOptions}
+      disabled
+    />
   </div>
 );

--- a/lib/Selection/stories/BasicUsage.js
+++ b/lib/Selection/stories/BasicUsage.js
@@ -1,0 +1,11 @@
+/**
+ * Selection basic usage
+ */
+
+import React from 'react';
+
+export default () => (
+  <div>
+    Hello.
+  </div>
+);

--- a/lib/Selection/stories/BasicUsage.js
+++ b/lib/Selection/stories/BasicUsage.js
@@ -3,9 +3,28 @@
  */
 
 import React from 'react';
+import Selection from '@folio/stripes-components/lib/Selection';
+
+// the dataOptions prop takes an array of objects with 'label' and 'value' keys
+const countriesOptions = [
+  { value: 'AU', label: 'Australia' },
+  { value: 'CN', label: 'China' },
+  { value: 'DK', label: 'Denmark' },
+  { value: 'MX', label: 'Mexico' },
+  { value: 'SE', label: 'Sweden' },
+  { value: 'US', label: 'United States' },
+  { value: 'UK', label: 'United Kingdom' },
+  // ...obviously there are more....
+];
 
 export default () => (
   <div>
-    Hello.
+    <Selection
+      name="SelectionCountry"
+      label="Country"
+      id="countrySelect"
+      placeholder="Select country"
+      dataOptions={countriesOptions}
+    />
   </div>
 );

--- a/lib/Selection/stories/Selection.stories.js
+++ b/lib/Selection/stories/Selection.stories.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
+import readme from '../readme.md';
+import BasicUsage from './BasicUsage';
+
+storiesOf('Selection', module)
+  .addDecorator(withReadme(readme))
+  .add('Basic Usage', () => <BasicUsage />);


### PR DESCRIPTION
Initially I just wanted to add a storybook example for the `<Selection>` but I ended up making a few changes as well:

- Fixed a minor bug in the <Button> stories file that caused the Storybook to break
- Made sure that the disabled state actually can be activated (passing the disabled prop down to the <button> in SingleSelect
- Added the correct label class from sharedStyles/form.css so that the label matches the labels from the rest of the form components