### PR TITLE
Release v4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-components
 
-## 4.3.0 (IN PROGRESS)
+## [4.3.0](https://github.com/folio-org/stripes-components/tree/v4.3.0) (2018-10-31)
+[Full Changelog](https://github.com/folio-org/stripes-components/compare/v4.2.0...v4.3.0)
 
 * Make label margins consistent
 * Add ability to filter items in EntrySelector. Fixes STCOM-367.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "4.2.4",
+  "version": "4.3.0",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
* Make label margins consistent
* Add ability to filter items in EntrySelector. Fixes STCOM-367.
* Resolve issue recursion issue with `trapFocus` with multiple `<Layer>`s. STCOM-366.
* Clear console noise from `<Selection>`/`<SelectList>`. STCOM-369.
* Removed title attribute from AppIcon (STCOR-268) and minor line-height fix
* Fixed `<Layout>`'s `padding-end-gutter` rule.
* Use a CSS class to indicate whether `<EntrySelector>` has any entries. Available from v4.2.2.
* Added more flexbox classes to `<Layout>`. Available from v4.2.4.
* Resize icons
* Export `<NavListItem>`