### PR TITLE
Deprecate passThroughValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * `makeQueryFunction` once more correctly handles relation modifiers, fixing a regression introduced in commit 1bf498d3. Fixes STCOM-321. Available from v3.0.7.
 * Added `csvShowButton` prop to <MultiColumnList>. [UIU-459](https://issues.folio.org/browse/UIU-459) Available from v3.0.8
 * Added `<MultiSelection>` component. [STCOM-263](https://issues.folio.org/browse/STCOM-263)
+* Deprecate `passThroughValue` prop on `Datepicker` and `Timepicker`
 
 ## [3.0.0](https://github.com/folio-org/stripes-components/tree/v3.0.0) (2018-07-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v2.0.0...v3.0.0)

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -39,7 +39,7 @@ const propTypes = {
   meta: PropTypes.object,
   onChange: PropTypes.func,
   onSetDate: PropTypes.func,
-  passThroughValue: PropTypes.string,
+  passThroughValue: deprecated(PropTypes.string, 'Use alternative design'),
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
   screenReaderMessage: PropTypes.string,

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { intlShape } from 'react-intl';
 import PropTypes from 'prop-types';
+import { deprecated } from 'prop-types-extra';
 import TetherComponent from 'react-tether';
 import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
 import moment from 'moment-timezone';
@@ -26,7 +27,7 @@ const propTypes = {
   locale: PropTypes.string,
   meta: PropTypes.object,
   onChange: PropTypes.func,
-  passThroughValue: PropTypes.string,
+  passThroughValue: deprecated(PropTypes.string, 'Use alternative design'),
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
   screenReaderMessage: PropTypes.string,


### PR DESCRIPTION
Removing `passThroughValue` will toss out a lot of complexity from `<Datepicker>` and `<Timepicker>`.  `ui-checkin` is the only `folio-org` repo using `passThroughValue`, and I'm closing in on an alternative design solution. Probably a good time to start throwing deprecation warnings.
