### PR TITLE
STCOM-296 Repeal and replace title attributes

### DIFF
--- a/lib/Accordion/headers/FilterAccordionHeader.js
+++ b/lib/Accordion/headers/FilterAccordionHeader.js
@@ -94,7 +94,6 @@ class FilterAccordionHeader extends React.Component {
             size="small"
             iconSize="small"
             icon="clearX"
-            title={`Clear selected filters for "${label}"`}
             ariaLabel={`Clear selected filters for "${label}"`}
             onClick={this.handleClearButtonClick}
           /> : null

--- a/lib/Avatar/Avatar.js
+++ b/lib/Avatar/Avatar.js
@@ -5,15 +5,17 @@
 import React from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
+import { deprecated } from 'prop-types-extra';
 import css from './Avatar.css';
 
 const propTypes = {
   alt: PropTypes.string,
+  ariaLabel: PropTypes.string,
   src: PropTypes.string,
-  title: PropTypes.string,
+  title: deprecated(PropTypes.string, 'Use ariaLabel instead'),
 };
 
-const Avatar = ({ src, alt, title, ...rest }) => {
+const Avatar = ({ src, alt, title, ariaLabel, ...rest }) => {
   // Placeholder SVG
   let content = (
     // eslint-disable-next-line max-len
@@ -22,7 +24,7 @@ const Avatar = ({ src, alt, title, ...rest }) => {
 
   // If we have a src attribute
   if (src) {
-    content = (<img src={src} alt={alt} title={title} />);
+    content = (<img src={src} alt={alt} aria-label={ariaLabel || title} />);
   }
 
   return (

--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -320,25 +320,27 @@ class Calendar extends React.Component {
 
             return (
               <td key={day.format('D-MM')}>
-                <DayButton
-                  data-test-date={titleFormattedDay}
-                  onFocus={this.props.buttonFocus}
-                  className={dayClasses}
-                  title={
-                    <FormattedMessage
-                      id="stripes-components.selectDay"
-                      values={{ dayOfWeek: titleDayString, date: titleFormattedDay }}
-                    />
-                  }
-                  onDayClick={this.handleDayClick}
-                  day={day}
-                  onKeyDown={isExcluded ? this.keyDownOnExcluded : this.props.onKeyDown}
-                  onBlur={this.props.onBlur}
-                  disabled={isExcluded}
-                  id={`datepicker-choose-date-button-${day.format('D')}-${id}`}
+                <FormattedMessage
+                  id="stripes-components.selectDay"
+                  values={{ dayOfWeek: titleDayString, date: titleFormattedDay }}
                 >
-                  {day.format('D')}
-                </DayButton>
+                  {ariaLabel => (
+                    <DayButton
+                      data-test-date={titleFormattedDay}
+                      onFocus={this.props.buttonFocus}
+                      className={dayClasses}
+                      ariaLabel={ariaLabel}
+                      onDayClick={this.handleDayClick}
+                      day={day}
+                      onKeyDown={isExcluded ? this.keyDownOnExcluded : this.props.onKeyDown}
+                      onBlur={this.props.onBlur}
+                      disabled={isExcluded}
+                      id={`datepicker-choose-date-button-${day.format('D')}-${id}`}
+                    >
+                      {day.format('D')}
+                    </DayButton>
+                  )}
+                </FormattedMessage>
               </td>
             );
           },
@@ -372,35 +374,44 @@ class Calendar extends React.Component {
             <thead>
               <tr>
                 <td>
-                  <button
-                    data-test-calendar-previous-year
-                    id={`datepicker-previous-year-button-${id}`}
-                    className={css.nav}
-                    type="button"
-                    onClick={this.previousYear}
-                    onKeyDown={this.props.onKeyDown}
-                    tabIndex="-1"
-                    style={arrowStyle}
-                    title={<FormattedMessage id="stripes-components.goToPreviousYear" />}
-                  >
-                    <Icon icon="left-double-chevron" />
-                  </button>
+                  <FormattedMessage id="stripes-components.goToPreviousYear">
+                    {ariaLabel => (
+                      <button
+                        data-test-calendar-previous-year
+                        id={`datepicker-previous-year-button-${id}`}
+                        className={css.nav}
+                        type="button"
+                        onClick={this.previousYear}
+                        onKeyDown={this.props.onKeyDown}
+                        tabIndex="-1"
+                        style={arrowStyle}
+                        ariaLabel={ariaLabel}
+                      >
+                        <Icon icon="left-double-chevron" />
+                      </button>
+                    )}
+                  </FormattedMessage>
                 </td>
+
                 <td>
-                  <button
-                    data-test-calendar-previous-month
-                    id={`datepicker-previous-month-button-${id}`}
-                    href="#"
-                    className={css.nav}
-                    type="button"
-                    onClick={this.previousMonth}
-                    onKeyDown={this.props.onKeyDown}
-                    tabIndex="-1"
-                    style={arrowStyle}
-                    title={<FormattedMessage id="stripes-components.goToPreviousMonth" />}
-                  >
-                    <Icon icon="left-arrow" />
-                  </button>
+                  <FormattedMessage id="stripes-components.goToPreviousMonth">
+                    {ariaLabel => (
+                      <button
+                        data-test-calendar-previous-month
+                        id={`datepicker-previous-month-button-${id}`}
+                        href="#"
+                        className={css.nav}
+                        type="button"
+                        onClick={this.previousMonth}
+                        onKeyDown={this.props.onKeyDown}
+                        tabIndex="-1"
+                        style={arrowStyle}
+                        ariaLabel={ariaLabel}
+                      >
+                        <Icon icon="left-arrow" />
+                      </button>
+                    )}
+                  </FormattedMessage>
                 </td>
                 <td colSpan="3">
                   <span className={css.selectedMonth} data-test-calendar-header>
@@ -408,36 +419,44 @@ class Calendar extends React.Component {
                   </span>
                 </td>
                 <td>
-                  <button
-                    data-test-calendar-next-month
-                    href="#"
-                    id={`datepicker-next-month-button-${id}`}
-                    className={css.nav}
-                    type="button"
-                    onClick={this.nextMonth}
-                    onKeyDown={this.props.onKeyDown}
-                    tabIndex="-1"
-                    style={arrowStyle}
-                    title={<FormattedMessage id="stripes-components.goToNextMonth" />}
-                  >
-                    <Icon icon="right-arrow" />
-                  </button>
+                  <FormattedMessage id="stripes-components.goToNextMonth">
+                    {ariaLabel => (
+                      <button
+                        data-test-calendar-next-month
+                        href="#"
+                        id={`datepicker-next-month-button-${id}`}
+                        className={css.nav}
+                        type="button"
+                        onClick={this.nextMonth}
+                        onKeyDown={this.props.onKeyDown}
+                        tabIndex="-1"
+                        style={arrowStyle}
+                        ariaLabel={ariaLabel}
+                      >
+                        <Icon icon="right-arrow" />
+                      </button>
+                    )}
+                  </FormattedMessage>
                 </td>
                 <td>
-                  <button
-                    data-test-calendar-next-year
-                    href="#"
-                    id={`datepicker-next-year-button-${id}`}
-                    className={css.nav}
-                    type="button"
-                    onClick={this.nextYear}
-                    onKeyDown={this.props.onKeyDown}
-                    tabIndex="-1"
-                    style={arrowStyle}
-                    title={<FormattedMessage id="stripes-components.goToNextYear" />}
-                  >
-                    <Icon icon="right-double-chevron" />
-                  </button>
+                  <FormattedMessage id="stripes-components.goToNextYear">
+                    {ariaLabel => (
+                      <button
+                        data-test-calendar-next-year
+                        href="#"
+                        id={`datepicker-next-year-button-${id}`}
+                        className={css.nav}
+                        type="button"
+                        onClick={this.nextYear}
+                        onKeyDown={this.props.onKeyDown}
+                        tabIndex="-1"
+                        style={arrowStyle}
+                        title={ariaLabel}
+                      >
+                        <Icon icon="right-double-chevron" />
+                      </button>
+                    )}
+                  </FormattedMessage>
                 </td>
               </tr>
               <tr>

--- a/lib/Datepicker/DayButton.js
+++ b/lib/Datepicker/DayButton.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const propTypes = {
+  ariaLabel: PropTypes.string,
   children: PropTypes.node,
   className: PropTypes.string,
   day: PropTypes.object,
@@ -10,7 +11,6 @@ const propTypes = {
   onDayClick: PropTypes.func,
   onFocus: PropTypes.func,
   onKeyDown: PropTypes.func,
-  title: PropTypes.string,
 };
 
 const DayButton = (props) => {

--- a/lib/EntrySelector/EntrySelector.js
+++ b/lib/EntrySelector/EntrySelector.js
@@ -106,13 +106,12 @@ class EntrySelector extends React.Component {
     const lastMenu = (
       <PaneMenu>
         <FormattedMessage id="stripes-components.button.edit">
-          {title => (
+          {ariaLabel => (
             editable && <IconButton
               icon="edit"
               onClick={() => this.props.onEdit(item)}
               id="clickable-edit-item"
-              ariaLabel="edit"
-              title={title}
+              ariaLabel={ariaLabel}
               size="medium"
             />
           )}
@@ -179,7 +178,7 @@ class EntrySelector extends React.Component {
 
     const LastMenu = addMenu || (
       <PaneMenu>
-        <Button title={addButtonTitle} onClick={this.props.onAdd} buttonStyle="primary paneHeaderNewButton">
+        <Button ariaLabel={addButtonTitle} onClick={this.props.onAdd} buttonStyle="primary paneHeaderNewButton">
           <Icon icon="plus-sign">
             <FormattedMessage id="stripes-components.button.new" />
           </Icon>

--- a/lib/Icon/Icon.js
+++ b/lib/Icon/Icon.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { deprecated } from 'prop-types-extra';
 import classNames from 'classnames';
 import css from './Icon.css';
 import icons from './icons';
@@ -9,6 +10,7 @@ import icons from './icons';
 
 class Icon extends React.Component {
   static propTypes = {
+    ariaLabel: PropTypes.string,
     children: PropTypes.node,
     icon: PropTypes.oneOf(Object.keys(icons)),
     iconClassName: PropTypes.string,
@@ -28,7 +30,7 @@ class Icon extends React.Component {
       'warn',
       'success',
     ]),
-    title: PropTypes.string,
+    title: deprecated(PropTypes.string, 'Use ariaLabel instead'),
   }
 
   static defaultProps = {
@@ -38,7 +40,18 @@ class Icon extends React.Component {
   }
 
   render() {
-    const { icon, children, title, iconClassName, id, size, status, iconRootClass, iconPosition } = this.props;
+    const {
+      icon,
+      children,
+      title,
+      ariaLabel,
+      iconClassName,
+      id,
+      size,
+      status,
+      iconRootClass,
+      iconPosition
+    } = this.props;
 
     const getRootClass = classNames(
       css.icon,
@@ -71,7 +84,7 @@ class Icon extends React.Component {
       <span
         className={getRootClass}
         tabIndex="-1"
-        title={title}
+        aria-label={ariaLabel || title}
         id={id}
       >
         <IconSVG className={getSVGClass} />

--- a/lib/Icon/tests/Icon-test.js
+++ b/lib/Icon/tests/Icon-test.js
@@ -55,7 +55,7 @@ describe('Icon', () => {
     });
 
     it('Renders supplied title', () => {
-      expect(icon.title).to.equal('icon-title');
+      expect(icon.ariaLabel).to.equal('icon-title');
     });
 
     it('Renders with default size medium', () => {

--- a/lib/Icon/tests/interactor.js
+++ b/lib/Icon/tests/interactor.js
@@ -13,7 +13,7 @@ export default interactor(class IconInteractor {
 
   id = attribute('id');
   className = attribute('class');
-  title = property('title');
+  ariaLabel = attribute('aria-label');
   label = text();
 
   isSmall = hasClass(`.${css.icon} svg`, css.small);

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -523,7 +523,6 @@ class MCLRenderer extends React.Component {
           key={`${col}-${rowIndex}`}
           className={`${css.cell} ${showOverflow}`}
           style={cellStyle}
-          title={stringValue}
         >
           {value}
         </div>

--- a/lib/PaneHeader/PaneHeader.js
+++ b/lib/PaneHeader/PaneHeader.js
@@ -193,7 +193,7 @@ class PaneHeader extends Component {
         )
         }
         { paneSub && (
-          <p title={paneSub} id={`${this._id}-subtitle`} className={css.paneSub}><span>{paneSub}</span></p>
+          <p id={`${this._id}-subtitle`} className={css.paneSub}><span>{paneSub}</span></p>
         ) }
       </div>
     );

--- a/lib/TextField/TextFieldIcon.js
+++ b/lib/TextField/TextFieldIcon.js
@@ -3,15 +3,16 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { deprecated } from 'prop-types-extra';
 import css from './TextField.css';
 import Icon from '../Icon';
 import IconButton from '../IconButton';
 
-const TextFieldIcon = ({ onClick, title, icon, iconClassName, onMouseDown, tabIndex, id, iconSize }) => (
+const TextFieldIcon = ({ onClick, title, ariaLabel, icon, iconClassName, onMouseDown, tabIndex, id, iconSize }) => (
   <div className={css.textFieldIcon}>
     { (typeof onClick === 'function' || typeof onMouseDown === 'function') ? (
       <IconButton
-        title={title}
+        ariaLabel={ariaLabel || title}
         onClick={onClick}
         onMouseDown={onMouseDown}
         tabIndex={tabIndex}
@@ -25,6 +26,7 @@ const TextFieldIcon = ({ onClick, title, icon, iconClassName, onMouseDown, tabIn
 );
 
 TextFieldIcon.propTypes = {
+  ariaLabel: PropTypes.string,
   icon: PropTypes.string,
   iconClassName: PropTypes.string,
   iconSize: PropTypes.string,
@@ -32,7 +34,7 @@ TextFieldIcon.propTypes = {
   onClick: PropTypes.func,
   onMouseDown: PropTypes.func,
   tabIndex: PropTypes.string,
-  title: PropTypes.string,
+  title: deprecated(PropTypes.string, 'Use ariaLabel instead'),
 };
 
 TextFieldIcon.defaultProps = {


### PR DESCRIPTION
Resolves https://issues.folio.org/browse/STCOM-296

The `title` attributes on `Avatar`, `Icon`, and `TextFieldIcon` have been deprecated and replaced by `ariaLabel`. `title` will still continue to work for now.