### PR TITLE
cancel Callout's timers on unmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Include `data-total-count` in `<MultiColumnList>'. Available from v4.3.2.
 * Don't pass `onSelectItem` to components that don't use it. Fixes STCOR-280. Available from 4.3.2.
 * Introduce `tagName` prop on `<Pane>`
+* Cancel `<Callout>`'s timers on unmount.
 
 ## [4.3.1](https://github.com/folio-org/stripes-components/tree/v4.3.0) (2018-11-01)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v4.3.0...v4.3.1)

--- a/lib/Callout/Callout.js
+++ b/lib/Callout/Callout.js
@@ -13,6 +13,7 @@ class Callout extends React.Component {
     this.state = {
       callouts: [],
     };
+    this.timeouts = [];
 
     this.sendCallout = this.sendCallout.bind(this);
     this.removeCallout = this.removeCallout.bind(this);
@@ -20,6 +21,12 @@ class Callout extends React.Component {
 
   componentDidMount() {
     this.updateCalloutContainer();
+  }
+
+  componentWillUnmount() {
+    this.timeouts.forEach(t => {
+      window.clearTimeout(t);
+    });
   }
 
   updateCalloutContainer() {
@@ -35,7 +42,7 @@ class Callout extends React.Component {
       );
       newState.callouts.push(newCallout);
       if (timeout !== 0) {
-        window.setTimeout(() => { this.removeCallout(newCallout.id); }, timeout);
+        this.timeouts.push(window.setTimeout(() => { this.removeCallout(newCallout.id); }, timeout));
       }
       return newState;
     });


### PR DESCRIPTION
Squash this console warning:
```
Can't perform a React state update on an unmounted component.
This is a no-op, but it indicates a memory leak in your application.
To fix, cancel all subscriptions and asynchronous tasks in the
componentWillUnmount method.
    in Callout (created by EntryWrapper)
...
```