### PR TITLE
Release v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-components
 
-## 3.2.0 (IN PROGRESS)
+## [3.2.0](https://github.com/folio-org/stripes-components/tree/v3.2.0) (2018-09-28)
+[Full Changelog](https://github.com/folio-org/stripes-components/compare/v3.1.0...v3.2.0)
 
 * Update `stripes-form` dependency to v1.0.0
 * Fix paneset CSS behavior on narrow screens

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
* Update `stripes-form` dependency to v1.0.0
* Fix paneset CSS behavior on narrow screens
* Change global base font size from 14px to 16px
* Expose legend as tag for `<Headline>`
* Adjust headline sizes
* Expose `<Headline>` ref