### PR TITLE
STCOM-354 Use input type="search" for SearchField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-components
 
+## 3.3.0 (IN PROGRESS)
+
+* Use input type="search" for `<SearchField>`
+
 ## [3.2.0](https://github.com/folio-org/stripes-components/tree/v3.2.0) (2018-09-28)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v3.1.0...v3.2.0)
 

--- a/lib/SearchField/SearchField.js
+++ b/lib/SearchField/SearchField.js
@@ -100,6 +100,7 @@ const SearchField = (props) => {
         onClearField={onClear}
         placeholder={inputPlaceholder}
         startControl={!hasSearchableIndexes ? searchIcon : null}
+        type="search"
         value={value || ''}
       />
     </div>


### PR DESCRIPTION
## Purpose
Related to https://issues.folio.org/browse/STCOM-354

## Approach
`normalize.css` takes care of the style nuances of `input type="search"`:
```
/**
 * 1. Correct the odd appearance in Chrome and Safari.
 * 2. Correct the outline style in Safari.
 */

[type="search"] {
  -webkit-appearance: textfield; /* 1 */
  outline-offset: -2px; /* 2 */
}

/**
 * Remove the inner padding and cancel buttons in Chrome and Safari on macOS.
 */

[type="search"]::-webkit-search-cancel-button,
[type="search"]::-webkit-search-decoration {
  -webkit-appearance: none;
}
```