### PR TITLE
indicate whether `<EntrySelector>` has any entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Clear console noise from `<Selection>`/`<SelectList>`. STCOM-369.
 * Removed title attribute from AppIcon (STCOR-268) and minor line-height fix
 * Fixed `<Layout>`'s `padding-end-gutter` rule.
+* Use a CSS class to indicate whether `<EntrySelector>` has any entries. Available from v4.2.2.
 
 ## [4.2.0](https://github.com/folio-org/stripes-components/tree/v4.2.0) (2018-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v4.1.0...v4.2.0)

--- a/lib/EntrySelector/EntrySelector.js
+++ b/lib/EntrySelector/EntrySelector.js
@@ -189,7 +189,7 @@ class EntrySelector extends React.Component {
         <Pane defaultWidth="fill" lastMenu={LastMenu} paneTitle={paneTitle} noOverflow>
           {this.props.rowFilter}
           <NavList>
-            <NavListSection activeLink={this.activeLink(links)}>
+            <NavListSection activeLink={this.activeLink(links)} className={contentData.length ? 'hasEntries' : ''}>
               {links}
             </NavListSection>
           </NavList>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
Use a CSS class to indicate when this component is rendered with one or
more entries. This component may re-render once results become
available, but there's no easy way for a test to know that because there
are no element classes, no element ids, nothin'. It would have to parse
some crazy long nested structure of divs and anchors, which feels pretty
nasty.

In fact, the loan renewal tests in platform core sometimes blow up when
trying to click on non-existent links because they don't have a good way
to test whether those links are present. This helps.

Refs [UITEST-55](https://issues.folio.org/browse/UITEST-55)