### PR TITLE
Upgrade eslint-config-stripes to 3.1.1

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,16 +19,10 @@
   ],
   "parser": "babel-eslint",
   "rules": {
-    "import/no-extraneous-dependencies": ["error", {
-      "devDependencies": true
-    }],
-    "lines-between-class-members": ["error", "always", { "exceptAfterSingleLine": true }],
     "max-len": ["warn", { "code": 120 }],
     "no-console": ["error", {
       "allow": ["warn", "error"]
     }],
-    "operator-linebreak": ["off"],
-    "react/sort-prop-types": ["error"],
-    "react/destructuring-assignment": ["off"]
+    "react/sort-prop-types": ["error"]
   }
 }

--- a/lib/Selection/SelectList.js
+++ b/lib/Selection/SelectList.js
@@ -48,7 +48,7 @@ const defaultProps = {
   rootRef: React.createRef(),
 };
 
-class SelectList extends React.Component { // eslint-disable-line react/no-deprecated
+class SelectList extends React.Component {
   constructor(props) {
     super(props);
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@bigtest/interactor": "^0.7.2",
     "@bigtest/mocha": "^0.5.0",
-    "@folio/eslint-config-stripes": "^3.0.0",
+    "@folio/eslint-config-stripes": "^3.1.1",
     "@folio/stripes-cli": "^1.3.1",
     "@storybook/addon-actions": "^3.2.16",
     "@storybook/addon-knobs": "^3.3.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -256,7 +256,7 @@
   dependencies:
     "@bigtest/convergence" "^0.10.0"
 
-"@folio/eslint-config-stripes@^3.0.0":
+"@folio/eslint-config-stripes@^3.1.1":
   version "3.1.100035"
   resolved "https://repository.folio.org/repository/npm-folioci/@folio/eslint-config-stripes/-/eslint-config-stripes-3.1.100035.tgz#9ee0061b86c369745af822a23af18512f946b92e"
   dependencies:
@@ -3159,7 +3159,7 @@ commander@2.15.1:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
-commander@2.17.x, commander@^2.11.0, commander@^2.13.0, commander@^2.15.0, commander@^2.15.1, commander@^2.9.0, commander@~2.17.1:
+commander@2.17.x, commander@^2.13.0, commander@^2.15.0, commander@^2.15.1, commander@^2.9.0, commander@~2.17.1:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
 
@@ -3168,6 +3168,10 @@ commander@2.9.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
+
+commander@^2.11.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.18.0.tgz#2bf063ddee7c7891176981a2cc798e5754bc6970"
 
 commander@~2.13.0:
   version "2.13.0"


### PR DESCRIPTION
Removes rules that now appear in the shared config.