### PR TITLE
Fix react/sort-comp for Callout

### DIFF
--- a/lib/Callout/Callout.js
+++ b/lib/Callout/Callout.js
@@ -18,12 +18,12 @@ class Callout extends React.Component {
     this.removeCallout = this.removeCallout.bind(this);
   }
 
-  updateCalloutContainer() {
-    this.calloutContainer = document.getElementById('OverlayContainer');
-  }
-
   componentDidMount() {
     this.updateCalloutContainer();
+  }
+
+  updateCalloutContainer() {
+    this.calloutContainer = document.getElementById('OverlayContainer');
   }
 
   sendCallout({ type = 'success', message, timeout = 6000 }) {


### PR DESCRIPTION
Introduced in https://github.com/folio-org/stripes-components/pull/633; was causing an ESLint ordering error.