### PR TITLE
Move AutoSuggest into component library

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Component | doc | categories
 [`<Accordion>`](lib/Accordion) | [doc](lib/Accordion/readme.md) | structure
 [`<AddressFieldGroup>`](lib/AddressFieldGroup) | [doc](lib/AddressFieldGroup/readme.md) | control, prefab
 [`<AppIcon>`](lib/AppIcon) | [doc](lib/AppIcon/readme.md) | design
+[`<AutoSuggest>`](lib/AutoSuggest) | [doc](lib/AutoSuggest/readme.md) | control
 [`<Avatar>`](lib/Avatar) | [doc](lib/Avatar/readme.md) | data-display
 [`<Badge>`](lib/Badge) | [doc](lib/Badge/readme.md) | data-display, design
 [`<Button>`](lib/Button) | [doc](lib/Button/readme/general.md) | control

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 /* form elements */
+export { default as AutoSuggest } from './lib/AutoSuggest';
 export { default as Badge } from './lib/Badge';
 export { default as Button } from './lib/Button';
 export { default as Checkbox } from './lib/Checkbox';

--- a/lib/AutoSuggest/AutoSuggest.css
+++ b/lib/AutoSuggest/AutoSuggest.css
@@ -1,0 +1,26 @@
+.AutoSuggest {
+  position: relative;
+  top: 100%;
+  width: '100%';
+  right: 0;
+  padding: 0;
+  z-index: 1000;
+  margin-top: -7px;
+  font-size: 14px;
+  text-align: left;
+  list-style: none;
+  background-color: #fff;
+  background-clip: padding-box;
+  border-radius: 4px;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+}
+
+.textFieldDiv {
+  position: 'relative';
+  width: '100%';
+}
+
+.downshift {
+  display: 'inline-block';
+  position: 'relative';
+}

--- a/lib/AutoSuggest/AutoSuggest.css
+++ b/lib/AutoSuggest/AutoSuggest.css
@@ -1,3 +1,5 @@
+@import '../variables.css';
+
 .AutoSuggest {
   position: relative;
   top: 100%;
@@ -6,7 +8,7 @@
   padding: 0;
   z-index: 1000;
   margin-top: -7px;
-  font-size: 14px;
+  font-size: var(--font-size-small);
   text-align: left;
   list-style: none;
   background-color: #fff;

--- a/lib/AutoSuggest/AutoSuggest.js
+++ b/lib/AutoSuggest/AutoSuggest.js
@@ -3,9 +3,9 @@ import Downshift from 'downshift';
 import PropTypes from 'prop-types';
 import uniqueId from 'lodash/uniqueId';
 import TetherComponent from 'react-tether';
-import injectIntl from '@folio/stripes-components/lib/InjectIntl';
-import TextField from '@folio/stripes-components/lib/TextField';
-import reduxFormField from '@folio/stripes-components/lib/ReduxFormField';
+import injectIntl from '../InjectIntl';
+import TextField from '../TextField';
+import reduxFormField from '../ReduxFormField';
 import css from './AutoSuggest.css';
 
 const defaultProps = {

--- a/lib/AutoSuggest/AutoSuggest.js
+++ b/lib/AutoSuggest/AutoSuggest.js
@@ -1,0 +1,175 @@
+import React from 'react';
+import Downshift from 'downshift';
+import PropTypes from 'prop-types';
+import uniqueId from 'lodash/uniqueId';
+import TetherComponent from 'react-tether';
+import injectIntl from '@folio/stripes-components/lib/InjectIntl';
+import TextField from '@folio/stripes-components/lib/TextField';
+import reduxFormField from '@folio/stripes-components/lib/ReduxFormField';
+import css from './AutoSuggest.css';
+
+const defaultProps = {
+  validationEnabled: true,
+  tether: {
+    attachment: 'top left',
+    renderElementTo: null,
+    targetAttachment: 'bottom left',
+    optimizations: {
+      gpu: false,
+    },
+    constraints: [
+      {
+        to: 'scrollParent',
+      },
+    ],
+  },
+};
+
+const propTypes = {
+  error: PropTypes.string,
+  id: PropTypes.string,
+  items: PropTypes.arrayOf(PropTypes.object).isRequired,
+  label: PropTypes.string,
+  meta: PropTypes.object,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  required: PropTypes.bool,
+  screenReaderMessage: PropTypes.string,
+  tether: PropTypes.object,
+  validationEnabled: PropTypes.bool,
+  value: PropTypes.string,
+};
+
+class AutoSuggest extends React.Component {
+  static propTypes = propTypes;
+  static defaultProps = defaultProps;
+
+  constructor(props) {
+    super(props);
+    this.container = React.createRef();
+    this.textfield = React.createRef();
+    this.testId = this.props.id || uniqueId('detailname-');
+    this.autoSuggestId = `list-dropdown-${this.testId}`;
+  }
+
+  getInputWidth() { // eslint-disable-line consistent-return
+    if (this.textfield.current) {
+      const { input : { current : { offsetWidth } } } = this.textfield.current;
+      return offsetWidth;
+    }
+  }
+
+  render() {
+    const { tether,
+      items,
+      label,
+      value,
+      required,
+      validationEnabled, onBlur, error, onChange } = this.props;
+
+    const textfieldRef = this.textfield;
+    const mergedTetherProps = { ...AutoSuggest.defaultProps.tether, ...tether };
+    const testId = this.testId;
+    const autoSuggestId = this.autoSuggestId;
+    const listWidth = this.getInputWidth();
+    const inputProps = {
+      autoComplete: 'off',
+      required,
+      label,
+      validationEnabled,
+      ref: textfieldRef,
+      id: testId,
+      error,
+    };
+
+    return (
+      <Downshift
+        style={{ display: 'inline-block', position: 'relative' }}
+        itemToString={item => (item ? item.value : '')}
+        onChange={selectedItem => onChange(selectedItem.value)}
+        onStateChange={({ inputValue }) => onChange(inputValue)}
+        selectedItem={value}
+        inputValue={value}
+      >
+        {({
+          getInputProps,
+          getItemProps,
+          getMenuProps,
+          selectedItem,
+          highlightedIndex,
+          isOpen,
+          inputValue,
+        }) => (
+          <div className={css.downshift}>
+            <TetherComponent {...mergedTetherProps}>
+              <div
+                className={css.TextFieldDiv}
+                ref={(ref) => { this.container = ref; }}
+                aria-live="assertive"
+                aria-relevant="additions"
+              >
+                <TextField {...getInputProps(
+                  { ...inputProps,
+                    onBlur }
+                )}
+                />
+              </div>
+              <ul
+                className={css.AutoSuggest}
+                {...getMenuProps({
+                  refKey: 'innerRef',
+                  id: autoSuggestId,
+                  style: { width: `${listWidth}px` }
+                }, { suppressRefError: true })}
+              >
+                {isOpen
+                  ? items
+                    .filter(item => !inputValue || item.value.includes(inputValue))
+                    .map((item, index) => (
+                      <li
+                        {...getItemProps({
+                          key: item.value,
+                          index,
+                          item,
+                          style: {
+                            padding: '5px',
+                            cursor: 'default',
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            backgroundColor:
+                                highlightedIndex === index ? 'lightgray' : 'white',
+                            fontWeight: selectedItem === item ? 'bold' : 'normal',
+                          },
+                        })}
+                      >
+                        {item.value}
+                      </li>
+                    ))
+                  : null}
+              </ul>
+            </TetherComponent>
+          </div>
+        )
+            }
+      </Downshift>
+    );
+  }
+}
+
+export default reduxFormField(
+  injectIntl(
+    AutoSuggest, { withRef: true }
+  ), ({ input, meta }) => ({
+    dirty: meta.dirty,
+    error: (meta.touched && meta.error ? meta.error : ''),
+    loading: meta.asyncValidating,
+    name: input.name,
+    onBlur: input.onBlur,
+    onChange: input.onChange,
+    onFocus: input.onFocus,
+    touched: meta.touched,
+    valid: meta.valid,
+    value: input.value,
+    warning: (meta.touched && meta.warning ? meta.warning : ''),
+  })
+);

--- a/lib/AutoSuggest/index.js
+++ b/lib/AutoSuggest/index.js
@@ -1,0 +1,1 @@
+export { default } from './AutoSuggest';

--- a/lib/AutoSuggest/readme.md
+++ b/lib/AutoSuggest/readme.md
@@ -1,0 +1,15 @@
+# AutoSuggest
+Displays a dropdown with a list of suggestions based on the entered string in the textfield.
+
+## Usage
+```
+import AutoSuggest from '../../lib/AutoSuggest';
+
+// later in your JSX....
+<AutoSuggest items={items} />
+```
+
+## AutoSuggest Configuration
+prop | description | default | required
+-- | -- | -- | --
+items | 'list of items to display | |


### PR DESCRIPTION
## Purpose
With the move to `@folio/stripes`, importing from the `stripes-components` directory structure will no longer be possible.

`AutoSuggest` was using some un-exported APIs from `stripes-components`, and was in healthy enough shape to warrant moving it to `stripes-components` proper. This will help unblock https://github.com/folio-org/ui-organization/pull/133

## Next Steps
Tests. Storybook stories.