### PR TITLE
Layout: Fixed padding-end-gutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add ability to filter items in EntrySelector. Fixes STCOM-367.
 * Resolve issue recursion issue with `trapFocus` with multiple `<Layer>`s. STCOM-366.
 * Clear console noise from `<Selection>`/`<SelectList>`. STCOM-369.
+* Fixed `<Layout>`'s `padding-end-gutter` rule.
 
 ## [4.2.0](https://github.com/folio-org/stripes-components/tree/v4.2.0) (2018-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v4.1.0...v4.2.0)

--- a/lib/Layout/styles/padding.css
+++ b/lib/Layout/styles/padding.css
@@ -25,5 +25,5 @@
 }
 
 .padding-end-gutter {
-  padding-left: var(--gutter);
+  padding-right: var(--gutter);
 }


### PR DESCRIPTION
Both `padding-start-gutter` and `padding-end-gutter` were just setting the `padding-left` property. Changed it so `padding-end-gutter` now sets the `padding-right` property instead.