### PR TITLE
Add more headline sizes

### DIFF
--- a/lib/Headline/Headline.css
+++ b/lib/Headline/Headline.css
@@ -37,18 +37,36 @@
 
 /**
  * Size
+ * Follows HTML5 headline specs
+ * https://www.w3.org/TR/html5/rendering.html#sections-and-headings
  */
 
-.sizeSmall {
-  font-size: 14px;
+.sizeXxsmall { /* default browser h6 proportion */
+  font-size: 0.67em;
 }
 
-.sizeMedium {
-  font-size: 18px;
+.sizeXsmall { /* default browser h5 proportion */
+  font-size: 0.83em;
 }
 
-.sizeLarge {
-  font-size: 24px;
+.sizeDefault { /* default browser h4 proportion */
+  font-size: 1em;
+}
+
+.sizeSmall { /* default browser h3 proportion */
+  font-size: 1.17em;
+}
+
+.sizeMedium { /* default browser h2 proportion */
+  font-size: 1.5em;
+}
+
+.sizeLarge { /* default browser h1 proportion */
+  font-size: 2em;
+}
+
+.sizeXlarge {
+  font-size: 2.5em;
 }
 
 /**
@@ -59,14 +77,30 @@
   margin-bottom: 0;
 }
 
+.marginXxsmall {
+  margin-bottom: 2.33em;
+}
+
+.marginXsmall {
+  margin-bottom: 1.67em;
+}
+
+.marginDefault {
+  margin-bottom: 1.33em;
+}
+
 .marginSmall {
-  margin-bottom: 8px;
+  margin-bottom: 1.33em;
 }
 
 .marginMedium {
-  margin-bottom: 12px;
+  margin-bottom: 0.83em;
 }
 
 .marginLarge {
-  margin-bottom: 14px;
+  margin-bottom: 0.67em;
+}
+
+.marginXlarge {
+  margin-bottom: 0.5em;
 }

--- a/lib/Headline/Headline.css
+++ b/lib/Headline/Headline.css
@@ -42,31 +42,31 @@
  */
 
 .sizeXxsmall { /* default browser h6 proportion */
-  font-size: 0.67em;
+  font-size: 0.67rem;
 }
 
 .sizeXsmall { /* default browser h5 proportion */
-  font-size: 0.83em;
+  font-size: 0.83rem;
 }
 
 .sizeDefault { /* default browser h4 proportion */
-  font-size: 1em;
+  font-size: 1rem;
 }
 
-.sizeSmall { /* default browser h3 proportion */
-  font-size: 1.17em;
+.sizeSmall {
+  font-size: 1rem;
 }
 
-.sizeMedium { /* default browser h2 proportion */
-  font-size: 1.5em;
+.sizeMedium {
+  font-size: 1.28rem;
 }
 
-.sizeLarge { /* default browser h1 proportion */
-  font-size: 2em;
+.sizeLarge {
+  font-size: 1.71rem;
 }
 
 .sizeXlarge {
-  font-size: 2.5em;
+  font-size: 2.5rem;
 }
 
 /**

--- a/lib/Headline/Headline.js
+++ b/lib/Headline/Headline.js
@@ -55,14 +55,26 @@ Headline.propTypes = {
   faded: PropTypes.bool,
   flex: PropTypes.bool,
   margin: PropTypes.oneOf([ // If nothing is set it will default to the value of size
+    'xxsmall',
+    'xsmall',
+    'default',
     'small',
     'medium',
     'large',
+    'xlarge',
     'none',
     ''
   ]),
-  size: PropTypes.oneOf(['small', 'medium', 'large']),
-  tag: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'div']),
+  size: PropTypes.oneOf([
+    'xxsmall',
+    'xsmall',
+    'default',
+    'small',
+    'medium',
+    'large',
+    'xlarge'
+  ]),
+  tag: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'div', 'legend']),
 };
 
 export default Headline;

--- a/lib/Headline/readme.md
+++ b/lib/Headline/readme.md
@@ -14,8 +14,8 @@ Renders headlines in different sizes and with different tags, margins and styles
 Name | Type | Description | Options | Default
 --- | --- | --- | --- | ---
 children | node | Alternative way to set the label of the headline | | |
-size | string | The size of the headline | small, medium, large | medium
-margin | string | The bottom margin of the component. Automatically matches the size-prop. | small, medium, large, none | medium
-tag | string | The tag of the headline | h1, h2, h3, h4, h5, h6, p, div | h2
+size | string | The size of the headline | xxsmall, xsmall, default, small, medium, large, xlarge | medium
+margin | string | The bottom margin of the component. Automatically matches the size-prop. | xxsmall, xsmall, default, small, medium, large, xlarge, none | medium
+tag | string | The tag of the headline | h1, h2, h3, h4, h5, h6, p, div, legend | h2
 faded | boolean | Adds faded style to headline (gray color) | true/false | false
 bold | boolean | Adds bold style to headline | true/false | true

--- a/lib/Headline/stories/BasicUsage.js
+++ b/lib/Headline/stories/BasicUsage.js
@@ -7,7 +7,16 @@ import Headline from '../Headline';
 
 const BasicUsage = () => (
   <div>
-    <Headline size="small" margin="large">
+    <Headline size="xxsmall">
+      XX Small Headline
+    </Headline>
+    <Headline size="xsmall">
+      X Small Headline
+    </Headline>
+    <Headline size="default">
+      Default Text Size Headline
+    </Headline>
+    <Headline size="small">
       Small Headline
     </Headline>
     <Headline size="medium">
@@ -15,6 +24,9 @@ const BasicUsage = () => (
     </Headline>
     <Headline size="large">
       Large Headline
+    </Headline>
+    <Headline size="xlarge">
+      X Large Headline
     </Headline>
     <hr />
     <Headline size="large" margin="none" faded>

--- a/lib/global.css
+++ b/lib/global.css
@@ -57,35 +57,6 @@ fieldset {
   border: none;
 }
 
-legend {
-  font-size: 1.3em;
-  font-weight: bold;
-}
-
-h1 {
-  font-size: 1.9rem;
-}
-
-h2 {
-  font-size: 1.7rem;
-}
-
-h3 {
-  font-size: 1.5rem;
-}
-
-h4 {
-  font-size: 1.3rem;
-}
-
-h5 {
-  font-size: 1.1rem;
-}
-
-h6 {
-  font-size: 1rem;
-}
-
 ul {
   margin: 0 0 14px;
 }


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/STCOM-342
I want to be able to use a `legend` tag with the `<Headline>` component to get consistent styles.

## Approach
Removed global heading and legend styles, then set the new `<Headline>` sizes to browser default proportions:
https://www.w3.org/TR/html5/rendering.html#sections-and-headings

The existing sizes remain unchanged.

## Screenshots
### Before
<img width="179" alt="before" src="https://user-images.githubusercontent.com/230597/45786525-7317de00-bc36-11e8-8b35-995961b2db04.png">

### After
<img width="280" alt="after" src="https://user-images.githubusercontent.com/230597/45786534-790dbf00-bc36-11e8-8599-6690179a87bc.png">


