### PR TITLE
Deprecate craftLayerUrl()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-components
 
+## 4.1.0 (IN PROGRESS)
+
+* Deprecate craftLayerUrl()
+
 ## [4.0.0](https://github.com/folio-org/stripes-components/tree/v4.0.0) (2018-10-02)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v3.3.0...v4.0.0)
 

--- a/util/craftLayerUrl.js
+++ b/util/craftLayerUrl.js
@@ -1,8 +1,13 @@
-import _ from 'lodash';
+import { includes } from 'lodash';
 
 function craftLayerUrl(mode) {
+  console.warn(
+    '\nWarning: craftLayerUrl() is deprecated and will be removed in the\n' +
+         'next major version of @folio/stripes-components.\n\n' +
+         '<SearchAndSort> now has its own craftLayerUrl().\n'
+  );
   const url = this.props.location.pathname + this.props.location.search;
-  return _.includes(url, '?') ? `${url}&layer=${mode}` : `${url}?layer=${mode}`;
+  return includes(url, '?') ? `${url}&layer=${mode}` : `${url}?layer=${mode}`;
 }
 
 export default craftLayerUrl;


### PR DESCRIPTION
`craftLayerUrl()` assists with `<SearchAndSort>`'s routing, and will be deprecated for any other use (modules should define their own routes, instead of relying on `<SearchAndSort>` to do it for them).