### PR TITLE
Update exports for stripes-v1.0.0 usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,4 +70,3 @@ export { default as ExportCsv } from './lib/ExportCsv';
 
 /* utilities */
 export { default as omitProps } from './util/omitProps';
-export { default as craftLayerUrl } from './util/craftLayerUrl';

--- a/index.js
+++ b/index.js
@@ -63,7 +63,11 @@ export { default as SearchField } from './lib/SearchField';
 
 /* specific use */
 export { default as FilterPane } from './lib/FilterPane';
-export { default as FilterGroups } from './lib/FilterGroups';
+export { default as FilterGroups, filterState, filters2cql, onChangeFilter } from './lib/FilterGroups';
 export { default as FilterControlGroup } from './lib/FilterControlGroup';
 export { default as FilterPaneSearch } from './lib/FilterPaneSearch';
 export { default as ExportCsv } from './lib/ExportCsv';
+
+/* utilities */
+export { default as omitProps } from './util/omitProps';
+export { default as craftLayerUrl } from './util/craftLayerUrl';


### PR DESCRIPTION
Changes for the conversion to `stripes v1.0.0`
* added exports of functions from `util` directory as needed by core-platform modules.
* add exports of a few named exports from `<FilterGroups>` - these should definitely go to stripes-smart-components as they relate most to the functionality of `SearchAndSort`