### PR TITLE
STCOM-324 Remove input and meta propTypes from Selection

### DIFF
--- a/lib/Selection/Selection.js
+++ b/lib/Selection/Selection.js
@@ -7,11 +7,9 @@ import SingleSelect from './SingleSelect';
 const propTypes = {
   emptyMessage: PropTypes.string,
   formatter: PropTypes.func,
-  input: PropTypes.object,
   label: PropTypes.string,
   labelIsValue: PropTypes.bool,
   listMaxHeight: PropTypes.string,
-  meta: PropTypes.object,
   name: PropTypes.string,
   tether: PropTypes.object,
 };


### PR DESCRIPTION
Resolves https://issues.folio.org/browse/STCOM-324.

I confirmed that `<SingleSelect>` is using `reduxFormField` effectively. This change doesn't really get us much besides one less instance of `meta` and `input` props when we search around the repo. Since `<Selection>` isn't doing anything with any props besides passing them along, we're not missing out on any prop type validation by removing these.