### PR TITLE
Remove deprecated props from Datepicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Remove `<Settings>`; it's now in `stripes-smart-components`
 * Remove deprecated util functions
 * Remove old version of `<RepeatableField>`
+* Remove deprecated props from `<Datepicker>`
 
 ## [3.3.0](https://github.com/folio-org/stripes-components/tree/v3.3.0) (2018-10-01)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v3.2.0...v3.3.0)

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { intlShape } from 'react-intl';
 import PropTypes from 'prop-types';
-import { deprecated } from 'prop-types-extra';
 import TetherComponent from 'react-tether';
 import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
 import moment from 'moment-timezone';
@@ -23,14 +22,8 @@ const propTypes = {
   dateFormat: PropTypes.string,
   disabled: PropTypes.bool,
   exclude: PropTypes.func,
-  excludeDates: deprecated(PropTypes.oneOfType([
-    PropTypes.array,
-    PropTypes.object,
-    PropTypes.string,
-  ]), 'Use `exclude` property instead'),
   hideOnChoose: PropTypes.bool,
   id: PropTypes.string,
-  ignoreLocalOffset: deprecated(PropTypes.bool, 'Use timeZone="UTC" instead'),
   input: PropTypes.object,
   intl: intlShape.isRequired,
   label: PropTypes.string,
@@ -38,7 +31,6 @@ const propTypes = {
   meta: PropTypes.object,
   onChange: PropTypes.func,
   onSetDate: PropTypes.func,
-  passThroughValue: deprecated(PropTypes.string, 'Use alternative design'),
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
   screenReaderMessage: PropTypes.string,
@@ -73,16 +65,6 @@ const defaultProps = {
   useFocus: true,
 };
 
-const isSameDay = (a, b) => {
-  if (moment.isMoment(a) && moment.isMoment(b)) {
-    return a.isSame(b, 'day');
-  }
-  if (moment.isMoment(a) && typeof b === 'string') {
-    return a.isSame(moment(b), 'day');
-  }
-  return false;
-};
-
 class Datepicker extends React.Component {
   static propTypes = propTypes;
   static defaultProps = defaultProps;
@@ -98,8 +80,7 @@ class Datepicker extends React.Component {
 
     // Set time zone
     this.timeZone = props.timeZone || props.intl.timeZone;
-
-    const parseTimeZone = props.ignoreLocalOffset ? 'UTC' : this.timeZone;
+    const parseTimeZone = this.timeZone;
 
     this.locale = props.locale || props.intl.locale;
 
@@ -116,14 +97,9 @@ class Datepicker extends React.Component {
     let presentedValue = null;
 
     // if we aren't using redux form...
-    if (typeof this.props.input === 'undefined') {
-      if (this.props.value === this.props.passThroughValue && typeof this.props.date === 'undefined') {
-        presentedValue = this.props.passThroughValue;
-        inputValue = moment.tz(parseTimeZone).format(this._dateFormat);
-      }
-      // if we are using redux-form...
-    } else if (this.props.input.value === this.props.passThroughValue) {
-      presentedValue = this.props.passThroughValue;
+    if ((typeof this.props.input === 'undefined' && typeof this.props.date === 'undefined')
+      || this.props.input.value === '') {
+      presentedValue = '';
       inputValue = moment.tz(parseTimeZone).format(this._dateFormat);
     } else if (this.props.input.value !== '') {
       inputValue = moment(this.props.input.value, this._dateFormat)
@@ -152,42 +128,24 @@ class Datepicker extends React.Component {
   static getDerivedStateFromProps(nextProps, prevState) {
     // When the selected date has changed, update the state with it
     let inputValue;
-    let presentedValue = null;
     const _dateFormat = prevState._dateFormat;
     if (nextProps.input) {
       if (nextProps.input.value !== '' && nextProps.input.value !== prevState.input.value) {
-        const passRE = new RegExp(`^${nextProps.input.value}`, 'i');
-        if (nextProps.input.value === prevState.passThroughValue || passRE.test(prevState.passThroughValue)) {
-          presentedValue = nextProps.input.value;
-          inputValue = moment.tz(prevState.parseTimeZone).format(_dateFormat);
-        } else {
-          inputValue = moment.tz(nextProps.input.value, prevState.parseTimeZone).format(_dateFormat);
-          presentedValue = inputValue;
-        }
+        inputValue = moment.tz(nextProps.input.value, prevState.parseTimeZone).format(_dateFormat);
         return {
-          presentedValue,
           dateString: inputValue,
-          input: nextProps.input,
-          passThroughValue: nextProps.passThroughValue,
+          input: nextProps.input
         };
       } else if (nextProps.input.value === '' && nextProps.input.value !== prevState.input.value) {
         inputValue = '';
         return {
-          presentedValue,
           dateString: inputValue,
-          input: nextProps.input,
-          passThroughValue: nextProps.passThroughValue,
+          input: nextProps.input
         };
       }
     } else if (prevState.value !== '' && prevState.date !== nextProps.date) {
-      if (nextProps.value === this.props.passThroughValue && nextProps.date === 'undefined') {
-        inputValue = moment.tz(prevState.parseTimeZone).format(_dateFormat);
-        presentedValue = this.props.passThroughValue;
-      } else {
-        inputValue = moment.tz(prevState.parseTimeZone).format(_dateFormat);
-      }
+      inputValue = moment.tz(prevState.parseTimeZone).format(_dateFormat);
       return {
-        presentedValue,
         dateString: inputValue,
         value: nextProps.value,
         date: nextProps.date,
@@ -378,18 +336,7 @@ class Datepicker extends React.Component {
     if (e.target.value === '') {
       this.clearDate();
     } else {
-      const ptREx = new RegExp(`^${e.target.value}`, 'i');
-      if (ptREx.test(this.props.passThroughValue)) {
-        if (this.props.onChange) { this.props.onChange(e); }
-        if (this.props.input.onChange) {
-          this.props.input.onChange(e.target.value);
-        }
-        this.setState({
-          presentedValue: e.target.value,
-        });
-      } else {
-        this.handleSetDate(e, e.target.value, e.target.value);
-      }
+      this.handleSetDate(e, e.target.value, e.target.value);
     }
   }
 
@@ -402,22 +349,6 @@ class Datepicker extends React.Component {
     if (this.props.input.onChange) {
       this.props.input.onChange('');
     }
-  }
-
-  deprecatedExcludeDates = date => {
-    const { excludeDates } = this.props;
-
-    if (Array.isArray(excludeDates)) {
-      return excludeDates.reduce((shouldExclude, excluded) => {
-        if (shouldExclude) {
-          return true;
-        } else {
-          return isSameDay(date, excluded);
-        }
-      }, false);
-    }
-
-    return isSameDay(date, excludeDates);
   }
 
   cleanForScreenReader(str) {
@@ -477,7 +408,7 @@ class Datepicker extends React.Component {
   }
 
   renderCalendar() {
-    const { excludeDates, exclude } = this.props;
+    const { exclude } = this.props;
 
     return (
       <RootCloseWrapper onRootClose={this.handleRootClose}>
@@ -489,7 +420,7 @@ class Datepicker extends React.Component {
           onKeyDown={this.handleKeyDown}
           onBlur={this.hideCalendar}
           locale={this.locale}
-          exclude={excludeDates ? this.deprecatedExcludeDates : exclude}
+          exclude={exclude}
           id={this.testId}
         />
       </RootCloseWrapper>

--- a/lib/Datepicker/readme.md
+++ b/lib/Datepicker/readme.md
@@ -18,14 +18,10 @@ Name | type | description | default | required
 `useFocus` | bool | if set to false, component relies solely on clicking the calendar icon to toggle appearance of calendar. | true | false
 `autoFocus` | bool | If this prop is `true`, component will automatically focus on mount | |
 `disabled` | bool | if true, field will be disabled for focus or entry. | false | false
-`ignoreLocalOffset` (deprecated)  | bool | if true, ignores the time zone setting and treats the date as UTC to display the date.
-| false | false. See below for more explanation
 `readOnly` | bool | if true, field will be readonly. 'Calendar' and 'clear' buttons will be omitted. | false | false
 `value` | string | date to be displayed in the textfield. In forms, this is supplied by the initialValues prop supplied to the form | "" | false
 `onChange` | func | Event handler to handle updates to the datefield text. | | false
 `screenReaderMessage` | string | Additional message to be read by screenreaders when textfield is focused in addition to the label and format - which are always read. | | false
-`excludeDates` (deprecated)  | array, string or Moment object | Disables supplied dates from being selected in the calendar. | | false
-`passThroughValue` (deprecated) | string | Can be used to set dynamic values up to the form - values should be inspected/adjusted in a handler at submission time (like a button click that calls `submit()`.) See below for usage example. |  |
 `timeZone` | string | Overrides the time zone provided by context. | "UTC" | false
 `locale` | string | Overrides the locale provided by context. | "en" | false
 

--- a/lib/Datepicker/tests/Datepicker-ReduxForm-test.js
+++ b/lib/Datepicker/tests/Datepicker-ReduxForm-test.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import { describe, beforeEach, afterEach, it } from '@bigtest/mocha';
+import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 import mock from 'jest-mock';
-import moment from 'moment';
 import { Field } from 'redux-form';
 import TestForm from '../../../tests/TestForm';
 
@@ -403,100 +402,6 @@ describe('Datepicker with Redux Form integration', () => {
       it('returns an RFC2822 datetime string for specific time zone', () => {
         expect(onChange.mock.calls[0][1]).to.equal('2018');
       });
-    });
-  });
-
-  describe('excludeDates prop', () => {
-    let error;
-
-    describe('string value', () => {
-      beforeEach(async () => {
-        error = console.error;
-        console.error = mock.fn();
-
-        await mountWithContext(
-          <TestForm initialValues={{ calendar: '04/05/2018' }}>
-            <Field
-              name="calendar"
-              component={Datepicker}
-              excludeDates="04/01/2018"
-            />
-          </TestForm>
-        );
-
-        await datepicker.clickInput();
-      });
-
-      afterEach(() => { console.error = error; });
-
-      it('logs a deprecation warning', () => {
-        expect(console.error.mock.calls.length).to.equal(1);
-        expect(console.error.mock.calls[0][0]).to.have.string('The prop `excludeDates` of `Datepicker` is deprecated.');
-      });
-
-      it('excludes the passed in date', () => {
-        expect(datepicker.calendar.excludedDates).to.deep.equal(
-          ['04/01/2018']
-        );
-      });
-
-      it('makes excluded days disabled', () => {
-        expect(datepicker.calendar.days(0).disabled).to.be.true;
-      });
-    });
-
-    describe('multiple dates', () => {
-      beforeEach(async () => {
-        error = console.error;
-        console.error = mock.fn();
-
-        await mountWithContext(
-          <TestForm initialValues={{ calendar: '04/05/2018' }}>
-            <Field
-              name="calendar"
-              component={Datepicker}
-              excludeDates={['04/01/2018', moment('04/03/2018', 'MM/DD/YYYY')]}
-            />
-          </TestForm>
-        );
-
-        await datepicker.clickInput();
-      });
-
-      afterEach(() => { console.error = error; });
-
-      it('excludes multipe dates', () => {
-        expect(datepicker.calendar.excludedDates).to.deep.equal(
-          ['04/01/2018', '04/03/2018']
-        );
-      });
-
-      it('makes excluded days disabled', () => {
-        expect(datepicker.calendar.days(0).disabled).to.be.true;
-        expect(datepicker.calendar.days(2).disabled).to.be.true;
-      });
-    });
-  });
-
-  describe('ignoreLocalOffset deprecation', () => {
-    let error;
-
-    beforeEach(async () => {
-      error = console.error;
-      console.error = mock.fn();
-
-      await mountWithContext(
-        <Datepicker ignoreLocalOffset />
-      );
-    });
-
-    afterEach(() => { console.error = error; });
-
-    it('logs warning when used', () => {
-      expect(console.error.mock.calls.length).to.equal(1);
-      expect(console.error.mock.calls[0][0]).to.have.string(
-        'The prop `ignoreLocalOffset` of `Datepicker` is deprecated.'
-      );
     });
   });
 

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -191,62 +191,6 @@ describe('Datepicker', () => {
     });
   });
 
-  describe('passThroughValue', () => {
-    let onBlur;
-    let onChange;
-
-    beforeEach(async () => {
-      onBlur = mock.fn();
-      onChange = mock.fn();
-
-      await mountWithContext(
-        <Datepicker
-          passThroughValue="yesterday"
-          input={{
-            value: 'yesterday',
-            onBlur,
-            onChange
-          }}
-        />
-      );
-    });
-
-    it('has yesterday is in input field', () => {
-      expect(datepicker.inputValue).to.equal('yesterday');
-    });
-
-    describe.skip('blur the input field', () => {
-      beforeEach(async () => datepicker.focusInput());
-
-      it('does not have any day selected', () => {
-        expect(datepicker.calendar.selected).to.be.undefined;
-      });
-    });
-
-    describe.skip('clearing and typing in yesterday', () => {
-      beforeEach(async () => {
-        await datepicker.fillAndBlur('04/01/2018');
-        await datepicker.fillAndBlur('yesterday');
-      });
-
-      it('called onBlur twice', () => {
-        expect(onBlur.mock.calls.length).to.be.equal(2);
-      });
-
-      it('sends yesterday to onBlur', () => {
-        expect(onBlur.mock.calls[1]).to.be.equal('yesterday');
-      });
-
-      it('called onChange twice', () => {
-        expect(onChange.mock.calls.length).to.be.equal(2);
-      });
-
-      it('sends yesterday to onChange', () => {
-        expect(onChange.mock.calls[1]).to.be.equal('yesterday');
-      });
-    });
-  });
-
   describe('press enter opens the calendar', () => {
     beforeEach(async () => {
       await mountWithContext(<Datepicker />);


### PR DESCRIPTION
Removes `excludeDates`, `ignoreLocalOffset`, and `passThroughValue`.

There's definitely more refactoring to do here (with `reduxFormField()`'s help), but we get some nice deletions out of this.