### PR TITLE
Regenerate yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -317,46 +317,20 @@
     webpack-bundle-analyzer "^2.9.1"
     yargs "^10.0.3"
 
-"@folio/stripes-components@^2.0.0":
-  version "2.0.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-components/-/stripes-components-2.0.0.tgz#dcd1459e017f1f986aa5e022d04ebb257f450270"
-  dependencies:
-    "@folio/stripes-form" "^0.8.1"
-    "@folio/stripes-react-hotkeys" "^1.0.0"
-    "@storybook/addon-actions" "^3.2.16"
-    "@storybook/addon-knobs" "^3.2.16"
-    classnames "^2.2.5"
-    create-react-class "^15.5.3"
-    dom-helpers "^3.2.1"
-    file-loader "^1.1.5"
-    lodash "^4.17.4"
-    moment "^2.17.1"
-    moment-range "^3.0.3"
-    mousetrap "^1.6.1"
-    prop-types "^15.5.10"
-    prop-types-extra "^1.0.1"
-    react "^15.6.1"
-    react-dom "^15.6.1"
-    react-flexbox-grid "1.1.3"
-    react-overlays "^0.8.0"
-    react-router-dom "^4.1.1"
-    react-test-renderer "^15.6.1"
-    react-tether "0.5.7"
-    react-transition-group "^2.2.1"
-    redux-form "^7.0.3"
-    typeface-source-sans-pro "^0.0.44"
-
 "@folio/stripes-components@^3.0.0":
-  version "3.0.8"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-components/-/stripes-components-3.0.8.tgz#b8b94e035eea5da13a5deec5c8cc364459ac946d"
+  version "3.1.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-components/-/stripes-components-3.1.0.tgz#92f53322b503226ef3d4f915fe959c573116d220"
   dependencies:
     "@folio/stripes-connect" "^3.1.3"
-    "@folio/stripes-form" "^0.8.2"
-    "@folio/stripes-react-hotkeys" "^1.0.0"
+    "@folio/stripes-form" "^0.9.0"
+    "@folio/stripes-react-hotkeys" "^1.1.0"
+    "@folio/stripes-util" "^1.0.0"
     classnames "^2.2.5"
     dom-helpers "^3.2.1"
+    downshift "^2.0.16"
     json2csv "^4.2.1"
     lodash "^4.17.4"
+    memoize-one "^4.0.0"
     moment "^2.17.1"
     moment-range "^3.0.3"
     moment-timezone "^0.5.14"
@@ -476,16 +450,6 @@
     webpack-hot-middleware "^2.22.2"
     webpack-virtual-modules "^0.1.10"
 
-"@folio/stripes-form@^0.8.1", "@folio/stripes-form@^0.8.2":
-  version "0.8.2"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-form/-/stripes-form-0.8.2.tgz#614a4448a21f01e2ef9e1b8336fe4be552d5e352"
-  dependencies:
-    "@folio/stripes-components" "^2.0.0"
-    prop-types "^15.5.10"
-    react "^15.3.2"
-    react-router "^4.1.1"
-    redux-form "^7.0.3"
-
 "@folio/stripes-form@^0.9.0":
   version "0.9.0"
   resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-form/-/stripes-form-0.9.0.tgz#3a6825cb493438e5f6083b1ef0260c6c4da3429d"
@@ -501,7 +465,7 @@
   version "0.0.2"
   resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-logger/-/stripes-logger-0.0.2.tgz#7ca7bb45c6c3eea7c81f65abb93a45d1566b0ebb"
 
-"@folio/stripes-react-hotkeys@^1.0.0", "@folio/stripes-react-hotkeys@^1.1.0":
+"@folio/stripes-react-hotkeys@^1.1.0":
   version "1.1.0"
   resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-react-hotkeys/-/stripes-react-hotkeys-1.1.0.tgz#4954003d6f272863fcc01044bef174f2322b125f"
   dependencies:
@@ -543,7 +507,7 @@
     react-inspector "^2.2.2"
     uuid "^3.2.1"
 
-"@storybook/addon-knobs@^3.2.16", "@storybook/addon-knobs@^3.3.11":
+"@storybook/addon-knobs@^3.3.11":
   version "3.4.10"
   resolved "https://registry.yarnpkg.com/@storybook/addon-knobs/-/addon-knobs-3.4.10.tgz#57a5639758aa77e7c697acc3b31e728cffc260ac"
   dependencies:
@@ -3411,7 +3375,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.5.2, create-react-class@^15.5.3, create-react-class@^15.6.0, create-react-class@^15.6.2:
+create-react-class@^15.5.2, create-react-class@^15.5.3, create-react-class@^15.6.2:
   version "15.6.3"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
   dependencies:
@@ -9632,15 +9596,6 @@ react-docgen@^3.0.0-beta11:
     node-dir "^0.1.10"
     recast "^0.15.0"
 
-react-dom@^15.6.1:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
-
 react-dom@^16.3.0:
   version "16.5.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.5.0.tgz#57704e5718669374b182a17ea79a6d24922cb27d"
@@ -9733,7 +9688,7 @@ react-onclickoutside@^6.5.0:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz#6a5b5b8b4eae6b776259712c89c8a2b36b17be93"
 
-react-overlays@^0.8.0, react-overlays@^0.8.3:
+react-overlays@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.8.3.tgz#fad65eea5b24301cca192a169f5dddb0b20d3ac5"
   dependencies:
@@ -9800,13 +9755,6 @@ react-style-proptype@^3.0.0:
   dependencies:
     prop-types "^15.5.4"
 
-react-test-renderer@^15.6.1:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.6.2.tgz#d0333434fc2c438092696ca770da5ed48037efa8"
-  dependencies:
-    fbjs "^0.8.9"
-    object-assign "^4.1.0"
-
 react-test-renderer@^16.3.1:
   version "16.5.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.5.0.tgz#1aeca0edc4f27f63265dcaed80ba82e11e762f56"
@@ -9815,13 +9763,6 @@ react-test-renderer@^16.3.1:
     prop-types "^15.6.2"
     react-is "^16.5.0"
     schedule "^0.3.0"
-
-react-tether@0.5.7:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/react-tether/-/react-tether-0.5.7.tgz#418ea61041b65b958271478489b71a3572f01422"
-  dependencies:
-    prop-types "^15.5.8"
-    tether "^1.3.7"
 
 react-tether@^1.0.1:
   version "1.0.1"
@@ -9873,16 +9814,6 @@ react-treebeard@^2.1.0:
     radium "^0.19.0"
     shallowequal "^0.2.2"
     velocity-react "^1.3.1"
-
-react@^15.3.2, react@^15.6.1:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
-  dependencies:
-    create-react-class "^15.6.0"
-    fbjs "^0.8.9"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
 
 react@^16.3.0:
   version "16.5.0"
@@ -11437,7 +11368,7 @@ test-exclude@^4.2.0, test-exclude@^4.2.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
-tether@^1.3.7, tether@^1.4.3:
+tether@^1.4.3:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/tether/-/tether-1.4.4.tgz#9dc6eb2b3e601da2098fd264e7f7a8b264de1125"
 


### PR DESCRIPTION
The circular dependency between `stripes-form` and `stripes-components` should be going away soon, but in the meantime:

Now that there's a new release of both `stripes-form` and `stripes-components`, regenerating the lockfile finally gets rid of the `@folio/stripes-components@^2.0.0` that was hanging out in there.