### PR TITLE
Change NavListSection label to node

### DIFF
--- a/lib/NavListSection/NavListSection.js
+++ b/lib/NavListSection/NavListSection.js
@@ -12,7 +12,7 @@ const propTypes = {
     PropTypes.node,
   ]),
   className: PropTypes.string,
-  label: PropTypes.string,
+  label: PropTypes.node,
   stripped: PropTypes.bool,
 };
 


### PR DESCRIPTION
`label` should be able to accept a `<FormattedMessage>`.

Change prevents this:
```
Warning: Failed prop type: Invalid prop `label` of type `object` supplied to `NavListSection`, expected `string`.
```