### PR TITLE
Added 'odd' class for NavListItem 

### DIFF
--- a/lib/NavListItem/NavListItem.css
+++ b/lib/NavListItem/NavListItem.css
@@ -42,6 +42,7 @@
 }
 
 /* if stripped styles is activated in NavList */
-.stripped .NavListItem:nth-child(odd):not(.isActive):not(:hover):not(:active) {
-  background-color: rgba(0, 0, 0, 0.05);
+.stripped .NavListItem:nth-child(odd):not(.isActive):not(:hover):not(:active),
+.NavListItem.odd:not(.isActive):not(:hover):not(:active) {
+  background-color: var(--color-fill-table-row-odd);
 }


### PR DESCRIPTION
Added 'odd' class for NavListItem that can be used to control background-color of even/odd rows manually in a list of NavListItem's (when used outside a NavListSection with `striped=true`.

 Replaced hardcoded rgba color with color variable.