### PR TITLE
Remove default fieldset padding

### DIFF
--- a/lib/global.css
+++ b/lib/global.css
@@ -55,6 +55,7 @@ strong {
 
 fieldset {
   border: none;
+  padding: 0;
 }
 
 legend {


### PR DESCRIPTION
Part of https://issues.folio.org/browse/STCOM-342

Will encourage semantic usage of `<fieldset>` and `<legend>` without the odd styles browsers have by default for those elements.