### PR TITLE
update to current stripes-react-hotkeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * `makeQueryFunction` once more correctly handles relation modifiers, fixing a regression introduced in commit 1bf498d3. Fixes STCOM-321. Available from v3.0.7.
 * Added `<MultiSelection>` component. [STCOM-263](https://issues.folio.org/browse/STCOM-263)
 * Deprecate `passThroughValue` prop on `Datepicker` and `Timepicker`
+* Update stripes-react-hotkeys dependency to support current versions of React.
 
 ## [3.0.0](https://github.com/folio-org/stripes-components/tree/v3.0.0) (2018-07-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v2.0.0...v3.0.0)

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "@folio/stripes-connect": "^3.1.3",
     "@folio/stripes-form": "^0.8.2",
-    "@folio/stripes-react-hotkeys": "^1.0.0",
+    "@folio/stripes-react-hotkeys": "^1.1.0",
     "@folio/stripes-util": "^1.0.1",
     "classnames": "^2.2.5",
     "dom-helpers": "^3.2.1",


### PR DESCRIPTION
The previous release of stripes-react-hotkeys was hard-coded to use
React 15. The 1.1.0 release instead pulls in an unversioned release as a
peerDependency, i.e. it does the same thing stripes-components does and
will get us the same version of the library.