### PR TITLE
Allow 'iconAriaHidden' on <AppIcon> and updated PaneHeader

### DIFF
--- a/lib/AppIcon/AppIcon.js
+++ b/lib/AppIcon/AppIcon.js
@@ -12,7 +12,7 @@ import classNames from 'classnames';
 import { withStripes } from '@folio/stripes-core/src/StripesContext';
 import css from './AppIcon.css';
 
-const AppIcon = ({ size, icon, style, children, className, tag, app, iconKey, stripes }) => {
+const AppIcon = ({ iconAriaHidden, size, icon, style, children, className, tag, app, iconKey, stripes }) => {
   /**
    * Icon from context
    *
@@ -79,7 +79,7 @@ const AppIcon = ({ size, icon, style, children, className, tag, app, iconKey, st
    */
   return (
     <Element className={rootStyles} style={style}>
-      <span className={css.icon}>
+      <span className={css.icon} aria-hidden={iconAriaHidden}>
         {getIcon()}
       </span>
       { children && <span className={css.label}>{children}</span> }
@@ -96,6 +96,7 @@ AppIcon.propTypes = {
     src: PropTypes.string.isRequired,
     title: PropTypes.string,
   }),
+  iconAriaHidden: PropTypes.bool,
   iconKey: PropTypes.string,
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   stripes: PropTypes.shape({

--- a/lib/AppIcon/AppIcon.js
+++ b/lib/AppIcon/AppIcon.js
@@ -110,6 +110,7 @@ AppIcon.defaultProps = {
   iconKey: 'app',
   size: 'medium',
   tag: 'span',
+  iconAriaHidden: true,
 };
 
 export default withStripes(AppIcon);

--- a/lib/AppIcon/readme.md
+++ b/lib/AppIcon/readme.md
@@ -36,14 +36,14 @@ AppIcon supports different ways of loading icons.
 ```
 
 ## Props
-Name | Type | Description
--- | -- | --
-app | string | The lowercased name of an app, e.g. "users" or "inventory". It will get the icon from metadata located in the stripes-object which should be available in React Context.
-iconKey | string | A specific icon-key for apps with multiple icons. Defaults to "app" which corresponds to the required default app-icon of an app.
-iconAriaHidden | bool | Applies aria-hidden to the icon element
-icon | object | Icon in form of an object
-size | string | Determines the size of the icon. (small, medium, large)
-style | object | For adding custom style to component
-className | string | For adding custom class to component
-tag | string | Choose HTML-element (defaults to a span element)
-children | node | Add content next to the icon - e.g. a label
+Name | Type | Description | default
+-- | -- | -- | --
+app | string | The lowercased name of an app, e.g. "users" or "inventory". It will get the icon from metadata located in the stripes-object which should be available in React Context. Read more [here](https://github.com/folio-org/stripes-core/blob/master/doc/app-metadata.md#icons). | undefined
+iconKey | string | A specific icon-key for apps with multiple icons. Defaults to "app" which corresponds to the required default app-icon of an app. | app
+iconAriaHidden | bool | Applies aria-hidden to the icon element. Since `<AppIcon>`'s mostly are rendered in proximity of a label or inside an element with a label (e.g. a button), we set aria-hidden to true per default to avoid screen readers reading the alt/title attributes of the icon | true
+icon | object | Icon in form of an object. E.g. { src, alt, title } | undefined
+size | string | Determines the size of the icon. (small, medium, large) | medium
+style | object | For adding custom style to component | undefined
+className | string | For adding custom class to component | undefined
+tag | string | Changes the rendered root HTML-element | span
+children | node | Add content next to the icon - e.g. a label | undefined

--- a/lib/AppIcon/readme.md
+++ b/lib/AppIcon/readme.md
@@ -40,6 +40,7 @@ Name | Type | Description
 -- | -- | --
 app | string | The lowercased name of an app, e.g. "users" or "inventory". It will get the icon from metadata located in the stripes-object which should be available in React Context.
 iconKey | string | A specific icon-key for apps with multiple icons. Defaults to "app" which corresponds to the required default app-icon of an app.
+iconAriaHidden | bool | Applies aria-hidden to the icon element
 icon | object | Icon in form of an object
 size | string | Determines the size of the icon. (small, medium, large)
 style | object | For adding custom style to component

--- a/lib/PaneHeader/PaneHeader.js
+++ b/lib/PaneHeader/PaneHeader.js
@@ -173,9 +173,7 @@ class PaneHeader extends Component {
         { paneTitle && (
           <h2 className={css.paneTitle} aria-describedby={paneSub && `${this._id}-subtitle`}>
             { appIcon &&
-              <span aria-hidden="true">
-                <AppIcon size="small" app={appIcon.app} appIconKey={appIcon.key} />
-              </span>
+              <AppIcon aria-hidden="true" size="small" app={appIcon.app} appIconKey={appIcon.key} />
             }
             <span
               tabIndex="-1"

--- a/lib/PaneHeader/PaneHeader.js
+++ b/lib/PaneHeader/PaneHeader.js
@@ -173,7 +173,7 @@ class PaneHeader extends Component {
         { paneTitle && (
           <h2 className={css.paneTitle} aria-describedby={paneSub && `${this._id}-subtitle`}>
             { appIcon &&
-              <AppIcon aria-hidden="true" size="small" app={appIcon.app} appIconKey={appIcon.key} />
+              <AppIcon iconAriaHidden size="small" app={appIcon.app} appIconKey={appIcon.key} />
             }
             <span
               tabIndex="-1"


### PR DESCRIPTION
Today I noticed that the icon in the PaneHeader was a bit misaligned and after some brief investigation I found that it had been wrapped in an additional `<span>` with `aria-hidden="true"`.

To avoid having the extra span I decided to add an "ariaHidden" prop to the AppIcon but then I realized that the AppIcon can have a label so it does not make sense to make the whole component aria-hidden.

Instead, I added the prop "iconAriaHidden" which only applies to the icon itself - leaving the label (if available) to still be readable by screen readers.