### PR TITLE
STCOM-88 Update <RadioButton> and <RadioButtonGroup> to work independently of Redux Form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 4.0.0 (IN PROGRESS)
 
+* Update `<RadioButton>` and `<RadioButtonGroup>` to work independently of Redux Form
 
 ## [3.3.0](https://github.com/folio-org/stripes-components/tree/v3.3.0) (2018-10-01)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v3.2.0...v3.3.0)

--- a/lib/RadioButton/RadioButton.css
+++ b/lib/RadioButton/RadioButton.css
@@ -91,3 +91,30 @@
     background-color: #fff;
   }
 }
+
+/**
+ * Feedback
+ */
+.hasWarning {
+  & .radioFeedback {
+    color: var(--warn);
+  }
+
+  & .labelCheck {
+    border-color: var(--warn);
+  }
+}
+
+.hasError {
+  & .radioFeedback {
+    color: var(--error);
+  }
+
+  & .labelCheck {
+    border-color: var(--error);
+  }
+}
+
+.radioFeedback {
+  font-size: 12px;
+}

--- a/lib/RadioButton/RadioButton.css
+++ b/lib/RadioButton/RadioButton.css
@@ -95,12 +95,16 @@
 /**
  * Feedback
  */
+.radioFeedback {
+  font-size: 12px;
+}
+
 .hasWarning {
   & .radioFeedback {
     color: var(--warn);
   }
 
-  & .labelCheck {
+  & .input {
     border-color: var(--warn);
   }
 }
@@ -110,11 +114,7 @@
     color: var(--error);
   }
 
-  & .labelCheck {
+  & .input {
     border-color: var(--error);
   }
-}
-
-.radioFeedback {
-  font-size: 12px;
 }

--- a/lib/RadioButton/RadioButton.js
+++ b/lib/RadioButton/RadioButton.js
@@ -148,7 +148,6 @@ class RadioButton extends React.Component {
     if (!name) {
       ariaProps['aria-label'] = `${label}`;
     }
-    const { ...inputAriaProps } = ariaProps;
 
     return (
       <div className={this.getRootStyle()}>
@@ -156,7 +155,7 @@ class RadioButton extends React.Component {
           <input
             id={id}
             type="radio"
-            {...inputAriaProps}
+            {...ariaProps}
             checked={checked}
             {...inputCustom}
             name={name}

--- a/lib/RadioButton/RadioButton.js
+++ b/lib/RadioButton/RadioButton.js
@@ -1,41 +1,119 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+
+import reduxFormField from '../ReduxFormField';
 import separateComponentProps from '../../util/separateComponentProps';
 import css from './RadioButton.css';
 
-const propTypes = {
-  autoFocus: PropTypes.bool,
-  children: PropTypes.node,
-  error: PropTypes.bool,
-  id: PropTypes.string,
-  inline: PropTypes.bool,
-  input: PropTypes.object,
-  label: PropTypes.string,
-  marginBottom0: PropTypes.bool,
-  meta: PropTypes.object,
-  onBlur: PropTypes.func,
-  onFocus: PropTypes.func,
-};
-
 class RadioButton extends React.Component {
+  static propTypes = {
+    autoFocus: PropTypes.bool,
+    checked: PropTypes.bool,
+    className: PropTypes.string,
+    disabled: PropTypes.bool,
+    error: PropTypes.string,
+    fullWidth: PropTypes.bool,
+    hover: PropTypes.bool,
+    id: PropTypes.string,
+    inline: PropTypes.bool,
+    label: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.node,
+    ]),
+    labelClass: PropTypes.string,
+    labelStyle: PropTypes.object,
+    marginBottom0: PropTypes.bool,
+    name: PropTypes.string,
+    onBlur: PropTypes.func,
+    onChange: PropTypes.func,
+    onFocus: PropTypes.func,
+    value: PropTypes.string,
+    warning: PropTypes.string,
+  };
+
   constructor(props) {
     super(props);
+
+    this.state = {
+      inputInFocus: false
+    };
+
+    this.handleChange = this.handleChange.bind(this);
     this.handleFocus = this.handleFocus.bind(this);
     this.handleBlur = this.handleBlur.bind(this);
-    this.state = {
-      inputInFocus: false,
-    };
+    this.getFeedbackClasses = this.getFeedbackClasses.bind(this);
+    this.getFeedbackElement = this.getFeedbackElement.bind(this);
+  }
+
+  getLabelStyle() {
+    return classNames(
+      css.radioLabel,
+      { [`${css[this.props.labelStyle]}`]: !this.props.labelClass && this.props.labelStyle },
+      { [`${css.disabledLabel}`]: this.props.disabled },
+      { [css.labelFocused]: this.state.inputInFocus },
+      this.props.labelClass,
+    );
+  }
+
+  getRootStyle() {
+    return classNames(
+      [`${css.radioButton}`],
+      { [`${css.noLabel}`]: !this.props.label },
+      { [`${css.hover}`]: this.props.hover },
+      { [`${css.hovered}`]: (this.props.hover && this.state.inputInFocus) },
+      { [`${css.fullWidth}`]: this.props.fullWidth },
+      { [`${css.marginBottom0}`]: this.props.marginBottom0 },
+      { [`${css.inline}`]: this.props.inline },
+      this.props.className,
+      this.getFeedbackClasses(),
+    );
+  }
+
+  // Add feedback class on warning or error
+  getFeedbackClasses() {
+    const { warning, error } = this.props;
+    const classes = [];
+
+    // Check if error or warning
+    if (error) {
+      classes.push(css.hasError);
+    } else if (warning) {
+      classes.push(css.hasWarning);
+    }
+
+    // Add the feedback class if we have feedback classes
+    if (classes.length) {
+      classes.push(css.hasFeedback);
+    }
+
+    return classes;
+  }
+
+  // Get feedback element (if there's any feedback to show)
+  getFeedbackElement() {
+    const hasFeedback = !!this.getFeedbackClasses().length;
+    if (!hasFeedback) {
+      return false;
+    }
+
+    const error = this.props.error;
+    const warning = this.props.warning;
+
+    // Currently prefering error over warning
+    return (<div className={css.radioFeedback}>{error || warning}</div>);
+  }
+
+  handleChange(e) {
+    if (this.props.onChange) {
+      this.props.onChange(e);
+    }
   }
 
   handleFocus(e) {
     this.setState({
       inputInFocus: true,
     });
-
-    if (this.props.input && this.props.input.onFocus) {
-      this.props.input.onFocus(e);
-    }
 
     if (this.props.onFocus) {
       this.props.onFocus(e);
@@ -47,59 +125,68 @@ class RadioButton extends React.Component {
       inputInFocus: false,
     });
 
-    if (this.props.input && this.props.input.onBlur) {
-      this.props.input.onBlur(e);
-    }
-
     if (this.props.onBlur) {
       this.props.onBlur(e);
     }
   }
 
-  getLabelStyle() {
-    return classNames(
-      css.radioLabel,
-      { [css.labelFocused]: this.state.inputInFocus },
-      { [css.error]: this.props.error }
-    );
-  }
-
-  getRootStyle() {
-    let rootStyle = css.radioButton;
-    rootStyle += this.props.inline ? ` ${css.inline}` : '';
-    rootStyle += this.props.marginBottom0 ? ` ${css.marginBottom0}` : '';
-    return rootStyle;
-  }
-
   render() {
-    const { label, input } = this.props;
-    // eslint-disable-next-line react/forbid-foreign-prop-types
-    const [, inputProps] = separateComponentProps(this.props, RadioButton.propTypes);
+    const {
+      autoFocus,
+      checked,
+      disabled,
+      id,
+      label,
+      name,
+      value
+    } = this.props;
 
-    if (input) {
-      Object.assign(inputProps, input);
+    // eslint-disable-next-line react/forbid-foreign-prop-types
+    const [, inputCustom] = separateComponentProps(this.props, RadioButton.propTypes);
+
+    const ariaProps = {};
+    if (!name) {
+      ariaProps['aria-label'] = `${label}`;
     }
+    const { ...inputAriaProps } = ariaProps;
 
     return (
       <div className={this.getRootStyle()}>
-        <label htmlFor={this.props.id} className={this.getLabelStyle()}>
+        <label htmlFor={id} className={this.getLabelStyle()}>
           <input
-            {...inputProps}
-            autoFocus={this.props.autoFocus}
-            id={this.props.id}
-            className={css.input}
+            id={id}
             type="radio"
+            {...inputAriaProps}
+            checked={checked}
+            {...inputCustom}
+            name={name}
+            className={css.input}
+            onChange={this.handleChange}
             onFocus={this.handleFocus}
             onBlur={this.handleBlur}
+            disabled={disabled}
+            ref={(ref) => { this.input = ref; }}
+            autoFocus={autoFocus}
+            value={value}
           />
           <span className={css.labelPseudo} />
           { label && <span className={css.labelText}>{label}</span>}
         </label>
+        {this.getFeedbackElement()}
       </div>
     );
   }
 }
 
-RadioButton.propTypes = propTypes;
-
-export default RadioButton;
+export default reduxFormField(
+  RadioButton,
+  ({ input, meta }) => ({
+    checked: input.checked,
+    onChange: input.onChange,
+    onBlur: input.onBlur,
+    onFocus: input.onFocus,
+    warning: (meta.touched && meta.warning ? meta.warning : ''),
+    error: (meta.touched && meta.error ? meta.error : ''),
+    value: input.value
+  })
+);

--- a/lib/RadioButton/RadioButton.js
+++ b/lib/RadioButton/RadioButton.js
@@ -94,7 +94,7 @@ class RadioButton extends React.Component {
   getFeedbackElement() {
     const hasFeedback = !!this.getFeedbackClasses().length;
     if (!hasFeedback) {
-      return false;
+      return null;
     }
 
     const error = this.props.error;

--- a/lib/RadioButton/readme.md
+++ b/lib/RadioButton/readme.md
@@ -1,0 +1,64 @@
+# RadioButton
+Renders a basic HTML radio button.
+
+## Usage
+
+```
+<RadioButton
+  checked={true}
+  value="bananas"
+  onChange={(event) => {
+    // consume event.target.value
+  }}
+/>
+```
+
+## Properties
+
+Name | type | description | default | required
+--- | --- | --- | --- | ---
+autoFocus | bool | If this prop is `true`, will automatically focus on mount | `false` | false
+checked | bool | | | false
+className | string | | | false
+disabled | bool | | | false
+error | string | | | false
+fullWidth | bool | Styles input to a width of 100% of its container. | | false
+hover | bool | | | false
+id | string | HTML id attribute applied to input - will also set the HtmlFor attribute of the label. |  | false
+inline | bool | | | false
+label | string | Adds an html `<label>` tag container a string to the element. | | false
+labelClass | string | | | false
+labelStyle | string | | | false
+marginBottom0 | bool | Styles the input with no bottom margin. | false | false
+name | string | | | false
+onBlur | func | | | false
+onChange | func | Event handler for the input's `onChange` event. **This prop isn't necessary if part of a redux-form (see below)** | | false
+onFocus | func | | | false
+value | string | Sets the selected value for the input. **This prop isn't necessary if part of a redux-form (see below)** | | false
+warning | string | | | false
+
+
+## Use with Redux Form
+```
+import { RadioButton } from '@folio/stripes-components';
+
+...
+
+  <Field
+    component={RadioButton}
+    label="green"
+    name="bananas"
+    type="radio"
+    value="green"
+  />
+
+  <Field
+    component={RadioButton}
+    label="ripe"
+    name="bananas"
+    type="radio"
+    value="ripe"
+  />
+```
+
+[`<RadioButtonGroup>`](../RadioButtonGroup) makes working with Redux Form easier.

--- a/lib/RadioButton/stories/BasicUsage.js
+++ b/lib/RadioButton/stories/BasicUsage.js
@@ -28,9 +28,9 @@ export default class BasicUsage extends React.Component {
           value: 'option_4',
         },
         {
-          label: 'Option 5 (with error)',
+          label: 'Option 5',
           value: 'option_5',
-          error: true,
+          error: '(with error)',
         },
       ],
     };
@@ -43,14 +43,10 @@ export default class BasicUsage extends React.Component {
         { options.map((option, i) => (
           <RadioButton
             key={i}
-            error={option.error === true}
-            input={
-              {
-                name: option.value,
-                checked: option.value === selected,
-                onChange: () => { this.setState({ selected: option.value }); },
-              }
-            }
+            error={option.error}
+            name={option.value}
+            checked={option.value === selected}
+            onChange={() => { this.setState({ selected: option.value }); }}
             id={option.value}
             label={option.label}
           />

--- a/lib/RadioButton/tests/RadioButton-ReduxForm-test.js
+++ b/lib/RadioButton/tests/RadioButton-ReduxForm-test.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { Field } from 'redux-form';
+import { mountWithContext } from '../../../tests/helpers';
+import TestForm from '../../../tests/TestForm';
+
+import RadioButton from '../RadioButton';
+import RadioButtonInteractor from './interactor';
+
+describe('RadioButton with Redux Form', () => {
+  const radioButton1 = new RadioButtonInteractor('#radio-button-1');
+  const radioButton2 = new RadioButtonInteractor('#radio-button-2');
+  let output = false;
+
+  beforeEach(async () => {
+    await mountWithContext(
+      <TestForm>
+        <div id="radio-button-1">
+          <Field
+            component={RadioButton}
+            label="green"
+            name="bananas"
+            onChange={(event) => {
+              output = event.target.checked;
+            }}
+            type="radio"
+            value="green"
+          />
+        </div>
+        <div id="radio-button-2">
+          <Field
+            component={RadioButton}
+            label="ripe"
+            name="bananas"
+            type="radio"
+            validate={value => (value === 'green' ? 'Not ready to eat' : undefined)}
+            value="ripe"
+            warn={value => (value === 'ripe' ? 'Warning: may be mushy' : undefined)}
+          />
+        </div>
+      </TestForm>
+    );
+  });
+
+  it('displays the input as unchecked', () => {
+    expect(radioButton1.isChecked).to.be.false;
+  });
+
+  describe('clicking the label', () => {
+    beforeEach(async () => {
+      await radioButton1.clickAndBlur();
+    });
+
+    it('toggles the value', () => {
+      expect(output).to.be.true;
+    });
+
+    it('displays the input as checked', () => {
+      expect(radioButton1.isChecked).to.be.true;
+    });
+
+    it('displays the error text', () => {
+      expect(radioButton1.feedbackText).to.equal('Not ready to eat');
+    });
+
+    it('applies an error class', () => {
+      expect(radioButton1.hasErrorStyle).to.be.true;
+    });
+
+    describe('toggling to a different radio button', () => {
+      beforeEach(async () => {
+        await radioButton2.clickAndBlur();
+      });
+
+      it('displays warning text', () => {
+        expect(radioButton2.feedbackText).to.equal('Warning: may be mushy');
+      });
+
+      it('applies a warning class', () => {
+        expect(radioButton2.hasWarningStyle).to.be.true;
+      });
+    });
+  });
+});

--- a/lib/RadioButton/tests/RadioButton-test.js
+++ b/lib/RadioButton/tests/RadioButton-test.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { mount } from '../../../tests/helpers';
+
+import RadioButton from '../RadioButton';
+import RadioButtonInteractor from './interactor';
+
+describe('RadioButton', () => {
+  const radioButton = new RadioButtonInteractor();
+
+  describe('with an id', () => {
+    beforeEach(async () => {
+      await mount(
+        <RadioButton id="checkbox-test" />
+      );
+    });
+
+    it('has an id on the input element', () => {
+      expect(radioButton.id).to.equal('checkbox-test');
+    });
+  });
+
+  describe('with warning text', () => {
+    beforeEach(async () => {
+      await mount(
+        <RadioButton warning="That's not a great value." />
+      );
+    });
+
+    it('displays the warning text', () => {
+      expect(radioButton.feedbackText).to.equal('That\'s not a great value.');
+    });
+
+    it('applies a warning class', () => {
+      expect(radioButton.hasWarningStyle).to.be.true;
+    });
+  });
+
+  describe('with error text', () => {
+    beforeEach(async () => {
+      await mount(
+        <RadioButton error="That's a bad value." />
+      );
+    });
+
+    it('displays the error text', () => {
+      expect(radioButton.feedbackText).to.equal('That\'s a bad value.');
+    });
+
+    it('applies an error class', () => {
+      expect(radioButton.hasErrorStyle).to.be.true;
+    });
+  });
+
+  describe('with a value', () => {
+    let output;
+
+    beforeEach(async () => {
+      await mount(
+        <RadioButton
+          value="bananas"
+          onChange={(event) => {
+            output = event.target.value;
+          }}
+        />
+      );
+    });
+
+    it('displays the input as unchecked', () => {
+      expect(radioButton.isChecked).to.be.false;
+    });
+
+    describe('clicking the label', () => {
+      beforeEach(async () => {
+        await radioButton.clickLabel();
+      });
+
+      it('toggles the value', () => {
+        expect(output).to.equal('bananas');
+      });
+
+      it('displays the input as checked', () => {
+        expect(radioButton.isChecked).to.be.true;
+      });
+    });
+  });
+});

--- a/lib/RadioButton/tests/interactor.js
+++ b/lib/RadioButton/tests/interactor.js
@@ -1,0 +1,30 @@
+import {
+  attribute,
+  blurrable,
+  clickable,
+  hasClass,
+  interactor,
+  property,
+  text,
+  value,
+} from '@bigtest/interactor';
+import styles from '../RadioButton.css';
+
+const rootClass = `.${styles.radioButton}`;
+
+export default interactor(class CheckboxInteractor {
+  id = attribute('input', 'id');
+  clickLabel = clickable('label');
+  blurInput = blurrable('input');
+  inputValue = value('input');
+  isChecked = property('input', 'checked');
+  feedbackText = text(`.${styles.radioFeedback}`);
+  hasWarningStyle = hasClass(rootClass, styles.hasWarning);
+  hasErrorStyle = hasClass(rootClass, styles.hasError);
+
+  clickAndBlur() {
+    return this
+      .clickLabel()
+      .blurInput();
+  }
+});

--- a/lib/RadioButtonGroup/RadioButtonGroup.js
+++ b/lib/RadioButtonGroup/RadioButtonGroup.js
@@ -1,48 +1,61 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ReduxFormField from '../ReduxFormField';
 import RadioButton from '../RadioButton';
 import css from './RadioButtonGroup.css';
 
 const propTypes = {
   children: PropTypes.node.isRequired,
-  input: PropTypes.object,
+  error: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  meta: PropTypes.object,
-  selectedValue: PropTypes.string,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  value: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  warning: PropTypes.string
 };
 
 function RadioButtonGroup(props) {
-  const { input, meta: { touched, error, warning }, ...rest } = props;
-  const { value, ...inputAttr } = input;
+  const { error, label, onBlur, onChange, onFocus, value, warning, ...rest } = props;
 
-  const selected = props.selectedValue || value;
-
-  const { label, ...inputCustom } = { ...rest };
   const displayedChildren = React.Children.map(props.children,
     (child) => {
-      if (child.type !== RadioButton) { return child; }
-      const newProps = { ...inputAttr, ...inputCustom };
-      newProps.checked = selected.toString() === child.props.value;
-      newProps.marginBottom0 = true;
-      const elemProps = Object.assign({}, newProps, child.props);
-      return React.cloneElement(child, elemProps, []);
+      if (child.type === RadioButton && value !== undefined) {
+        return React.cloneElement(child, {
+          checked: value.toString() === child.props.value,
+          marginBottom0: true,
+          onBlur,
+          onChange,
+          onFocus
+        });
+      } else {
+        return child;
+      }
     });
 
-  const warningElement = touched && warning ? <div className={css.groupWarning}>{warning}</div> : null;
-  const errorElement = touched && error ? <div className={css.groupError}>{error}</div> : null;
+  const warningElement = warning ? <div className={css.groupWarning}>{warning}</div> : null;
+  const errorElement = error ? <div className={css.groupError}>{error}</div> : null;
 
   return (
-    <div className={css.groupRoot}>
-      <fieldset>
-        <legend className={css.groupLabel}>{label}</legend>
-        {displayedChildren}
-        {warningElement}
-        {errorElement}
-      </fieldset>
-    </div>
+    <fieldset className={css.groupRoot} {...rest}>
+      <legend className={css.groupLabel}>{label}</legend>
+      {displayedChildren}
+      {warningElement}
+      {errorElement}
+    </fieldset>
   );
 }
 
 RadioButtonGroup.propTypes = propTypes;
 
-export default RadioButtonGroup;
+export default ReduxFormField(
+  RadioButtonGroup,
+  ({ input, meta }) => ({
+    error: (meta.touched && meta.error ? meta.error : ''),
+    onBlur: input.onBlur,
+    onChange: input.onChange,
+    onFocus: input.onFocus,
+    value: input.value,
+    warning: (meta.touched && meta.warning ? meta.warning : '')
+  })
+);

--- a/lib/RadioButtonGroup/readme.md
+++ b/lib/RadioButtonGroup/readme.md
@@ -20,6 +20,11 @@ Example with redux-form `<Field>` component:
 ## Props
 Name | type | description | default | required |
 --- | --- | --- | --- | --- |
-selectedValue | string | Sets default value for radio button set - **Not necessary for redux-form - will use the form's initialValues prop instead** | | |
 children | node or array of nodes | Set of `<RadioButton>`s for usage. Can include other tags (headers, spans, etc.) | | &#10004;|
+error | string | | | |
 label | string or node | Content to render in the `<legend>` tag of the created `<fieldset>`. | | |
+`onBlur` | func |  | |
+`onChange` | func | | |
+`onFocus` | func | | |
+value | string | Sets default value for radio button set - **Not necessary for redux-form - will use the form's initialValues prop instead** | | |
+warning | string | | | |

--- a/lib/RadioButtonGroup/stories/BasicUsage.js
+++ b/lib/RadioButtonGroup/stories/BasicUsage.js
@@ -1,0 +1,19 @@
+/**
+ * Radio Button Group example
+ */
+
+import React from 'react';
+import RadioButtonGroup from '../RadioButtonGroup';
+import RadioButton from '../../RadioButton';
+
+export default class BasicUsage extends React.Component {
+  render() {
+    return (
+      <RadioButtonGroup>
+        <RadioButton label="Inline Radio Button 1" name="fruit" value="apples" />
+        <RadioButton label="Inline Radio Button 2" name="fruit" value="oranges" />
+        <RadioButton label="Inline Radio Button 3" name="fruit" value="bananas" />
+      </RadioButtonGroup>
+    );
+  }
+}

--- a/lib/RadioButtonGroup/stories/RadioButtonGroup.stories.js
+++ b/lib/RadioButtonGroup/stories/RadioButtonGroup.stories.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import BasicUsage from './BasicUsage';
+
+storiesOf('Radio Button Group', module)
+  .add('Basic Usage', () => (<BasicUsage />));

--- a/lib/RadioButtonGroup/tests/RadioButtonGroup-ReduxForm-test.js
+++ b/lib/RadioButtonGroup/tests/RadioButtonGroup-ReduxForm-test.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { Field } from 'redux-form';
+import { mountWithContext } from '../../../tests/helpers';
+import TestForm from '../../../tests/TestForm';
+import RadioButtonGroup from '../RadioButtonGroup';
+import RadioButton from '../../RadioButton';
+import RadioButtonGroupInteractor from './interactor';
+
+describe('RadioButtonGroup with Redux Form', () => {
+  const radioButtonGroup = new RadioButtonGroupInteractor();
+
+  beforeEach(async () => {
+    await mountWithContext(
+      <TestForm>
+        <Field
+          name="testField"
+          component={RadioButtonGroup}
+          validate={value => (value === 'no' ? 'testField is invalid' : undefined)}
+          warn={value => (value === 'yes' ? 'testField has a warning' : undefined)}
+        >
+          <p>Some help text</p>
+          <RadioButton label="Yes" value="yes" />
+          <RadioButton label="No" value="no" />
+        </Field>
+      </TestForm>
+    );
+  });
+
+  it('displays the first option as unselected', () => {
+    expect(radioButtonGroup.options(0).isChecked).to.be.false;
+  });
+
+  it('displays the second option as unselected', () => {
+    expect(radioButtonGroup.options(1).isChecked).to.be.false;
+  });
+
+  describe('selecting an option', () => {
+    beforeEach(async () => {
+      await radioButtonGroup.options(0).clickAndBlur();
+    });
+
+    it('displays the first option as selected', () => {
+      expect(radioButtonGroup.options(0).isChecked).to.be.true;
+    });
+
+    it('displays the second option as unselected', () => {
+      expect(radioButtonGroup.options(1).isChecked).to.be.false;
+    });
+
+    it('displays an warning message', () => {
+      expect(radioButtonGroup.feedbackText).to.equal('testField has a warning');
+    });
+
+    describe('selecting another option', () => {
+      beforeEach(async () => {
+        await radioButtonGroup.options(1).clickAndBlur();
+      });
+
+      it('displays the first option as unselected', () => {
+        expect(radioButtonGroup.options(0).isChecked).to.be.false;
+      });
+
+      it('displays the second option as selected', () => {
+        expect(radioButtonGroup.options(1).isChecked).to.be.true;
+      });
+
+      it('displays an error message', () => {
+        expect(radioButtonGroup.feedbackText).to.equal('testField is invalid');
+      });
+    });
+  });
+});

--- a/lib/RadioButtonGroup/tests/RadioButtonGroup-test.js
+++ b/lib/RadioButtonGroup/tests/RadioButtonGroup-test.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { mount } from '../../../tests/helpers';
+import RadioButtonGroup from '../RadioButtonGroup';
+import RadioButton from '../../RadioButton';
+import RadioButtonGroupInteractor from './interactor';
+
+describe('RadioButtonGroup', () => {
+  const radioButtonGroup = new RadioButtonGroupInteractor();
+
+  describe('without value controlled', () => {
+    beforeEach(async () => {
+      await mount(
+        <RadioButtonGroup>
+          <RadioButton label="Yes" name="radioField" value="yes" />
+          <RadioButton label="No" name="radioField" value="no" />
+        </RadioButtonGroup>
+      );
+    });
+
+    it('displays the first option as unselected', () => {
+      expect(radioButtonGroup.options(0).isChecked).to.be.false;
+    });
+
+    it('displays the second option as unselected', () => {
+      expect(radioButtonGroup.options(1).isChecked).to.be.false;
+    });
+
+    describe('selecting an option', () => {
+      beforeEach(async () => {
+        await radioButtonGroup.options(0).clickAndBlur();
+      });
+
+      it('displays the first option as selected', () => {
+        expect(radioButtonGroup.options(0).isChecked).to.be.true;
+      });
+
+      it('displays the second option as unselected', () => {
+        expect(radioButtonGroup.options(1).isChecked).to.be.false;
+      });
+
+      describe('selecting another option', () => {
+        beforeEach(async () => {
+          await radioButtonGroup.options(1).clickAndBlur();
+        });
+
+        it('displays the first option as unselected', () => {
+          expect(radioButtonGroup.options(0).isChecked).to.be.false;
+        });
+
+        it('displays the second option as selected', () => {
+          expect(radioButtonGroup.options(1).isChecked).to.be.true;
+        });
+      });
+    });
+  });
+
+  describe('with value controlled', () => {
+    beforeEach(async () => {
+      await mount(
+        <RadioButtonGroup value="no">
+          <RadioButton label="Yes" name="radioField" value="yes" />
+          <RadioButton label="No" name="radioField" value="no" />
+        </RadioButtonGroup>
+      );
+    });
+
+    it('displays the first option as unselected', () => {
+      expect(radioButtonGroup.options(0).isChecked).to.be.false;
+    });
+
+    it('displays the second option as selected', () => {
+      expect(radioButtonGroup.options(1).isChecked).to.be.true;
+    });
+  });
+
+  describe('with a warning', () => {
+    beforeEach(async () => {
+      await mount(
+        <RadioButtonGroup warning="radioField has a warning">
+          <RadioButton label="Yes" name="radioField" value="yes" />
+          <RadioButton label="No" name="radioField" value="no" />
+        </RadioButtonGroup>
+      );
+    });
+
+    it('displays an warning message', () => {
+      expect(radioButtonGroup.feedbackText).to.equal('radioField has a warning');
+    });
+  });
+
+  describe('with an error', () => {
+    beforeEach(async () => {
+      await mount(
+        <RadioButtonGroup error="radioField has an error">
+          <RadioButton label="Yes" name="radioField" value="yes" />
+          <RadioButton label="No" name="radioField" value="no" />
+        </RadioButtonGroup>
+      );
+    });
+
+    it('displays an warning message', () => {
+      expect(radioButtonGroup.feedbackText).to.equal('radioField has an error');
+    });
+  });
+});

--- a/lib/RadioButtonGroup/tests/interactor.js
+++ b/lib/RadioButtonGroup/tests/interactor.js
@@ -1,0 +1,17 @@
+import {
+  attribute,
+  collection,
+  interactor,
+  text
+} from '@bigtest/interactor';
+import RadioButtonInteractor from '../../RadioButton/tests/interactor';
+import styles from '../RadioButtonGroup.css';
+import radioButtonStyles from '../../RadioButton/RadioButton.css';
+
+const radioButtonRootClass = `.${radioButtonStyles.radioButton}`;
+
+export default interactor(class RadioButtonGroupInteractor {
+  id = attribute('input', 'id');
+  options = collection(radioButtonRootClass, RadioButtonInteractor);
+  feedbackText = text(`.${styles.groupFeedback}`);
+});


### PR DESCRIPTION
## Purpose
Resolves [STCOM-88](https://issues.folio.org/browse/STCOM-88), [STCOM-322](https://issues.folio.org/browse/STCOM-322), and [STCOM-323](https://issues.folio.org/browse/STCOM-323).

Replaces https://github.com/folio-org/stripes-components/pull/567.

## Approach
- Use `reduxFormField()` for consistent logic with or without Redux Form.
- Made the props identical between `<Checkbox>` and `<RadioButton>`.
- Checked against the eHoldings acceptance tests. Found and fixed several regressions that way.
- Updated stories and readme.

## Versioning
Contains significant prop changes to `<RadioButton>` and `<RadioButtonGroup>`. I bumped to the next major version in `package.json` and the changelog. Consumers of those two components with Redux Form shouldn't expect any breaking changes.

## TODO
- [x] Add more documentation to readme