### PR TITLE
AutoSuggest: Fixed bugs where AS would throw errors

### DIFF
--- a/lib/AutoSuggest/AutoSuggest.js
+++ b/lib/AutoSuggest/AutoSuggest.js
@@ -133,7 +133,6 @@ class AutoSuggest extends React.Component {
               <ul
                 className={css.AutoSuggest}
                 {...getMenuProps({
-                  refKey: 'innerRef',
                   id: autoSuggestId,
                   style: { width: `${listWidth}px` }
                 }, { suppressRefError: true })}

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -214,7 +214,7 @@ class TextField extends Component {
     this.input.current.focus();
   }
 
-  onFocus = () => {
+  onFocus = event => {
     const { onFocus } = this.props;
 
     if (!this.state.focused) {
@@ -223,7 +223,7 @@ class TextField extends Component {
       });
 
       if (typeof onFocus === 'function') {
-        onFocus();
+        onFocus(event);
       }
     }
   }
@@ -238,7 +238,7 @@ class TextField extends Component {
       });
 
       if (typeof onBlur === 'function') {
-        onBlur();
+        onBlur(event);
       }
     }
   }


### PR DESCRIPTION
AutoSuggest was constantly throwing two errors onto the console.

For reference, the component hierarchy is: AutoSuggest > Downshift > TextField

1. When the TextField lost focus (on blur), Downshift was trying to access the `event` in its blur handler. TextField wasn't passing on the `event` so Downshift threw TypeErrors when it tried to access the event properties. Fixed by passing along `event`.
2. React complained that it didn't know what the `innerRef` property was. We're setting it on a `ul`, so we [don't actually _need_ to be setting `innerRef`](https://github.com/paypal/downshift#getmenuprops). Removed it.
