### PR TITLE
Add documentation reference for moment.utc

### DIFF
--- a/lib/Datepicker/readme.md
+++ b/lib/Datepicker/readme.md
@@ -1,5 +1,5 @@
 # Datepicker
-### Usage
+## Usage
 
 ```js
 import { Datepicker } from '@folio/stripes/components';
@@ -9,7 +9,7 @@ import { Datepicker } from '@folio/stripes/components';
 <Field component={Datepicker} />
 ```
 
-### Props
+## Props
 Name | type | description | default | required
 --- | --- | --- | --- | ---
 `label` | string | visible field label | | false
@@ -27,9 +27,22 @@ Name | type | description | default | required
 
 <!-- dateFormat | string | system formatting for date. [Moment.js formats](https://momentjs.com/docs/#/displaying/format/) are supported | "MM/DD/YYYY" | false-->
 
+## Working with Dates
 
-### Features
-#### Keyboard Navigation
+Using a `value` that does not include any time or timezone
+information, such as `12/01`, the date is assumed by `moment()` to be
+in the local timezone. When the local timezone is east of UTC, such as
+`+03:00`, and converted to UTC for internationalization formatting,
+the offset will be subtracted from the date. So `12/01` will appear as
+`11/30` in timezones east of UTC.
+
+When comparing or manipulating dates, it is safest to operate in UTC
+mode and leave display formatting to internationalization helpers. If
+using moment, this can be done via
+[`moment.utc()`](http://momentjs.com/docs/#/parsing/utc/).
+
+## Features
+### Keyboard Navigation
 * **Up arrow** - Move cursor up in the calendar (backwards 1 week)
 * **Down arrow** - Move cursor down in the calendar (forwards 1 week)
 * **Left arrow** - Move cursor left 1 day in the calendar (backwards 1 day)

--- a/lib/Timepicker/readme.md
+++ b/lib/Timepicker/readme.md
@@ -19,6 +19,20 @@ Name | type | description | default | required
 `timeZone` | string | Overrides the time zone provided by context. | "UTC" | false
 `locale` | string | Overrides the locale provided by context. | "en" | false
 
+## Working with Times
+
+Using a `value` that does not include any timezone information, the
+time is assumed by `moment()` to be in the local timezone. When the
+local timezone is east of UTC, such as `+03:00`, and converted to UTC
+for internationalization formatting, the offset will be subtracted
+from the time. For example, a value of `12:00` will appear as `9:00`
+UTC when viewed in the EEST timezone.
+
+When comparing or manipulating dates, it is safest to operate in UTC
+mode and leave display formatting to internationalization helpers. If
+using moment, this can be done via
+[`moment.utc()`](http://momentjs.com/docs/#/parsing/utc/).
+
 ## Usage in Redux-form
 Redux form will provide `input` and `meta` props to the component when it is used with a redux-form `<Field>` component. The component's value and validation are supplied through these.
 ```


### PR DESCRIPTION
## Purpose

Tests related to dates were found to be failing for some people in other timezones. Upon investigating they were rightfully failing because UTC dates were incorrectly being formatted as local dates. This was happening because `moment()` assumes values to be local time when there is no timezone information. So dates such as `12/01` were being formatted as `11/30` when viewed in timezones east of UTC.

Related: [STCOR-265](https://issues.folio.org/browse/STCOR-265)

## Approach

Working with dates can be a nightmare. When comparing or manipulating dates, it is safest to always work in UTC and let internationalization helpers handle formatting the display for local timezones. This PR adds a short description to the `Datepicker` and `Timepicker` docs and links to `moment.utc()`.

## Future Work

The `Datepicker` and `Timepicker` components use `moment()`, but for the reasons listed here, they should use `moment.utc()` and let internationalization helpers worry about display.