### PR TITLE
Create wider type stack with consistent variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.3.0 (IN PROGRESS)
 
 * Use input type="search" for `<SearchField>`
+* Create wider type stack
 
 ## [3.2.0](https://github.com/folio-org/stripes-components/tree/v3.2.0) (2018-09-28)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v3.1.0...v3.2.0)

--- a/lib/Accordion/Accordion.css
+++ b/lib/Accordion/Accordion.css
@@ -152,7 +152,7 @@
 
   & .labelArea {
     padding-left: 4px;
-    color: var(--color-text-p1);
+    color: var(--color-text-p2);
   }
 }
 

--- a/lib/Accordion/Accordion.css
+++ b/lib/Accordion/Accordion.css
@@ -112,7 +112,6 @@
   align-items: center;
   padding: 0;
   background-color: transparent;
-  font-size: 18px;
   min-height: 44px;
   width: 100%;
   color: var(--color-text);

--- a/lib/AddressFieldGroup/AddressEdit/AddressEdit.css
+++ b/lib/AddressFieldGroup/AddressEdit/AddressEdit.css
@@ -8,7 +8,7 @@
 .legend {
   display: block;
   width: 100%;
-  font-size: var(--xLargeFontSize);
+  font-size: var(--font-size-x-large);
   color: #333;
   border: 0;
   margin-bottom: 6px;
@@ -17,7 +17,7 @@
 
 .subLegend {
   composes: legend;
-  font-size: var(--largeFontSize);
+  font-size: var(--font-size-large);
   color: #777;
 }
 
@@ -107,7 +107,7 @@
 .primaryToggle {
   padding: 4px 8px;
   color: #555;
-  font-size: var(--xSmallFontSize);
+  font-size: var(--font-size-x-small);
   cursor: pointer;
   margin-bottom: 0;
 

--- a/lib/AddressFieldGroup/AddressEdit/AddressEdit.css
+++ b/lib/AddressFieldGroup/AddressEdit/AddressEdit.css
@@ -8,7 +8,7 @@
 .legend {
   display: block;
   width: 100%;
-  font-size: 21px;
+  font-size: var(--xLargeFontSize);
   color: #333;
   border: 0;
   margin-bottom: 6px;
@@ -17,7 +17,7 @@
 
 .subLegend {
   composes: legend;
-  font-size: 18px;
+  font-size: var(--largeFontSize);
   color: #777;
 }
 
@@ -107,7 +107,7 @@
 .primaryToggle {
   padding: 4px 8px;
   color: #555;
-  font-size: 12px;
+  font-size: var(--xSmallFontSize);
   cursor: pointer;
   margin-bottom: 0;
 

--- a/lib/Badge/Badge.css
+++ b/lib/Badge/Badge.css
@@ -40,14 +40,14 @@
  */
 
 .small {
-  font-size: 10px;
+  font-size: var(--xxSmallFontSize);
   height: 18px;
   min-width: 18px;
   line-height: 18px;
 }
 
 .medium {
-  font-size: 14px;
+  font-size: var(--smallFontSize);
   height: 22px;
   min-width: 22px;
   line-height: 22px;

--- a/lib/Badge/Badge.css
+++ b/lib/Badge/Badge.css
@@ -40,14 +40,14 @@
  */
 
 .small {
-  font-size: var(--xxSmallFontSize);
+  font-size: var(--font-size-xx-small);
   height: 18px;
   min-width: 18px;
   line-height: 18px;
 }
 
 .medium {
-  font-size: var(--smallFontSize);
+  font-size: var(--font-size-small);
   height: 22px;
   min-width: 22px;
   line-height: 22px;

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -248,7 +248,7 @@
     max-height: 16rem;
     height: 16rem;
     color: #fff;
-    font-size: 2rem;
+    font-size: var(--xxLargeFontSize);
     border-radius: 0;
   }
 }

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -34,6 +34,7 @@
   box-shadow: 0 0 0 18px rgba(0, 0, 0, 0);
   opacity: 1;
   font-weight: var(--text-weight-button);
+  font-size: var(--smallFontSize);
 
   &.slim {
     padding: 5px 2px;

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -34,7 +34,7 @@
   box-shadow: 0 0 0 18px rgba(0, 0, 0, 0);
   opacity: 1;
   font-weight: var(--text-weight-button);
-  font-size: var(--smallFontSize);
+  font-size: var(--font-size-small);
 
   &.slim {
     padding: 5px 2px;
@@ -249,7 +249,7 @@
     max-height: 16rem;
     height: 16rem;
     color: #fff;
-    font-size: var(--xxLargeFontSize);
+    font-size: var(--font-size-xx-large);
     border-radius: 0;
   }
 }

--- a/lib/Checkbox/Checkbox.css
+++ b/lib/Checkbox/Checkbox.css
@@ -49,7 +49,7 @@
   flex-grow: 2;
   position: relative;
   border-radius: var(--radius);
-  font-size: var(--smallFontSize);
+  font-size: var(--mediumFontSize);
 
   &.disabledLabel {
     opacity: 0.65;

--- a/lib/Checkbox/Checkbox.css
+++ b/lib/Checkbox/Checkbox.css
@@ -49,6 +49,7 @@
   flex-grow: 2;
   position: relative;
   border-radius: var(--radius);
+  font-size: var(--smallFontSize);
 
   &.disabledLabel {
     opacity: 0.65;
@@ -79,7 +80,7 @@
  * Checkbox feedback
  */
 .checkboxFeedback {
-  font-size: 12px;
+  font-size: var(--xSmallFontSize);
 }
 
 /**

--- a/lib/Checkbox/Checkbox.css
+++ b/lib/Checkbox/Checkbox.css
@@ -49,7 +49,7 @@
   flex-grow: 2;
   position: relative;
   border-radius: var(--radius);
-  font-size: var(--mediumFontSize);
+  font-size: var(--font-size-medium);
 
   &.disabledLabel {
     opacity: 0.65;
@@ -80,7 +80,7 @@
  * Checkbox feedback
  */
 .checkboxFeedback {
-  font-size: var(--xSmallFontSize);
+  font-size: var(--font-size-x-small);
 }
 
 /**

--- a/lib/Datepicker/Calendar.css
+++ b/lib/Datepicker/Calendar.css
@@ -83,7 +83,7 @@
 .selectedMonth {
   display: block;
   text-align: center;
-  font-size: var(--smallFontSize);
+  font-size: var(--font-size-small);
 }
 
 .nav {
@@ -104,6 +104,6 @@
 }
 
 .weekday {
-  font-size: var(--mediumFontSize);
+  font-size: var(--font-size-medium);
   text-align: center;
 }

--- a/lib/Datepicker/Calendar.css
+++ b/lib/Datepicker/Calendar.css
@@ -83,6 +83,7 @@
 .selectedMonth {
   display: block;
   text-align: center;
+  font-size: var(--smallFontSize);
 }
 
 .nav {
@@ -103,6 +104,6 @@
 }
 
 .weekday {
-  font-size: 0.9rem;
+  font-size: var(--mediumFontSize);
   text-align: center;
 }

--- a/lib/Dropdown/Dropdown.css
+++ b/lib/Dropdown/Dropdown.css
@@ -19,7 +19,7 @@
   display: none;
   float: left;
   min-width: 90vw;
-  font-size: 14px;
+  font-size: var(--mediumFontSize);
   text-align: left;
   list-style: none;
   background-color: #fff;

--- a/lib/Dropdown/Dropdown.css
+++ b/lib/Dropdown/Dropdown.css
@@ -19,7 +19,7 @@
   display: none;
   float: left;
   min-width: 90vw;
-  font-size: var(--mediumFontSize);
+  font-size: var(--font-size-medium);
   text-align: left;
   list-style: none;
   background-color: #fff;

--- a/lib/DropdownMenu/DropdownMenu.css
+++ b/lib/DropdownMenu/DropdownMenu.css
@@ -10,7 +10,7 @@
   min-width: 90vw;
   padding: 5px 0;
   margin: 2px 0 0;
-  font-size: var(--mediumFontSize);
+  font-size: var(--font-size-medium);
   text-align: left;
   list-style: none;
   background-color: #fff;

--- a/lib/DropdownMenu/DropdownMenu.css
+++ b/lib/DropdownMenu/DropdownMenu.css
@@ -10,7 +10,7 @@
   min-width: 90vw;
   padding: 5px 0;
   margin: 2px 0 0;
-  font-size: 14px;
+  font-size: var(--mediumFontSize);
   text-align: left;
   list-style: none;
   background-color: #fff;

--- a/lib/Headline/Headline.css
+++ b/lib/Headline/Headline.css
@@ -11,7 +11,7 @@
 .headline {
   margin-top: 0;
   font-weight: var(--text-weight-headline);
-  line-height: var(--lineHeight);
+  line-height: var(--line-height);
 
   /* Faded */
   &.isFaded {
@@ -42,31 +42,31 @@
  */
 
 .sizeXxSmall { /* default browser h6 proportion */
-  font-size: var(--xxSmallFontSize);
+  font-size: var(--font-size-xx-small);
 }
 
 .sizeXSmall {
-  font-size: var(--xSmallFontSize);
+  font-size: var(--font-size-x-small);
 }
 
 .sizeSmall { /* default browser h5 proportion */
-  font-size: var(--smallFontSize);
+  font-size: var(--font-size-small);
 }
 
 .sizeMedium { /* default browser h4 proportion */
-  font-size: var(--mediumFontSize);
+  font-size: var(--font-size-medium);
 }
 
 .sizeLarge { /* default browser h3 proportion */
-  font-size: var(--largeFontSize);
+  font-size: var(--font-size-large);
 }
 
 .sizeXLarge { /* default browser h2 proportion */
-  font-size: var(--xLargeFontSize);
+  font-size: var(--font-size-x-large);
 }
 
 .sizeXxLarge { /* default browser h1 proportion */
-  font-size: var(--xxLargeFontSize);
+  font-size: var(--font-size-xx-large);
 }
 
 /**

--- a/lib/Headline/Headline.css
+++ b/lib/Headline/Headline.css
@@ -10,8 +10,8 @@
 
 .headline {
   margin-top: 0;
-  color: var(--color-text);
   font-weight: var(--text-weight-headline);
+  line-height: 1.4;
 
   /* Faded */
   &.isFaded {
@@ -41,15 +41,31 @@
  * https://www.w3.org/TR/html5/rendering.html#sections-and-headings
  */
 
-.sizeSmall { /* default browser h3 proportion */
+.sizeXxSmall { /* default browser h6 proportion */
+  font-size: 0.67rem;
+}
+
+.sizeXSmall {
+  font-size: 0.75rem;
+}
+
+.sizeSmall { /* default browser h5 proportion */
+  font-size: 0.83rem;
+}
+
+.sizeMedium { /* default browser h4 proportion */
+  font-size: 1rem;
+}
+
+.sizeLarge { /* default browser h3 proportion */
   font-size: 1.17rem;
 }
 
-.sizeMedium { /* default browser h2 proportion */
-  font-size: 1.5rem;
+.sizeXLarge { /* default browser h2 proportion */
+  font-size: 1.50rem;
 }
 
-.sizeLarge { /* default browser h1 proportion */
+.sizeXxLarge { /* default browser h1 proportion */
   font-size: 2rem;
 }
 
@@ -61,14 +77,30 @@
   margin-bottom: 0;
 }
 
+.marginXxSmall {
+  margin-bottom: 2.33em;
+}
+
+.marginXSmall {
+  margin-bottom: 2em;
+}
+
 .marginSmall {
-  margin-bottom: 1em;
+  margin-bottom: 1.67em;
 }
 
 .marginMedium {
-  margin-bottom: 0.83em;
+  margin-bottom: 1.33em;
 }
 
 .marginLarge {
+  margin-bottom: 1em;
+}
+
+.marginXLarge {
+  margin-bottom: 0.83em;
+}
+
+.marginXxLarge {
   margin-bottom: 0.67em;
 }

--- a/lib/Headline/Headline.css
+++ b/lib/Headline/Headline.css
@@ -11,7 +11,7 @@
 .headline {
   margin-top: 0;
   font-weight: var(--text-weight-headline);
-  line-height: 1.4;
+  line-height: var(--lineHeight);
 
   /* Faded */
   &.isFaded {
@@ -42,31 +42,31 @@
  */
 
 .sizeXxSmall { /* default browser h6 proportion */
-  font-size: 0.67rem;
+  font-size: var(--xxSmallFontSize);
 }
 
 .sizeXSmall {
-  font-size: 0.75rem;
+  font-size: var(--xSmallFontSize);
 }
 
 .sizeSmall { /* default browser h5 proportion */
-  font-size: 0.83rem;
+  font-size: var(--smallFontSize);
 }
 
 .sizeMedium { /* default browser h4 proportion */
-  font-size: 1rem;
+  font-size: var(--mediumFontSize);
 }
 
 .sizeLarge { /* default browser h3 proportion */
-  font-size: 1.17rem;
+  font-size: var(--largeFontSize);
 }
 
 .sizeXLarge { /* default browser h2 proportion */
-  font-size: 1.50rem;
+  font-size: var(--xLargeFontSize);
 }
 
 .sizeXxLarge { /* default browser h1 proportion */
-  font-size: 2rem;
+  font-size: var(--xxLargeFontSize);
 }
 
 /**

--- a/lib/Headline/Headline.js
+++ b/lib/Headline/Headline.js
@@ -46,7 +46,7 @@ Headline.defaultProps = {
   bold: true,
   faded: false,
   margin: '', // Determined by size if nothing is set
-  size: 'small',
+  size: 'medium',
   tag: 'div',
 };
 
@@ -58,13 +58,17 @@ Headline.propTypes = {
   faded: PropTypes.bool,
   flex: PropTypes.bool,
   margin: PropTypes.oneOf([ // If nothing is set it will default to the value of size
+    'xx-small',
+    'x-small',
     'small',
     'medium',
     'large',
+    'x-large',
+    'xx-large',
     'none',
     ''
   ]),
-  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  size: PropTypes.oneOf(['xx-small', 'x-small', 'small', 'medium', 'large', 'x-large', 'xx-large']),
   tag: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'div', 'legend']),
 };
 

--- a/lib/Headline/readme.md
+++ b/lib/Headline/readme.md
@@ -14,8 +14,8 @@ Renders headlines in different sizes and with different tags, margins and styles
 Name | Type | Description | Options | Default
 --- | --- | --- | --- | ---
 children | node | Alternative way to set the label of the headline | | |
-size | string | The size of the headline | small, medium, large | small
-margin | string | The bottom margin of the component. Automatically matches the size-prop. | small, medium, large, none | small
+size | string | The size of the headline | xx-small, x-small, small, medium, large, x-large, xx-large | medium
+margin | string | The bottom margin of the component. Automatically matches the size-prop. | xx-small, x-small, small, medium, large, x-large, xx-large, none | medium
 tag | string | The tag of the headline | h1, h2, h3, h4, h5, h6, p, div, legend | div
 faded | boolean | Adds faded style to headline (gray color) | true/false | false
 bold | boolean | Adds bold style to headline | true/false | true

--- a/lib/Headline/stories/BasicUsage.js
+++ b/lib/Headline/stories/BasicUsage.js
@@ -7,6 +7,12 @@ import Headline from '../Headline';
 
 const BasicUsage = () => (
   <div>
+    <Headline size="xx-small">
+      XX Small Headline
+    </Headline>
+    <Headline size="x-small">
+      X Small Headline
+    </Headline>
     <Headline size="small">
       Small Headline
     </Headline>
@@ -15,6 +21,12 @@ const BasicUsage = () => (
     </Headline>
     <Headline size="large">
       Large Headline
+    </Headline>
+    <Headline size="x-large">
+      X Large Headline
+    </Headline>
+    <Headline size="xx-large">
+      XX Large Headline
     </Headline>
     <hr />
     <Headline size="large" margin="none" faded>

--- a/lib/Icon/stories/style.css
+++ b/lib/Icon/stories/style.css
@@ -27,7 +27,6 @@
 }
 
 .iconGridItem p {
-  font-size: 12px;
+  font-size: var(--xSmallFontSize);
   margin-top: 6px;
 }
-

--- a/lib/Icon/stories/style.css
+++ b/lib/Icon/stories/style.css
@@ -27,6 +27,6 @@
 }
 
 .iconGridItem p {
-  font-size: var(--xSmallFontSize);
+  font-size: var(--font-size-x-small);
   margin-top: 6px;
 }

--- a/lib/KeyValue/KeyValue.css
+++ b/lib/KeyValue/KeyValue.css
@@ -5,6 +5,8 @@
   font-weight: var(--text-weight-basis);
   margin-bottom: 2px;
   color: var(--color-text-p2);
+  font-size: var(--smallFontSize);
+  line-height: var(--lineHeight);
 }
 
 .kvRoot {

--- a/lib/KeyValue/KeyValue.css
+++ b/lib/KeyValue/KeyValue.css
@@ -5,8 +5,8 @@
   font-weight: var(--text-weight-basis);
   margin-bottom: 2px;
   color: var(--color-text-p2);
-  font-size: var(--smallFontSize);
-  line-height: var(--lineHeight);
+  font-size: var(--font-size-small);
+  line-height: var(--line-height);
 }
 
 .kvRoot {

--- a/lib/LayoutHeader/LayoutHeader.css
+++ b/lib/LayoutHeader/LayoutHeader.css
@@ -9,27 +9,27 @@
   min-height: 34px;
 
   & h1 {
-    font-size: var(--xxLargeFontSize);
+    font-size: var(--font-size-xx-large);
   }
 
   & h2 {
-    font-size: var(--xLargeFontSize);
+    font-size: var(--font-size-x-large);
   }
 
   & h3 {
-    font-size: var(--largeFontSize);
+    font-size: var(--font-size-large);
   }
 
   & h4 {
-    font-size: var(--mediumFontSize);
+    font-size: var(--font-size-medium);
   }
 
   & h5 {
-    font-size: var(--smallFontSize);
+    font-size: var(--font-size-small);
   }
 
   & h6 {
-    font-size: var(--xSmallFontSize);
+    font-size: var(--font-size-x-small);
   }
 }
 

--- a/lib/LayoutHeader/LayoutHeader.css
+++ b/lib/LayoutHeader/LayoutHeader.css
@@ -9,24 +9,27 @@
   min-height: 34px;
 
   & h1 {
-    font-size: 1.3rem;
+    font-size: var(--xxLargeFontSize);
   }
 
   & h2 {
-    font-size: 1.2 rem;
+    font-size: var(--xLargeFontSize);
   }
 
   & h3 {
-    font-size: 1rem;
+    font-size: var(--largeFontSize);
   }
 
   & h4 {
-    font-size: 0.9rem;
+    font-size: var(--mediumFontSize);
   }
 
-  & h5,
+  & h5 {
+    font-size: var(--smallFontSize);
+  }
+
   & h6 {
-    font-size: 0.8rem;
+    font-size: var(--xSmallFontSize);
   }
 }
 

--- a/lib/Modal/Modal.css
+++ b/lib/Modal/Modal.css
@@ -56,7 +56,7 @@
   overflow: auto;
   width: 100%;
   max-height: calc(100% - 44px - 2rem);
-  line-height: var(--lineHeight);
+  line-height: var(--line-height);
 }
 
 .modalControls {

--- a/lib/Modal/Modal.css
+++ b/lib/Modal/Modal.css
@@ -56,6 +56,7 @@
   overflow: auto;
   width: 100%;
   max-height: calc(100% - 44px - 2rem);
+  line-height: var(--lineHeight);
 }
 
 .modalControls {

--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -85,9 +85,10 @@
   align-items: center;
   flex-shrink: 0;
   flex-grow: 0;
-  padding: 6px 5px;
+  padding: 0.5em;
   font-weight: 600;
   color: var(--color-text-p2);
+  font-size: var(--smallFontSize);
 
   &.clickable {
     cursor: pointer;
@@ -111,7 +112,7 @@
   align-items: center;
   flex-shrink: 0;
   flex-grow: 0;
-  padding: 5px 10px;
+  padding: 0.5em 0.67em;
   overflow: hidden;
 
   &.showOverflow {

--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -88,7 +88,7 @@
   padding: 0.5em;
   font-weight: 600;
   color: var(--color-text-p2);
-  font-size: var(--smallFontSize);
+  font-size: var(--font-size-small);
 
   &.clickable {
     cursor: pointer;

--- a/lib/PaneHeader/PaneHeader.css
+++ b/lib/PaneHeader/PaneHeader.css
@@ -64,7 +64,7 @@
 
 /* Pane title */
 .paneTitle {
-  font-size: var(--smallFontSize);
+  font-size: var(--font-size-small);
   font-weight: 600;
   align-items: center;
   letter-spacing: 0.04em;
@@ -79,7 +79,7 @@
 /* Pane sub */
 .paneSub {
   color: var(--color-text-p2);
-  font-size: var(--xSmallFontSize);
+  font-size: var(--font-size-x-small);
   line-height: 1.2;
 }
 

--- a/lib/PaneHeader/PaneHeader.css
+++ b/lib/PaneHeader/PaneHeader.css
@@ -64,7 +64,7 @@
 
 /* Pane title */
 .paneTitle {
-  font-size: inherit;
+  font-size: var(--smallFontSize);
   font-weight: 600;
   align-items: center;
   letter-spacing: 0.04em;
@@ -79,7 +79,7 @@
 /* Pane sub */
 .paneSub {
   color: var(--color-text-p2);
-  font-size: 11px;
+  font-size: var(--xSmallFontSize);
   line-height: 1.2;
 }
 

--- a/lib/RadioButton/RadioButton.css
+++ b/lib/RadioButton/RadioButton.css
@@ -33,6 +33,7 @@
   flex-grow: 2;
   color: var(--color-text-p2);
   border-radius: var(--radius);
+  font-size: var(--smallFontSize);
 
   &.error {
     color: var(--error);

--- a/lib/RadioButton/RadioButton.css
+++ b/lib/RadioButton/RadioButton.css
@@ -31,9 +31,8 @@
   min-height: 24px;
   cursor: pointer;
   flex-grow: 2;
-  color: var(--color-text-p2);
   border-radius: var(--radius);
-  font-size: var(--smallFontSize);
+  font-size: var(--mediumFontSize);
 
   &.error {
     color: var(--error);

--- a/lib/RadioButton/RadioButton.css
+++ b/lib/RadioButton/RadioButton.css
@@ -32,7 +32,7 @@
   cursor: pointer;
   flex-grow: 2;
   border-radius: var(--radius);
-  font-size: var(--mediumFontSize);
+  font-size: var(--font-size-medium);
 
   &.error {
     color: var(--error);

--- a/lib/RadioButtonGroup/RadioButtonGroup.css
+++ b/lib/RadioButtonGroup/RadioButtonGroup.css
@@ -6,7 +6,7 @@
 
 .groupLabel {
   display: block;
-  font-size: var(--mediumFontSize);
+  font-size: var(--smallFontSize);
   font-weight: var(--text-weight-basis);
   color: var(--color-text);
 

--- a/lib/RadioButtonGroup/RadioButtonGroup.css
+++ b/lib/RadioButtonGroup/RadioButtonGroup.css
@@ -6,7 +6,7 @@
 
 .groupLabel {
   display: block;
-  font-size: 14px;
+  font-size: var(--mediumFontSize);
   font-weight: var(--text-weight-basis);
   color: var(--color-text);
 
@@ -24,7 +24,7 @@ legend.groupLabel {
 
 .groupFeedback {
   padding: 0 0.4rem;
-  font-size: 0.8rem;
+  font-size: var(-xSmallFontSize);
 
   &:last-child {
     margin-bottom: var(--controlMarginBottom);

--- a/lib/RadioButtonGroup/RadioButtonGroup.css
+++ b/lib/RadioButtonGroup/RadioButtonGroup.css
@@ -6,7 +6,7 @@
 
 .groupLabel {
   display: block;
-  font-size: var(--smallFontSize);
+  font-size: var(--font-size-small);
   font-weight: var(--text-weight-basis);
   color: var(--color-text);
 
@@ -24,7 +24,7 @@ legend.groupLabel {
 
 .groupFeedback {
   padding: 0 0.4rem;
-  font-size: var(-xSmallFontSize);
+  font-size: var(--font-size-x-small);
 
   &:last-child {
     margin-bottom: var(--controlMarginBottom);

--- a/lib/TextField/stories/BasicUsage.js
+++ b/lib/TextField/stories/BasicUsage.js
@@ -21,19 +21,17 @@ const BasicUsage = () => (
       />
       <Button type="submit">Submit</Button>
     </form>
-    <br />
+    <hr />
     <TextField
       value="This field can't be changed"
       label="Read only field"
       readOnly
     />
-    <br />
     <TextField
       value="This field is disabled"
       label="Disabled field"
       disabled
     />
-    <br />
     <TextField
       validStylesEnabled
       value="Good value"
@@ -42,27 +40,23 @@ const BasicUsage = () => (
       valid
       dirty
     />
-    <br />
     <TextField
       label="Field with a validation error"
       value="Wrong value.."
       error="Here is an error message"
       touched
     />
-    <br />
     <TextField
       label="Field with validation warning"
       value="Not entirely valid value.."
       warning="Here is a warning"
       touched
     />
-    <br />
     <TextField
       label="Loading field"
       placeholder="Check out the spinner!"
       loading
     />
-    <br />
     <TextField
       label="Field with startControl and endControl props"
       startControl={<Icon icon="search" />}

--- a/lib/Timepicker/TimeDropdown.css
+++ b/lib/Timepicker/TimeDropdown.css
@@ -17,7 +17,7 @@
 
 .timepickerDropdownInput {
   padding: 0 10px;
-  font-size: 1.3rem;
+  font-size: var(--largeFontSize);
   width: 100%;
   margin-bottom: 0;
   text-align: center;

--- a/lib/Timepicker/TimeDropdown.css
+++ b/lib/Timepicker/TimeDropdown.css
@@ -17,7 +17,7 @@
 
 .timepickerDropdownInput {
   padding: 0 10px;
-  font-size: var(--largeFontSize);
+  font-size: var(--font-size-large);
   width: 100%;
   margin-bottom: 0;
   text-align: center;

--- a/lib/sharedStyles/form.css
+++ b/lib/sharedStyles/form.css
@@ -21,7 +21,9 @@
  */
 .label {
   display: block;
-  margin-bottom: 6px;
+  font-size: var(--smallFontSize);
+  line-height: var(--lineHeight);
+  margin-bottom: 0.5em;
   color: var(--color-text);
 
   &.required::after {
@@ -132,7 +134,7 @@ textarea.input {
 
 .feedbackBlock {
   padding: 0 var(--input-vertical-padding);
-  font-size: 0.9em;
+  font-size: var(--smallFontSize);
 
   &:last-child {
     margin-bottom: var(--controlMarginBottom);

--- a/lib/sharedStyles/form.css
+++ b/lib/sharedStyles/form.css
@@ -21,8 +21,8 @@
  */
 .label {
   display: block;
-  font-size: var(--smallFontSize);
-  line-height: var(--lineHeight);
+  font-size: var(--font-size-small);
+  line-height: var(--line-height);
   margin-bottom: 0.5em;
   color: var(--color-text);
 
@@ -134,7 +134,7 @@ textarea.input {
 
 .feedbackBlock {
   padding: 0 var(--input-vertical-padding);
-  font-size: var(--smallFontSize);
+  font-size: var(--font-size-small);
 
   &:last-child {
     margin-bottom: var(--controlMarginBottom);

--- a/lib/variables.css
+++ b/lib/variables.css
@@ -35,7 +35,7 @@
    * Size ratios from Fonts Module Level 3
    * https://www.w3.org/TR/css-fonts-3/#propdef-font-size
    */
-  --lineHeight: 1.4;
+  --lineHeight: 1.5;
   --xxSmallFontSize: 0.67rem;
   --xSmallFontSize: 0.75rem;
   --smallFontSize: 0.83rem;

--- a/lib/variables.css
+++ b/lib/variables.css
@@ -35,14 +35,14 @@
    * Size ratios from Fonts Module Level 3
    * https://www.w3.org/TR/css-fonts-3/#propdef-font-size
    */
-  --lineHeight: 1.5;
-  --xxSmallFontSize: 0.67rem;
-  --xSmallFontSize: 0.75rem;
-  --smallFontSize: 0.83rem;
-  --mediumFontSize: 1rem;
-  --largeFontSize: 1.17rem;
-  --xLargeFontSize: 1.5rem;
-  --xxLargeFontSize: 2rem;
+  --line-height: 1.5;
+  --font-size-xx-small: 0.67rem;
+  --font-size-x-small: 0.75rem;
+  --font-size-small: 0.83rem;
+  --font-size-medium: 1rem;
+  --font-size-large: 1.17rem;
+  --font-size-x-large: 1.5rem;
+  --font-size-xx-large: 2rem;
 
   /**
    * Font-weights

--- a/lib/variables.css
+++ b/lib/variables.css
@@ -23,24 +23,26 @@
   --danger: #900;
   --warn: #e27c3e;
   --success: #070;
-  --controlMarginBottom: 12px;
+  --controlMarginBottom: 1rem;
   --controlHeight: 24px;
   --radius: 6px;
-  --gutter: 15px;
+  --gutter: 1rem;
   --controlHeightSmall: 44px;
   --controlHeightTouch: var(--controlHeightSmall);
 
   /**
-   * Deprecated
+   * Font-size
+   * Size ratios from Fonts Module Level 3
+   * https://www.w3.org/TR/css-fonts-3/#propdef-font-size
    */
-  --bodyColor: var(--color-text);
-  --subLabelColor: var(--color-text-p2);
-  --labelColor: var(--color-text-p2);
-  --inputBorderColor: var(--color-border-p2);
-  --minor-divider-color: var(--color-border-p2);
-  --major-padding: var(--gutter);
-  --linkColor: var(--color-link);
-  --linkColorVisited: var(--color-link-visited);
+  --lineHeight: 1.4;
+  --xxSmallFontSize: 0.67rem;
+  --xSmallFontSize: 0.75rem;
+  --smallFontSize: 0.83rem;
+  --mediumFontSize: 1rem;
+  --largeFontSize: 1.17rem;
+  --xLargeFontSize: 1.5rem;
+  --xxLargeFontSize: 2rem;
 
   /**
    * Font-weights
@@ -54,6 +56,18 @@
   --text-weight-headline: calc(var(--text-weight-headline-basis) + ( var(--text-weight-headline-addition-factor) * var(--text-weights-are-bolder)));
   --text-weight-button: var(--text-weight);
   --text-weight-button-primary: calc(var(--text-weight-headline-basis) + ( var(--text-weight-headline-addition-factor) * var(--text-weights-are-bolder)));
+
+  /**
+   * Deprecated
+   */
+  --bodyColor: var(--color-text);
+  --subLabelColor: var(--color-text-p2);
+  --labelColor: var(--color-text-p2);
+  --inputBorderColor: var(--color-border-p2);
+  --minor-divider-color: var(--color-border-p2);
+  --major-padding: var(--gutter);
+  --linkColor: var(--color-link);
+  --linkColorVisited: var(--color-link-visited);
 }
 
 /* Lean on min-width queries to create mobile-first CSS. */


### PR DESCRIPTION
## Purpose
Have enough levels of hierarchy in font sizes (esp. for headlines) that laying out pages is easy.

## Approach
I created these variables, based on the very fresh CSS Fonts Module Level 3 recommendation:  https://www.w3.org/TR/css-fonts-3/#propdef-font-size
```
  --font-size-xx-small: 0.67rem;
  --font-size-x-small: 0.75rem;
  --font-size-small: 0.83rem;
  --font-size-medium: 1rem;
  --font-size-large: 1.17rem;
  --font-size-x-large: 1.5rem;
  --font-size-xx-large: 2rem;
```
The global base is set at 16px, as of https://github.com/folio-org/stripes-components/pull/611

I then updated every use of `font-size` in `stripes-components` to use one of those seven sizes.

The biggest restriction was that the font size of `<input>` elements need to be >=16px.

## Results
I generally set `<label>` and label-like elements to `--font-size-small`:

<img width="649" alt="screen shot 2018-09-28 at 10 03 51 pm" src="https://user-images.githubusercontent.com/230597/46240277-80397900-c36a-11e8-955f-6597cf58ef34.png">

<img width="148" alt="screen shot 2018-09-28 at 10 04 36 pm" src="https://user-images.githubusercontent.com/230597/46240278-83cd0000-c36a-11e8-9f1f-248c9b86704f.png">

Pane headers:
<img width="519" alt="screen shot 2018-09-28 at 10 05 03 pm" src="https://user-images.githubusercontent.com/230597/46240280-92b3b280-c36a-11e8-80e5-3d9599fed02c.png">

Modals:
<img width="783" alt="screen shot 2018-09-28 at 10 05 36 pm" src="https://user-images.githubusercontent.com/230597/46240286-a52dec00-c36a-11e8-8c58-8d80ae632e5e.png">

Buttons, at "small" font size by default:
<img width="359" alt="screen shot 2018-09-29 at 8 46 19 am" src="https://user-images.githubusercontent.com/230597/46246500-66c51b00-c3c4-11e8-9917-c20104df6bd0.png">

Filter groups:
<img width="166" alt="screen shot 2018-09-30 at 11 55 25 am" src="https://user-images.githubusercontent.com/230597/46260113-cea06200-c4a7-11e8-9a4e-64e51e6c3297.png">

Headlines:
<img width="281" alt="screen shot 2018-09-28 at 10 10 00 pm" src="https://user-images.githubusercontent.com/230597/46240323-4fa60f00-c36b-11e8-95ce-909492505e0c.png">


## Next steps
We'll probably want to tweak what size certain components use, but this stack should last as a flexible set of sizes that match the proportions browser vendors have converged on. Nearly any `font-size` declaration in any FOLIO module should use one of these variables.