### PR TITLE
Added src, title & alt props to AppIcon + retina detection

### DIFF
--- a/lib/AppIcon/AppIcon.js
+++ b/lib/AppIcon/AppIcon.js
@@ -15,7 +15,7 @@ import css from './AppIcon.css';
 const AppIcon = ({ size, icon, alt, title, src, style, children, className, tag, app, iconKey, stripes }) => {
   const getIcon = () => {
     let appIconProps;
-    
+
     /**
      * Icon from context
      *
@@ -34,7 +34,12 @@ const AppIcon = ({ size, icon, alt, title, src, style, children, className, tag,
       };
 
       // Use PNGs (if available) for small app icons on non-retina screens
-      const isRetina = window.matchMedia('(-webkit-min-device-pixel-ratio: 2), (min-device-pixel-ratio: 2), (min-resolution: 192dpi)').matches;
+      const isRetina = window.matchMedia(`
+        (-webkit-min-device-pixel-ratio: 2), 
+        (min-device-pixel-ratio: 2), 
+        (min-resolution: 192dpi)
+      `).matches;
+
       // Ignoring next block in tests since it can't be tested consistently
       // istanbul ignore next
       if (!isRetina && size === 'small' && appIcon.low && appIcon.low.src) {
@@ -51,15 +56,18 @@ const AppIcon = ({ size, icon, alt, title, src, style, children, className, tag,
       };
     }
 
-    if (appIconProps) {
-      return (
-        <img
-          src={typeof src !== 'undefined' ? src : appIconProps.src}
-          alt={typeof alt !== 'undefined' ? alt : appIconProps.alt}
-          title={typeof title !== 'undefined' ? title : appIconProps.title}
-        />
-      );
+    // No image props - return nothing and the placeholder will be active
+    if (!appIconProps) {
+      return null;
     }
+
+    return (
+      <img
+        src={typeof src !== 'undefined' ? src : appIconProps.src}
+        alt={typeof alt !== 'undefined' ? alt : appIconProps.alt}
+        title={typeof title !== 'undefined' ? title : appIconProps.title}
+      />
+    );
   };
 
   /**

--- a/lib/AppIcon/AppIcon.js
+++ b/lib/AppIcon/AppIcon.js
@@ -12,7 +12,7 @@ import classNames from 'classnames';
 import { withStripes } from '@folio/stripes-core/src/StripesContext';
 import css from './AppIcon.css';
 
-const AppIcon = ({ size, icon, style, children, className, tag, app, iconKey, stripes }) => {
+const AppIcon = ({ size, icon, alt, title style, children, className, tag, app, iconKey, stripes }) => {
   /**
    * Icon from context
    *
@@ -34,8 +34,8 @@ const AppIcon = ({ size, icon, style, children, className, tag, app, iconKey, st
 
       const appIconProps = {
         src,
-        alt: appIcon.alt,
-        title: appIcon.title,
+        alt: typeof alt !== 'undefined' ? alt : appIcon.alt,
+        title: typeof title !== 'undefined' ? title : appIcon.title,
       };
 
       return (<img src={appIconProps.src} alt={appIconProps.alt} title={appIconProps.title} {...appIconProps} />);
@@ -91,6 +91,8 @@ AppIcon.propTypes = {
   app: PropTypes.string,
   children: PropTypes.node,
   className: PropTypes.string,
+  alt: PropTypes.string,
+  title: PropTypes.string,
   icon: PropTypes.shape({
     alt: PropTypes.string,
     src: PropTypes.string.isRequired,

--- a/lib/AppIcon/AppIcon.js
+++ b/lib/AppIcon/AppIcon.js
@@ -12,49 +12,54 @@ import classNames from 'classnames';
 import { withStripes } from '@folio/stripes-core/src/StripesContext';
 import css from './AppIcon.css';
 
-const AppIcon = ({ size, icon, alt, title, style, children, className, tag, app, iconKey, stripes }) => {
-  /**
-   * Icon from context
-   *
-   * We get the icons from the metadata which is passed down via context.
-   * The default app icon has an iconKey of "app".
-   *
-   * If no icon is found we display a placeholder.
-   *
-   */
-  const iconFromMetadataContext = () => {
+const AppIcon = ({ size, icon, alt, title, src, style, children, className, tag, app, iconKey, stripes }) => {
+  const getIcon = () => {
+    let appIconProps;
+    
+    /**
+     * Icon from context
+     *
+     * We get the icons from the metadata which is passed down via context.
+     * The default app icon has an iconKey of "app".
+     *
+     * If no icon is found we display a placeholder.
+     *
+     */
     const appIcon = result(stripes, `metadata.${app}.icons.${iconKey}`);
     if (appIcon && appIcon.src) {
-      let src = appIcon.src;
-
-      // Use PNGs for small app icons
-      if (size === 'small' && appIcon.low && appIcon.low.src) {
-        src = appIcon.low.src;
-      }
-
-      const appIconProps = {
-        src,
-        alt: typeof alt !== 'undefined' ? alt : appIcon.alt,
-        title: typeof title !== 'undefined' ? title : appIcon.title,
+      appIconProps = {
+        src: appIcon.src,
+        alt: appIcon.alt,
+        title: appIcon.title,
       };
 
-      return (<img src={appIconProps.src} alt={appIconProps.alt} title={appIconProps.title} {...appIconProps} />);
+      // Use PNGs (if available) for small app icons on non-retina screens
+      const isRetina = window.matchMedia('(-webkit-min-device-pixel-ratio: 2), (min-device-pixel-ratio: 2), (min-resolution: 192dpi)').matches;
+      // Ignoring next block in tests since it can't be tested consistently
+      // istanbul ignore next
+      if (!isRetina && size === 'small' && appIcon.low && appIcon.low.src) {
+        appIconProps.src = appIcon.low.src;
+      }
     }
 
-    return null;
-  };
-
-  /**
-   * Return icon or placeholder
-   */
-  const getIcon = () => {
     /* If we have an image passed as an object */
     if (typeof icon === 'object') {
-      return (<img src={icon.src} title={icon.title} alt={icon.alt} {...icon} />);
+      appIconProps = {
+        src: icon.src,
+        alt: icon.alt,
+        title: icon.title,
+      };
     }
 
-    /* Return formatted icon - or placeholder if no icon was found */
-    return iconFromMetadataContext();
+    if (appIconProps) {
+      return (
+        <img
+          src={typeof src !== 'undefined' ? src : appIconProps.src}
+          alt={typeof alt !== 'undefined' ? alt : appIconProps.alt}
+          title={typeof title !== 'undefined' ? title : appIconProps.title}
+        />
+      );
+    }
   };
 
   /**
@@ -88,11 +93,10 @@ const AppIcon = ({ size, icon, alt, title, style, children, className, tag, app,
 };
 
 AppIcon.propTypes = {
+  alt: PropTypes.string,
   app: PropTypes.string,
   children: PropTypes.node,
   className: PropTypes.string,
-  alt: PropTypes.string,
-  title: PropTypes.string,
   icon: PropTypes.shape({
     alt: PropTypes.string,
     src: PropTypes.string.isRequired,
@@ -100,11 +104,13 @@ AppIcon.propTypes = {
   }),
   iconKey: PropTypes.string,
   size: PropTypes.oneOf(['small', 'medium', 'large']),
+  src: PropTypes.string,
   stripes: PropTypes.shape({
     metadata: PropTypes.object,
   }),
   style: PropTypes.object,
   tag: PropTypes.string,
+  title: PropTypes.string,
 };
 
 AppIcon.defaultProps = {

--- a/lib/AppIcon/AppIcon.js
+++ b/lib/AppIcon/AppIcon.js
@@ -12,7 +12,7 @@ import classNames from 'classnames';
 import { withStripes } from '@folio/stripes-core/src/StripesContext';
 import css from './AppIcon.css';
 
-const AppIcon = ({ size, icon, alt, title style, children, className, tag, app, iconKey, stripes }) => {
+const AppIcon = ({ size, icon, alt, title, style, children, className, tag, app, iconKey, stripes }) => {
   /**
    * Icon from context
    *

--- a/lib/AppIcon/readme.md
+++ b/lib/AppIcon/readme.md
@@ -28,6 +28,15 @@ AppIcon supports different ways of loading icons.
   <AppIcon icon={icon} />
   ```
 
+***3. Pass src, alt and title as props***
+```js
+  <AppIcon 
+    src="/static/some-icon.png"
+    alt="My Icon"
+    title="My Icon" 
+  />
+  ```
+
 **Add a label to the icon by passing it as a child**
   ```js
   <AppIcon>
@@ -39,12 +48,13 @@ AppIcon supports different ways of loading icons.
 Name | Type | Description
 -- | -- | --
 app | string | The lowercased name of an app, e.g. "users" or "inventory". It will get the icon from metadata located in the stripes-object which should be available in React Context.
+alt | string | Adds an 'alt'-attribute on the img-tag.
+children | node | Add content next to the icon - e.g. a label
+className | string | For adding custom class to component
 iconKey | string | A specific icon-key for apps with multiple icons. Defaults to "app" which corresponds to the required default app-icon of an app.
 icon | object | Icon in form of an object
 size | string | Determines the size of the icon. (small, medium, large)
+src | string | Manually set the 'src'-attribute on the img-tag
 style | object | For adding custom style to component
-className | string | For adding custom class to component
 tag | string | Choose HTML-element (defaults to a span element)
-children | node | Add content next to the icon - e.g. a label
-alt | string | Adds an 'alt'-attribute on the img-tag.
 title | string | Adds a 'title'-attribute on the img-tag

--- a/lib/AppIcon/readme.md
+++ b/lib/AppIcon/readme.md
@@ -46,3 +46,5 @@ style | object | For adding custom style to component
 className | string | For adding custom class to component
 tag | string | Choose HTML-element (defaults to a span element)
 children | node | Add content next to the icon - e.g. a label
+alt | string | Adds an 'alt'-attribute on the img-tag.
+title | string | Adds a 'title'-attribute on the img-tag

--- a/lib/AppIcon/tests/AppIcon-test.js
+++ b/lib/AppIcon/tests/AppIcon-test.js
@@ -76,22 +76,6 @@ describe('AppIcon', () => {
     it('Should render an img with an alt-attribute', () => {
       expect(appIcon.img.alt).to.equal(stripesMock.metadata.users.icons.app.alt);
     });
-
-    describe('Passing "small" to the size prop', () => {
-      beforeEach(async () => {
-        await mount(
-          <AppIcon
-            stripes={stripesMock}
-            app="users"
-            size="small"
-          />
-        );
-      });
-
-      it('Should render an <img> with a PNG file', () => {
-        expect(appIcon.img.src).to.include('.png');
-      });
-    });
   });
 
   describe('Rendering an AppIcon using an icon-object', () => {


### PR DESCRIPTION
In order to fix this issue: https://issues.folio.org/browse/STCOR-253, we need to be able to overwrite the alt and title attributes on the AppIcon. In this update, I changed the AppIcon so that it's possible to pass alt, src, and title as props without breaking the existing functionality.

I also updated the if statement for icons that are retrieved from the stripes context, that has a size of "small" to check if the user's screen is a non-retina screen. We only want to render the 14px PNG version of the icon for users on non-retina screens because the SVG version can get a bit blurry on non-retina screens.

Since the screen resolution (afaik) can't be tested consistently I decided to ignore this specific block of code from tests so that the test coverage is still 100%.
