### PR TITLE
Introduce deprecation warnings for makePathFunction

### DIFF
--- a/util/makePathFunction.js
+++ b/util/makePathFunction.js
@@ -1,6 +1,8 @@
 import { filters2cql } from '../lib/FilterGroups';
 
 function makePathFunction(basePath, findAll, queryTemplate, sortMap, filterConfig) {
+  console.warn('makePathFunction() deprecated; instead use makeQueryFunction()');
+
   return (queryParams, _pathComponents, _resourceValues, logger) => {
     const { query, filters, sort } = queryParams || {};
 


### PR DESCRIPTION
`makePathFunction()` was replaced by `makeQueryFunction()`.

No `folio-org` repos are still using `makePathFunction()`.