### PR TITLE
Expose headline ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Change global base font size from 14px to 16px
 * Expose legend as tag for `<Headline>`
 * Adjust headline sizes
+* Expose `<Headline>` ref
 
 ## [3.1.0](https://github.com/folio-org/stripes-components/tree/v3.1.0) (2018-09-13)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v3.0.0...v3.1.0)

--- a/lib/Headline/Headline.js
+++ b/lib/Headline/Headline.js
@@ -2,13 +2,16 @@
  * Component: Headline
  */
 
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { camelCase } from 'lodash';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import css from './Headline.css';
 
-const Headline = ({ size, margin, tag, faded, bold, flex, block, children, className, ...rest }) => {
+const Headline = forwardRef((
+  { size, margin, tag, faded, bold, flex, block, children, className, ...rest },
+  ref
+) => {
   /**
    * Get CSS classes depending on props
    */
@@ -35,9 +38,9 @@ const Headline = ({ size, margin, tag, faded, bold, flex, block, children, class
   const HeadlineTag = tag;
 
   return (
-    <HeadlineTag {...rest} className={getCssClasses()}>{children}</HeadlineTag>
+    <HeadlineTag {...rest} ref={ref} className={getCssClasses()}>{children}</HeadlineTag>
   );
-};
+});
 
 Headline.defaultProps = {
   bold: true,


### PR DESCRIPTION
## Purpose
I want to use `<Headline>` more extensively in `ui-eholdings` for consistent typography. In one place where we currently use a bare `<h2>`, we use a ref to focus it when its parent pane mounts:
https://github.com/folio-org/ui-eholdings/blob/9c2e05956bd95624c00856993786f17ecc617af2/src/components/details-view/details-view.js#L258-L264

## Approach
Expose a ref from `<Headline>` with ref forwarding: https://reactjs.org/docs/forwarding-refs.html