### PR TITLE
Adjust headline sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix paneset CSS behavior on narrow screens
 * Change global base font size from 14px to 16px
 * Expose legend as tag for `<Headline>`
+* Adjust headline sizes
 
 ## [3.1.0](https://github.com/folio-org/stripes-components/tree/v3.1.0) (2018-09-13)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v3.0.0...v3.1.0)

--- a/lib/Headline/Headline.css
+++ b/lib/Headline/Headline.css
@@ -37,18 +37,20 @@
 
 /**
  * Size
+ * Follows HTML5 headline specs
+ * https://www.w3.org/TR/html5/rendering.html#sections-and-headings
  */
 
-.sizeSmall {
-  font-size: 14px;
+.sizeSmall { /* default browser h3 proportion */
+  font-size: 1.17rem;
 }
 
-.sizeMedium {
-  font-size: 18px;
+.sizeMedium { /* default browser h2 proportion */
+  font-size: 1.5rem;
 }
 
-.sizeLarge {
-  font-size: 24px;
+.sizeLarge { /* default browser h1 proportion */
+  font-size: 2rem;
 }
 
 /**
@@ -60,13 +62,13 @@
 }
 
 .marginSmall {
-  margin-bottom: 8px;
+  margin-bottom: 1em;
 }
 
 .marginMedium {
-  margin-bottom: 12px;
+  margin-bottom: 0.83em;
 }
 
 .marginLarge {
-  margin-bottom: 14px;
+  margin-bottom: 0.67em;
 }

--- a/lib/Headline/Headline.js
+++ b/lib/Headline/Headline.js
@@ -43,7 +43,7 @@ Headline.defaultProps = {
   bold: true,
   faded: false,
   margin: '', // Determined by size if nothing is set
-  size: 'medium',
+  size: 'small',
   tag: 'div',
 };
 

--- a/lib/Headline/readme.md
+++ b/lib/Headline/readme.md
@@ -14,8 +14,8 @@ Renders headlines in different sizes and with different tags, margins and styles
 Name | Type | Description | Options | Default
 --- | --- | --- | --- | ---
 children | node | Alternative way to set the label of the headline | | |
-size | string | The size of the headline | small, medium, large | medium
-margin | string | The bottom margin of the component. Automatically matches the size-prop. | small, medium, large, none | medium
+size | string | The size of the headline | small, medium, large | small
+margin | string | The bottom margin of the component. Automatically matches the size-prop. | small, medium, large, none | small
 tag | string | The tag of the headline | h1, h2, h3, h4, h5, h6, p, div, legend | div
 faded | boolean | Adds faded style to headline (gray color) | true/false | false
 bold | boolean | Adds bold style to headline | true/false | true

--- a/lib/Headline/stories/BasicUsage.js
+++ b/lib/Headline/stories/BasicUsage.js
@@ -7,7 +7,7 @@ import Headline from '../Headline';
 
 const BasicUsage = () => (
   <div>
-    <Headline size="small" margin="large">
+    <Headline size="small">
       Small Headline
     </Headline>
     <Headline size="medium">

--- a/lib/global.css
+++ b/lib/global.css
@@ -58,30 +58,6 @@ fieldset {
   padding: 0;
 }
 
-h1 {
-  font-size: 1.9rem;
-}
-
-h2 {
-  font-size: 1.7rem;
-}
-
-h3 {
-  font-size: 1.5rem;
-}
-
-h4 {
-  font-size: 1.3rem;
-}
-
-h5 {
-  font-size: 1.1rem;
-}
-
-h6 {
-  font-size: 1rem;
-}
-
 ul {
   margin: 0 0 14px;
 }


### PR DESCRIPTION
## Purpose
Replaces https://github.com/folio-org/stripes-components/pull/606

## Approach
- Removed global heading styles, then set the new `<Headline>` sizes to browser default proportions:
https://www.w3.org/TR/html5/rendering.html#sections-and-headings
- Added `base` option that creates

### Before
![screen shot 2018-09-27 at 2 58 34 pm](https://user-images.githubusercontent.com/230597/46171335-da9ce180-c265-11e8-9ad2-3ee70a40a3b9.png)

### After
![screen shot 2018-09-27 at 2 56 19 pm](https://user-images.githubusercontent.com/230597/46171234-90b3fb80-c265-11e8-8aef-5fc020f00259.png)

