### PR TITLE
Fix MCL header padding

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -32,7 +32,7 @@
   border-radius: var(--radius);
   color: var(--color-text);
   text-decoration: none;
-  margin: 0 0.5rem;
+  margin: 0 calc(var(--gutter) / 2);
   outline: none;
 
   &:visited {
@@ -68,7 +68,7 @@
 .headerRow {
   display: flex;
   justify-content: flex-start;
-  margin: 0 0.5rem;
+  margin: 0 calc(var(--gutter) / 2);
   overflow: hidden;
   width: 100%;
 
@@ -82,7 +82,7 @@
   align-items: center;
   flex-shrink: 0;
   flex-grow: 0;
-  padding: 0.5rem;
+  padding: calc(var(--gutter) / 2);
   font-weight: 600;
   color: var(--color-text-p2);
   font-size: var(--font-size-small);
@@ -110,7 +110,7 @@
   flex-shrink: 0;
   flex-grow: 0;
   line-height: var(--line-height);
-  padding: 0.125rem 0.5rem;
+  padding: calc(var(--gutter) / 4) calc(var(--gutter) / 2);
   overflow: hidden;
 
   &.showOverflow {

--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -32,8 +32,7 @@
   border-radius: var(--radius);
   color: var(--color-text);
   text-decoration: none;
-  margin-left: 0.25rem;
-  margin-right: 0.25rem;
+  margin: 0 0.5rem;
   outline: none;
 
   &:visited {
@@ -69,8 +68,9 @@
 .headerRow {
   display: flex;
   justify-content: flex-start;
+  margin: 0 0.5rem;
   overflow: hidden;
-  width: calc(100% - 22px);
+  width: 100%;
 
   &.hScroll {
     overflow: auto;
@@ -82,7 +82,7 @@
   align-items: center;
   flex-shrink: 0;
   flex-grow: 0;
-  padding: 0.5rem 0.5rem;
+  padding: 0.5rem;
   font-weight: 600;
   color: var(--color-text-p2);
   font-size: var(--font-size-small);


### PR DESCRIPTION
Attempts to solve the same problem as https://github.com/folio-org/stripes-components/pull/669, where the `MultiColumnList` headers are not aligned with their column content.

Maintains `1rem` (`16px`) gutter, not `15px`.

### Before
![folio-testing aws indexdata com_users_view_filters active include 20inactive 20users sort name ipad 1](https://user-images.githubusercontent.com/230597/47583486-42a21e80-d91d-11e8-889c-b1b522031f78.png)

### After
![folio-testing aws indexdata com_users_filters active include 20inactive 20users sort name ipad](https://user-images.githubusercontent.com/230597/47583452-27cfaa00-d91d-11e8-9581-f15c35c90023.png)
