### PR TITLE
Minor badge label color fix

### DIFF
--- a/lib/Badge/Badge.css
+++ b/lib/Badge/Badge.css
@@ -4,12 +4,20 @@
   border-radius: 999px;
   font-weight: 700;
   display: inline-block;
-  color: var(--color-text-p2);
   text-align: center;
 }
 
+/**
+ * Label
+ */
 .label {
   padding: 0 6px;
+  color: #fff;
+}
+
+/* Force prevent color from changing on default badge when inside button/anchor with :active styles */
+.default .label {
+  color: var(--color-text-p2) !important;
 }
 
 /**
@@ -17,17 +25,14 @@
  */
 .default {
   background-color: var(--bgHover);
-  color: var(--color-text-p2);
 }
 
 .red {
-  color: #fff;
   background-color: var(--error);
 }
 
 .primary {
   background-color: var(--primary);
-  color: #fff;
 }
 
 /**


### PR DESCRIPTION
Badges should consistent label colors - even when inside an :active element.

Made default badge color very specific to prevent label from changing color when inside an element with interactionStyles applied (IconButton, Button etc.)

## Before
![image](https://user-images.githubusercontent.com/640976/45943186-a4e9c580-bfe5-11e8-9245-4f6e26ae5f2f.png)

## After
![image](https://user-images.githubusercontent.com/640976/45943223-cba7fc00-bfe5-11e8-9782-b8d00d54c2d2.png)
