### PR TITLE
Fix `makeQueryFunction` regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add min-height to expanded Accordion CSS
 * Added "tag"-icon to list of icons
 * Adjust <ModalFooter> button CSS
+* `makeQueryFunction` once more correctly handles relation modifiers, fixing a regression introduced in commit 1bf498d3. Fixes STCOM-321.
 
 ## [3.0.0](https://github.com/folio-org/stripes-components/tree/v3.0.0) (2018-07-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v2.0.0...v3.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Added "tag"-icon to list of icons
 * Adjust <ModalFooter> button CSS
 
-## [3.0.0](https://github.com/folio-org/stripes-components/tree/v3.0.0)
+## [3.0.0](https://github.com/folio-org/stripes-components/tree/v3.0.0) (2018-07-11)
 
 * In `<Datepicker>`, added a new `ignoreLocalOffset` prop that ignores the tenant timezone and treats the date as UTC to display the date. Fixes UIORG-55
 * Adjust address read only view. Fixes STCOM-152.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-components
 
 ## 4.0.0 (IN PROGRESS)
+
 * Expose `Settings` nav pane width via `navPaneWidth` prop.
 * Rename `errorText` and `warningText` props to `error` and `warning` for consistency. Fixes STCOM-314
 * Change button relationship margins
@@ -9,6 +10,7 @@
 * Adjust <ModalFooter> button CSS
 
 ## [3.0.0](https://github.com/folio-org/stripes-components/tree/v3.0.0) (2018-07-11)
+[Full Changelog](https://github.com/folio-org/stripes-components/compare/v2.0.0...v3.0.0)
 
 * In `<Datepicker>`, added a new `ignoreLocalOffset` prop that ignores the tenant timezone and treats the date as UTC to display the date. Fixes UIORG-55
 * Adjust address read only view. Fixes STCOM-152.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Add min-height to expanded Accordion CSS
 * Added "tag"-icon to list of icons
 * Adjust <ModalFooter> button CSS
-* `makeQueryFunction` once more correctly handles relation modifiers, fixing a regression introduced in commit 1bf498d3. Fixes STCOM-321.
+* `makeQueryFunction` once more correctly handles relation modifiers, fixing a regression introduced in commit 1bf498d3. Fixes STCOM-321. Available from v3.0.7.
 
 ## [3.0.0](https://github.com/folio-org/stripes-components/tree/v3.0.0) (2018-07-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v2.0.0...v3.0.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",

--- a/util/makeQueryFunction.js
+++ b/util/makeQueryFunction.js
@@ -38,7 +38,7 @@ function makeQueryFunction(findAll, queryTemplate, sortMap, filterConfig, failOn
       if (t.length === 1) {
         cql = `${qindex}="${query}*"`;
       } else {
-        cql = `${t[0]} =\${t[1]} "${query}*"`;
+        cql = `${t[0]} =\/${t[1]} "${query}*"`;
       }
     } else if (query) {
       cql = compilePathTemplate(queryTemplate, nsQueryParams, pathComponents, { query: resourceQuery });


### PR DESCRIPTION
It now once more correctly handles relation modifiers, fixing a regression introduced in commit 1bf498d3.

Fixes STCOM-321.