### PR TITLE
Mark deprecated Datepicker and Timepicker props in readmes

### DIFF
--- a/lib/Datepicker/readme.md
+++ b/lib/Datepicker/readme.md
@@ -18,14 +18,14 @@ Name | type | description | default | required
 `useFocus` | bool | if set to false, component relies solely on clicking the calendar icon to toggle appearance of calendar. | true | false
 `autoFocus` | bool | If this prop is `true`, component will automatically focus on mount | |
 `disabled` | bool | if true, field will be disabled for focus or entry. | false | false
-`ignoreLocalOffset` | bool | if true, ignores the time zone setting and treats the date as UTC to display the date.
+`ignoreLocalOffset` (deprecated)  | bool | if true, ignores the time zone setting and treats the date as UTC to display the date.
 | false | false. See below for more explanation
 `readOnly` | bool | if true, field will be readonly. 'Calendar' and 'clear' buttons will be omitted. | false | false
 `value` | string | date to be displayed in the textfield. In forms, this is supplied by the initialValues prop supplied to the form | "" | false
 `onChange` | func | Event handler to handle updates to the datefield text. | | false
 `screenReaderMessage` | string | Additional message to be read by screenreaders when textfield is focused in addition to the label and format - which are always read. | | false
-`excludeDates` | array, string or Moment object | Disables supplied dates from being selected in the calendar. | | false
-`passThroughValue` | string | Can be used to set dynamic values up to the form - values should be inspected/adjusted in a handler at submission time (like a button click that calls `submit()`.) See below for usage example. |  |
+`excludeDates` (deprecated)  | array, string or Moment object | Disables supplied dates from being selected in the calendar. | | false
+`passThroughValue` (deprecated) | string | Can be used to set dynamic values up to the form - values should be inspected/adjusted in a handler at submission time (like a button click that calls `submit()`.) See below for usage example. |  |
 `timeZone` | string | Overrides the time zone provided by context. | "UTC" | false
 `locale` | string | Overrides the locale provided by context. | "en" | false
 
@@ -44,12 +44,3 @@ Name | type | description | default | required
 * **Ctrl + PgDown** - forwards 1 year
 * **Enter** - Select date at cursor
 * **Esc** - Close calendar
-
-## Passthrough value
-Using the prop `passThroughValue` means that you expect a non-date string to be passed as a value, and want to use that to derive the time value that you do want submitted. An example of this would be to pass through "Today" and actually submit the current time (whenever the submit button is pressed.) "Today" can be set as an initial value, or the user can enter "Today".
-```
-<Field name="exampleDateReturned" label="Date returned" id="dateReturnDP" placeholder="Select Date" component={Datepicker} passThroughValue="Today"/>
-```
-
-## ignoreLocalOffset
-If your date does not lean on time for validation (eg: Birthdates, that shouldn't change their value based on time zone), apply the "ignoreLocalOffset" prop to the datepicker, for it to use UTC in its produced value. For dates that lean on time (eg: expiryDate), ignore this prop.

--- a/lib/Timepicker/readme.md
+++ b/lib/Timepicker/readme.md
@@ -14,7 +14,7 @@ Name | type | description | default | required
 `label` | string | If provided, will render a `<label>` tag with an `htmlFor` attribute directed at the provided `id` prop. | |
 `value` | string | Sets the value for the control. **Not necessary if using redux-form.** | |
 `onChange` | function | Callback function that will receive the control's current value and the onChange event object. `fn(e, value)` **Not necessary if using redux-form**, but it will still work if callback from a change is needed. |  |
-`passThroughValue` | string | Can be used to set dynamic values up to the form - values should be inspected/adjusted in a handler at submission time (like a button click that calls `submit()`.) See below for usage example. |  |
+`passThroughValue` (deprecated) | string | Can be used to set dynamic values up to the form - values should be inspected/adjusted in a handler at submission time (like a button click that calls `submit()`.) See below for usage example. |  |
 `autoFocus` | bool | If this prop is `true`, control will automatically focus on mount | |
 `timeZone` | string | Overrides the time zone provided by context. | "UTC" | false
 `locale` | string | Overrides the locale provided by context. | "en" | false
@@ -23,10 +23,3 @@ Name | type | description | default | required
 Redux form will provide `input` and `meta` props to the component when it is used with a redux-form `<Field>` component. The component's value and validation are supplied through these.
 ```
 <Field name="exampleTimeReturned" label="Time returned" id="timeReturnTP" placeholder="Select Time" component={Timepicker} />
-
-```
-## Passthrough value
-Using the prop `passThroughValue` means that you expect a non-time string to be passed as a value, and want to use that to derive the time value that you do want submitted. An example of this would be to pass through "Now" and actually submit the current time (whenever the submit button is pressed.) "Now" can be set as an initial value, or the user can enter "Now".
-```
-<Field name="exampleTimeReturned" label="Time returned" id="timeReturnTP" placeholder="Select Time" component={Timepicker} passThroughValue="Now"/>
-```


### PR DESCRIPTION
Follow-up from https://github.com/folio-org/stripes-components/pull/563

Removes explanations of deprecated props, and marks them as deprecated in the prop tables.