### PR TITLE
STCOM-274 Fix paneset CSS behavior on narrow screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change history for stripes-components
 
-## ## 3.2.0 (IN PROGRESS) 
+## 3.2.0 (IN PROGRESS)
 
 * Update `stripes-form` dependency to v1.0.0
+* Fix paneset CSS behavior on narrow screens
 
 ## [3.1.0](https://github.com/folio-org/stripes-components/tree/v3.1.0) (2018-09-13)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v3.0.0...v3.1.0)

--- a/lib/Pane/Pane.css
+++ b/lib/Pane/Pane.css
@@ -1,6 +1,7 @@
 @import '../variables.css';
 
 .pane {
+  background: #fff;
   border-right: 1px solid var(--color-border);
   height: 100%;
   max-height: calc(100vh - 44px);

--- a/lib/Pane/Pane.css
+++ b/lib/Pane/Pane.css
@@ -1,7 +1,7 @@
 @import '../variables.css';
 
 .pane {
-  background: #fff;
+  background: var(--bg);
   border-right: 1px solid var(--color-border);
   height: 100%;
   max-height: calc(100vh - 44px);

--- a/lib/Paneset/Paneset.css
+++ b/lib/Paneset/Paneset.css
@@ -4,20 +4,25 @@
   width: 100%;
   height: 100%;
   position: absolute;
-  display: flex;
-  flex-direction: row;
-  align-items: stretch;
-  justify-content: flex-start;
+  display: block;
   will-change: transform;
   overflow: hidden;
 
   & .paneset,
   &.nested {
     position: relative;
-    flex-grow: 2;
   }
 
   &.static {
     position: static;
+  }
+}
+
+@media (--mediumUp) {
+  .paneset {
+    display: flex;
+    flex-direction: row;
+    align-items: stretch;
+    justify-content: flex-start;
   }
 }

--- a/lib/Paneset/Paneset.css
+++ b/lib/Paneset/Paneset.css
@@ -3,8 +3,8 @@
 .paneset {
   width: 100%;
   height: 100%;
-  position: relative;
-  display: block;
+  position: absolute;
+  display: flex;
   flex-direction: row;
   align-items: stretch;
   justify-content: flex-start;
@@ -19,12 +19,5 @@
 
   &.static {
     position: static;
-  }
-}
-
-@media (--mediumUp) {
-  .paneset {
-    display: flex;
-    position: absolute;
   }
 }


### PR DESCRIPTION
Paneset no longer simply disappears on smaller screens. Still lots of related bugs to work out before https://issues.folio.org/browse/STCOM-274 is marked as done.

"After" screenshot also indicates poor grid usage.

### Before
![localhost_3000_users_view_d7af6445-28c6-58de-bb33-f9d5307825f4_query e sort name iphone 5_se](https://user-images.githubusercontent.com/230597/45979475-cc0bbb80-c014-11e8-895c-192c0202ce6e.png)

### After
![localhost_3000_settings_users_perms iphone 5_se](https://user-images.githubusercontent.com/230597/45979458-c615da80-c014-11e8-8e8c-bdb302818912.png)
