### PR TITLE
AutoSuggest: Fixed bug where not all <li>s were visible

### DIFF
--- a/lib/AutoSuggest/AutoSuggest.css
+++ b/lib/AutoSuggest/AutoSuggest.css
@@ -7,6 +7,8 @@
   right: 0;
   padding: 0;
   z-index: 1000;
+  max-height: 400px;
+  overflow: scroll;
   margin-top: -7px;
   text-align: left;
   list-style: none;


### PR DESCRIPTION
Quick follow-up to #704. Noticed that you couldn't see all items in the dropdown list if it went past the end of the page and there weren't any scrollbars. There's a more accurate way of handling this where we'd calculate how much spare room vertically we have in JS (perhaps also throwing the dropdown _above_ the textfield) but I stuck with the simple fix for now.