### PR TITLE
Update Modal propTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Include `data-total-count` in `<MultiColumnList>'. Available from v4.3.2.
 * Don't pass `onSelectItem` to components that don't use it. Fixes STCOR-280. Available from 4.3.2.
 * Introduce `tagName` prop on `<Pane>`
+* Update `<Modal>` `propTypes`
 
 ## [4.3.1](https://github.com/folio-org/stripes-components/tree/v4.3.0) (2018-11-01)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v4.3.0...v4.3.1)

--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -10,6 +10,7 @@ import Headline from '../Headline';
 import css from './Modal.css';
 
 const propTypes = {
+  ariaLabel: PropTypes.string,
   children: PropTypes.node.isRequired,
   /** Modal can be dismissed by clicking the background overlay */
   closeOnBackgroundClick: PropTypes.bool,
@@ -26,15 +27,12 @@ const propTypes = {
   enforceFocus: PropTypes.bool,
 
   /* Add a footer to the Modal (Optional) */
-  footer: PropTypes.oneOfType([
-    PropTypes.element,
-    PropTypes.node,
-  ]),
+  footer: PropTypes.node,
 
   /** Unique identifier for modal window. */
   id: PropTypes.string,
   /** Descriptive title for top of modal - also fills aria-label attribute for screen readers. */
-  label: PropTypes.string.isRequired,
+  label: PropTypes.node.isRequired,
   /** Callback that signals intent to close window -
    * boolean passed to 'open' prop can be set using
    * callback does not actually close the modal.
@@ -124,7 +122,7 @@ const Modal = (props) => {
               >
                 <WrappingElement
                   className={getModalClass()}
-                  aria-label={props['aria-label'] || props.label} // eslint-disable-line react/prop-types
+                  aria-label={props.ariaLabel}
                   id={props.id}
                 >
                   { props.showHeader &&

--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -31,7 +31,7 @@ const propTypes = {
 
   /** Unique identifier for modal window. */
   id: PropTypes.string,
-  /** Descriptive title for top of modal - also fills aria-label attribute for screen readers. */
+  /** Descriptive title for top of modal. */
   label: PropTypes.node.isRequired,
   /** Callback that signals intent to close window -
    * boolean passed to 'open' prop can be set using

--- a/lib/Modal/readme.md
+++ b/lib/Modal/readme.md
@@ -20,6 +20,7 @@ const footer = (
 ### Props
 Name | type | description | default | required
 --- | --- | --- | --- | ---
+ariaLabel | string | Fills aria-label attribute for screen readers. | |
 children | node | Content for the body of the modal. | | &#10004;
 closeOnBackgroundClick | bool | Modal can be dismissed by clicking the background overlay. | false |
 contentClass | string | Apply custom CSS classes to the content element | |
@@ -27,7 +28,7 @@ dismissible | bool | If true, renders a close 'X' in the starting corner of the 
 enforceFocus | bool | If true, automatically attempts to regain focus when its children are clicked.  | true |
 footer | node | Footer content of the modal. Pass a single component or multiple components wrapped in a Fragment. | |
 id | string | Used in the "id" attribute of the modal div. | |
-label | string | Descriptive title for top of modal - also fills aria-label attribute for screen readers. | | &#10004;
+label | string | Descriptive title for top of modal. | | &#10004;
 onClose | func | Callback that signals intent to close window. This callback does not actually close the modal, but can call code within its body that will change the boolean passed to the `open` prop. | |
 onOpen | func | Callback fired when modal opens. | noop |
 open | bool | Deciding value for rendering the modal(true) or not(false). | false | &#10004;

--- a/lib/Modal/tests/Modal-test.js
+++ b/lib/Modal/tests/Modal-test.js
@@ -69,7 +69,7 @@ describe('Modal', () => {
     });
 
     it(`It should have an aria-label of "${label}"`, () => {
-      expect(modal.ariaLabel).to.equal(label);
+      expect(modal.ariaLabel).to.equal(null);
     });
 
     it(`It should render with a label of "${label}"`, () => {

--- a/lib/Modal/tests/Modal-test.js
+++ b/lib/Modal/tests/Modal-test.js
@@ -14,6 +14,7 @@ import ModalInteractor from './interactor';
 describe('Modal', () => {
   const modal = new ModalInteractor();
   const label = 'My Modal';
+  const ariaLabel = 'My Modal ARIA Label';
   let onCloseFired;
 
   beforeEach(async () => {
@@ -25,6 +26,7 @@ describe('Modal', () => {
         closeOnBackgroundClick
         wrappingElement="form"
         label={label}
+        ariaLabel={ariaLabel}
         onClose={() => { onCloseFired = true; }}
         footer={<div>Test</div>}
       >
@@ -68,12 +70,14 @@ describe('Modal', () => {
       expect(modal.hasHeader).to.be.true;
     });
 
-    it(`It should have an aria-label of "${label}"`, () => {
-      expect(modal.ariaLabel).to.equal(null);
-    });
-
     it(`It should render with a label of "${label}"`, () => {
       expect(modal.label).to.equal(label);
+    });
+  });
+
+  describe(`When passing an ariaLabel of "${ariaLabel}" to a modal`, () => {
+    it(`It should have an aria-label of "${ariaLabel}"`, () => {
+      expect(modal.ariaLabel).to.equal(ariaLabel);
     });
   });
 


### PR DESCRIPTION
## Problem
It should be possible to give a `label` for the `<Modal>` header that's a `node`, not just a `string` (makes dealing with `react-intl` `<FormattedMessage>` much easier).
 
But `aria-label` needs to be a string, and `label` was being reused for both purposes.

## Approach
- Split the `ariaLabel` and `label` props.
- Accept a `node` for `label`.