### PR TITLE
Reduce pane header button margin

### DIFF
--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -185,7 +185,7 @@
   }
 
   &.paneHeaderNewButton {
-    margin-right: 1rem;
+    margin-right: 0.5rem;
   }
 
   &.noRadius {


### PR DESCRIPTION
The pane header "New" button had a bit too much margin.

### Before
![before](https://user-images.githubusercontent.com/230597/47583752-fd322100-d91d-11e8-9fa2-b0792ced44ce.png)

### After
![after](https://user-images.githubusercontent.com/230597/47583761-ff947b00-d91d-11e8-833a-d59202941497.png)

