### PR TITLE
STCOM-351 Iconbutton `ref` support

### DIFF
--- a/lib/IconButton/IconButton.js
+++ b/lib/IconButton/IconButton.js
@@ -60,7 +60,8 @@ const IconButton = React.forwardRef(({
         type: '',
         ref: null,
         innerRef: ref
-      });
+      }
+    );
     Element = Link;
   }
 

--- a/lib/IconButton/IconButton.js
+++ b/lib/IconButton/IconButton.js
@@ -10,7 +10,7 @@ import Icon from '../Icon';
 import css from './IconButton.css';
 import Badge from '../Badge';
 
-const IconButton = ({
+const IconButton = React.forwardRef(({
   icon,
   autoFocus,
   onClick,
@@ -30,7 +30,7 @@ const IconButton = ({
   size,
   iconSize,
   ...rest
-}) => {
+}, ref) => {
   let Element = 'button';
 
   let buttonProps = {
@@ -43,6 +43,7 @@ const IconButton = ({
     style,
     tabIndex,
     autoFocus,
+    ref,
     ...rest,
     'className': classNames(css.iconButton, { [css.hasBadge]: badgeCount }, css[size], className),
     'aria-label': ariaLabel,
@@ -52,7 +53,14 @@ const IconButton = ({
    * If button is a link
    */
   if (href || to) {
-    buttonProps = Object.assign(buttonProps, { to: href || to, type: '' });
+    buttonProps = Object.assign(
+      buttonProps,
+      {
+        to: href || to,
+        type: '',
+        ref: null,
+        innerRef: ref
+      });
     Element = Link;
   }
 
@@ -64,7 +72,7 @@ const IconButton = ({
       </span>
     </Element>
   );
-};
+});
 
 IconButton.propTypes = {
   ariaLabel: PropTypes.string,


### PR DESCRIPTION
# Purpose
Refs are good for focus-management in React. Buttons are typical focus-management targets, so this is definitely needed for those scenarios (it did not work previously)

## Approach
Use `React.forwarRef()` functionality... had to pass `innerRef` to `<Link>` since that's what it wanted.
 