### PR TITLE
Expose legend as tag for Headline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update `stripes-form` dependency to v1.0.0
 * Fix paneset CSS behavior on narrow screens
 * Change global base font size from 14px to 16px
+* Expose legend as tag for `<Headline>`
 
 ## [3.1.0](https://github.com/folio-org/stripes-components/tree/v3.1.0) (2018-09-13)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v3.0.0...v3.1.0)

--- a/lib/Headline/Headline.js
+++ b/lib/Headline/Headline.js
@@ -62,7 +62,7 @@ Headline.propTypes = {
     ''
   ]),
   size: PropTypes.oneOf(['small', 'medium', 'large']),
-  tag: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'div']),
+  tag: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'div', 'legend']),
 };
 
 export default Headline;

--- a/lib/Headline/readme.md
+++ b/lib/Headline/readme.md
@@ -16,6 +16,6 @@ Name | Type | Description | Options | Default
 children | node | Alternative way to set the label of the headline | | |
 size | string | The size of the headline | small, medium, large | medium
 margin | string | The bottom margin of the component. Automatically matches the size-prop. | small, medium, large, none | medium
-tag | string | The tag of the headline | h1, h2, h3, h4, h5, h6, p, div | div
+tag | string | The tag of the headline | h1, h2, h3, h4, h5, h6, p, div, legend | div
 faded | boolean | Adds faded style to headline (gray color) | true/false | false
 bold | boolean | Adds bold style to headline | true/false | true

--- a/lib/global.css
+++ b/lib/global.css
@@ -58,11 +58,6 @@ fieldset {
   padding: 0;
 }
 
-legend {
-  font-size: 1.3em;
-  font-weight: bold;
-}
-
 h1 {
   font-size: 1.9rem;
 }


### PR DESCRIPTION
Will make `<legend>` use easier, since it can be styled to look like the appropriate `<h*>` for its hierarchy context.