### PR TITLE
include data-total-count attribute in output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Remove `injectIntl()` fork
 * Simplify `ReduxFormField` usage
+* Include `data-total-count` in `<MultiColumnList>'. Available from v4.3.2.
 
 ## [4.3.1](https://github.com/folio-org/stripes-components/tree/v4.3.0) (2018-11-01)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v4.3.0...v4.3.1)

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -48,6 +48,7 @@ const propTypes = {
   sortedColumn: PropTypes.string,
   sortOrder: PropTypes.string,
   striped: PropTypes.bool,
+  totalCount: PropTypes.number,
   virtualize: PropTypes.bool,
   visibleColumns: PropTypes.arrayOf(PropTypes.string),
   width: PropTypes.number,
@@ -67,6 +68,7 @@ const defaultProps = {
   scrollToIndex: 0,
   selectedClass: css.selected,
   striped: true,
+  totalCount: 0,
 };
 
 class MCLRenderer extends React.Component {
@@ -886,6 +888,7 @@ class MCLRenderer extends React.Component {
               aria-label={ariaLabel}
               role="list"
               className={css.mclContainer}
+              data-total-count={this.props.totalCount}
             >
               <div
                 className={this.getHeaderStyle()}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
Previously, the row-count was included in the `title` attribute of the
table header, but `title` isn't a11y-friendly so we've been getting rid
of it. Nonetheless, we still need access to the row-count
programmatically for tests, so here it is.

An alternative would be to include a `data-test-row-count` attribute and
to include `data-test-*` attributes in our builds, but we don't have
those builds yet.