### PR TITLE
Export DefaultAccordionHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Change history for stripes-components
-## 4.1.0
-* fix issue with `<Datepicker>` calendar not applying the chosen value to its `<TextField>`.
 
 ## 4.1.0 (IN PROGRESS)
 
 * Deprecate craftLayerUrl()
 * Create new `<RepeatableField>`
+* Fix issue with `<Datepicker>` calendar not applying the chosen value to its `<TextField>`.
+* Export `<DefaultAccordionHeader>`
 
 ## [4.0.0](https://github.com/folio-org/stripes-components/tree/v4.0.0) (2018-10-02)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v3.3.0...v4.0.0)

--- a/index.js
+++ b/index.js
@@ -31,7 +31,14 @@ export { Grid, Row, Col } from './lib/LayoutGrid';
 export { default as Layout } from './lib/Layout';
 export { default as LayoutBox } from './lib/LayoutBox';
 export { default as LayoutHeader } from './lib/LayoutHeader';
-export { Accordion, AccordionSet, FilterAccordionHeader, ExpandAllButton, expandAllFunction } from './lib/Accordion';
+export {
+  Accordion,
+  AccordionSet,
+  DefaultAccordionHeader,
+  FilterAccordionHeader,
+  ExpandAllButton,
+  expandAllFunction
+} from './lib/Accordion';
 
 /* misc */
 export { default as Icon } from './lib/Icon';

--- a/lib/Accordion/index.js
+++ b/lib/Accordion/index.js
@@ -1,5 +1,6 @@
 export { default as Accordion } from './Accordion';
 export { default as AccordionSet } from './AccordionSet';
+export { default as DefaultAccordionHeader } from './headers/DefaultAccordionHeader';
 export { default as FilterAccordionHeader } from './headers/FilterAccordionHeader';
 export { default as ExpandAllButton } from './ExpandAllButton';
 export { default as expandAllFunction } from './expandAll';


### PR DESCRIPTION
This is the only component being consumed by `ui-eholdings` that wasn't already exported.