### PR TITLE
STCOM-286 - Fix overlapping TextField icons

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,8 @@ jobs:
       - run:
           name: Build storybook bundle
           command: yarn storybook-build
+      - store_artifacts:
+          path: ./.out
 
   test-chrome:
     docker:
@@ -76,18 +78,15 @@ jobs:
           name: Run tests
           command:
             yarn test
+            --coverage
             --karma.singleRun
             --karma.browsers=Chrome
-            --karma.reporters mocha junit BrowserStack
+            --karma.reporters mocha junit
             --karma.junitReporter.outputDir artifacts/junit/karma
       - store_test_results:
           path: ./artifacts/junit
       - store_artifacts:
-          name: Store junit test report
-          path: ./artifacts/junit
-      - store_artifacts:
-          name: Store code coverage report
-          path: ./artifacts/coverage/lcov.txt
+          path: ./artifacts
 
   test-firefox:
     docker:
@@ -101,16 +100,12 @@ jobs:
             yarn test
             --karma.singleRun
             --karma.browsers=Firefox
-            --karma.reporters mocha junit BrowserStack
+            --karma.reporters mocha junit
             --karma.junitReporter.outputDir artifacts/junit/karma
       - store_test_results:
           path: ./artifacts/junit
       - store_artifacts:
-          name: Store junit test report
-          path: ./artifacts/junit
-      - store_artifacts:
-          name: Store code coverage report
-          path: ./artifacts/coverage/lcov.txt
+          path: ./artifacts
 
   test-safari:
     docker:

--- a/lib/TextField/TextField.css
+++ b/lib/TextField/TextField.css
@@ -8,10 +8,6 @@
 .inputGroup {
   display: flex;
 
-  &:focus-within {
-    border: 1px solid var(--primary);
-  }
-
   & input {
     margin: 0;
     height: auto;
@@ -19,11 +15,7 @@
     flex: 1;
     background: none;
     border: none;
-
-    &:focus {
-      outline: none;
-      box-shadow: inset 0 0 0 2px rgba(37, 118, 195, 0.3);
-    }
+    outline: none;
   }
 }
 

--- a/lib/TextField/TextField.css
+++ b/lib/TextField/TextField.css
@@ -5,15 +5,36 @@
   width: 100%;
 }
 
+.inputGroup {
+  display: flex;
+
+  &:focus-within {
+    border: 1px solid var(--primary);
+  }
+
+  & input {
+    margin: 0;
+    height: auto;
+    width: 100%;
+    flex: 1;
+    background: none;
+    border: none;
+
+    &:focus {
+      outline: none;
+      box-shadow: inset 0 0 0 2px rgba(37, 118, 195, 0.3);
+    }
+  }
+}
+
 .startControls,
 .endControls {
   pointer-events: none;
   height: 100%;
-  position: absolute;
-  top: 0;
   display: flex;
   justify-content: flex-start;
   align-items: stretch;
+  flex: 0;
 }
 
 .startControls {

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -219,43 +219,44 @@ class TextField extends Component {
   onFocus = () => {
     const { onFocus } = this.props;
 
-    this.setState({
-      focused: true,
-    });
+    if (!this.state.focused) {
+      this.setState({
+        focused: true
+      });
 
-    if (typeof onFocus === 'function') {
-      onFocus();
+      if (typeof onFocus === 'function') {
+        onFocus();
+      }
     }
   }
 
-  onBlur = () => {
+  onBlur = event => {
     const { onBlur } = this.props;
+    const { currentTarget, relatedTarget } = event;
 
-    this.setState({
-      focused: false,
-    });
+    if (!(relatedTarget && currentTarget.contains(relatedTarget))) {
+      this.setState({
+        focused: false
+      });
 
-    if (typeof onBlur === 'function') {
-      onBlur();
+      if (typeof onBlur === 'function') {
+        onBlur();
+      }
     }
   }
 
   clearField() {
     const { onClearField } = this.props;
-    this.input.current.value = '';
-    const event = new Event('input', { bubbles: true });
-    this.input.current.dispatchEvent(event);
-    this.setState({
-      value: ''
+
+    this.setState({ value: '' }, () => {
+      // Fire callback
+      if (typeof onClearField === 'function') {
+        onClearField();
+      }
+
+      // Set focus on input again
+      this.focusInput();
     });
-
-    // Fire callback
-    if (typeof onClearField === 'function') {
-      onClearField();
-    }
-
-    // Set focus on input again
-    setTimeout(() => { this.input.current.focus(); }, 5);
   }
 
   handleChange(event) {
@@ -324,8 +325,6 @@ class TextField extends Component {
         autoFocus={this.props.autoFocus}
         name={name}
         onChange={this.handleChange}
-        onFocus={this.onFocus}
-        onBlur={this.onBlur}
         ref={this.input}
         required={required}
         value={this.state.value}
@@ -440,7 +439,11 @@ class TextField extends Component {
               {label}
           </label>
         )}
-        <div className={inputGroupStyles}>
+        <div
+          className={inputGroupStyles}
+          onFocus={this.onFocus}
+          onBlur={this.onBlur}
+        >
           {startControlElement}
           {component}
           {endControlElement}

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -325,6 +325,7 @@ class TextField extends Component {
         name={name}
         onChange={this.handleChange}
         onFocus={this.onFocus}
+        onBlur={this.onBlur}
         ref={this.input}
         required={required}
         value={this.state.value}
@@ -345,7 +346,6 @@ class TextField extends Component {
           ariaLabel={intl.formatMessage({ id: 'stripes-components.clearThisField' })}
           icon="clearX"
           id={clearFieldId || `clickable-${this.testId}-clear-field`}
-          onBlur={this.onBlur}
           onClick={this.clearField}
           tabIndex="-1"
         />
@@ -425,11 +425,10 @@ class TextField extends Component {
       { [this.props.focusedClass]: this.state.focused && this.props.focusedClass },
     );
 
-    const inputGroupStyles = classNames(
-      this.getInputStyle(),
-      css.inputGroup,
-      { [formStyles.isDisabled]: this.props.disabled }
-    );
+    const inputGroupStyles = classNames(this.getInputStyle(), css.inputGroup, {
+      [formStyles.isDisabled]: this.props.disabled,
+      [formStyles.isFocused]: this.state.focused
+    });
 
     return (
       <div className={wrapperStyles}>

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -165,7 +165,6 @@ class TextField extends Component {
     this.startControl = React.createRef();
     this.endControl = React.createRef();
 
-    this.calcPadding = this.calcPadding.bind(this);
     this.clearField = this.clearField.bind(this);
     this.handleChange = this.handleChange.bind(this);
 
@@ -191,39 +190,6 @@ class TextField extends Component {
       };
     }
     return null;
-  }
-
-  componentDidMount() {
-    // calculate padding only if endControl or startControl are in use.
-    if (this.props.endControl || this.props.startControl) {
-      requestAnimationFrame(() => {
-        if (this.input.current) {
-          const paddingObject = this.calcPadding();
-          Object.assign(this.input.current.style, paddingObject);
-        }
-      });
-    }
-  }
-
-  componentDidUpdate(prevProps) {
-    let shouldUpdatePadding = false;
-    if (prevProps.endControl !== this.props.endControl
-      || prevProps.startControl !== this.props.startControl) {
-      shouldUpdatePadding = true;
-    }
-
-    if (prevProps.loading !== this.props.loading) {
-      shouldUpdatePadding = true;
-    }
-
-    if (shouldUpdatePadding) {
-      requestAnimationFrame(() => {
-        if (this.input.current) {
-          const paddingObject = this.calcPadding();
-          Object.assign(this.input.current.style, paddingObject);
-        }
-      });
-    }
   }
 
   getInput() {
@@ -272,36 +238,6 @@ class TextField extends Component {
     if (typeof onBlur === 'function') {
       onBlur();
     }
-  }
-
-  calcPadding() {
-    let start;
-    let end;
-
-    if (this.input.current && window.getComputedStyle(this.input.current).direction === 'rtl') {
-      start = 'right';
-      end = 'left';
-    } else {
-      start = 'left';
-      end = 'right';
-    }
-
-    const styleObject = {};
-    let startWidth = 0;
-    let endWidth = 0;
-
-    if (this.startControl.current) {
-      startWidth = this.startControl.current.getBoundingClientRect().width + 8;
-    }
-
-    if (this.endControl.current) {
-      endWidth = this.endControl.current.getBoundingClientRect().width + 8;
-    }
-
-    styleObject[`padding-${start}`] = `${startWidth}px`;
-    styleObject[`padding-${end}`] = `${endWidth}px`;
-
-    return styleObject;
   }
 
   clearField() {
@@ -386,7 +322,6 @@ class TextField extends Component {
         aria-required={required}
         autoComplete={this.props.autoComplete}
         autoFocus={this.props.autoFocus}
-        className={this.getInputStyle()}
         name={name}
         onChange={this.handleChange}
         onFocus={this.onFocus}
@@ -398,6 +333,8 @@ class TextField extends Component {
 
     let validation = null;
     let clearField = null;
+    let startControlElement;
+    let endControlElement;
 
     if (this.props.hasClearIcon
       && !this.props.loading
@@ -453,23 +390,27 @@ class TextField extends Component {
       );
     }
 
-    const endControlElement = (
-      <div className={css.endControls}>
-        <div className={css.controlGroup} ref={this.endControl}>
-          {!this.props.readOnly && clearField}
-          {validation}
-          {endControl}
+    if ((!this.props.readOnly && clearField) || validation || endControl) {
+      endControlElement = (
+        <div className={css.endControls}>
+          <div className={css.controlGroup} ref={this.endControl}>
+            {!this.props.readOnly && clearField}
+            {validation}
+            {endControl}
+          </div>
         </div>
-      </div>
-    );
+      );
+    }
 
-    const startControlElement = (
-      <div className={css.startControls}>
-        <div className={css.controlGroup} ref={this.startControl}>
-          {startControl}
+    if (startControl) {
+      startControlElement = (
+        <div className={css.startControls}>
+          <div className={css.controlGroup} ref={this.startControl}>
+            {startControl}
+          </div>
         </div>
-      </div>
-    );
+      );
+    }
 
     const warningElement = this.props.warning ? (
       <div className={formStyles.feedbackWarning}>{this.props.warning}</div>
@@ -484,6 +425,12 @@ class TextField extends Component {
       { [this.props.focusedClass]: this.state.focused && this.props.focusedClass },
     );
 
+    const inputGroupStyles = classNames(
+      this.getInputStyle(),
+      css.inputGroup,
+      { [formStyles.isDisabled]: this.props.disabled }
+    );
+
     return (
       <div className={wrapperStyles}>
         { label && (
@@ -494,7 +441,7 @@ class TextField extends Component {
               {label}
           </label>
         )}
-        <div className={formStyles.inputGroup}>
+        <div className={inputGroupStyles}>
           {startControlElement}
           {component}
           {endControlElement}

--- a/lib/TextField/tests/TextField-test.js
+++ b/lib/TextField/tests/TextField-test.js
@@ -65,11 +65,6 @@ describe('TextField', () => {
     it('renders the supplied element in the end-control container', () => {
       expect(textfield.endControl).to.be.true;
     });
-
-    it('applies appropriate padding to the input', () => {
-      expect(parseFloat(textfield.inputComputed.paddingRight))
-        .to.be.above(parseFloat(textfield.inputComputed.paddingLeft));
-    });
   });
 
   describe('supplying a startControl', () => {
@@ -81,11 +76,6 @@ describe('TextField', () => {
 
     it('renders the supplied element in the start-control container', () => {
       expect(textfield.startControl).to.be.true;
-    });
-
-    it('applies appropriate padding to the input', () => {
-      expect(parseFloat(textfield.inputComputed.paddingLeft))
-        .to.be.above(parseFloat(textfield.inputComputed.paddingRight));
     });
   });
 

--- a/lib/TextField/tests/TextField-test.js
+++ b/lib/TextField/tests/TextField-test.js
@@ -12,7 +12,7 @@ describe('TextField', () => {
 
   beforeEach(async () => {
     await mountWithContext(
-      <TextField id="tfTest" />
+      <TextField id="tfTest" clearFieldId="clearField" />
     );
   });
 
@@ -28,13 +28,30 @@ describe('TextField', () => {
     expect(textfield.id).to.equal('tfTest');
   });
 
-  describe('entering text into the field', async () => {
+  describe('entering text into the field', () => {
     beforeEach(async () => {
       await textfield.fillInput('test');
     });
 
     it('updates the value', () => {
       expect(textfield.val).to.equal('test');
+    });
+
+    describe('then clicking clear', () => {
+      beforeEach(async () => {
+        await textfield
+          .focusInput() // clear is only visible when focused
+          .when(() => !!textfield.val) // wait for a value
+          .clickClearButton(); // click clear
+      });
+
+      it('clears the value', () => {
+        expect(textfield.val).to.be.empty;
+      });
+
+      it('focuses the input', () => {
+        expect(textfield.isFocused).to.be.true;
+      });
     });
   });
 

--- a/lib/TextField/tests/TextField-test.js
+++ b/lib/TextField/tests/TextField-test.js
@@ -114,9 +114,11 @@ describe('TextField', () => {
   });
 
   describe('supplying an onFocus handler', () => {
-    let focusEventFired = false;
+    let focusEventFired;
 
     beforeEach(async () => {
+      focusEventFired = false;
+
       await mountWithContext(
         <TextField onFocus={() => { focusEventFired = true; }} />
       );
@@ -127,6 +129,10 @@ describe('TextField', () => {
         await textfield.focusInput();
       });
 
+      it('focuses the field', () => {
+        expect(textfield.isFocused).to.be.true;
+      });
+
       it('fires the event', () => {
         expect(focusEventFired).to.be.true;
       });
@@ -134,9 +140,11 @@ describe('TextField', () => {
   });
 
   describe('supplying an onBlur handler', () => {
-    let blurEventFired = false;
+    let blurEventFired;
 
     beforeEach(async () => {
+      blurEventFired = false;
+
       await mountWithContext(
         <TextField onBlur={() => { blurEventFired = true; }} />
       );
@@ -144,7 +152,13 @@ describe('TextField', () => {
 
     describe('blurring the field', () => {
       beforeEach(async () => {
-        await textfield.blurInput();
+        await textfield
+          .focusInput()
+          .blurInput();
+      });
+
+      it.always('blurs the field', () => {
+        expect(textfield.isFocused).to.be.false;
       });
 
       it('fires the event', () => {

--- a/lib/TextField/tests/interactor.js
+++ b/lib/TextField/tests/interactor.js
@@ -21,6 +21,7 @@ import { selectorFromClassnameString } from '../../../tests/helpers';
 
 const rootClass = `.${css.textField}`;
 const errorClass = selectorFromClassnameString(`.${formCss.feedbackError}`);
+const groupClass = `.${css.inputGroup}`;
 
 function computedStyle(selector) {
   return computed(function () {
@@ -49,10 +50,10 @@ export default interactor(class TextFieldInteractor {
   hasClearButton = isPresent('#clearField');
   clickClearButton = clickable('#clearField');
   rendersBottomMargin0 = hasClass(rootClass, css.marginBottom0);
-  hasWarningStyle = hasClass('input', formCss.hasWarning);
-  hasErrorStyle = hasClass('input', formCss.hasError);
-  hasChangedStyle = hasClass('input', formCss.isChanged);
-  hasValidStyle = hasClass('input', formCss.isValid);
+  hasWarningStyle = hasClass(groupClass, formCss.hasWarning);
+  hasErrorStyle = hasClass(groupClass, formCss.hasError);
+  hasChangedStyle = hasClass(groupClass, formCss.isChanged);
+  hasValidStyle = hasClass(groupClass, formCss.isValid);
   hasLoadingIcon = isPresent(`.${css.loadingIcon}`);
 
   fillAndBlur(val) {

--- a/lib/TextField/tests/interactor.js
+++ b/lib/TextField/tests/interactor.js
@@ -8,7 +8,6 @@ import {
   focusable,
   hasClass,
   interactor,
-  is,
   isPresent,
   text,
   value,
@@ -30,7 +29,7 @@ function computedStyle(selector) {
 }
 
 export default interactor(class TextFieldInteractor {
-  isFocused = is('input', ':focus');
+  isFocused = hasClass(groupClass, formCss.isFocused);
   val = value('input');
   fillInput = fillable('input');
   blurInput = blurrable('input');

--- a/lib/sharedStyles/form.css
+++ b/lib/sharedStyles/form.css
@@ -61,7 +61,8 @@
     margin-bottom: 0;
   }
 
-  &:disabled {
+  &:disabled,
+  &.isDisabled {
     background-color: #ebebe4;
     color: #777;
   }
@@ -100,7 +101,8 @@
 /**
  * Specific <input> style
  */
-input.input {
+input.input,
+.input input {
   height: var(--controlHeightSmall);
   min-height: var(--controlHeightSmall);
   padding: var(--input-horizontal-padding) var(--input-vertical-padding);
@@ -150,7 +152,8 @@ textarea.input {
  * Wider screens
  */
 @media (--mediumUp) {
-  input.input {
+  input.input,
+  .input input {
     height: var(--controlHeight);
     min-height: var(--controlHeight);
   }

--- a/lib/sharedStyles/form.css
+++ b/lib/sharedStyles/form.css
@@ -44,7 +44,8 @@
   letter-spacing: 0.4px;
   border-radius: 0;
 
-  &:focus {
+  &:focus,
+  &.isFocused {
     border: 1px solid var(--primary);
     box-shadow: inset 0 0 0 2px rgba(37, 118, 195, 0.3);
   }


### PR DESCRIPTION
## Purpose

[STCOM-286](https://issues.folio.org/browse/STCOM-286) - `TextField` can occasionally get in a state where it does not have adequate padding for the search icon at the beginning of the field.

While unable to reproduce this case specifically, I was able to reproduce a related issue in storybook:

1. Open storybook
2. Navigate to the `TextField` basic usage and scroll down to the start/end control example
3. Refresh the page and scroll down to the example again
4. Observe that the final example is now double the width of the viewport due to excessive padding.

#### Explanation:

Storybook injects CSS for a module on demand. When this page loads for the first time, there are no styles associated with icon sizes, so the icons default to 100% width.

`TextField` is mounted and calculates the ridiculous padding.

CSS is loaded, icons are resized, but the `TextField` padding remains.

I suspect this is similar to what is happening when the icon overlaps the text, except when the padding is calculated, the icon has no size at all. Resulting in the overlap once styles are applied.

## Approach

Remove the padding calculations and use flexbox instead.

Flexbox allows us to layout the control components next to the input field while keeping everything within the proper width and expanding the input to be as wide as it can be accounting for any controls. All without having to do any manual calculations, re-rendering the component, or interacting with the DOM at all.

In order to achieve this, the styles needed to be moved to the input group that contains the controls and input elements. The input is then made transparent so the group styles are visible from behind. 

This has the caveat of disabled and focus styles not being able to encompass the entire input group. To counteract this, `isDisabled` and `isFocused` classes were added to the shared form styles and applied to the input group.

The previous blur handler only applied when clicking clear. It has been moved to the input group, and logic was added to the blur handler to ensure it is only blurred when focus is not within the group itself, and that focus is only called when not already focused. The clear handler was also adjusted to utilize `setState`'s callback instead of relying on a timeout of `5`.

## Screenshots

**Before:**

![before](https://user-images.githubusercontent.com/5005153/45518443-2be1a700-b777-11e8-9c55-b8705e1fff9a.gif)

**After:**

![after](https://user-images.githubusercontent.com/5005153/45636218-bf172700-ba6c-11e8-8e12-a50b672679d5.gif)

