### PR TITLE
Make label margins consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-components
 
+## 4.3.1 (IN PROGRESS)
+
+* Make label margins consistent
+
 ## [4.2.0](https://github.com/folio-org/stripes-components/tree/v4.2.0) (2018-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v4.1.0...v4.2.0)
 

--- a/lib/KeyValue/KeyValue.css
+++ b/lib/KeyValue/KeyValue.css
@@ -3,7 +3,7 @@
 .kvLabel {
   display: block;
   font-weight: var(--text-weight-basis);
-  margin-bottom: 2px;
+  margin-bottom: 0.25rem;
   color: var(--color-text-p2);
   font-size: var(--font-size-small);
   line-height: var(--line-height);

--- a/lib/sharedStyles/form.css
+++ b/lib/sharedStyles/form.css
@@ -18,7 +18,7 @@
   display: block;
   font-size: var(--font-size-small);
   line-height: var(--line-height);
-  margin-bottom: 0.5em;
+  margin-bottom: 0.25rem;
   color: var(--color-text);
 
   &.required::after {


### PR DESCRIPTION
## Purpose
`<KeyValue>` is essentially used like a form element, with a label... except the margins were inconsistent for the label/key element. I noticed in eHoldings when I tried to do
```
<KeyValue>
<Button />
</KeyValue>
```
and the spacing was a lot tighter than I expected. Labels had 8px margin bottom, while the key had 2px.

## Approach
I met in the middle - now `label`s and the "keys" of `<KeyValue>` both have a `0.25rem` (`4px`) bottom margin.