### PR TITLE
STCOM-366 Focus-trapping with multiple layers.

### DIFF
--- a/lib/Layer/Layer.js
+++ b/lib/Layer/Layer.js
@@ -108,7 +108,7 @@ class Layer extends React.Component {
 
   maybeEnforceFocus() {
     if (this.props.enforceFocus) {
-      trapFocus(this.contentRef.current);
+      trapFocus(this.contentRef.current, [...document.querySelectorAll(`.${css.LayerRoot}`)]);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",

--- a/util/trapFocus.js
+++ b/util/trapFocus.js
@@ -1,14 +1,18 @@
 import contains from 'dom-helpers/query/contains';
+import layerCss from '../lib/Layer/Layer.css';
 
 const getDefaultExceptions = () => [
   document.getElementById('OverlayContainer'),
   ...document.querySelectorAll('.tether-element'),
+  ...document.querySelectorAll(`.${layerCss.LayerRoot}`)
 ];
 
 export default function trapFocus(container, exceptions = getDefaultExceptions()) {
-  if (container && !contains(container, document.activeElement)) {
-    if (exceptions.filter((e) => contains(e, document.activeElement)).length === 0) {
-      container.focus();
+  if (container && container.className !== document.activeElement.className) {
+    if (container && !contains(container, document.activeElement)) {
+      if (exceptions.filter((e) => contains(e, document.activeElement)).length === 0) {
+        container.focus();
+      }
     }
   }
 }

--- a/util/trapFocus.js
+++ b/util/trapFocus.js
@@ -7,7 +7,7 @@ const getDefaultExceptions = () => [
 
 export default function trapFocus(container, exceptions) {
   if (container && container.className !== document.activeElement.className) {
-    if (container && !contains(container, document.activeElement)) {
+    if (!contains(container, document.activeElement)) {
       if ([...getDefaultExceptions(), ...exceptions].filter((e) => contains(e, document.activeElement)).length === 0) {
         container.focus();
       }

--- a/util/trapFocus.js
+++ b/util/trapFocus.js
@@ -2,7 +2,7 @@ import contains from 'dom-helpers/query/contains';
 
 const getDefaultExceptions = () => [
   document.getElementById('OverlayContainer'),
-  ...document.querySelectorAll('.tether-element')
+  ...document.querySelectorAll('.tether-element'),
 ];
 
 export default function trapFocus(container, exceptions) {

--- a/util/trapFocus.js
+++ b/util/trapFocus.js
@@ -1,16 +1,14 @@
 import contains from 'dom-helpers/query/contains';
-import layerCss from '../lib/Layer/Layer.css';
 
 const getDefaultExceptions = () => [
   document.getElementById('OverlayContainer'),
-  ...document.querySelectorAll('.tether-element'),
-  ...document.querySelectorAll(`.${layerCss.LayerRoot}`)
+  ...document.querySelectorAll('.tether-element')
 ];
 
-export default function trapFocus(container, exceptions = getDefaultExceptions()) {
+export default function trapFocus(container, exceptions) {
   if (container && container.className !== document.activeElement.className) {
     if (container && !contains(container, document.activeElement)) {
-      if (exceptions.filter((e) => contains(e, document.activeElement)).length === 0) {
+      if ([...getDefaultExceptions(), ...exceptions].filter((e) => contains(e, document.activeElement)).length === 0) {
         container.focus();
       }
     }


### PR DESCRIPTION
## Bug - multiple layers present throws the focus-trapping of Layer into an endless recursion.
The existence of this bug/PR illustrates the difficulty with accessibility and focus-management that comes with the layer-based routing setup ( mentioned here: https://issues.folio.org/browse/STRIPES-537). Inventory uses `<Layer>` in a slightly different way than most other ui-modules since it leans on both a URL path **and** a `layer` query parameter - it creates a situation where there is more than one Layer component present. Both have focus-trapping, and so they battle! This results in the recursion.

While the transition of focus is still maintained by this PR, the accessibility only gets weaker as more layers are present and more focusable elements. A real fix under current conditions would involve a top-layer 'manager' component for these along with a corresponding PR to insert it into stripes-core  or at least additional responsibility on Paneset which will lay additional dependency on React context - still in a shaky phase while we warm up to `stripes v1.0.0`.

Here forward, I recommend we investigate refactor for a more 'page-based' approach to the structure of ui modules.
