### PR TITLE
Improve dev tools output for forwardRef

### DIFF
--- a/lib/InjectIntl/InjectIntl.js
+++ b/lib/InjectIntl/InjectIntl.js
@@ -1,14 +1,17 @@
 import React, { Component, forwardRef } from 'react';
 import PropTypes from 'prop-types';
+import hoistNonReactStatics from 'hoist-non-react-statics';
 import { intlShape } from 'react-intl';
 
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
+}
+
 export default function injectIntl(WrappedComponent, options = {}) {
-  const { withRef = false } = options;
-  const componentName = WrappedComponent.displayName || WrappedComponent.name || 'Component';
+  const { intlPropName = 'intl', withRef = false } = options;
 
   class InjectIntl extends Component {
-    static WrappedComponent = WrappedComponent;
-    static displayName = `InjectIntl(${componentName})`;
+    static displayName = `InjectIntl(${getDisplayName(WrappedComponent)})`;
 
     static propTypes = {
       forwardedRef: PropTypes.oneOfType([
@@ -23,6 +26,8 @@ export default function injectIntl(WrappedComponent, options = {}) {
       intl: intlShape
     };
 
+    static WrappedComponent = WrappedComponent;
+
     render() {
       const {
         forwardedRef,
@@ -32,21 +37,21 @@ export default function injectIntl(WrappedComponent, options = {}) {
       return (
         <WrappedComponent
           {...rest}
-          intl={this.context.intl}
+          {...{ [intlPropName]: this.context.intl }}
           ref={withRef ? forwardedRef : null}
         />
       );
     }
   }
 
-  function forward(props, ref) {
-    return <InjectIntl forwardedRef={ref} {...props} />;
-  }
-
-  forward.displayName = componentName;
-
   if (withRef) {
-    return forwardRef(forward);
+    const ForwardedComponent = forwardRef((props, ref) => {
+      return <InjectIntl {...props} forwardedRef={ref} />;
+    });
+
+    ForwardedComponent.displayName = `${InjectIntl.displayName}`;
+    return hoistNonReactStatics(ForwardedComponent, InjectIntl);
   }
-  return forward;
+
+  return hoistNonReactStatics(InjectIntl, WrappedComponent);
 }

--- a/lib/ReduxFormField/ReduxFormField.js
+++ b/lib/ReduxFormField/ReduxFormField.js
@@ -21,7 +21,7 @@ const reduxFormField = (WrappedComponent, config) => {
     }
   }
 
-  const componentName = WrappedComponent.displayName || WrappedComponent.name;
+  const componentName = WrappedComponent.displayName || WrappedComponent.name || 'Component';
   fieldWithRef.displayName = `ReduxFormField(${componentName})`;
 
   return forwardRef(fieldWithRef);

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "classnames": "^2.2.5",
     "dom-helpers": "^3.2.1",
     "downshift": "^2.0.16",
+    "hoist-non-react-statics": "^3.1.0",
     "json2csv": "^4.2.1",
     "lodash": "^4.17.4",
     "memoize-one": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6448,6 +6448,13 @@ hoist-non-react-statics@^3.0.0:
   dependencies:
     react-is "^16.3.2"
 
+hoist-non-react-statics@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.1.0.tgz#42414ccdfff019cd2168168be998c7b3bd5245c0"
+  integrity sha512-MYcYuROh7SBM69xHGqXEwQqDux34s9tz+sCnxJmN18kgWh6JFdTw/5YdZtqsOdZJXddE/wUpCzfEdDrJj8p0Iw==
+  dependencies:
+    react-is "^16.3.2"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"


### PR DESCRIPTION
## Purpose
When prepping a PR to `react-intl` to share our `forwardRef` usage upstream, I noticed some sloppiness around how we label components using `InjectIntl`. 

## Approach
- Now components using `injectIntl()` that don't opt into `withRef` have one less layer of component tree.
- `hoist-non-react-statics` helps with sending around `displayName`.
- The `intlPropName` change just aligns our fork closer to the upstream `InjectIntl`.

### Before
<img width="1159" alt="screen shot 2018-10-30 at 6 53 27 pm" src="https://user-images.githubusercontent.com/230597/47757835-449a1380-dc76-11e8-8672-f3c079dbff0b.png">

### After
<img width="1033" alt="screen shot 2018-10-30 at 6 52 23 pm" src="https://user-images.githubusercontent.com/230597/47757838-46fc6d80-dc76-11e8-9465-aa8d217fb748.png">
