### PR TITLE
Shrink MetaSection font sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.2.0 (IN PROGRESS)
 
 * Add clone option to EntrySelector. Fixes STCOM-364.
+* Shrink `<MetaSection>` font sizes
 
 ## [4.1.0](https://github.com/folio-org/stripes-components/tree/v4.1.0) (2018-10-01)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v4.0.0...v4.1.0)

--- a/lib/MetaSection/MetaSection.css
+++ b/lib/MetaSection/MetaSection.css
@@ -4,11 +4,13 @@
   border-radius: 4px;
   background-color: var(--color-fill);
   margin-bottom: 10px;
+  font-size: var(--font-size-small);
+  line-height: var(--line-height);
 }
 
 .metaSectionContent {
-  margin-top: -6px;
-  padding: 0 0 4px 27px;
+  margin-top: -0.5rem;
+  padding: 0.5rem 0 0.5rem 0.33rem;
   color: var(--color-text);
 }
 


### PR DESCRIPTION
The `<MetaSection>` was a little large for its context. I've shrunk it down from `font-size-medium` to `font-size-small`.

### Before

<img width="378" alt="screen shot 2018-10-09 at 4 12 27 pm" src="https://user-images.githubusercontent.com/230597/46699080-5f7ce900-cbde-11e8-82c5-47481f54eed3.png">

### After

<img width="379" alt="screen shot 2018-10-09 at 4 11 49 pm" src="https://user-images.githubusercontent.com/230597/46699096-64da3380-cbde-11e8-86cd-b2a46bb58b19.png">
