### PR TITLE
Added 'contentClass' prop to <Modal>

### DIFF
--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -14,6 +14,8 @@ const propTypes = {
   children: PropTypes.node.isRequired,
   /** Modal can be dismissed by clicking the background overlay */
   closeOnBackgroundClick: PropTypes.bool,
+  /* Apply custom CSS classes on the content element */
+  contentClass: PropTypes.string,
   /** If true, renders a close 'X' in the starting corner of the modal */
   dismissible: PropTypes.bool,
   /**
@@ -80,7 +82,7 @@ const defaultProps = {
 const Modal = (props) => {
   const WrappingElement = props.wrappingElement;
 
-  function getModalScope() {
+  const getModalScope = () => {
     let container;
     switch (props.scope) {
       case 'module':
@@ -90,14 +92,17 @@ const Modal = (props) => {
         break;
     }
     return container;
-  }
+  };
 
-  function getModalClass() {
-    return classNames(
-      css.modal,
-      css[props.size],
-    );
-  }
+  const getModalClass = () => classNames(
+    css.modal,
+    css[props.size],
+  );
+
+  const getContentClass = () => classNames(
+    css.modalContent,
+    props.contentClass,
+  );
 
   const dismissMsg = props.intl.formatMessage({ id: 'stripes-components.dismissModal' });
 
@@ -152,7 +157,7 @@ const Modal = (props) => {
                       </div>
                     </div>
                   }
-                  <div className={css.modalContent} id={props.id && `${props.id}-content`}>
+                  <div className={getContentClass()} id={props.id && `${props.id}-content`}>
                     {props.children}
                   </div>
                   {

--- a/lib/Modal/readme.md
+++ b/lib/Modal/readme.md
@@ -21,16 +21,17 @@ const footer = (
 ### Props
 Name | type | description | default | required
 --- | --- | --- | --- | ---
-label | string | Descriptive title for top of modal - also fills aria-label attribute for screen readers. | | &#10004;
+children | node | Content for the body of the modal. | | &#10004;
+closeOnBackgroundClick | bool | Modal can be dismissed by clicking the background overlay. | false |
+contentClass | string | Apply custom CSS classes to the content element | |
+dismissible | bool | If true, renders a close 'X' in the starting corner of the modal. | false |
+enforceFocus | bool | If true, automatically attempts to regain focus when its children are clicked.  | true |
+footer | node | Footer content of the modal. Pass a single component or multiple components wrapped in a Fragment. | |
 id | string | Used in the "id" attribute of the modal div. | |
+label | string | Descriptive title for top of modal - also fills aria-label attribute for screen readers. | | &#10004;
 onClose | func | Callback that signals intent to close window. This callback does not actually close the modal, but can call code within its body that will change the boolean passed to the `open` prop. | |
 onOpen | func | Callback fired when modal opens. | noop |
 open | bool | Deciding value for rendering the modal(true) or not(false). | false | &#10004;
-scope | string | Parent element for modal. Defaults to 'module' which keeps the main navigation visible. A value of 'root' covers the entire view. | 'module' |
-closeOnBackgroundClick | bool | Modal can be dismissed by clicking the background overlay. | false |
-dismissible | bool | If true, renders a close 'X' in the starting corner of the modal. | false |
-children | node | Content for the body of the modal. | | &#10004;
-footer | node | Footer content of the modal. Pass a single component or multiple components wrapped in a Fragment. | |
-wrappingElement | string | Change the HTML-tag of the wrapping element. Useful if the modal is a form. | |
-enforceFocus | bool | If true, automatically attempts to regain focus when its children are clicked.  | true |
 restoreFocus | bool | If true, the modal will restore focus to previously focused element once modal is hidden. | true |
+scope | string | Parent element for modal. Defaults to 'module' which keeps the main navigation visible. A value of 'root' covers the entire view. | 'module' |
+wrappingElement | string | Change the HTML-tag of the wrapping element. Useful if the modal is a form. | |


### PR DESCRIPTION
- Added 'contentClass' prop that makes it possible to apply class names to the content area of the Modal
- Updated readme
- Changed the order of props to be alphabetical in the readme
- Re-factored functions to be arrow-functions

The reasoning behind adding this class is that I need to be able to add some classes to fix some issues in the `ui-plugin-find-user` but in general I think it's a nice option to have when working with the Modal-component.

Issue: https://github.com/folio-org/ui-plugin-find-user/pull/37