### PR TITLE
Release v4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Change history for stripes-components
 
-## 4.2.0 (IN PROGRESS)
+## [4.2.0](https://github.com/folio-org/stripes-components/tree/v4.2.0) (2018-10-11)
+[Full Changelog](https://github.com/folio-org/stripes-components/compare/v4.1.0...v4.2.0)
 
 * Add clone option to EntrySelector. Fixes STCOM-364.
+* Export `<RepeatableField>`
 * Shrink `<MetaSection>` font sizes
+* Decouple form element styles
 * Polish form control sizing
 
 ## [4.1.0](https://github.com/folio-org/stripes-components/tree/v4.1.0) (2018-10-01)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
* Add clone option to EntrySelector. Fixes STCOM-364.
* Export `<RepeatableField>`
* Shrink `<MetaSection>` font sizes
* Decouple form element styles
* Polish form control sizing