### PR TITLE
Datepicker - update presentedValue on change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Change history for stripes-components
+## 4.1.0
+* fix issue with `<Datepicker>` calendar not applying the chosen value to its `<TextField>`.
 
 ## [4.0.0](https://github.com/folio-org/stripes-components/tree/v4.0.0) (2018-10-02)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v3.3.0...v4.0.0)

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -133,12 +133,14 @@ class Datepicker extends React.Component {
       if (nextProps.input.value !== '' && nextProps.input.value !== prevState.input.value) {
         inputValue = moment.tz(nextProps.input.value, prevState.parseTimeZone).format(_dateFormat);
         return {
+          presentedValue: inputValue,
           dateString: inputValue,
           input: nextProps.input
         };
       } else if (nextProps.input.value === '' && nextProps.input.value !== prevState.input.value) {
         inputValue = '';
         return {
+          presentedValue: '',
           dateString: inputValue,
           input: nextProps.input
         };
@@ -515,7 +517,7 @@ class Datepicker extends React.Component {
       textfieldProps = {
         ...textfieldProps,
         meta: this.props.meta,
-        input,
+        input : { ...input, value: this.getPresentedValue() },
         onChange: this.handleFieldChange
       };
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
# Bug
Encountered an issue with an empty datepicker - clicking a date in the calendar would not allow me to set a date - but it worked to change the date after I entered some text in the textfield. This PR adds the `presentedValue` to the gDSFP call.