### PR TITLE
STCOM-356 Remove child.type checks

### DIFF
--- a/lib/DropdownMenu/DropdownMenu.js
+++ b/lib/DropdownMenu/DropdownMenu.js
@@ -3,7 +3,6 @@ import React, { cloneElement } from 'react';
 import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
 import PropTypes from 'prop-types';
 import separateComponentProps from '../../util/separateComponentProps';
-import MenuItem from '../MenuItem';
 import css from './DropdownMenu.css';
 
 const propTypes = {
@@ -69,19 +68,16 @@ class DropdownMenu extends React.Component {
   renderChildren() {
     const { children, onSelectItem, onSelect } = this.props;
     return React.Children.map(React.Children.toArray(children), (child) => {
-      if (child.type === MenuItem) {
-        return cloneElement(child,
-          Object.assign(
-            {},
-            child.props,
-            {
-              onSelectItem,
-              onSelect,
-            },
-          ),
-          child.props.children);
-      }
-      return child;
+      return cloneElement(child,
+        Object.assign(
+          {},
+          child.props,
+          {
+            onSelectItem,
+            onSelect,
+          },
+        ),
+        child.props.children);
     });
   }
 

--- a/lib/RadioButtonGroup/RadioButtonGroup.js
+++ b/lib/RadioButtonGroup/RadioButtonGroup.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import RadioButton from '../RadioButton';
 import css from './RadioButtonGroup.css';
 
 const propTypes = {
@@ -20,7 +19,6 @@ function RadioButtonGroup(props) {
   const { label, ...inputCustom } = { ...rest };
   const displayedChildren = React.Children.map(props.children,
     (child) => {
-      if (child.type !== RadioButton) { return child; }
       const newProps = { ...inputAttr, ...inputCustom };
       newProps.checked = selected.toString() === child.props.value;
       newProps.marginBottom0 = true;

--- a/lib/SegmentedControl/SegmentedControl.js
+++ b/lib/SegmentedControl/SegmentedControl.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import css from './SegmentedControl.css';
-import Button from '../Button';
 import createChainedFunction from '../../util/createChainedFunction';
 
 const propTypes = {
@@ -24,39 +23,35 @@ const SegmentedControl = (props) => {
   const Tag = props.tag;
 
   const renderedChildren = React.Children.map(props.children, (child, i) => {
-    if (child.type === Button) {
-      const childDecoration = child.props.id === props.activeId ? 'primary noLRMargin' : 'noLRMargin default';
-      let childRadius;
-      const lastIndex = React.Children.count(props.children) - 1;
-      if (i === 0) {
-        if (i === lastIndex) {
-          childRadius = ''; // if there's only one button in the nav, it just gets the standard radius.
-        } else {
-          childRadius = 'noRightRadius lastBorderOnly';
-        }
-      } else if (i === lastIndex) {
-        childRadius = 'noLeftRadius';
+    const childDecoration = child.props.id === props.activeId ? 'primary noLRMargin' : 'noLRMargin default';
+    let childRadius;
+    const lastIndex = React.Children.count(props.children) - 1;
+    if (i === 0) {
+      if (i === lastIndex) {
+        childRadius = ''; // if there's only one button in the nav, it just gets the standard radius.
       } else {
-        childRadius = 'noRadius lastBorderOnly';
+        childRadius = 'noRightRadius lastBorderOnly';
       }
-      const childStyle = `${childDecoration} ${childRadius}`;
-      const btn = React.cloneElement(
-        child,
-        Object.assign({}, child.props, {
-          fullWidth: true,
-          buttonStyle: childStyle,
-          onClick: createChainedFunction(child.props.onClick, () => props.onActivate({ id: child.props.id })),
-        }),
-        child.props.children,
-      );
-      return (
-        <div className={css.segment}>
-          {btn}
-        </div>
-      );
+    } else if (i === lastIndex) {
+      childRadius = 'noLeftRadius';
+    } else {
+      childRadius = 'noRadius lastBorderOnly';
     }
-
-    return child;
+    const childStyle = `${childDecoration} ${childRadius}`;
+    const btn = React.cloneElement(
+      child,
+      Object.assign({}, child.props, {
+        fullWidth: true,
+        buttonStyle: childStyle,
+        onClick: createChainedFunction(child.props.onClick, () => props.onActivate({ id: child.props.id })),
+      }),
+      child.props.children,
+    );
+    return (
+      <div className={css.segment}>
+        {btn}
+      </div>
+    );
   });
 
   return (


### PR DESCRIPTION
`react-hot-loader` prevents accurate `type` evaluations of children: https://issues.folio.org/browse/STCOM-356

By disabling these checks, these components are easier to misuse, but if they're used as intended and documented, everything should be fine.