### PR TITLE
Fixed misaligned RadioButton and Checkbox

### DIFF
--- a/lib/Checkbox/Checkbox.css
+++ b/lib/Checkbox/Checkbox.css
@@ -44,6 +44,7 @@
   padding: 4px 5px;
   min-height: var(--controlHeight);
   display: flex;
+  align-items: baseline;
   cursor: pointer;
   flex-grow: 2;
   position: relative;
@@ -102,7 +103,6 @@ input.checkboxInput {
   display: flex;
   overflow: hidden;
   flex-shrink: 0;
-  margin-top: 2px;
 
   & svg {
     opacity: 0;

--- a/lib/RadioButton/RadioButton.css
+++ b/lib/RadioButton/RadioButton.css
@@ -27,6 +27,7 @@
   position: relative;
   line-height: 120%;
   display: flex;
+  align-items: baseline;
   min-height: 24px;
   cursor: pointer;
   flex-grow: 2;
@@ -60,7 +61,6 @@
   border-radius: 999px;
   background: #fff;
   flex-shrink: 0;
-  margin-top: 2px;
 }
 
 .labelPseudo::after {


### PR DESCRIPTION
After the font-size changed there were some minor misalignments in the RadioButton and the Checkbox component.

## Fix
Removed margin-top from custom checkbox/radio button and applied align-items: baseline to the parent elements. This fixes the misaligned checkbox/radioButtons and it's also less 'hardcoded' therefore making it work better with different font-sizes.

## Before
![image](https://user-images.githubusercontent.com/640976/46209134-41d19900-c32d-11e8-9f68-4e3e05a6abeb.png)

![image](https://user-images.githubusercontent.com/640976/46209125-3c744e80-c32d-11e8-80cb-ba45917a33af.png)


## After
![image](https://user-images.githubusercontent.com/640976/46209538-68440400-c32e-11e8-8061-1eb04a75b5bc.png)

![image](https://user-images.githubusercontent.com/640976/46209071-0505a200-c32d-11e8-98a0-ac29012d93fc.png)
