### PR TITLE
STCOM-355 Add padding to accordion content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Use input type="search" for `<SearchField>`
 * Create wider type stack
+* Add padding to accordion content
 
 ## [3.2.0](https://github.com/folio-org/stripes-components/tree/v3.2.0) (2018-09-28)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v3.1.0...v3.2.0)

--- a/lib/Accordion/Accordion.css
+++ b/lib/Accordion/Accordion.css
@@ -73,7 +73,7 @@
 .content {
   max-height: 0; /* hidden */
   overflow: hidden;
-  padding: 0.5em 0 1em 1.5em;
+  margin: 0.5em 0 1em 1.5em;
   transition: max-height 0.25s ease;
 
   &.expanded {

--- a/lib/Accordion/Accordion.css
+++ b/lib/Accordion/Accordion.css
@@ -73,6 +73,7 @@
 .content {
   max-height: 0; /* hidden */
   overflow: hidden;
+  padding: 0.5em 0 1em 1.5em;
   transition: max-height 0.25s ease;
 
   &.expanded {

--- a/lib/FilterControlGroup/FilterControlGroup.css
+++ b/lib/FilterControlGroup/FilterControlGroup.css
@@ -1,7 +1,8 @@
 @import "../variables";
 
 .filterList {
-  padding: 0 0 0 10px;
+  margin: -0.5em 0 0 -1em;
+  padding: 0;
   border-radius: var(--radius);
 }
 


### PR DESCRIPTION
Resolves https://issues.folio.org/browse/STCOM-355

<img width="676" alt="screen shot 2018-10-01 at 12 44 24 pm" src="https://user-images.githubusercontent.com/230597/46305771-f9f28200-c577-11e8-8d87-fb1c38adbc41.png">

Filter groups were already good, but needed some CSS changes to override the new defaults:

<img width="168" alt="screen shot 2018-10-01 at 12 44 33 pm" src="https://user-images.githubusercontent.com/230597/46305770-f959eb80-c577-11e8-81f7-85125b9329c3.png">