### PR TITLE
Fix timepicker intl bug

### DIFF
--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -129,7 +129,7 @@ class Timepicker extends React.Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) { // eslint-disable-line react/no-deprecated
+  componentWillReceiveProps(nextProps, nextContext) { // eslint-disable-line react/no-deprecated
     let inputValue;
     let presentedValue = null;
     if (nextProps.input) { // if we're using redux-form....
@@ -165,8 +165,8 @@ class Timepicker extends React.Component {
     }
 
     // adjust displayed time format for a change in locale
-    if (nextProps.intl.locale !== this.props.intl.locale) {
-      moment.locale(nextProps.intl.locale);
+    if (nextContext.intl.locale !== this.context.intl.locale) {
+      moment.locale(nextContext.intl.locale);
       this.setState(prevState => {
         let newTimeString = prevState.timeString;
         if (newTimeString !== '') {


### PR DESCRIPTION
Introduced in https://github.com/folio-org/stripes-components/pull/696

`intl` is consumed from `context` now instead of `props` in the `Timepicker`, and not all locations were updated.