### PR TITLE
Minor TextField class name changes

### DIFF
--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -27,6 +27,10 @@ class TextField extends Component {
      */
     autoFocus: PropTypes.bool,
     /**
+     * Apply class names to the root element
+     */
+    className: PropTypes.string,
+    /**
      * Id to apply to clear field button.
      */
     clearFieldId: PropTypes.string,
@@ -208,7 +212,6 @@ class TextField extends Component {
     return classNames(
       classStringFromProps,
       sharedInputStylesHelper(this.props),
-      this.props.inputClass,
     );
   }
 
@@ -328,6 +331,7 @@ class TextField extends Component {
         ref={this.input}
         required={required}
         value={this.state.value}
+        className={this.props.inputClass}
       />
     );
 
@@ -422,6 +426,7 @@ class TextField extends Component {
     const wrapperStyles = classNames(
       css.textField,
       { [this.props.focusedClass]: this.state.focused && this.props.focusedClass },
+      this.props.className,
     );
 
     const inputGroupStyles = classNames(this.getInputStyle(), css.inputGroup, {


### PR DESCRIPTION
Added className prop that applies to the root element.

Moved 'inputClass' prop to be applied to the input itself.

This fixes the styling of the "Sign in" route TextField's.