### PR TITLE
STCOM-369 quiet console warnings from SelectList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Change history for stripes-components
 
-## 4.3.1 (IN PROGRESS)
+## 4.3.0 (IN PROGRESS)
 
 * Make label margins consistent
 * Add ability to filter items in EntrySelector. Fixes STCOM-367.
+* Resolve issue recursion issue with `trapFocus` with multiple `<Layer>`s. STCOM-366.
+* Clear console noise from `<Selection>`/`<SelectList>`. STCOM-369.
 
 ## [4.2.0](https://github.com/folio-org/stripes-components/tree/v4.2.0) (2018-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v4.1.0...v4.2.0)

--- a/lib/Selection/SelectList.js
+++ b/lib/Selection/SelectList.js
@@ -288,7 +288,7 @@ class SelectList extends React.Component {
 
     return (
       <div
-        hidden={this.props.visible ? undefined : 'true'}
+        hidden={this.props.visible ? undefined : true}
         className={this.getRootClass()}
         style={{ width: this.props.width }}
         id={`sl-container-${this.props.id}`}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
## Bug
`<SelectList>` was generating a console error since a string attribute was being applied where a boolean would be best. Not a functional bug, just a noisy one - still, the less noise, the better...
![image](https://user-images.githubusercontent.com/20704067/46955309-41890b80-d058-11e8-97b5-42aae12cd18f.png)
