### PR TITLE
check presence of props.onClick before calling it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.4.0 (IN PROGRESS)
 
 * `color` chokes on rgb/rgba; use hex values instead.
+* Validate presence of `props.onClick()` before calling it.
 
 ## [4.3.0](https://github.com/folio-org/stripes-components/tree/v4.3.0) (2018-10-31)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v4.2.0...v4.3.0)

--- a/lib/Button/Button.js
+++ b/lib/Button/Button.js
@@ -59,7 +59,9 @@ function Button(props) {
 
   function handleAnchorClick(e) {
     if (e && !props.allowAnchorClick) e.preventDefault();
-    props.onClick(e);
+    if (props.onClick) {
+      props.onClick(e);
+    }
   }
 
   const inputCustom = omitProps(props, [


### PR DESCRIPTION
Best not to call a function that doesn't exist.