### PR TITLE
Introduce tagName prop on Pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Updated Pane/PaneHeader to accept a `actionMenu`-prop. Added deprecation warning for the `actionMenuItems`-prop (STCOM-388)
 * Include `data-total-count` in `<MultiColumnList>'. Available from v4.3.2.
 * Don't pass `onSelectItem` to components that don't use it. Fixes STCOR-280. Available from 4.3.2.
+* Introduce `tagName` prop on `<Pane>`
 
 ## [4.3.1](https://github.com/folio-org/stripes-components/tree/v4.3.0) (2018-11-01)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v4.3.0...v4.3.1)

--- a/lib/Pane/Pane.js
+++ b/lib/Pane/Pane.js
@@ -38,11 +38,13 @@ const propTypes = {
   paneTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   paneTitleRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
   subheader: PropTypes.node,
+  tagName: PropTypes.string,
   transition: PropTypes.string,
 };
 
 const defaultProps = {
   padContent: true,
+  tagName: 'section',
   transition: 'none',
 };
 
@@ -155,10 +157,16 @@ class Pane extends React.Component {
       lastMenu,
       actionMenuItems,
       actionMenu,
+      tagName: Element,
       ...rest
     } = this.props;
     return (
-      <section className={css.pane} style={this.state.style} ref={(ref) => { this.el = ref; }}>
+      <Element
+        className={css.pane}
+        style={this.state.style}
+        ref={(ref) => { this.el = ref; }}
+        {...rest}
+      >
         <PaneHeader
           paneTitle={paneTitle}
           paneTitleRef={paneTitleRef}
@@ -171,13 +179,12 @@ class Pane extends React.Component {
           onClose={this.handleClose}
           key={`${this.id}-header`}
           id={this.id}
-          {...rest}
         />
         {this.props.subheader}
         <div key={`${this.id}-content`} className={this.getContentClass()} onFocus={this.setLatestFocused}>
           {this.props.children}
         </div>
-      </section>
+      </Element>
     );
   }
 }

--- a/lib/Pane/Pane.js
+++ b/lib/Pane/Pane.js
@@ -158,6 +158,7 @@ class Pane extends React.Component {
       actionMenuItems,
       actionMenu,
       tagName: Element,
+      dismissible,
       ...rest
     } = this.props;
     return (
@@ -179,6 +180,7 @@ class Pane extends React.Component {
           onClose={this.handleClose}
           key={`${this.id}-header`}
           id={this.id}
+          dismissible={dismissible}
         />
         {this.props.subheader}
         <div key={`${this.id}-content`} className={this.getContentClass()} onFocus={this.setLatestFocused}>


### PR DESCRIPTION
## Purpose
Allows `<Pane>` to be a `<form>` and applies any props to the top level element, so we won't have to wrap `<Pane>` in any other kind of tag.

Current spots where this is a problem:
- https://github.com/folio-org/ui-inventory/pull/353
- eHoldings settings: http://folio-snapshot.aws.indexdata.com/settings/eholdings/knowledge-base

## Change
This moves the `...rest` props spread from `<PaneHeader>` to the top level element of `<Pane>`. May have unknown side effects.