### PR TITLE
Polish form control sizing

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,7 +1,7 @@
 <style type="text/css">
   body {
     margin: 0;
-    padding: 15px;
+    padding: 1rem;
     position: relative;
   }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add clone option to EntrySelector. Fixes STCOM-364.
 * Shrink `<MetaSection>` font sizes
+* Polish form control sizing
 
 ## [4.1.0](https://github.com/folio-org/stripes-components/tree/v4.1.0) (2018-10-01)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v4.0.0...v4.1.0)

--- a/lib/Accordion/Accordion.css
+++ b/lib/Accordion/Accordion.css
@@ -23,7 +23,6 @@
   width: 100%;
   display: flex;
   align-items: center;
-  min-height: calc(var(--control-height) + 4px);
 
   /* transition: background-color 0.3s; */
 
@@ -111,9 +110,8 @@
   outline: none;
   display: flex;
   align-items: center;
-  padding: 0;
+  padding: calc(var(--input-vertical-padding) * 4) var(--input-horizontal-padding);
   background-color: transparent;
-  min-height: 44px;
   width: 100%;
   color: var(--color-text);
 
@@ -136,15 +134,14 @@
 .filterSetHeader {
   composes: interactionStyles boxOffsetStartSmall from "../sharedStyles/interactionStyles.css";
   composes: header;
-  border-radius: var(--radius 4px);
-  min-height: var(--control-height 24px);
+  border-radius: var(--radius);
   appearance: none;
   background: none;
   border: none;
   font-size: inherit;
-  padding: 2px 0;
+  padding: var(--input-vertical-padding) 0;
   width: 100%;
-  line-height: 120%;
+  line-height: var(--line-height);
   text-align: left;
 
   &:focus {

--- a/lib/AppIcon/AppIcon.css
+++ b/lib/AppIcon/AppIcon.css
@@ -31,7 +31,6 @@
 .icon {
   display: inline-block;
   position: relative;
-  box-shadow: 0 0 0 18px rgba(0, 0, 0, 0);
   opacity: 1;
   transition: none;
   border-radius: 25%;

--- a/lib/AutoSuggest/AutoSuggest.css
+++ b/lib/AutoSuggest/AutoSuggest.css
@@ -13,8 +13,8 @@
   list-style: none;
   background-color: #fff;
   background-clip: padding-box;
-  border-radius: 4px;
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
 }
 
 .textFieldDiv {

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -12,40 +12,48 @@
 
 .button {
   composes: interactionStyles from "../sharedStyles/interactionStyles.css";
-  padding: 0 10px;
-  height: var(--control-height-small);
+  padding: 0.125rem 1rem;
   text-align: center;
   -webkit-appearance: none;
   cursor: pointer;
   color: #555;
-  border-radius: 6px;
-  transition: background-color 0.25s, color 0.25s, opacity 0.07s, box-shadow 0s;
+  border-radius: var(--radius);
+  transition: background-color 0.25s, color 0.25s, opacity 0.07s;
   background-color: transparent;
   border: transparent;
   margin: 0 0 var(--gutter);
-  max-height: var(--control-height-small);
   white-space: nowrap;
-  line-height: 100%;
+  line-height: 1.85;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   text-decoration: none;
   outline: 0;
-  box-shadow: 0 0 0 18px rgba(0, 0, 0, 0);
   opacity: 1;
   font-weight: var(--text-weight-button);
   font-size: var(--font-size-small);
-
-  &.slim {
-    padding: 5px 2px;
-  }
 
   &.block {
     display: block;
   }
 
   & + .button {
-    margin-left: 4px;
+    margin-left: 0.25rem;
+  }
+
+  &.fullWidth {
+    width: 100%;
+  }
+
+  &.fieldControl {
+    background-color: transparent;
+    margin: 0;
+    padding: 0;
+  }
+
+  & + .button.fullWidth,
+  & + .button.fieldControl {
+    margin-left: 0;
   }
 
   /**
@@ -146,8 +154,6 @@
     background-color: transparent;
     border: 1px solid transparent;
     margin: 0;
-    max-height: var(--control-height-touch);
-    height: var(--control-height-touch);
     border-radius: 0;
     padding: 8px;
 
@@ -179,7 +185,7 @@
   }
 
   &.paneHeaderNewButton {
-    margin-right: 15px;
+    margin-right: 1rem;
   }
 
   &.noRadius {
@@ -205,7 +211,7 @@
     border: 1px solid transparent;
     cursor: pointer;
     color: var(--primary);
-    padding: 4px;
+    padding: 0.25em;
   }
 
   &.bottomMargin0,
@@ -216,17 +222,6 @@
   &.paddingSide0 {
     padding-left: 0;
     padding-right: 0;
-  }
-
-  &.fullWidth {
-    width: 100%;
-  }
-
-  &.fieldControl {
-    background-color: transparent;
-    margin: 0;
-    height: var(--control-height);
-    padding: 0;
   }
 
   &[disabled] {
@@ -240,17 +235,12 @@
     }
   }
 
-  &:not(.fullWidth, .fieldControl) + .button {
-    margin: 0 4px;
+  &.mega {
+    font-size: var(--font-size-large);
   }
 
-  &.mega {
-    width: 100%;
-    max-height: 16rem;
-    height: 16rem;
-    color: #fff;
-    font-size: var(--font-size-xx-large);
-    border-radius: 0;
+  &.slim {
+    padding: 0.125rem 0.5rem;
   }
 }
 
@@ -258,18 +248,16 @@
   & .button {
     & + .button {
       margin-left: 0;
-      margin-right: 4px;
+      margin-right: 0.25rem;
+    }
+
+    & + .button.fullWidth,
+    & + .button.fieldControl {
+      margin-right: 0;
     }
 
     &.textAlignStart {
       text-align: right;
     }
-  }
-}
-
-@media (--medium-up) {
-  .button {
-    height: var(--control-height);
-    max-height: var(--control-height);
   }
 }

--- a/lib/Button/stories/Button.stories.js
+++ b/lib/Button/stories/Button.stories.js
@@ -5,4 +5,5 @@ import stories from './index';
 
 storiesOf('Button', module)
   .add('Basic Usage', withReadme(readme, stories.general))
-  .add('Styles', withReadme(readme, stories.styles));
+  .add('Styles', withReadme(readme, stories.styles))
+  .add('Sizes', withReadme(readme, stories.sizes));

--- a/lib/Button/stories/sizes.js
+++ b/lib/Button/stories/sizes.js
@@ -1,7 +1,20 @@
 import React from 'react';
+import Button from '../Button';
 
 export default () => (
-  <div>
-        To be added..
+  <div style={{ maxWidth: '800px' }}>
+    <h3>Mega</h3>
+    <Button buttonStyle="default mega">Default</Button>
+    <Button buttonStyle="primary mega">Primary</Button>
+    <Button buttonStyle="danger mega">Danger</Button>
+    <Button buttonStyle="success mega">Success</Button>
+    <Button buttonStyle="warning mega">Warning</Button>
+    <hr />
+    <h3>Slim</h3>
+    <Button buttonStyle="default slim">Default</Button>
+    <Button buttonStyle="primary slim">Primary</Button>
+    <Button buttonStyle="danger slim">Danger</Button>
+    <Button buttonStyle="success slim">Success</Button>
+    <Button buttonStyle="warning slim">Warning</Button>
   </div>
 );

--- a/lib/Button/stories/styles.js
+++ b/lib/Button/stories/styles.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Button from '../Button';
 
 export default () => (
-  <div style={{ maxWidth: '800px' }}>
+  <div style={{ maxWidth: '500px' }}>
     <h3>Colors</h3>
     <Button>Default</Button>
     <Button buttonStyle="primary">Primary</Button>

--- a/lib/Callout/Callout.css
+++ b/lib/Callout/Callout.css
@@ -14,20 +14,19 @@
 
 .base {
   padding: 1rem;
-  border-radius: 4px;
+  border-radius: var(--radius);
   background-color: #fff;
   width: 35%;
   pointer-events: all;
   position: relative;
   transition: all 0.2s ease;
   display: flex;
-  box-shadow: 0 4px 19px 0 rgba(0, 0, 0, 0.39);
+  box-shadow: var(--shadow);
 
   &.error {
     background-color: color(var(--error, #900) tint(25%));
     border-color: var(--error);
     color: #fff;
-    box-shadow: 0 4px 19px 0 rgba(153, 0, 0, 0.39);
 
     & :global .stripes__icon {
       fill: #fff;
@@ -38,7 +37,6 @@
     background-color: color(var(--success, #060) tint(25%));
     border-color: var(--success);
     color: #fff;
-    box-shadow: 0 4px 19px 0 rgba(0, 112, 0, 0.39);
 
     & :global .stripes__icon {
       fill: #fff;
@@ -71,7 +69,7 @@
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  border-radius: var(--radius, 4px);
+  border-radius: var(--radius);
   margin-bottom: 4px;
 
   & .message {

--- a/lib/Checkbox/Checkbox.css
+++ b/lib/Checkbox/Checkbox.css
@@ -8,6 +8,7 @@
   display: flex;
   position: relative;
   color: var(--color-text);
+  line-height: var(--line-height);
 
   &.fullWidth {
     width: 100%;
@@ -41,8 +42,7 @@
 
 .checkboxLabel {
   composes: interactionStyles from "../sharedStyles/interactionStyles.css";
-  padding: 4px 5px;
-  min-height: var(--control-height);
+  padding: var(--input-vertical-padding) var(--input-horizontal-padding);
   display: flex;
   align-items: baseline;
   cursor: pointer;
@@ -99,7 +99,7 @@ input.checkboxInput {
   width: var(--checkbox-size);
   height: var(--checkbox-size);
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius);
   background: var(--color-fill-form-element);
   display: flex;
   overflow: hidden;

--- a/lib/Datepicker/Calendar.css
+++ b/lib/Datepicker/Calendar.css
@@ -3,10 +3,10 @@
 .calendar {
   position: relative;
   background: #fff;
-  border-radius: 4px;
+  border-radius: var(--radius);
   border: 1px solid #bcbcbc;
   padding: 4px;
-  box-shadow: 0 4px 19px 0 rgba(0, 0, 0, 0.39);
+  box-shadow: var(--shadow);
   z-index: 9999;
 }
 
@@ -94,9 +94,8 @@
   border: 0;
   text-align: center;
   color: #333;
-  border-radius: 4px;
-  margin-bottom: 4px;
-  padding: 4px 0;
+  border-radius: var(--radius);
+  padding: 0.25rem 0;
 
   &:hover {
     background: #eee;

--- a/lib/Dropdown/Dropdown.css
+++ b/lib/Dropdown/Dropdown.css
@@ -25,11 +25,11 @@
   background-color: #fff;
   background-clip: padding-box;
   border: 1px solid #ccc;
-  border-radius: 4px;
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
 
   &.hasPadding {
-    padding: 15px;
+    padding: 1rem;
   }
 
   & ul {

--- a/lib/DropdownMenu/DropdownLayout.css
+++ b/lib/DropdownMenu/DropdownLayout.css
@@ -1,7 +1,7 @@
 @import '../variables.css';
 
 .dropdownHeader {
-  padding: 0 15px;
+  padding: 0 1rem;
   height: 44px;
   border-bottom: 1px solid #ccc;
   font-weight: 600;
@@ -22,7 +22,7 @@
 .dropdownColumn {
   height: 100%;
   overflow: auto;
-  padding: 15px;
+  padding: 1rem;
 
   & + .dropdownColumn {
     border-left: 1px solid #ccc;

--- a/lib/DropdownMenu/DropdownMenu.css
+++ b/lib/DropdownMenu/DropdownMenu.css
@@ -16,8 +16,8 @@
   background-color: #fff;
   background-clip: padding-box;
   border: 1px solid #ccc;
-  border-radius: 4px;
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
 
   & ul {
     list-style: none;

--- a/lib/Icon/stories/style.css
+++ b/lib/Icon/stories/style.css
@@ -8,7 +8,7 @@
 }
 
 .iconGridItem {
-  margin: 15px;
+  margin: 1rem;
   text-align: center;
   flex-basis: 130px;
   display: flex;

--- a/lib/IconButton/IconButton.css
+++ b/lib/IconButton/IconButton.css
@@ -37,15 +37,15 @@
  */
 
 .medium {
-  width: var(--control-height-touch);
-  height: var(--control-height-touch);
-  min-width: var(--control-height-touch);
+  width: 44px;
+  height: 44px;
+  min-width: 44px;
   padding: 0 10px;
 }
 
 .small {
-  width: var(--control-height);
-  height: var(--control-height);
-  min-width: var(--control-height);
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
   padding: 0 5px;
 }

--- a/lib/Layout/stories/classNamePropertiesMapping.js
+++ b/lib/Layout/stories/classNamePropertiesMapping.js
@@ -3,7 +3,7 @@
  */
 
 const variables = {
-  '--gutter': '15px',
+  '--gutter': '16px',
 };
 
 export default {

--- a/lib/Layout/styles/margin.css
+++ b/lib/Layout/styles/margin.css
@@ -52,5 +52,5 @@
 
 /* class for aligning buttons or other non-labeled elements with labeled text inputs, selects, etc */
 .marginTopLabelSpacer {
-  margin-top: 1.5rem;
+  margin-top: 1.75rem;
 }

--- a/lib/List/List.css
+++ b/lib/List/List.css
@@ -31,8 +31,8 @@
     justify-content: space-between;
     align-items: center;
     padding: 5px 6px;
-    border-radius: 4px;
-    margin-bottom: 4px;
+    border-radius: var(--radius);
+    margin-bottom: 0.25rem;
   }
 }
 

--- a/lib/MetaSection/MetaSection.css
+++ b/lib/MetaSection/MetaSection.css
@@ -1,7 +1,7 @@
 @import '../variables';
 
 .metaSectionRoot {
-  border-radius: 4px;
+  border-radius: var(--radius);
   background-color: var(--color-fill);
   margin-bottom: 10px;
   font-size: var(--font-size-small);

--- a/lib/Modal/Modal.css
+++ b/lib/Modal/Modal.css
@@ -35,7 +35,7 @@
 
 .modalFooter {
   border-top: 1px solid var(--color-border-p2);
-  padding: var(--gutter);
+  padding: 0.5rem 0.25rem;
   display: flex;
   align-items: center;
   flex-flow: row-reverse wrap;
@@ -46,7 +46,7 @@
   justify-content: center;
   align-items: center;
   font-weight: 600;
-  min-height: 44px;
+  min-height: 2.75em;
   padding: 0 1em;
 }
 

--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -29,11 +29,11 @@
   display: flex;
   justify-content: flex-start;
   align-items: stretch;
-  border-radius: 7px;
+  border-radius: var(--radius);
   color: var(--color-text);
   text-decoration: none;
-  margin-left: 5px;
-  margin-right: 5px;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
   outline: none;
 
   &:visited {
@@ -72,9 +72,6 @@
   overflow: hidden;
   width: calc(100% - 22px);
 
-  /* header columns has padding of their own and we need a total of 15px from edge to text */
-  padding: 6px 10px 0;
-
   &.hScroll {
     overflow: auto;
   }
@@ -85,7 +82,7 @@
   align-items: center;
   flex-shrink: 0;
   flex-grow: 0;
-  padding: 0.5em;
+  padding: 0.5rem 0.5rem;
   font-weight: 600;
   color: var(--color-text-p2);
   font-size: var(--font-size-small);
@@ -112,7 +109,8 @@
   align-items: center;
   flex-shrink: 0;
   flex-grow: 0;
-  padding: 0.5em 0.67em;
+  line-height: var(--line-height);
+  padding: 0.125rem 0.5rem;
   overflow: hidden;
 
   &.showOverflow {
@@ -140,12 +138,12 @@
   display: flex;
   justify-content: center;
   align-content: center;
-  height: 25px;
-  width: 45px;
-  padding: 4px 6px 0 0;
+  height: 1.5rem;
+  width: 3rem;
+  padding: 0.25rem 0.5rem 0 0;
   background-color: rgba(255, 255, 255, 0.5);
 }
 
 .emptyMessage {
-  padding: 15px;
+  padding: 1rem;
 }

--- a/lib/MultiColumnList/stories/basic.js
+++ b/lib/MultiColumnList/stories/basic.js
@@ -24,7 +24,12 @@ export default class General extends React.Component {
         selectedRow={this.state.selected}
         onRowClick={this.onRowClick}
         columnMapping={{
+          active: 'Active',
+          name: 'Name',
           patronGroup: 'Patron group',
+          email: 'Email',
+          phone: 'Phone',
+          barcode: 'Barcode'
         }}
       />
     );

--- a/lib/MultiSelection/MultiSelect.css
+++ b/lib/MultiSelection/MultiSelect.css
@@ -41,7 +41,6 @@
   margin: 2px;
   background-color: transparent;
   padding: 0 4px;
-  height: var(--control-height);
   border-width: 0;
   outline: 0;
 }

--- a/lib/NavListItem/NavListItem.css
+++ b/lib/NavListItem/NavListItem.css
@@ -10,7 +10,6 @@
   padding: 5px 10px;
   color: var(--body-color);
   border-radius: var(--radius);
-  min-height: var(--control-height);
   text-align: left;
   outline: 0;
 

--- a/lib/Pane/stories/BasicUsage.js
+++ b/lib/Pane/stories/BasicUsage.js
@@ -7,7 +7,7 @@ import Paneset from '../../Paneset';
 import Pane from '../Pane';
 
 const BasicUsage = () => (
-  <div style={{ margin: '-15px' }}>
+  <div style={{ margin: '-1rem' }}>
     <Paneset>
       <Pane defaultWidth="20%" paneTitle="Filters">
         Pane Content

--- a/lib/Pane/stories/PaneHeader.js
+++ b/lib/Pane/stories/PaneHeader.js
@@ -39,22 +39,24 @@ const actionMenuItems = [
 ];
 
 const PaneHeaderExample = () => (
-  <Paneset>
-    <Pane defaultWidth="20%" paneTitle="Filters" dismissible onClose={() => {}}>
-      Some content..
-    </Pane>
-    <Pane
-      actionMenuItems={actionMenuItems}
-      firstMenu={firstMenu}
-      lastMenu={lastMenu}
-      defaultWidth="fill"
-      paneTitle="Lorem Ipsum is simply dummy text of the printing and typesetting industry."
-      paneSub="121 results found"
-      onClose={() => {}}
-    >
-      Some content..
-    </Pane>
-  </Paneset>
+  <div style={{ margin: '-1rem' }}>
+    <Paneset>
+      <Pane defaultWidth="20%" paneTitle="Filters" dismissible onClose={() => {}}>
+        Some content..
+      </Pane>
+      <Pane
+        actionMenuItems={actionMenuItems}
+        firstMenu={firstMenu}
+        lastMenu={lastMenu}
+        defaultWidth="fill"
+        paneTitle="Lorem Ipsum is simply dummy text of the printing and typesetting industry."
+        paneSub="121 results found"
+        onClose={() => {}}
+      >
+        Some content..
+      </Pane>
+    </Paneset>
+  </div>
 );
 
 export default PaneHeaderExample;

--- a/lib/PaneHeader/PaneHeader.css
+++ b/lib/PaneHeader/PaneHeader.css
@@ -6,7 +6,7 @@
   align-items: center;
   justify-content: space-between;
   border-bottom: 1px solid var(--color-border-p2);
-  min-height: 45px;
+  min-height: 2.75em;
   position: relative;
   will-change: transform;
 }

--- a/lib/PaneSubheader/PaneSubheader.css
+++ b/lib/PaneSubheader/PaneSubheader.css
@@ -1,6 +1,6 @@
 .subheader {
   background-color: rgba(0, 0, 0, 0.1);
-  border-radius: 4px;
+  border-radius: var(--radius);
   padding: 8px;
   margin: 4px;
 }

--- a/lib/RadioButton/RadioButton.css
+++ b/lib/RadioButton/RadioButton.css
@@ -23,12 +23,11 @@
 
 .radioLabel {
   composes: interactionStyles from "../sharedStyles/interactionStyles.css";
-  padding: 4px 5px;
+  padding: var(--input-vertical-padding) var(--input-horizontal-padding);
   position: relative;
-  line-height: 120%;
+  line-height: var(--line-height);
   display: flex;
   align-items: baseline;
-  min-height: 24px;
   cursor: pointer;
   flex-grow: 2;
   border-radius: var(--radius);

--- a/lib/RadioButtonGroup/stories/BasicUsage.js
+++ b/lib/RadioButtonGroup/stories/BasicUsage.js
@@ -10,9 +10,9 @@ export default class BasicUsage extends React.Component {
   render() {
     return (
       <RadioButtonGroup>
-        <RadioButton label="Inline Radio Button 1" name="fruit" value="apples" />
-        <RadioButton label="Inline Radio Button 2" name="fruit" value="oranges" />
-        <RadioButton label="Inline Radio Button 3" name="fruit" value="bananas" />
+        <RadioButton label="Radio Button 1" name="fruit" value="apples" />
+        <RadioButton label="Radio Button 2" name="fruit" value="oranges" />
+        <RadioButton label="Radio Button 3" name="fruit" value="bananas" />
       </RadioButtonGroup>
     );
   }

--- a/lib/RepeatableField/RepeatableField.css
+++ b/lib/RepeatableField/RepeatableField.css
@@ -17,10 +17,6 @@
 
 .repeatableFieldRemoveItem {
   flex: 0 0 3em;
-  margin-top: 2.25em;
+  margin-top: 1.75em;
   text-align: center;
-
-  @media (--medium-up) {
-    margin-top: 1.5em;
-  }
 }

--- a/lib/SearchField/stories/BasicUsage.js
+++ b/lib/SearchField/stories/BasicUsage.js
@@ -89,7 +89,7 @@ export default class SearchFieldUsage extends Component {
           selectedIndex={hasSearchableIndexes ? this.state.selectedIndex : null}
           searchableIndexesPlaceholder="Search all.."
         />
-        <div style={{ marginTop: '15px', color: '#888' }}>
+        <div style={{ marginTop: '1rem', color: '#888' }}>
           { this.state.value ? `You typed: ${this.state.value}` : 'Try entering a value in the search field.'}
         </div>
       </div>

--- a/lib/Select/Select.css
+++ b/lib/Select/Select.css
@@ -8,8 +8,8 @@
 
 .selectControl {
   appearance: none;
-  height: var(--controlHeightSmall);
-  padding: 0 20px 0 var(--input-vertical-padding);
+  line-height: var(--line-height);
+  padding: var(--input-vertical-padding) var(--input-horizontal-padding);
 
   &.placeholder {
     color: #888;
@@ -27,16 +27,6 @@
 .selectIcon {
   position: absolute;
   right: 0;
-  top: 10px;
+  top: 0.25em;
   pointer-events: none;
-}
-
-@media (--medium-up) {
-  .selectControl {
-    height: var(--controlHeight);
-  }
-
-  .selectIcon {
-    top: 0;
-  }
 }

--- a/lib/Select/stories/BasicUsage.js
+++ b/lib/Select/stories/BasicUsage.js
@@ -34,7 +34,6 @@ const BasicUsage = () => (
       label="Select your favorite snack"
       dataOptions={options}
     />
-    <br />
     <Select
       validStylesEnabled
       label="With valid styles"
@@ -43,21 +42,18 @@ const BasicUsage = () => (
       dirty
       valid
     />
-    <br />
     <Select
       label="With warning styles"
       dataOptions={options}
       warning="Here is a warning"
       touched
     />
-    <br />
     <Select
       label="With error styles"
       dataOptions={options}
       error="Here is an error"
       touched
     />
-    <br />
     <Select
       label="Select your favorite snack"
       dataOptions={options}

--- a/lib/Selection/Selection.css
+++ b/lib/Selection/Selection.css
@@ -7,9 +7,8 @@
 .selectionListRoot {
   z-index: 9999;
   background-color: #fff;
-  border-radius: 4px;
   border: 1px solid #ccc;
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  box-shadow: var(--shadow);
 }
 
 .selectionListStatus {
@@ -30,8 +29,8 @@
 }
 
 .selectionControl {
-  height: var(--control-height);
-  padding: 0 8px;
+  line-height: var(--line-height);
+  padding: var(--input-vertical-padding) var(--input-horizontal-padding);
   width: 100%;
   display: flex;
   align-items: flex-start;
@@ -44,7 +43,7 @@
 }
 
 .selectionFilterContainer {
-  padding: 4px;
+  padding: 0.5rem;
 }
 
 .selectionEndControls {
@@ -60,7 +59,6 @@
 }
 
 .selectionFilter {
-  border-radius: var(--radius, 4px);
   width: 100%;
   padding: 4px 8px;
   border-style: solid;
@@ -97,32 +95,31 @@
 /* Selection List Options */
 
 .option {
-  padding: 6px;
+  padding: 0.5rem;
   cursor: default;
   display: flex;
   justify-content: space-between;
 
   &.selected {
-    background: var(--primary, #0c577f);
+    background: var(--color-fill-current);
     color: #fff;
     transition: all 0.2s;
 
     &:hover {
-      background-color: rgb(0, 95, 146);
+      background-color: var(--color-fill-current);
     }
 
     &.cursor {
-      color: #fff;
-      background-color: rgb(0, 95, 146);
+      background-color: var(--color-fill-current);
     }
   }
 
   &.cursor {
-    background-color: var(--hover, #ccc);
+    background-color: var(--color-fill-hover);
   }
 
   &:hover {
-    background-color: #ccc;
+    background-color: var(--color-fill-hover);
   }
 
   &.optionCentered {
@@ -164,7 +161,6 @@
   width: 100%;
   border-width: 0;
   padding: 2px 4px;
-  height: var(--control-height);
 }
 
 .selectionMultiSelected {

--- a/lib/TextArea/TextArea.css
+++ b/lib/TextArea/TextArea.css
@@ -9,13 +9,7 @@
   }
 
   & textarea {
-    min-height: var(--controlHeightSmall);
-    padding: var(--input-horizontal-padding) var(--input-vertical-padding);
-  }
-}
-
-@media (--mediumUp) {
-  .textArea textarea {
-    min-height: var(--controlHeight);
+    line-height: var(--line-height);
+    padding: var(--input-vertical-padding) var(--input-horizontal-padding);
   }
 }

--- a/lib/TextArea/stories/BasicUsage.js
+++ b/lib/TextArea/stories/BasicUsage.js
@@ -12,15 +12,11 @@ const BasicUsage = () => (
       placeholder="Placeholder Text"
       required
     />
-    <br />
-    <br />
     <TextArea
       value="This field is disabled"
       label="Disabled field"
       disabled
     />
-    <br />
-    <br />
     <TextArea
       validStylesEnabled
       touched
@@ -28,8 +24,6 @@ const BasicUsage = () => (
       dirty
       label="Field with validation success"
     />
-    <br />
-    <br />
     <TextArea
       value="Wrong value.."
       onChange={() => {}}
@@ -37,8 +31,6 @@ const BasicUsage = () => (
       error="Here is an error message"
       label="Field with a validation error"
     />
-    <br />
-    <br />
     <TextArea
       value="Not entirely valid value.."
       onChange={() => {}}

--- a/lib/TextField/TextField.css
+++ b/lib/TextField/TextField.css
@@ -5,9 +5,8 @@
   width: 100%;
 
   & input {
-    height: var(--controlHeightSmall);
-    min-height: var(--controlHeightSmall);
-    padding: var(--input-horizontal-padding) var(--input-vertical-padding);
+    line-height: var(--line-height);
+    padding: var(--input-vertical-padding) var(--input-horizontal-padding);
   }
 }
 
@@ -28,7 +27,8 @@
 .startControls,
 .endControls {
   pointer-events: none;
-  height: 100%;
+  padding: 0 0.125em;
+  height: 1.75em;
   display: flex;
   justify-content: flex-start;
   align-items: stretch;
@@ -36,21 +36,15 @@
 }
 
 .startControls {
-  padding-left: 2px;
-  height: 100%;
   justify-content: flex-start;
 }
 
 .endControls {
-  padding-right: 2px;
-  height: 100%;
-  width: 100%;
   justify-content: flex-end;
 }
 
 .controlGroup {
   pointer-events: all;
-  height: var(--control-height-small);
   display: flex;
   align-items: center;
 }
@@ -77,15 +71,6 @@
 .textFieldIcon {
   display: flex;
   align-items: center;
-}
-
-@media (--medium-up) {
-  .textField input {
-    height: var(--controlHeight);
-    min-height: var(--controlHeight);
-  }
-
-  .controlGroup {
-    height: var(--control-height);
-  }
+  height: 1.75em;
+  padding: 0 0.25rem;
 }

--- a/lib/Timepicker/TimeDropdown.css
+++ b/lib/Timepicker/TimeDropdown.css
@@ -3,38 +3,16 @@
 .timepickerContainer {
   position: relative;
   background: #fff;
-  border-radius: 4px;
+  border-radius: var(--radius);
   border: 1px solid #bcbcbc;
-  padding: 4px 8px;
+  padding: 0.5rem;
   width: 230px;
-  box-shadow: 0 4px 19px 0 rgba(0, 0, 0, 0.39);
+  box-shadow: var(--shadow);
   z-index: 9999;
 }
 
 .center {
   text-align: center;
-}
-
-.timepickerDropdownInput {
-  padding: 0 10px;
-  font-size: var(--font-size-large);
-  width: 100%;
-  margin-bottom: 0;
-  text-align: center;
-
-  /* suppress weird stylind in firefox */
-  border: 1px solid var(--color-border);
-  -moz-appearance: textfield;
-
-  &::-webkit-inner-spin-button,
-  &::-webkit-outer-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-  }
-
-  &:focus {
-    border-color: var(--primary, #2b75bb);
-  }
 }
 
 .srOnly {

--- a/lib/Timepicker/TimeDropdown.js
+++ b/lib/Timepicker/TimeDropdown.js
@@ -10,6 +10,7 @@ import { extendMoment } from 'moment-range';
 import Button from '../Button';
 import IconButton from '../IconButton';
 import { Row, Col } from '../LayoutGrid';
+import TextField from '../TextField';
 import css from './TimeDropdown.css';
 
 const moment = extendMoment(Moment);
@@ -344,7 +345,7 @@ class TimeDropdown extends React.Component {
         </Row>
         <Row center={this.props.hoursFormat === '12' ? undefined : 'xs'}>
           <Col xs={4}>
-            <input
+            <TextField
               aria-label="hours"
               ref={(h) => { this.hourField = h; }}
               placeholder="HH"
@@ -352,21 +353,20 @@ class TimeDropdown extends React.Component {
               tabIndex={this.props.visible ? '0' : '-1'}
               min={hourMin}
               max={hourMax}
-              className={css.timepickerDropdownInput}
               type="number"
               value={this.state.hour}
               onChange={(e) => { this.enterTime(e, 'hour'); }}
               onBlur={(e) => { this.handleBlur(e, 'hour'); }}
               id={`timeDD-${this.props.id}-hour-input`}
+              marginBottom0
             />
           </Col>
           <Col xs={1} className={css.center}><strong>:</strong></Col>
           <Col xs={4}>
-            <input
+            <TextField
               aria-label="minutes"
               ref={(m) => { this.minuteField = m; }}
               placeholder="MM"
-              className={css.timepickerDropdownInput}
               tabIndex={this.props.visible ? '0' : '-1'}
               type="number"
               min="0"
@@ -375,6 +375,7 @@ class TimeDropdown extends React.Component {
               onChange={(e) => { this.enterTime(e, 'minute'); }}
               onBlur={(e) => { this.handleBlur(e, 'minute'); }}
               id={`timeDD-${this.props.id}-minute-input`}
+              marginBottom0
             />
           </Col>
           {this.state.hoursFormat === '12' &&
@@ -419,6 +420,7 @@ class TimeDropdown extends React.Component {
               onKeyDown={this.setTimeHandleKeyDown}
               tabIndex={this.props.visible ? '0' : '-1'}
               fullWidth
+              marginBottom0
               onClick={this.confirmTime}
               id={`clickable-timeDD-${this.props.id}-set-time`}
             >

--- a/lib/global.css
+++ b/lib/global.css
@@ -73,6 +73,7 @@ textarea,
 select {
   font-size: inherit;
   font-family: inherit;
+  letter-spacing: inherit;
 }
 
 button {

--- a/lib/sharedStyles/interactionStyles.css
+++ b/lib/sharedStyles/interactionStyles.css
@@ -11,10 +11,10 @@
   --focus-dot-offset-default: 4px;
   --focus-dot-offset-small: -5px;
   --focus-dot-offset-medium: -10px;
-  --focus-dot-offset-large: -15px;
+  --focus-dot-offset-large: -1rem;
   --box-offset-small: -5px;
   --box-offset-medium: -10px;
-  --box-offset-large: -15px;
+  --box-offset-large: -1rem;
 }
 
 .interactionStyles {

--- a/lib/variables.css
+++ b/lib/variables.css
@@ -14,7 +14,7 @@
   --color-fill-hover: rgba(37, 118, 195, 0.2);
   --color-fill-focus: rgba(37, 118, 195, 0.3);
   --color-fill-active: var(--primary);
-  --shadow: 0 10px 30px 0 rgba(0, 0, 0, 0.24);
+  --shadow: 0 4px 32px rgba(0, 0, 0, 0.175);
   --bg: #fcfcfc;
   --bg-hover: color(var(--bg) contrast(100%) blend(var(--bg) 90%));
   --primary: #2b75bb;
@@ -23,14 +23,11 @@
   --danger: #900;
   --warn: #e27c3e;
   --success: #070;
-  --control-margin-bottom: 12px;
-  --control-height: 24px;
+  --control-margin-bottom: 1rem;
   --radius: 6px;
-  --gutter: 15px;
-  --control-height-small: 44px;
-  --control-height-touch: var(--control-height-small);
-  --input-horizontal-padding: 4px;
-  --input-vertical-padding: 8px;
+  --gutter: 1rem;
+  --input-horizontal-padding: 0.5rem;
+  --input-vertical-padding: 0.125rem;
 
   /**
    * Font-size


### PR DESCRIPTION
## Purpose
With the type stack changes in https://github.com/folio-org/stripes-components/pull/611 and https://github.com/folio-org/stripes-components/pull/627, form controls were no longer consistently sized. `<Button>` was significantly shorter than `<TextField>`, and `<Select>` seemed to miss a few memos. That made composing those things together a bit of a mess.

## Approach
- Lean more heavily on the existing `--input-horizontal-padding` and `--input-vertical-padding` CSS variables (which in most cases, were used backwards of their naming). Those values were converted to `rem`, but are otherwise unchanged.
- Make `<TextField>`, `<Select>`, `<Button>`, etc. all the same height through `padding` and `line-height`, instead of setting an explicit `height`.
- The global letter spacing wasn't being reflected with form controls in Storybook. Fixed.
- The `--radius` variable is now being consistently used.
- The `--shadow` variable is now being consistenly used.
- The `<Timepicker>` dropdown uses `<TextField>` now instead of bare `<input>`s.
- `16px` is now the go-to `gutter` size, since that makes the math really easy (`1 rem`).
- `em` or `rem` nearly always preferred over `px`
- `MultiColumnList` layout tightened up; it had been less dense with the move from 14px to 16px base

## Next steps
- Should the icon, icon button, and app icon sizes be revisited? Maybe no changes needed, but worth an evaluation.
- Should we create a touch target that surrounds buttons that's larger than their visual size?

## Screenshots

### Before
<img width="527" alt="screen shot 2018-10-10 at 6 56 52 pm" src="https://user-images.githubusercontent.com/230597/46772665-c70a6580-ccbe-11e8-870a-97d1b686f0ba.png">

![localhost_9001__selectedkind textfield selectedstory basic 20usage full 1 addons 1 stories 1 panelright 0 addonpanel react_storybook 2freadme 2fpanel ipad](https://user-images.githubusercontent.com/230597/46772671-cd004680-ccbe-11e8-92fd-0351e346dc6f.png)

### After
<img width="529" alt="screen shot 2018-10-10 at 6 56 28 pm" src="https://user-images.githubusercontent.com/230597/46772677-d4275480-ccbe-11e8-8014-bf4096f2073b.png">

![localhost_9001__selectedkind textfield selectedstory basic 20usage full 1 addons 1 stories 1 panelright 0 addonpanel react_storybook 2freadme 2fpanel ipad 1](https://user-images.githubusercontent.com/230597/46772688-da1d3580-ccbe-11e8-9546-8a3fafa42c4e.png)


