### PR TITLE
Added "to"-prop to <Button> and updated tests

### DIFF
--- a/lib/Button/Button.js
+++ b/lib/Button/Button.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/button-has-type */
 import React from 'react';
 import className from 'classnames';
+import Link from 'react-router-dom/Link';
 import PropTypes from 'prop-types';
 import css from './Button.css';
 import omitProps from '../../util/omitProps';
@@ -78,28 +79,55 @@ function Button(props) {
     'onClick',
     'allowAnchorClick',
     'buttonRef',
-    'type'
+    'type',
+    'to',
   ]);
-  const { children, onClick, type } = props;
+  const { children, onClick, type, to } = props;
 
+  const buttonInner = <span className={css.buttonInner}>{children}</span>;
+  const sharedProps = {
+    ...inputCustom,
+    onClick,
+    className: getStyle(),
+    ref: getButtonRef,
+  };
+
+  // Render a react router link
+  // if the "to" prop is provided
+  if (to) {
+    return (
+      <Link
+        to={to}
+        role="button"
+        {...sharedProps}
+      >
+        {buttonInner}
+      </Link>
+    );
+  }
+
+  // Render a regular anchor tag
+  // if the "href" prop is provided
   if (props.href) {
     return (
       <a
         role="button"
-        className={getStyle()}
         href={props.href}
+        {...sharedProps}
         onClick={handleAnchorClick}
-        ref={getButtonRef}
-        {...inputCustom}
       >
-        <span className={css.buttonInner}>{children}</span>
+        {buttonInner}
       </a>
     );
   }
 
+  // Render a button element as default
   return (
-    <button className={getStyle()} type={type} onClick={onClick} ref={getButtonRef} {...inputCustom}>
-      <span className={css.buttonInner}>{children}</span>
+    <button
+      type={type}
+      {...sharedProps}
+    >
+      {buttonInner}
     </button>
   );
 }

--- a/lib/Button/readme.md
+++ b/lib/Button/readme.md
@@ -26,6 +26,7 @@ marginBottom0 | bool | Remove bottom margin |
 paddingSide0 | bool | Remove padding on the sides |
 fullWidth | fullWidth | Forces the button width to 100% |
 href | string | Returns an anchor-tag with an href-attribute |
+to | string | Returns an instance of react-router-dom's <Link> |
 allowAnchorClick | bool | Allow anchor click |
 onClick | function | Adds an onClick handler |
 role | string | Adds [role-attribute](https://www.w3.org/wiki/PF/XTech/HTML5/RoleAttribute) to the button |,

--- a/lib/Button/tests/Button-test.js
+++ b/lib/Button/tests/Button-test.js
@@ -10,7 +10,7 @@ import Button from '../Button';
 import css from '../Button.css';
 import ButtonInteractor from './interactor';
 
-describe.only('Button', () => {
+describe('Button', () => {
   const button = new ButtonInteractor();
   let clicked;
   let ref;

--- a/lib/Button/tests/Button-test.js
+++ b/lib/Button/tests/Button-test.js
@@ -1,23 +1,26 @@
 import React from 'react';
+import { StaticRouter } from 'react-router'; /* eslint-disable-line import/no-extraneous-dependencies */
+import Link from 'react-router-dom/Link';
 import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 
 import { mount } from '../../../tests/helpers';
 
 import Button from '../Button';
+import css from '../Button.css';
 import ButtonInteractor from './interactor';
 
-describe('Button', () => {
+describe.only('Button', () => {
   const button = new ButtonInteractor();
+  let clicked;
+  let ref;
 
   describe('rendering a button', () => {
-    let clicked;
-
     beforeEach(async () => {
       clicked = false;
 
       await mount(
-        <Button onClick={() => { clicked = true; }} id="button-test">
+        <Button onClick={() => { clicked = true; }} id="button-test" buttonRef={r => { ref = r; }}>
           test
         </Button>
       );
@@ -47,6 +50,10 @@ describe('Button', () => {
       it('calls the onClick handler', () => {
         expect(clicked).to.be.true;
       });
+    });
+
+    it('buttonRef callback returns a HTML element instance', () => {
+      expect(ref instanceof Element).to.be.true;
     });
   });
 
@@ -93,6 +100,48 @@ describe('Button', () => {
       it('calls the click handler', () => {
         expect(anchorClicked).to.be.true;
       });
+    });
+  });
+
+  describe('Passing multiple button styles to buttonStyle', () => {
+    beforeEach(async () => {
+      await mount(
+        <Button buttonStyle="marginBottom0 primary">
+          My Button
+        </Button>
+      );
+    });
+
+    it('should have the corresponding class names', () => {
+      expect(button.class).to.include(css.marginBottom0).and.to.include(css.primary);
+    });
+  });
+
+  describe('Passing a string to the "to" prop', () => {
+    const to = '/my-custom-url';
+    clicked = false;
+    ref = null;
+    beforeEach(async () => {
+      await mount(
+        <StaticRouter context={{}}>
+          <Button to={to} onClick={() => { clicked = true; }} buttonRef={r => { ref = r; }}>
+            My Link Button
+          </Button>
+        </StaticRouter>
+      );
+      await button.click();
+    });
+
+    it('renders an anchor tag', () => {
+      expect(button.isAnchor).to.be.true;
+    });
+
+    it('should still fire onClick event when clicked', () => {
+      expect(clicked).to.be.true;
+    });
+
+    it('buttonRef callback should return an instance of react-router-dom\'s <Link>', () => {
+      return expect(ref instanceof Link).to.be.true;
     });
   });
 });


### PR DESCRIPTION
Added 'to' prop to <Button> that returns an instance of react-router-dom's `<Link>` component - useful for changing routes inside the react-router powered application. It's still possible to pass a href-prop which renders a regular link - useful for external links.

I added tests for this new addition as well as a few other tests to reach 100% test coverage 🎊