### PR TITLE
Fix missing CSS var import in Icon story

### DIFF
--- a/lib/Icon/stories/style.css
+++ b/lib/Icon/stories/style.css
@@ -1,3 +1,5 @@
+@import '../../variables';
+
 .iconGrid {
   padding: 0;
   margin: 0;


### PR DESCRIPTION
Fixes
```
WARNING in ./node_modules/css-loader??ref--4-1!./node_modules/postcss-loader/lib??ref--4-2!./lib/Icon/stories/style.css
(Emitted value instead of an instance of Error) postcss-custom-properties: /Users/jeffrey/Sites/folio/stripes-components/lib/Icon/stories/style.css:30:3: variable '--font-size-x-small' is undefined and used without a fallback
```