### PR TITLE
UIU-459: export csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add min-height to expanded Accordion CSS
 * Added "tag"-icon to list of icons
 * Adjust <ModalFooter> button CSS
+* Added `csvShowButton` prop to <MultiColumnList>. [UIU-459](https://issues.folio.org/browse/UIU-459) Available from v3.0.7
 
 ## [3.0.0](https://github.com/folio-org/stripes-components/tree/v3.0.0)
 

--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -149,3 +149,9 @@
 .emptyMessage {
   padding: 15px;
 }
+
+.actionBarContainer {
+  display: flex;
+  align-items: baseline;
+  justify-content: flex-end;
+}

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -892,7 +892,7 @@ class MCLRenderer extends React.Component { // eslint-disable-line react/no-depr
             onClick={() => { exportToCsv(contentData, csvExcludeKeys); }}
             style={{ margin: '5px 15px 0 -10px' }}
           >
-            <FormattedMessage id='stripes-components.exportToCsv' />
+            <FormattedMessage id="stripes-components.exportToCsv" />
           </Button>
           )}
         </div>

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -5,20 +5,25 @@ import classnames from 'classnames';
 import isEqual from 'lodash/isEqual';
 
 import injectIntl from '../InjectIntl';
+import Button from '../Button';
 import Icon from '../Icon';
 import EmptyMessage from '../EmptyMessage';
 import { HotKeys } from '../HotKeys';
 import getNextFocusable from '../../util/getNextFocusable';
 import css from './MCLRenderer.css';
 import defaultRowFormatter from './defaultRowFormatter';
+import exportToCsv from './exportToCsv';
 
 const propTypes = {
+  actionBar: PropTypes.object,
   autosize: PropTypes.bool,
   columnMapping: PropTypes.object,
   columnOverflow: PropTypes.object,
   columnWidths: PropTypes.object,
   containerRef: PropTypes.func,
   contentData: PropTypes.arrayOf(PropTypes.object),
+  csvExcludeKeys: PropTypes.arrayOf(PropTypes.string),
+  csvShowButton: PropTypes.bool,
   formatter: PropTypes.object,
   headerMetadata: PropTypes.object,
   headerRowClass: PropTypes.string,
@@ -820,7 +825,8 @@ class MCLRenderer extends React.Component { // eslint-disable-line react/no-depr
       width,
       columnMapping,
       interactive,
-      intl
+      intl,
+      csvExcludeKeys
     } = this.props;
 
     // if contentData is empty, render empty message...
@@ -875,63 +881,78 @@ class MCLRenderer extends React.Component { // eslint-disable-line react/no-depr
     }
 
     const renderedHeaders = this.generateHeaders();
+
     return (
-      <HotKeys handlers={this.handlers} noWrapper>
-        <div
-          style={this.getContainerStyle()}
-          tabIndex="0" // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
-          id={this.props.id}
-          ref={this.serveContainerRef}
-          aria-label={intl.formatMessage(
-            { id: 'stripes-components.tableColumnCount' },
-            { count: this.state.columns.length }
+      <div>
+        <div className={css.actionBarContainer} style={{ width }} >
+          {this.props.actionBar}
+          {this.props.csvShowButton && (
+          <Button
+            id="export-csv"
+            onClick={() => { exportToCsv(contentData, csvExcludeKeys); }}
+            style={{ margin: '5px 15px 0 -10px' }}
+          >
+            Export to CSV
+          </Button>
           )}
-          role="list"
-          className={css.mclContainer}
-        >
+        </div>
+        <HotKeys handlers={this.handlers} noWrapper>
           <div
-            className={this.getHeaderStyle()}
-            ref={(ref) => { this.headerRow = ref; }}
-            onScroll={this.handleHeaderScroll}
+            style={this.getContainerStyle()}
+            tabIndex="0" // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
+            id={this.props.id}
+            ref={this.serveContainerRef}
+            aria-label={intl.formatMessage(
+              { id: 'stripes-components.tableColumnCount' },
+              { count: this.state.columns.length }
+            )}
+            role="list"
+            className={css.mclContainer}
           >
-            {renderedHeaders}
-          </div>
-          <div
-            className={css.scrollable}
-            style={this.getBodyStyle()}
-            onScroll={this.props.virtualize ? this.handleInfiniteScroll : this.handleFiniteScroll}
-            ref={(ref) => { this.scrollContainer = ref; }}
-          >
-            {this.props.virtualize &&
-              <div
-                className={css.heightSpacer}
-                style={{ height: this.state.adjustedHeight || this.state.totalRows * this.state.averageRowHeight }}
-              >
+            <div
+              className={this.getHeaderStyle()}
+              ref={(ref) => { this.headerRow = ref; }}
+              onScroll={this.handleHeaderScroll}
+            >
+              {renderedHeaders}
+            </div>
+            <div
+              className={css.scrollable}
+              style={this.getBodyStyle()}
+              onScroll={this.props.virtualize ? this.handleInfiniteScroll : this.handleFiniteScroll}
+              ref={(ref) => { this.scrollContainer = ref; }}
+            >
+              {this.props.virtualize &&
                 <div
-                  className={css.rowContainer}
-                  role="group"
-                  style={{ top: this.state.contentTop }}
-                  ref={(ref) => { this.rowContainer = ref; this.measureNewRows(); }}
+                  className={css.heightSpacer}
+                  style={{ height: this.state.adjustedHeight || this.state.totalRows * this.state.averageRowHeight }}
                 >
-                  {renderedRows}
+                  <div
+                    className={css.rowContainer}
+                    role="group"
+                    style={{ top: this.state.contentTop }}
+                    ref={(ref) => { this.rowContainer = ref; this.measureNewRows(); }}
+                  >
+                    {renderedRows}
+                  </div>
+                </div>
+              }
+              {!this.props.virtualize &&
+                renderedRows
+              }
+
+            </div>
+            {
+              this.props.loading &&
+              <div className={css.contentLoadingRow}>
+                <div className={css.contentLoading}>
+                  <Icon icon="spinner-ellipsis" width="35px" />
                 </div>
               </div>
             }
-            {!this.props.virtualize &&
-              renderedRows
-            }
-
           </div>
-          {
-            this.props.loading &&
-            <div className={css.contentLoadingRow}>
-              <div className={css.contentLoading}>
-                <Icon icon="spinner-ellipsis" width="35px" />
-              </div>
-            </div>
-          }
-        </div>
-      </HotKeys>
+        </HotKeys>
+      </div>
     );
   }
 }

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { intlShape } from 'react-intl';
+import { FormattedMessage, intlShape } from 'react-intl';
 import classnames from 'classnames';
 import isEqual from 'lodash/isEqual';
 
@@ -892,7 +892,7 @@ class MCLRenderer extends React.Component { // eslint-disable-line react/no-depr
             onClick={() => { exportToCsv(contentData, csvExcludeKeys); }}
             style={{ margin: '5px 15px 0 -10px' }}
           >
-            Export to CSV
+            <FormattedMessage id='stripes-components.exportToCsv' />
           </Button>
           )}
         </div>

--- a/lib/MultiColumnList/exportToCsv.js
+++ b/lib/MultiColumnList/exportToCsv.js
@@ -1,0 +1,59 @@
+import { Parser } from 'json2csv';
+
+function triggerDownload(csv, fileTitle) {
+  const exportedFilename = fileTitle ? fileTitle + '.csv' : 'export.csv';
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  if (navigator.msSaveBlob) { // IE 10+
+    navigator.msSaveBlob(blob, exportedFilename);
+  } else {
+    const link = document.createElement('a');
+    if (link.download !== undefined) { // feature detection
+      // Browsers that support HTML5 download attribute
+      const url = URL.createObjectURL(blob);
+      link.setAttribute('href', url);
+      link.setAttribute('download', exportedFilename);
+      link.style.visibility = 'hidden';
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } else {
+      console.error('Failed to trigger download for CSV data');
+    }
+  }
+}
+
+// Returns an array of all nested keys in an object
+const keyify = (obj, prefix = '') =>
+  Object.keys(obj).reduce((res, el) => {
+    if (Array.isArray(obj[el])) {
+      return res;
+    } else if (typeof obj[el] === 'object' && obj[el] !== null) {
+      return [...res, ...keyify(obj[el], prefix + el + '.')];
+    } else {
+      return [...res, prefix + el];
+    }
+  }, []);
+
+// Returns the first list with the values of the second list omitted
+const omitFields = (allFields, excludedFields) => {
+  excludedFields.forEach((field) => {
+    const index = allFields.indexOf(field);
+    if (index !== -1) {
+      allFields.splice(index, 1);
+    }
+  });
+  return allFields;
+};
+
+export default function exportToCsv(objectArray, excludedFields = []) {
+  if (!(objectArray && objectArray.length > 0)) {
+    // console.debug('No data to export');
+    return;
+  }
+
+  const allFields = keyify(objectArray[0]);
+  const fields = omitFields(allFields, excludedFields);
+  const parser = new Parser({ fields });
+  const csv = parser.parse(objectArray);
+  triggerDownload(csv);
+}

--- a/lib/MultiColumnList/readme.md
+++ b/lib/MultiColumnList/readme.md
@@ -57,6 +57,8 @@ Name | type | description | default | required
 `rowFormatter`  | func | function of shape `<name>({rowIndex, rowClass, rowData, cells, rowProps}){return <reactElement>}` that can be used to supply custom row layout. Forking [defaultRowFormatter](defaultRowFormatter.js) is a good place to start if you need to use this. | `defaultRowFormatter` |
 `interactive` | bool | Applies a "pointer" cursor when the mouse hovers over a row | `true` |
 `headerRowClass` | string | Applies a css class to the header row of the list. | |
+`csvShowButton` | bool | Displays the "Export to CSV" button
+`csvExcludeKeys` | array of strings | List of columns in the data that should be excluded in the CSV
 
 ## Usability: Clickable Rows vs clickable cells
 Using both types of interaction is not good for users or developers, so it's best to simply use one or the other. For clickable cell content, place clickable elements within `formatter`s. Clickable rows are easily created by using the `onRowClick` prop.

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@folio/stripes-react-hotkeys": "^1.0.0",
     "classnames": "^2.2.5",
     "dom-helpers": "^3.2.1",
+    "json2csv": "^4.2.1",
     "lodash": "^4.17.4",
     "moment": "^2.17.1",
     "moment-range": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",

--- a/translations/stripes-components/en.json
+++ b/translations/stripes-components/en.json
@@ -50,6 +50,7 @@
   "tableColumnCount": "Table with {count} columns",
   "button.edit": "Edit",
   "button.new": "+ New",
+  "exportToCsv": "Export to CSV",
   "selection.emptyList": "List is empty",
   "selection.noMatches": "No matching options",
   "selection.filterOptionsLabel": "{label} options filter",


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-459

- `exportToCsv(csv)` is in its own file for transforming the JSON to CSV, optionally omitting columns, and triggering the download
- MultiColumnList was originally just the table. I added a sibling that precedes it, ActionbarContainer, which caused the whitespace diff seen on Github. This container has two children: the optional prop `actionbar` and the "Export to CSV" `<Button>`
- increment patch version so it can be consumed by `ui-users`