### PR TITLE
Added RTL compatible spacing between Icon and Badge

### DIFF
--- a/lib/IconButton/IconButton.css
+++ b/lib/IconButton/IconButton.css
@@ -16,11 +16,6 @@
   background: none;
   color: var(--color-icon);
 
-  /* Let the button expand in width if we have a badge */
-  &.hasBadge {
-    width: auto;
-  }
-
   & + .iconButton {
     margin-left: 0.25em;
   }
@@ -49,4 +44,20 @@
       margin-right: 0.25em;
     }
   }
+}
+
+/**
+ * With badge
+ */
+
+/* Let the button expand in width if we have a badge */
+.iconButton.hasBadge {
+  width: auto;
+}
+
+/* Add spacing between icon and badge */
+.hasBadge .icon::after {
+  content: '';
+  width: 0.3em;
+  display: inline-block;
 }

--- a/lib/IconButton/IconButton.js
+++ b/lib/IconButton/IconButton.js
@@ -68,7 +68,7 @@ const IconButton = React.forwardRef(({
   return (
     <Element {...buttonProps}>
       <span className={classNames(css.iconButtonInner, css[`${size}Offset`])} {...rest}>
-        <Icon icon={icon} size={iconSize} iconClassName={iconClassName} />
+        <Icon icon={icon} size={iconSize} iconRootClass={css.icon} iconClassName={iconClassName} />
         { badgeCount !== undefined && <Badge size="medium" color={badgeColor}>{badgeCount}</Badge> }
       </span>
     </Element>

--- a/lib/Selection/Selection.css
+++ b/lib/Selection/Selection.css
@@ -38,7 +38,7 @@
 
   &.marginBottom0 {
     /* stylelint-disable-next-line length-zero-no-unit */
-    margin-bottom: 0px;
+    margin-bottom: 0;
   }
 }
 


### PR DESCRIPTION
Since we removed the white-space from icons, the icon and the badge was a little bit too close to each other.

This PR adds some spacing in a RTL compatible way.

## Before
![image](https://user-images.githubusercontent.com/640976/47787094-12d48b80-dd0e-11e8-84f5-474cf7e3d499.png)


## After
![image](https://user-images.githubusercontent.com/640976/47787048-f0db0900-dd0d-11e8-887d-3e2277684983.png)
