### PR TITLE
Clean button ref-handling

### DIFF
--- a/lib/Button/Button.js
+++ b/lib/Button/Button.js
@@ -12,7 +12,10 @@ export const propTypes = {
   autoFocus: PropTypes.bool,
   bottomMargin0: PropTypes.bool,
   buttonClass: PropTypes.string,
-  buttonRef: PropTypes.func,
+  buttonRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.object
+  ]),
   buttonStyle: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.node,
@@ -59,12 +62,6 @@ function Button(props) {
     props.onClick(e);
   }
 
-  function getButtonRef(ref) {
-    if (props.buttonRef) {
-      props.buttonRef(ref);
-    }
-  }
-
   const inputCustom = omitProps(props, [
     'buttonClass',
     'buttonStyle',
@@ -82,14 +79,14 @@ function Button(props) {
     'type',
     'to',
   ]);
-  const { children, onClick, type, to } = props;
+  const { children, onClick, type, to, buttonRef } = props;
 
   const buttonInner = <span className={css.buttonInner}>{children}</span>;
   const sharedProps = {
     ...inputCustom,
     onClick,
     className: getStyle(),
-    ref: getButtonRef,
+    ref: buttonRef,
   };
 
   // Render a react router link


### PR DESCRIPTION
## Purpose
Currently, if `<Button>` is passed a `buttonRef` prop via `React.createRef()` it does not work since `<Button>` treats it as a function internally.
## Approach
Instead of using the method `getButtonRef` simply pass the prop right through to the element... also, expanded propTypes since `React.creatdRef()` creates an object.

Less code == more coverage, amiright?