### PR TITLE
Make Headline a div by default

### DIFF
--- a/lib/Headline/Headline.js
+++ b/lib/Headline/Headline.js
@@ -44,7 +44,7 @@ Headline.defaultProps = {
   faded: false,
   margin: '', // Determined by size if nothing is set
   size: 'medium',
-  tag: 'h2',
+  tag: 'div',
 };
 
 Headline.propTypes = {

--- a/lib/Headline/readme.md
+++ b/lib/Headline/readme.md
@@ -16,6 +16,6 @@ Name | Type | Description | Options | Default
 children | node | Alternative way to set the label of the headline | | |
 size | string | The size of the headline | small, medium, large | medium
 margin | string | The bottom margin of the component. Automatically matches the size-prop. | small, medium, large, none | medium
-tag | string | The tag of the headline | h1, h2, h3, h4, h5, h6, p, div | h2
+tag | string | The tag of the headline | h1, h2, h3, h4, h5, h6, p, div | div
 faded | boolean | Adds faded style to headline (gray color) | true/false | false
 bold | boolean | Adds bold style to headline | true/false | true


### PR DESCRIPTION
`h1`/`h2`/`h*`, etc. should always be in descending order.

By switching the default `<Headline>` tag to be a `<div>`, consumers won't lazily end up with out-of-order `<h2>`s.