### PR TITLE
`color()` chokes on rgb/rgba; use hex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-components
 
+## 4.4.0 (IN PROGRESS)
+
+* `color` chokes on rgb/rgba; use hex values instead.
+
 ## [4.3.0](https://github.com/folio-org/stripes-components/tree/v4.3.0) (2018-10-31)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v4.2.0...v4.3.0)
 

--- a/lib/variables.css
+++ b/lib/variables.css
@@ -15,7 +15,7 @@
   --color-fill-focus: rgba(37, 118, 195, 0.3);
   --color-fill-active: var(--primary);
   --shadow: 0 4px 32px rgba(0, 0, 0, 0.175);
-  --bg: rgba(255, 255, 255, 1);
+  --bg: #fff;
   --bg-hover: color(var(--bg) contrast(100%) blend(var(--bg) 90%));
   --primary: #2b75bb;
   --secondary: #999;


### PR DESCRIPTION
hsl and rgba
when all we want is opaque white
call `color(hex)`, the others, nay,
to paint the background with delight