### PR TITLE
AutoSuggest: Added custom search/render functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * `color` chokes on rgb/rgba; use hex values instead.
 * Validate presence of `props.onClick()` before calling it.
 * Allow node prop types for labels and validation messages
+* `<AutoSuggest>` updated with custom search and render functionality.
 
 ## [4.3.0](https://github.com/folio-org/stripes-components/tree/v4.3.0) (2018-10-31)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v4.2.0...v4.3.0)

--- a/lib/AutoSuggest/AutoSuggest.css
+++ b/lib/AutoSuggest/AutoSuggest.css
@@ -8,7 +8,6 @@
   padding: 0;
   z-index: 1000;
   margin-top: -7px;
-  font-size: var(--font-size-small);
   text-align: left;
   list-style: none;
   background-color: #fff;

--- a/lib/AutoSuggest/AutoSuggest.js
+++ b/lib/AutoSuggest/AutoSuggest.js
@@ -8,7 +8,10 @@ import reduxFormField from '../ReduxFormField';
 import css from './AutoSuggest.css';
 
 const defaultProps = {
-  validationEnabled: true,
+  includeItem: (item, searchString) => item.value.includes(searchString),
+  onChange: () => {},
+  renderOption: item => (item ? item.value : ''),
+  renderValue: item => (item ? item.value : ''),
   tether: {
     attachment: 'top left',
     renderElementTo: null,
@@ -22,20 +25,26 @@ const defaultProps = {
       },
     ],
   },
+  valueKey: 'value',
+  validationEnabled: true,
 };
 
 const propTypes = {
   error: PropTypes.node,
   id: PropTypes.string,
+  includeItem: PropTypes.func,
   items: PropTypes.arrayOf(PropTypes.object).isRequired,
   label: PropTypes.node,
   onBlur: PropTypes.func,
   onChange: PropTypes.func,
+  renderOption: PropTypes.func,
+  renderValue: PropTypes.func,
   required: PropTypes.bool,
   screenReaderMessage: PropTypes.string,
   tether: PropTypes.object,
   validationEnabled: PropTypes.bool,
   value: PropTypes.string,
+  valueKey: PropTypes.string,
 };
 
 class AutoSuggest extends React.Component {
@@ -58,12 +67,21 @@ class AutoSuggest extends React.Component {
   }
 
   render() {
-    const { tether,
+    const {
+      error,
+      includeItem,
       items,
       label,
-      value,
+      onBlur,
+      onChange,
+      renderOption,
+      renderValue,
       required,
-      validationEnabled, onBlur, error, onChange } = this.props;
+      tether,
+      validationEnabled,
+      value,
+      valueKey,
+    } = this.props;
 
     const textfieldRef = this.textfield;
     const mergedTetherProps = { ...AutoSuggest.defaultProps.tether, ...tether };
@@ -83,8 +101,8 @@ class AutoSuggest extends React.Component {
     return (
       <Downshift
         style={{ display: 'inline-block', position: 'relative' }}
-        itemToString={item => (item ? item.value : '')}
-        onChange={selectedItem => onChange(selectedItem.value)}
+        itemToString={renderValue}
+        onChange={selectedItem => onChange(selectedItem[valueKey])}
         onStateChange={({ inputValue }) => onChange(inputValue)}
         selectedItem={value}
         inputValue={value}
@@ -122,15 +140,15 @@ class AutoSuggest extends React.Component {
               >
                 {isOpen
                   ? items
-                    .filter(item => !inputValue || item.value.includes(inputValue))
+                    .filter(item => !inputValue || includeItem(item, inputValue))
                     .map((item, index) => (
                       <li
                         {...getItemProps({
-                          key: item.value,
+                          key: item[valueKey],
                           index,
                           item,
                           style: {
-                            padding: '5px',
+                            padding: '1rem',
                             cursor: 'default',
                             display: 'flex',
                             justifyContent: 'space-between',
@@ -140,7 +158,7 @@ class AutoSuggest extends React.Component {
                           },
                         })}
                       >
-                        {item.value}
+                        {renderOption(item)}
                       </li>
                     ))
                   : null}

--- a/lib/AutoSuggest/readme.md
+++ b/lib/AutoSuggest/readme.md
@@ -12,4 +12,9 @@ import { AutoSuggest } from '@folio/stripes/components';
 ## AutoSuggest Configuration
 prop | description | default | required
 -- | -- | -- | --
-items | 'list of items to display | |
+includeItem | Callback that returns whether to include the item in the list of results. | `(item, searchString) => item.value.includes(searchString)` |
+items | List of items to display | | Yes
+onChange | Callback called when the value changes | |
+renderOption | Callback that renders the item in the dropdown | `item => item.value` |
+renderValue | Callback that render the item in the input field | `item => item.value` |
+valueKey | The key in the item object to use as the value. | `"value"`


### PR DESCRIPTION
AutoSuggest is pretty prescriptive about what it expects from its parents and as a result, wasn't flexible enough to use as-is in the ERM modules. It currently drives everything off of the `value` field of an object which is limiting.

This PR gives us the ability to custom render the value and dropdown items, as well as construct more elaborate searches.

Going forward, this component could use a pass in the beauty parlour but I'm hoping to get at least this _functionality_ in now since I'd like to use it asap.