### PR TITLE
Destructure all Pane props

### DIFF
--- a/lib/Pane/Pane.js
+++ b/lib/Pane/Pane.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import uniqueId from 'lodash/uniqueId';
 import css from './Pane.css';
 import PaneHeader from '../PaneHeader';
 import { withPaneset } from '../Paneset/PanesetContext';
@@ -64,7 +64,7 @@ class Pane extends React.Component {
       contentMinWidth: 0, // eslint-disable-line react/no-unused-state
     };
 
-    this.id = _.uniqueId();
+    this.id = uniqueId();
     this.contentMinWidth = 0;
     this.getContentWidth = this.getContentWidth.bind(this);
     this.handleClose = this.handleClose.bind(this);
@@ -149,18 +149,30 @@ class Pane extends React.Component {
 
   render() {
     const {
-      paneTitleRef,
-      paneTitle,
-      paneSub,
-      appIcon,
-      firstMenu,
-      lastMenu,
-      actionMenuItems,
       actionMenu,
-      tagName: Element,
+      actionMenuAutoFocus, // eslint-disable-line no-unused-vars
+      actionMenuItems,
+      appIcon,
+      children,
+      defaultWidth, // eslint-disable-line no-unused-vars
       dismissible,
+      firstMenu,
+      fluidContentWidth, // eslint-disable-line no-unused-vars
+      height, // eslint-disable-line no-unused-vars
+      lastMenu,
+      noOverflow, // eslint-disable-line no-unused-vars
+      onClose, // eslint-disable-line no-unused-vars
+      padContent, // eslint-disable-line no-unused-vars
+      paneset, // eslint-disable-line no-unused-vars
+      paneSub,
+      paneTitle,
+      paneTitleRef,
+      subheader,
+      tagName: Element,
+      transition, // eslint-disable-line no-unused-vars
       ...rest
     } = this.props;
+
     return (
       <Element
         className={css.pane}
@@ -182,9 +194,9 @@ class Pane extends React.Component {
           id={this.id}
           dismissible={dismissible}
         />
-        {this.props.subheader}
+        {subheader}
         <div key={`${this.id}-content`} className={this.getContentClass()} onFocus={this.setLatestFocused}>
-          {this.props.children}
+          {children}
         </div>
       </Element>
     );


### PR DESCRIPTION
https://github.com/folio-org/stripes-components/pull/714 started passing along `...props` to its top-level element, but we weren't omitting some props from getting to the DOM.

Example side-effect:
```
react-dom.development.js:506 Warning: React does not recognize the `fluidContentWidth` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `fluidcontentwidth` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

Includes importing specific lodash API instead of the whole `_`.