### PR TITLE
Updated icon color variable to 62% black to improve contrast

### DIFF
--- a/lib/variables.css
+++ b/lib/variables.css
@@ -3,7 +3,7 @@
   --color-text-p2: rgba(0, 0, 0, 0.62);
   --color-border: rgba(0, 0, 0, 0.2);
   --color-border-p2: rgba(0, 0, 0, 0.1);
-  --color-icon: rgba(0, 0, 0, 0.3);
+  --color-icon: rgba(0, 0, 0, 0.62);
   --color-link: var(--primary);
   --color-link-visited: #4f2bbb;
   --color-fill: rgba(0, 0, 0, 0.03);


### PR DESCRIPTION
The icon color is failing when tested with contrast ratio tools so we are making it a bit darker.

This should fix the icon related issues in:
https://issues.folio.org/browse/STCOM-377

## Before
![image](https://user-images.githubusercontent.com/640976/47657411-505fda00-db91-11e8-91e6-ef540d0a99fd.png)

## After 
![image](https://user-images.githubusercontent.com/640976/47657372-3b834680-db91-11e8-8d77-44cebee1650a.png)

