### PR TITLE
STCOM-338:  Adjust filter search header + inline caret icons

### DIFF
--- a/lib/Accordion/Accordion.css
+++ b/lib/Accordion/Accordion.css
@@ -134,7 +134,7 @@
  * Filter set header
  */
 .filterSetHeader {
-  composes: interactionStyles from "../sharedStyles/interactionStyles.css";
+  composes: interactionStyles boxOffsetStartSmall from "../sharedStyles/interactionStyles.css";
   composes: header;
   border-radius: var(--radius 4px);
   min-height: var(--controlHeight 24px);
@@ -150,6 +150,10 @@
 
   &:focus {
     outline: none;
+  }
+
+  & .labelArea {
+    padding-left: 4px;
   }
 }
 

--- a/lib/Accordion/Accordion.css
+++ b/lib/Accordion/Accordion.css
@@ -146,7 +146,6 @@
   width: 100%;
   line-height: 120%;
   text-align: left;
-  color: var(--color-text-p2);
 
   &:focus {
     outline: none;
@@ -154,7 +153,12 @@
 
   & .labelArea {
     padding-left: 4px;
+    color: var(--color-text-p1);
   }
+}
+
+svg.filterSetHeaderIcon {
+  fill: var(--color-text-p2);
 }
 
 .clearButtonVisible {

--- a/lib/Accordion/headers/FilterAccordionHeader.js
+++ b/lib/Accordion/headers/FilterAccordionHeader.js
@@ -76,7 +76,7 @@ class FilterAccordionHeader extends React.Component {
             ref={this.props.toggleRef}
             id={`accordion-toggle-button-${this.props.id}`}
           >
-            { disabled ? null : <Icon size="small" icon={`${open ? 'up' : 'down'}-caret-inline`} /> }
+            { disabled ? null : <Icon iconClassName={css.filterSetHeaderIcon} size="small" icon={`${open ? 'up' : 'down'}-caret-inline`} /> }
             <div className={css.labelArea}>
               <div className={css.filterSetLabel}>{label}</div>
             </div>

--- a/lib/Accordion/headers/FilterAccordionHeader.js
+++ b/lib/Accordion/headers/FilterAccordionHeader.js
@@ -76,7 +76,7 @@ class FilterAccordionHeader extends React.Component {
             ref={this.props.toggleRef}
             id={`accordion-toggle-button-${this.props.id}`}
           >
-            { disabled ? null : <Icon size="small" icon={`${open ? 'up' : 'down'}-caret`} /> }
+            { disabled ? null : <Icon size="small" icon={`${open ? 'up' : 'down'}-caret-inline`} /> }
             <div className={css.labelArea}>
               <div className={css.filterSetLabel}>{label}</div>
             </div>

--- a/lib/FilterGroups/FilterGroups.css
+++ b/lib/FilterGroups/FilterGroups.css
@@ -3,5 +3,6 @@
 */
 
 .filterGroupLabel {
-  composes: boxOffsetStartMedium hasDot focusDotPositionStart focusDotOffsetSmall from "../sharedStyles/interactionStyles.css";
+  composes: boxOffsetStartLarge hasDot focusDotPositionStart focusDotOffsetSmall from "../sharedStyles/interactionStyles.css";
+  padding-left: 9px !important;
 }

--- a/lib/FilterGroups/FilterGroups.css
+++ b/lib/FilterGroups/FilterGroups.css
@@ -2,7 +2,10 @@
  * Filter Groups
 */
 
-.filterGroupLabel {
+.interactionStyles {
   composes: boxOffsetStartLarge hasDot focusDotPositionStart focusDotOffsetSmall from "../sharedStyles/interactionStyles.css";
-  padding-left: 9px !important;
+}
+
+label.filterGroupLabel {
+  padding-left: 9px;
 }

--- a/lib/Icon/icons.js
+++ b/lib/Icon/icons.js
@@ -9,6 +9,16 @@ import classNames from 'classnames';
 import dotSpinner from './DotSpinner.css';
 
 export default {
+  'down-caret-inline': ({ style, className }) => (
+    <svg focusable="false" style={style} className={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14">
+      <path d="M12.6 4.3c-.4-.4-1-.4-1.4 0L7 8.4 2.9 4.3c-.4-.4-1-.4-1.4 0-.4.4-.4 1 0 1.4l4.8 4.8c.2.2.5.3.7.3s.5-.1.7-.3l4.8-4.8c.4-.4.4-1 .1-1.4z" />
+    </svg>
+  ),
+  'up-caret-inline': ({ style, className }) => (
+    <svg focusable="false" style={style} className={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14">
+      <path d="M1.4 10.6c.4.4 1 .4 1.4 0L7 6.4l4.1 4.1c.4.4 1 .4 1.4 0 .4-.4.4-1 0-1.4L7.7 4.3C7.5 4.1 7.3 4 7 4s-.5.1-.7.3L1.4 9.2c-.3.3-.3 1 0 1.4z" />
+    </svg>
+  ),
   'external-link': ({ style, className }) => (
     <svg focusable="false" style={style} className={className} viewBox="0 0 14 14">
       <path d="M13.689.852a1.003 1.003 0 0 0-.923-.618H9.008a1 1 0 0 0 0 2h1.344L4.124 8.462a.999.999 0 1 0 1.414 1.414l6.228-6.228v1.343a1 1 0 0 0 2 0V1.234c0-.13-.027-.26-.077-.382z" />


### PR DESCRIPTION
## Issue
https://issues.folio.org/browse/STCOM-338

## Changes
- Added up-caret-inline and down-caret-inline (From now on we will begin adding the `-inline` suffix  to icons that are meant to be applied inline with text - I will rename current inline icons later)
- Added new icons to FilterGroup header
- Updated colors of label and icon
- Adjusted styling to match new changes

## Before
![image](https://user-images.githubusercontent.com/640976/45694154-ef3ef280-bb5e-11e8-865b-36d59d883933.png) 


## After
![image](https://user-images.githubusercontent.com/640976/45694193-05e54980-bb5f-11e8-9a14-24d714ce9524.png)
