### PR TITLE
Updated margins/paddings for MCL

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -32,8 +32,8 @@
   border-radius: var(--radius);
   color: var(--color-text);
   text-decoration: none;
-  margin-left: 0.25rem;
-  margin-right: 0.25rem;
+  margin-left: calc(var(--gutter) / 3);
+  margin-right: calc(var(--gutter) / 3);
   outline: none;
 
   &:visited {
@@ -82,7 +82,7 @@
   align-items: center;
   flex-shrink: 0;
   flex-grow: 0;
-  padding: 0.5rem 0.5rem;
+  padding: 0.5rem var(--gutter);
   font-weight: 600;
   color: var(--color-text-p2);
   font-size: var(--font-size-small);
@@ -110,7 +110,7 @@
   flex-shrink: 0;
   flex-grow: 0;
   line-height: var(--line-height);
-  padding: 0.125rem 0.5rem;
+  padding: 0.125rem calc(var(--gutter) * 0.666666666666667);
   overflow: hidden;
 
   &.showOverflow {

--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -32,8 +32,8 @@
   border-radius: var(--radius);
   color: var(--color-text);
   text-decoration: none;
-  margin-left: calc(var(--gutter) / 3);
-  margin-right: calc(var(--gutter) / 3);
+  margin-left: calc(var(--gutter) * 0.3333333);
+  margin-right: calc(var(--gutter) * 0.3333333);
   outline: none;
 
   &:visited {

--- a/lib/variables.css
+++ b/lib/variables.css
@@ -25,7 +25,7 @@
   --success: #070;
   --control-margin-bottom: 1rem;
   --radius: 6px;
-  --gutter: 1rem;
+  --gutter: 0.9375rem; /* Computes to 15px when body font-size is 16px */
   --input-horizontal-padding: 0.5rem;
   --input-vertical-padding: 0.125rem;
 


### PR DESCRIPTION
Updated `--gutter` variable to correspond to 15px when computed (on a font-size of 16px). 

Updated padding/margin for MCL header, row, and cells using the `-gutter` variable so that there is the correct spacing from edge to content (15px).

Ideally, the gutter should remain a static `15px` which is the system-wide default gutter padding/margin. For now, I have changed it into a corresponding rem-value. We can later on decide to change it into pixels and the spacing will still match.

## Before
![before](https://user-images.githubusercontent.com/640976/47566655-ac75f480-d92c-11e8-86d4-b1be6a53a2c5.png)

## After
![after](https://user-images.githubusercontent.com/640976/47566665-b3046c00-d92c-11e8-810a-0b1f6c06ff2f.png)


