### PR TITLE
Move icon sizing to SVG instead of root element

### DIFF
--- a/lib/Icon/Icon.css
+++ b/lib/Icon/Icon.css
@@ -89,7 +89,7 @@ Note: Using pseudo elements to add spacing for RTL support
 .label::after {
   content: '';
   display: none;
-  width: 0.22em;
+  width: 0.35em;
 }
 
 .icon-position-start .label::before,

--- a/lib/Icon/Icon.css
+++ b/lib/Icon/Icon.css
@@ -10,24 +10,28 @@
   &:focus {
     outline: none;
   }
-
-  &.small {
-    font-size: 0.83em;
-  }
-
-  &.medium {
-    font-size: 1em;
-  }
-
-  &.large {
-    font-size: 1.17em;
-  }
 }
 
 :global .stripes__icon {
   fill: currentColor;
   height: 1em;
   width: 1em;
+}
+
+/**
+ * Sizes
+ */
+
+.small {
+  font-size: 0.83em;
+}
+
+.medium {
+  font-size: 1em;
+}
+
+.large {
+  font-size: 1.17em;
 }
 
 /**

--- a/lib/Icon/Icon.js
+++ b/lib/Icon/Icon.js
@@ -43,7 +43,6 @@ class Icon extends React.Component {
     const getRootClass = classNames(
       css.icon,
       iconRootClass,
-      css[size],
       // If icon position is defined
       { [css[`icon-position-${iconPosition}`]]: children && iconPosition },
       // If a status is defined
@@ -58,6 +57,7 @@ class Icon extends React.Component {
       'stripes__icon',
       iconClassName,
       `icon-${icon}`,
+      css[size],
     );
 
     // Defaults to the default-icon

--- a/lib/Icon/tests/Icon-test.js
+++ b/lib/Icon/tests/Icon-test.js
@@ -13,7 +13,7 @@ import icons from '../icons';
 import css from '../Icon.css';
 import Icon from '../Icon';
 
-describe('Icon', () => {
+describe.only('Icon', () => {
   const icon = new IconInteractor();
   const iconClassName = 'icon-class';
   const iconRootClass = 'icon-root-class';
@@ -94,12 +94,13 @@ describe('Icon', () => {
   Object.keys(sizes).forEach(size => {
     describe(`When passing a string of "${size}" using the "size"-prop`, () => {
       const sizeClassName = css[size];
+
       beforeEach(async () => {
         await mount(<Icon icon="clearX" size={size} />);
       });
 
-      it(`It should render an icon with a className of "${sizeClassName}"`, () => {
-        expect(icon.className).to.include(sizeClassName);
+      it(`It should render an SVG with a className of "${sizeClassName}"`, () => {
+        expect(icon.svg.className).to.include(sizeClassName);
       });
 
       it(`It should have a width of ${sizes[size].width}px`, () => {
@@ -121,21 +122,21 @@ describe('Icon', () => {
   // that probably will be removed in the future in replacement of a loading component
   const testableIcons = Object.keys(icons).filter(key => ['spinner-ellipsis'].indexOf(key) < 0);
 
-  testableIcons.forEach((key) => {
-    describe(`When passing a string of "${key}" using the "icon"-prop`, () => {
-      beforeEach(async () => {
-        await mount(<Icon icon={key} iconClassName={iconClassName} />);
-      });
+  // testableIcons.forEach((key) => {
+  //   describe(`When passing a string of "${key}" using the "icon"-prop`, () => {
+  //     beforeEach(async () => {
+  //       await mount(<Icon icon={key} iconClassName={iconClassName} />);
+  //     });
 
-      it('It should render a svg', () => {
-        expect(icon.svg.isPresent).to.be.true;
-      });
+  //     it('It should render a svg', () => {
+  //       expect(icon.svg.isPresent).to.be.true;
+  //     });
 
-      it(`SVG should include a className of "${iconClassName}"`, () => {
-        expect(icon.svg.className).to.include(iconClassName);
-      });
-    });
-  });
+  //     it(`SVG should include a className of "${iconClassName}"`, () => {
+  //       expect(icon.svg.className).to.include(iconClassName);
+  //     });
+  //   });
+  // });
 
   /**
    * Testing icon rendered without passing an icon-prop

--- a/lib/Icon/tests/Icon-test.js
+++ b/lib/Icon/tests/Icon-test.js
@@ -99,7 +99,7 @@ describe('Icon', () => {
         await mount(<Icon icon="clearX" size={size} />);
       });
 
-      it(`It should render an SVG with a className of "${sizeClassName}"`, () => {
+      it(`It should render a SVG with a className of "${sizeClassName}"`, () => {
         expect(icon.svg.className).to.include(sizeClassName);
       });
 

--- a/lib/Icon/tests/Icon-test.js
+++ b/lib/Icon/tests/Icon-test.js
@@ -13,7 +13,7 @@ import icons from '../icons';
 import css from '../Icon.css';
 import Icon from '../Icon';
 
-describe.only('Icon', () => {
+describe('Icon', () => {
   const icon = new IconInteractor();
   const iconClassName = 'icon-class';
   const iconRootClass = 'icon-root-class';
@@ -122,21 +122,21 @@ describe.only('Icon', () => {
   // that probably will be removed in the future in replacement of a loading component
   const testableIcons = Object.keys(icons).filter(key => ['spinner-ellipsis'].indexOf(key) < 0);
 
-  // testableIcons.forEach((key) => {
-  //   describe(`When passing a string of "${key}" using the "icon"-prop`, () => {
-  //     beforeEach(async () => {
-  //       await mount(<Icon icon={key} iconClassName={iconClassName} />);
-  //     });
+  testableIcons.forEach((key) => {
+    describe(`When passing a string of "${key}" using the "icon"-prop`, () => {
+      beforeEach(async () => {
+        await mount(<Icon icon={key} iconClassName={iconClassName} />);
+      });
 
-  //     it('It should render a svg', () => {
-  //       expect(icon.svg.isPresent).to.be.true;
-  //     });
+      it('It should render a svg', () => {
+        expect(icon.svg.isPresent).to.be.true;
+      });
 
-  //     it(`SVG should include a className of "${iconClassName}"`, () => {
-  //       expect(icon.svg.className).to.include(iconClassName);
-  //     });
-  //   });
-  // });
+      it(`SVG should include a className of "${iconClassName}"`, () => {
+        expect(icon.svg.className).to.include(iconClassName);
+      });
+    });
+  });
 
   /**
    * Testing icon rendered without passing an icon-prop

--- a/lib/Icon/tests/interactor.js
+++ b/lib/Icon/tests/interactor.js
@@ -16,9 +16,9 @@ export default interactor(class IconInteractor {
   title = property('title');
   label = text();
 
-  isSmall = hasClass(css.small);
-  isMedium = hasClass(css.medium);
-  isLarge = hasClass(css.large);
+  isSmall = hasClass(`.${css.icon} svg`, css.small);
+  isMedium = hasClass(`.${css.icon} svg`, css.medium);
+  isLarge = hasClass(`.${css.icon} svg`, css.large);
 
   isError = hasClass(css.error);
   isWarn = hasClass(css.warn);


### PR DESCRIPTION
The size of the icon should not affect the font-size of the label.

E.g. when using an `<Icon>` inside of a `<Button>` we need the label to enherit the font-size from the button.

I also adjusted the spacing between icon and label.

## Before
<img width="321" alt="screenshot 2018-10-31 11 30 24" src="https://user-images.githubusercontent.com/640976/47782969-d6029780-dd01-11e8-8a3a-197326d165e4.png">

## After
<img width="323" alt="screenshot 2018-10-31 11 39 14" src="https://user-images.githubusercontent.com/640976/47782970-d864f180-dd01-11e8-8d2a-c9de822288f8.png">
