### PR TITLE
Migration docs

### DIFF
--- a/CHANGEMANAGEMENT.md
+++ b/CHANGEMANAGEMENT.md
@@ -1,16 +1,16 @@
 # Breaking Changes and Deprecations
 Change happens. We learn more, we find better ways to do things. We clean house and beautify API's, improve user experience, accessibility, and developer experience. 
-Through the RFC(Request for comment) process, modifications to the component library are proposed and agreed upon by the community of FOLIO developers. The outcome of this process is an iterative plan to accomplish the proposed goal. The changes are weighed against NFR's - not limited to maintainability, platform stability, testability, extent of migration effort - with breaking change as final resort.
+Through the Request for comment (RFC) process, modifications to the component library are proposed and agreed upon by the community of FOLIO developers. The outcome of this process is an iterative plan to accomplish the proposed goal. The changes are weighed against non-functional requirements's (NFR's) - not limited to maintainability, platform stability, testability, extent of migration effort - with breaking change as final resort.
 ## Break as softly as possible.
 Through adequate release planning and up-front migration development, we aim to facilitate platform stability and reduce development stress, providing adequate timelines for migration to new code.
 ## Semver
-We use the Semver versioning system where changes to the Major number(the first one) represent a present backwards incompatibility.
+We use the Semver versioning system where changes to the Major number (the first one) represent a present backwards incompatibility.
 Some examples of how we determine version number changes:
 * **Patch Version -** fully compatible bug fixes, minor improvements. ex: `3.0.9` to `3.0.10`.
 * **Minor Version -** new props, components, capabilities. ex: `3.0.10` to `3.1.0`.
 * **Major Version -** an incompatible change is present in the system. Removal of a component or component props with no co-existing replacement. ex: `3.1.0` to `4.0.0`.
 ## Console Warnings
-Whenever possible, the release of breaking changes is proceeded by console warnings. These may appear months prior to the actual breaking change, depending on the extent of migration effort.
+Whenever possible, the release of breaking changes is preceded by console warnings. These may appear months prior to the actual breaking change, depending on the extent of migration effort.
 ## Available migration
 The new ways of doing things should be available for developers at their announcement. These may exist as parallel release, or in updated branches.
 ### Parallel release

--- a/CHANGEMANAGEMENT.md
+++ b/CHANGEMANAGEMENT.md
@@ -1,0 +1,28 @@
+# Breaking Changes and Deprecations
+Change happens. We learn more, we find better ways to do things. We clean house and beautify API's, improve user experience, accessibility, and developer experience. 
+Through the RFC(Request for comment) process, modifications to the component library are proposed and agreed upon by the community of FOLIO developers. The outcome of this process is an iterative plan to accomplish the proposed goal. The changes are weighed against NFR's - not limited to maintainability, platform stability, testability, extent of migration effort - with breaking change as final resort.
+## Break as softly as possible.
+Through adequate release planning and up-front migration development, we aim to facilitate platform stability and reduce development stress, providing adequate timelines for migration to new code.
+## Semver
+We use the Semver versioning system where changes to the Major number(the first one) represent a present backwards incompatibility.
+Some examples of how we determine version number changes:
+* **Patch Version -** fully compatible bug fixes, minor improvements. ex: `3.0.9` to `3.0.10`.
+* **Minor Version -** new props, components, capabilities. ex: `3.0.10` to `3.1.0`.
+* **Major Version -** an incompatible change is present in the system. Removal of a component or component props with no co-existing replacement. ex: `3.1.0` to `4.0.0`.
+## Console Warnings
+Whenever possible, the release of breaking changes is proceeded by console warnings. These may appear months prior to the actual breaking change, depending on the extent of migration effort.
+## Available migration
+The new ways of doing things should be available for developers at their announcement. These may exist as parallel release, or in updated branches.
+### Parallel release
+When possible, new solutions will exist together within a platform. With both solutions present, UI module developers may switch over to the new API/component/utility and release their updates to a point release of their module.
+### Updated Branches
+If they cannot be released in parallel, new changes may live in a separate branch of the `stripes-components` repo, so necessary migration work may be achieved even before the breaking changes are released. Multiple upcoming breaking changes may be pooled within a dedicated branch for the next version of the library, so a developer may clone the branch and possibly `yarn-link` it into their local workspace.
+
+## Example scenario
+### Moving Components
+We may see fit to move components from one core repo to another so to adequately support that component's dependencies. Say, for example, we're at version 3.0.10 and It's decided that we will move `<XReduxyExampleComponent>` (`<XREC>`) component to another core repo.
+**Step 1:** We copy the component to its new home and merge those changes to the master of that repo. Changes are logged at the new repo.
+**Step 2:** We place a console warning (as mentioned above) that the path to `<XREC>` should be updated. Migration is additionally documented in our [Migration document](MIGRATION.md) and the change is logged as a deprecation warning in our [change log](CHANGELOG.md). We bump our Minor version for this release. We're `v3.1.0` now.
+**Step 3:** The changes are released and exist in parallel for a release cycle, giving ample time for developers to perform updates.
+**Step 4:** Developers make the necessary changes and the console warnings no longer appear when importing `<XREC>` from its new path...
+**Step 5:** `<XREC>` is removed from `stripes-components` in a new major version.  `4.0.0`

--- a/CHANGEMANAGEMENT.md
+++ b/CHANGEMANAGEMENT.md
@@ -21,8 +21,13 @@ If they cannot be released in parallel, new changes may live in a separate branc
 ## Example scenario
 ### Moving Components
 We may see fit to move components from one core repo to another so to adequately support that component's dependencies. Say, for example, we're at version 3.0.10 and It's decided that we will move `<XReduxyExampleComponent>` (`<XREC>`) component to another core repo.
+
 **Step 1:** We copy the component to its new home and merge those changes to the master of that repo. Changes are logged at the new repo.
+
 **Step 2:** We place a console warning (as mentioned above) that the path to `<XREC>` should be updated. Migration is additionally documented in our [Migration document](MIGRATION.md) and the change is logged as a deprecation warning in our [change log](CHANGELOG.md). We bump our Minor version for this release. We're `v3.1.0` now.
+
 **Step 3:** The changes are released and exist in parallel for a release cycle, giving ample time for developers to perform updates.
+
 **Step 4:** Developers make the necessary changes and the console warnings no longer appear when importing `<XREC>` from its new path...
+
 **Step 5:** `<XREC>` is removed from `stripes-components` in a new major version.  `4.0.0`

--- a/MIGRATIONPATHS.md
+++ b/MIGRATIONPATHS.md
@@ -1,0 +1,17 @@
+# Stripes-Components Migration Paths
+## 3.0 to 4.0 (Upcoming release)
+[Some Components and utilities have moved](#some-components-and-utilities-have-moved)
+### Some Components and utilities have moved
+We've provided console warnings for these items. If you've used these in your module with a `stripes-components` path, you'll simply have to update your import path:
+Component/Util | New path
+-- | --
+`<AddressList>` | `@folio/stripes-smart-components/lib/AddressFieldGroup/AddressList`
+`<AddressEditList>` | `@folio/stripes-smart-components/lib/AddressFieldGroup/AddressEdit/AddressEditList` 
+`<EmbeddedAddressForm>` | `@folio/stripes-smart-components/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm`
+`<EditableList>` | `@folio/stripes-smart-components/lib/EditableList`
+`<Settings>` | `@folio/stripes-smart-components/lib/Settings`
+`<Pluggable>`  | `@folio/stripes-core/lib/Pluggable`
+`makeQueryFunction()` | `@folio/stripes-smart-components/lib/SearchAndSort/makeQueryFunction`
+
+
+

--- a/MIGRATIONPATHS.md
+++ b/MIGRATIONPATHS.md
@@ -8,6 +8,5 @@ We've provided console warnings for these items. If you've used these in your mo
 Component/Util | New path
 -- | --
 `<AddressList>`, `<AddressEditList>`, `<EditableList>`, `<Settings>`  | `import { ... } from '@folio/stripes-smart-components'`
-`<EmbeddedAddressForm>` | `@folio/stripes-smart-components/AddressFieldGroup/AddressEdit/EmbeddedAddressForm` 
 `<Pluggable>`  | `@folio/stripes-core/lib/Pluggable`
 `makeQueryFunction()` | `import { makeQueryFunction } from '@folio/stripes-smart-components'`

--- a/MIGRATIONPATHS.md
+++ b/MIGRATIONPATHS.md
@@ -8,6 +8,6 @@ We've provided console warnings for these items. If you've used these in your mo
 Component/Util | New path
 -- | --
 `<AddressList>`, `<AddressEditList>`, `<EditableList>`, `<Settings>`  | `import { ... } from '@folio/stripes-smart-components'`
-`<EmbeddedAddressForm>` | `@folio/stripes-smart-components/AddressFieldGroup/EmbeddedAddressForm` 
+`<EmbeddedAddressForm>` | `@folio/stripes-smart-components/AddressFieldGroup/AddressEdit/EmbeddedAddressForm` 
 `<Pluggable>`  | `@folio/stripes-core/lib/Pluggable`
 `makeQueryFunction()` | `import { makeQueryFunction } from '@folio/stripes-smart-components'`

--- a/MIGRATIONPATHS.md
+++ b/MIGRATIONPATHS.md
@@ -1,5 +1,6 @@
 # Stripes-Components Migration Paths
-## 3.0 to 4.0
+## 3.x to 4.x
+Upcoming release.
 [Some Components and utilities have moved](#some-components-and-utilities-have-moved)
 ### Some Components and utilities have moved
 We've provided console warnings for these items. If you've used these in your module with a `stripes-components` path, you'll simply have to update your import path:

--- a/MIGRATIONPATHS.md
+++ b/MIGRATIONPATHS.md
@@ -14,6 +14,3 @@ Component/Util | New path
 `<Settings>` | `@folio/stripes-smart-components/lib/Settings`
 `<Pluggable>`  | `@folio/stripes-core/lib/Pluggable`
 `makeQueryFunction()` | `@folio/stripes-smart-components/lib/SearchAndSort/makeQueryFunction`
-
-
-

--- a/MIGRATIONPATHS.md
+++ b/MIGRATIONPATHS.md
@@ -3,6 +3,7 @@
 [Some Components and utilities have moved](#some-components-and-utilities-have-moved)
 ### Some Components and utilities have moved
 We've provided console warnings for these items. If you've used these in your module with a `stripes-components` path, you'll simply have to update your import path:
+
 Component/Util | New path
 -- | --
 `<AddressList>` | `@folio/stripes-smart-components/lib/AddressFieldGroup/AddressList`

--- a/MIGRATIONPATHS.md
+++ b/MIGRATIONPATHS.md
@@ -1,5 +1,5 @@
 # Stripes-Components Migration Paths
-## 3.0 to 4.0 (Upcoming release)
+## 3.0 to 4.0
 [Some Components and utilities have moved](#some-components-and-utilities-have-moved)
 ### Some Components and utilities have moved
 We've provided console warnings for these items. If you've used these in your module with a `stripes-components` path, you'll simply have to update your import path:

--- a/MIGRATIONPATHS.md
+++ b/MIGRATIONPATHS.md
@@ -1,16 +1,13 @@
 # Stripes-Components Migration Paths
 ## 3.x to 4.x
-Upcoming release.
-[Some Components and utilities have moved](#some-components-and-utilities-have-moved)
+Upcoming release.  
+
 ### Some Components and utilities have moved
 We've provided console warnings for these items. If you've used these in your module with a `stripes-components` path, you'll simply have to update your import path:
 
 Component/Util | New path
 -- | --
-`<AddressList>` | `@folio/stripes-smart-components/lib/AddressFieldGroup/AddressList`
-`<AddressEditList>` | `@folio/stripes-smart-components/lib/AddressFieldGroup/AddressEdit/AddressEditList` 
-`<EmbeddedAddressForm>` | `@folio/stripes-smart-components/lib/AddressFieldGroup/AddressEdit/EmbeddedAddressForm`
-`<EditableList>` | `@folio/stripes-smart-components/lib/EditableList`
-`<Settings>` | `@folio/stripes-smart-components/lib/Settings`
+`<AddressList>`, `<AddressEditList>`, `<EditableList>`, `<Settings>`  | `import { ... } from '@folio/stripes-smart-components'`
+`<EmbeddedAddressForm>` | `@folio/stripes-smart-components/AddressFieldGroup/EmbeddedAddressForm` 
 `<Pluggable>`  | `@folio/stripes-core/lib/Pluggable`
-`makeQueryFunction()` | `@folio/stripes-smart-components/lib/SearchAndSort/makeQueryFunction`
+`makeQueryFunction()` | `import { makeQueryFunction } from '@folio/stripes-smart-components'`

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 * [Patterns - UI Recipes](#patterns)
 * [Testing](#testing)
 * [FAQ](#faq)
+* [Migration Paths](MIGRATIONPATHS.md)
+* [Change Management](CHANGEMANAGEMENT.md)
 * [To be documented](#to-be-documented)
 * [Additional information](#additional-information)
 
@@ -136,7 +138,6 @@ tests locally in the Chrome browser.
 
 See our [testing documentation](docs/Testing.md) for more information
 on writing tests.
-
 
 ## FAQ
 Check our [Frequently asked questions for Module developers page](FAQ.md)


### PR DESCRIPTION
# Purpose
Adding some informational docs here that discuss managing breaking changes and versioning. 

## Migration paths
A guide for making changes due to upgrading stripes components. Ideally create a permanent document that we might be able to link to from deprecation console warnings or any other documentation to facilitate the upgrade process from any previous version.

There's probably already more that we can add to the migration document. Just floating this idea...

### Rendered markdown links for convenience...
[Change mangement](https://github.com/folio-org/stripes-components/blob/migration-docs/CHANGEMANAGEMENT.md)
[Migration paths](https://github.com/folio-org/stripes-components/blob/migration-docs/MIGRATIONPATHS.md)