### PR TITLE
Add more translations to storybook

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -13,24 +13,39 @@ import '../lib/global.css';
 // Load the locale data for all your defined locales
 import { setIntlConfig, withIntl } from 'storybook-addon-intl';
 
+import arTranslations from '../translations/stripes-components/ar.json';
+import caTranslations from '../translations/stripes-components/ca.json';
 import daTranslations from '../translations/stripes-components/da.json';
 import deTranslations from '../translations/stripes-components/de.json';
 import enTranslations from '../translations/stripes-components/en.json';
+import esTranslations from '../translations/stripes-components/es.json';
 import frTranslations from '../translations/stripes-components/fr.json';
 import huTranslations from '../translations/stripes-components/hu.json';
+import itTranslations from '../translations/stripes-components/it_IT.json';
+import ptTranslations from '../translations/stripes-components/pt_BR.json';
 
 import { addLocaleData } from 'react-intl';
+import arLocaleData from 'react-intl/locale-data/ar';
+import caLocaleData from 'react-intl/locale-data/ca';
 import daLocaleData from 'react-intl/locale-data/da';
 import deLocaleData from 'react-intl/locale-data/de';
 import enLocaleData from 'react-intl/locale-data/en';
+import esLocaleData from 'react-intl/locale-data/es';
 import frLocaleData from 'react-intl/locale-data/fr';
 import huLocaleData from 'react-intl/locale-data/hu';
+import itLocaleData from 'react-intl/locale-data/it';
+import ptLocaleData from 'react-intl/locale-data/pt';
 
+addLocaleData(arLocaleData);
+addLocaleData(caLocaleData);
 addLocaleData(daLocaleData);
 addLocaleData(deLocaleData);
 addLocaleData(enLocaleData);
+addLocaleData(esLocaleData);
 addLocaleData(frLocaleData);
 addLocaleData(huLocaleData);
+addLocaleData(itLocaleData);
+addLocaleData(ptLocaleData);
 
 // mimics the StripesTranslationPlugin in @folio/stripes-core
 function prefixKeys(obj) {
@@ -43,16 +58,21 @@ function prefixKeys(obj) {
 
 // Define messages
 const messages = {
+  ar: prefixKeys(arTranslations),
+  ca: prefixKeys(caTranslations),
   da: prefixKeys(daTranslations),
   de: prefixKeys(deTranslations),
   en: prefixKeys(enTranslations),
+  es: prefixKeys(esTranslations),
   fr: prefixKeys(frTranslations),
   hu: prefixKeys(huTranslations),
+  it: prefixKeys(itTranslations),
+  pt: prefixKeys(ptTranslations),
 };
 
 // Set intl configuration
 setIntlConfig({
-    locales: ['da', 'de', 'en', 'fr', 'hu'],
+    locales: ['ar', 'ca', 'da', 'de', 'en', 'es', 'fr', 'hu', 'it', 'pt'],
     defaultLocale: 'en',
     getMessages: (locale) => messages[locale]
 });


### PR DESCRIPTION
Adds more locales to storybook.

There are some question marks around how to handle country-specific translations (`es_ES`, `fr_FR`, etc.), so I ignored that wrinkle in this round.

The locale bootstrapping for `storybook` could use a refactor to just read the directory of translation files, but I just continued down the same hard-coded path.

<img width="1011" alt="screen shot 2018-11-12 at 10 25 54 am" src="https://user-images.githubusercontent.com/230597/48360716-6ecfd600-e665-11e8-9176-ad316c5b56b1.png">
