### PR TITLE
STCOM-292 Create new RepeatableField component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.1.0 (IN PROGRESS)
 
 * Deprecate craftLayerUrl()
+* Create new `<RepeatableField>`
 
 ## [4.0.0](https://github.com/folio-org/stripes-components/tree/v4.0.0) (2018-10-02)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v3.3.0...v4.0.0)

--- a/lib/ReduxFormFieldArray/ReduxFormFieldArray.js
+++ b/lib/ReduxFormFieldArray/ReduxFormFieldArray.js
@@ -1,0 +1,36 @@
+import React, { forwardRef } from 'react';
+import PropTypes from 'prop-types';
+
+const reduxFormFieldArray = (WrappedComponent, config) => {
+  function fieldArrayWithRef({ fields, meta, ...rest }, ref) {
+    if (meta !== undefined) {
+      return (
+        <WrappedComponent
+          ref={ref}
+          {...config({ fields, meta })}
+          {...rest}
+        />
+      );
+    } else {
+      return (
+        <WrappedComponent
+          fields={fields}
+          ref={ref}
+          {...rest}
+        />
+      );
+    }
+  }
+
+  const componentName = WrappedComponent.displayName || WrappedComponent.name;
+  fieldArrayWithRef.displayName = `reduxFormFieldArray(${componentName})`;
+
+  return forwardRef(fieldArrayWithRef);
+};
+
+reduxFormFieldArray.propTypes = {
+  config: PropTypes.func,
+  WrappedComponent: PropTypes.element.isRequired,
+};
+
+export default reduxFormFieldArray;

--- a/lib/ReduxFormFieldArray/index.js
+++ b/lib/ReduxFormFieldArray/index.js
@@ -1,0 +1,1 @@
+export { default } from './ReduxFormFieldArray';

--- a/lib/RepeatableField/RepeatableField.css
+++ b/lib/RepeatableField/RepeatableField.css
@@ -1,0 +1,26 @@
+@import "../variables.css";
+
+.repeatableField {
+  margin: 1em 0;
+  padding: 0;
+}
+
+.repeatableFieldList {
+  list-style-type: none;
+  padding: 0;
+}
+
+.repeatableFieldItem {
+  display: flex;
+  align-items: flex-start;
+}
+
+.repeatableFieldRemoveItem {
+  flex: 0 0 3em;
+  margin-top: 2.25em;
+  text-align: center;
+
+  @media (--medium-up) {
+    margin-top: 1.5em;
+  }
+}

--- a/lib/RepeatableField/RepeatableField.js
+++ b/lib/RepeatableField/RepeatableField.js
@@ -1,0 +1,109 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import reduxFormFieldArray from '../ReduxFormFieldArray';
+import Button from '../Button';
+import Headline from '../Headline';
+import IconButton from '../IconButton';
+import css from './RepeatableField.css';
+
+class RepeatableField extends Component {
+  static propTypes = {
+    addLabel: PropTypes.string,
+    emptyMessage: PropTypes.string,
+    fields: PropTypes.oneOfType([
+      PropTypes.array,
+      PropTypes.object
+    ]).isRequired,
+    legend: PropTypes.oneOfType([
+      PropTypes.node,
+      PropTypes.string
+    ]),
+    onAdd: PropTypes.func.isRequired,
+    onRemove: PropTypes.func.isRequired,
+    renderField: PropTypes.func.isRequired
+  };
+
+  render() {
+    const {
+      addLabel,
+      fields,
+      legend,
+      emptyMessage,
+      onAdd,
+      onRemove,
+      renderField
+    } = this.props;
+
+    return (
+      <fieldset
+        data-test-repeatable-field
+        className={css.repeatableField}
+      >
+        {legend && (
+          typeof legend === 'string' ? (
+            <Headline
+              data-test-repeatable-field-legend
+              tag="legend"
+            >
+              {legend}
+            </Headline>
+          ) : (
+            <div
+              data-test-repeatable-field-legend
+            >
+              {legend}
+            </div>
+          )
+        )}
+
+        {fields.length === 0 && emptyMessage && (
+          <p data-test-repeatable-field-empty-message>
+            {emptyMessage}
+          </p>
+        )}
+
+        {fields.length > 0 && (
+          <ul className={css.repeatableFieldList}>
+            {fields.map((field, index) => (
+              <li
+                className={css.repeatableFieldItem}
+                key={index}
+              >
+                {renderField(field, index, fields)}
+                <div
+                  className={css.repeatableFieldRemoveItem}
+                >
+                  <IconButton
+                    data-test-repeatable-field-remove-item-button
+                    icon="trashBin"
+                    onClick={() => onRemove(index)}
+                    size="small"
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+        {addLabel && (
+          <Button
+            data-test-repeatable-field-add-item-button
+            onClick={onAdd}
+            type="button"
+          >
+            {addLabel}
+          </Button>
+        )}
+      </fieldset>
+    );
+  }
+}
+
+export default reduxFormFieldArray(
+  RepeatableField,
+  ({ fields }) => ({
+    fields,
+    onAdd: () => fields.push({}),
+    onRemove: (index) => fields.remove(index)
+  })
+);

--- a/lib/RepeatableField/index.js
+++ b/lib/RepeatableField/index.js
@@ -1,0 +1,1 @@
+export { default } from './RepeatableField';

--- a/lib/RepeatableField/readme.md
+++ b/lib/RepeatableField/readme.md
@@ -1,0 +1,45 @@
+# Repeatable Field
+Form component for rendering arrays of editable data.
+
+## Usage
+```
+<RepeatableField
+  addLabel="+ Add author"
+  fields={fields}
+  onAdd={this.handleAdd}
+  onRemove={this.handleRemove}
+  renderField={() => (
+    <TextField
+      label="Author"
+      name="author"
+    />
+  )}
+/>
+```
+
+### With Redux Form
+```
+<FieldArray
+  addLabel="+ Add author"
+  component={RepeatableField}
+  name="authors"
+  renderField={(field, index) => (
+    <Field
+      component={TextField}
+      label="Name"
+      name={`name[${index}]`}
+    />
+  )}
+/>
+```
+
+## Props
+Name | type | description | default | required
+--- | --- | --- | --- | ---
+addLabel | string | Text for add field row button |
+emptyMessage | string | Text for when there are no rows; can be left blank |
+fields | array or object | Values that go with field rows | &#10004;
+legend | node or string | Legend text that accompanies the fieldset; can be left blank |
+onAdd | func | Callback fired when the add button is clicked |  | &#10004;
+onRemove | func | Callback fired when the remove row button is clicked |  | &#10004;
+renderField | func | Render function for each field row |  | &#10004;

--- a/lib/RepeatableField/stories/BasicUsage.js
+++ b/lib/RepeatableField/stories/BasicUsage.js
@@ -1,0 +1,42 @@
+import React, { Component } from 'react';
+import RepeatableField from '../RepeatableField';
+import TextField from '../../TextField';
+
+export default class BasicUsage extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      fields: []
+    };
+  }
+
+  handleAdd = () => {
+    this.setState(({ fields }) => ({
+      fields: fields.concat({})
+    }));
+  }
+
+  handleRemove = (index) => {
+    this.setState(({ fields }) => ({
+      fields: [...fields.slice(0, index), ...fields.slice(index + 1)]
+    }));
+  }
+
+  render() {
+    const { fields } = this.state;
+    return (
+      <RepeatableField
+        addLabel="+ Add author"
+        fields={fields}
+        onAdd={this.handleAdd}
+        onRemove={this.handleRemove}
+        renderField={() => (
+          <TextField
+            label="Author"
+            name="author"
+          />
+        )}
+      />
+    );
+  }
+}

--- a/lib/RepeatableField/stories/RepeatableField.stories.js
+++ b/lib/RepeatableField/stories/RepeatableField.stories.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
+import readme from '../readme.md';
+import BasicUsage from './BasicUsage';
+
+storiesOf('Repeatable Field', module)
+  .addDecorator(withReadme(readme))
+  .add('Basic Usage', () => <BasicUsage />);

--- a/lib/RepeatableField/tests/RepeatableField-ReduxForm-test.js
+++ b/lib/RepeatableField/tests/RepeatableField-ReduxForm-test.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { Field, FieldArray } from 'redux-form';
+import { mountWithContext } from '../../../tests/helpers';
+import TestForm from '../../../tests/TestForm';
+import RepeatableField from '../RepeatableField';
+import Headline from '../../Headline';
+import TextField from '../../TextField';
+import RepeatableFieldInteractor from './interactor';
+
+describe('RepeatableField with Redux Form', () => {
+  const repeatableField = new RepeatableFieldInteractor();
+
+  beforeEach(async () => {
+    await mountWithContext(
+      <TestForm>
+        <FieldArray
+          addLabel="+ Add person"
+          component={RepeatableField}
+          emptyMessage="No Bluths."
+          legend={<Headline size="large">Bluths</Headline>}
+          name="bananas"
+          renderField={(field, index) => (
+            <Field
+              component={TextField}
+              label="Name"
+              name={`name[${index}]`}
+            />
+          )}
+        />
+      </TestForm>
+    );
+  });
+
+  it('displays the legend', () => {
+    expect(repeatableField.legend).to.equal('Bluths');
+  });
+
+  it('displays the empty message', () => {
+    expect(repeatableField.emptyMessage).to.equal('No Bluths.');
+  });
+
+  it('displays an add button', () => {
+    expect(repeatableField.hasAddButton).to.be.true;
+  });
+
+  it('does not have any items yet', () => {
+    expect(repeatableField.items().length).to.equal(0);
+  });
+
+  describe('clicking the add button', () => {
+    beforeEach(async () => {
+      await repeatableField.clickAddButton();
+    });
+
+    it('has an item', () => {
+      expect(repeatableField.items().length).to.equal(1);
+    });
+
+    describe('clicking the add button again', () => {
+      beforeEach(async () => {
+        await repeatableField.clickAddButton();
+      });
+
+      it('has two items', () => {
+        expect(repeatableField.items().length).to.equal(2);
+      });
+
+      describe('clicking a remove button', () => {
+        beforeEach(async () => {
+          await repeatableField.items(1).clickRemoveButton();
+        });
+
+        it('has one item', () => {
+          expect(repeatableField.items().length).to.equal(1);
+        });
+      });
+    });
+
+    describe('clicking a remove button', () => {
+      beforeEach(async () => {
+        await repeatableField.items(0).clickRemoveButton();
+      });
+
+      it('has no items', () => {
+        expect(repeatableField.items().length).to.equal(0);
+      });
+    });
+  });
+});

--- a/lib/RepeatableField/tests/RepeatableField-test.js
+++ b/lib/RepeatableField/tests/RepeatableField-test.js
@@ -1,0 +1,114 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { mountWithContext } from '../../../tests/helpers';
+import RepeatableField from '../RepeatableField';
+import TextField from '../../TextField';
+import RepeatableFieldInteractor from './interactor';
+
+describe('RepeatableField', () => {
+  const repeatableField = new RepeatableFieldInteractor();
+
+  class RepeatableFieldDemo extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {
+        fields: []
+      };
+    }
+
+    handleAdd = () => {
+      this.setState(({ fields }) => ({
+        fields: fields.concat({})
+      }));
+    }
+
+    handleRemove = (index) => {
+      this.setState(({ fields }) => ({
+        fields: [...fields.slice(0, index), ...fields.slice(index + 1)]
+      }));
+    }
+
+    render() {
+      const { fields } = this.state;
+      return (
+        <RepeatableField
+          addLabel="+ Add person"
+          emptyMessage="No Bluths."
+          fields={fields}
+          legend="Bluths"
+          onAdd={this.handleAdd}
+          onRemove={this.handleRemove}
+          renderField={() => (
+            <TextField
+              label="Name"
+            />
+          )}
+        />
+      );
+    }
+  }
+
+  beforeEach(async () => {
+    await mountWithContext(
+      <RepeatableFieldDemo />
+    );
+  });
+
+  it('displays the legend', () => {
+    expect(repeatableField.legend).to.equal('Bluths');
+  });
+
+  it('displays the empty message', () => {
+    expect(repeatableField.emptyMessage).to.equal('No Bluths.');
+  });
+
+  it('displays an add button', () => {
+    expect(repeatableField.hasAddButton).to.be.true;
+  });
+
+  it('does not have any items yet', () => {
+    expect(repeatableField.items().length).to.equal(0);
+  });
+
+  describe('clicking the add button', () => {
+    beforeEach(async () => {
+      await repeatableField.clickAddButton();
+    });
+
+    it('has an item', () => {
+      expect(repeatableField.items().length).to.equal(1);
+    });
+
+    describe('clicking the add button again', () => {
+      beforeEach(async () => {
+        await repeatableField.clickAddButton();
+      });
+
+      it('has two items', () => {
+        expect(repeatableField.items().length).to.equal(2);
+      });
+
+      describe('clicking a remove button', () => {
+        beforeEach(async () => {
+          await repeatableField.items(1).clickRemoveButton();
+        });
+
+        it('has one item', () => {
+          expect(repeatableField.items().length).to.equal(1);
+        });
+      });
+    });
+
+    describe('clicking a remove button', () => {
+      beforeEach(async () => {
+        await repeatableField.items(0).clickRemoveButton();
+      });
+
+      it('has no items', () => {
+        expect(repeatableField.items().length).to.equal(0);
+      });
+    });
+  });
+});

--- a/lib/RepeatableField/tests/interactor.js
+++ b/lib/RepeatableField/tests/interactor.js
@@ -1,0 +1,22 @@
+import {
+  clickable,
+  collection,
+  interactor,
+  isPresent,
+  text
+} from '@bigtest/interactor';
+
+const RepeatableFieldItemInteractor = interactor(class RepeatableFieldItemInteractor {
+  clickRemoveButton = clickable('[data-test-repeatable-field-remove-item-button]')
+});
+
+export default interactor(class RepeatableFieldInteractor {
+  static defaultScope = '[data-test-repeatable-field]';
+
+  hasAddButton = isPresent('[data-test-repeatable-field-add-item-button]');
+  clickAddButton = clickable('[data-test-repeatable-field-add-item-button]');
+  legend = text('[data-test-repeatable-field-legend]');
+  emptyMessage = text('[data-test-repeatable-field-empty-message]');
+
+  items = collection('li', RepeatableFieldItemInteractor);
+});


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/STCOM-292

## Approach
Mimic the pattern used by `reduxFormField()` for `<Field>` with `reduxFormFieldArray` for `<FieldArray>`.

Instead of being an independent structure that relies on `redux-form`, `<RepeatableField>` can now stand on its own or be passed into the `<FieldArray>` `component` prop.