### PR TITLE
Pass along props to Modal wrapping element

### DIFF
--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -76,12 +76,32 @@ const defaultProps = {
 };
 
 const Modal = (props) => {
-  const WrappingElement = props.wrappingElement;
+  const {
+    children,
+    closeOnBackgroundClick,
+    contentClass,
+    dismissible,
+    enforceFocus,
+    footer,
+    id,
+    label,
+    onClose,
+    onOpen,
+    open,
+    restoreFocus,
+    scope,
+    showHeader,
+    size,
+    wrappingElement,
+    ...rest
+  } = props;
+
+  const WrappingElement = wrappingElement;
 
   const getModalScope = () => {
     let container;
 
-    if (props.scope === 'module') {
+    if (scope === 'module') {
       container = document.getElementById('OverlayContainer');
     }
 
@@ -90,19 +110,19 @@ const Modal = (props) => {
 
   const getModalClass = () => classNames(
     css.modal,
-    css[props.size],
+    css[size],
   );
 
   const getContentClass = () => classNames(
     css.modalContent,
-    props.contentClass,
+    contentClass,
   );
 
   return (
     <TransitionGroup>
-      { props.open &&
+      { open &&
         <Transition
-          in={props.open}
+          in={open}
           unmountOnExit
           timeout={400}
           appear
@@ -110,40 +130,41 @@ const Modal = (props) => {
           {
             (status) => (
               <OverlayModal
-                show={props.open}
+                show={open}
                 backdropClassName={css.backdrop}
                 className={classNames(css.modalRoot, css[status])}
                 container={getModalScope()}
-                onHide={props.onClose}
-                onShow={props.onOpen}
-                onBackdropClick={props.closeOnBackgroundClick ? props.onClose : () => {}}
-                enforceFocus={props.enforceFocus}
-                restoreFocus={props.restoreFocus}
+                onHide={onClose}
+                onShow={onOpen}
+                onBackdropClick={closeOnBackgroundClick ? onClose : () => {}}
+                enforceFocus={enforceFocus}
+                restoreFocus={restoreFocus}
               >
                 <WrappingElement
                   className={getModalClass()}
                   aria-label={props.ariaLabel}
                   id={props.id}
+                  {...rest}
                 >
-                  { props.showHeader &&
+                  { showHeader &&
                     <div className={css.modalHeader}>
                       <Headline
                         tag="h1"
                         size="small"
                         margin="none"
                         className={css.modalLabel}
-                        id={props.id && `${props.id}-label`}
+                        id={id && `${id}-label`}
                       >
                         {props.label}
                       </Headline>
                       <div className={css.modalControls}>
-                        {props.dismissible &&
+                        {dismissible &&
                           <FormattedMessage id="stripes-components.dismissModal">
                             {ariaLabel => (
                               <IconButton
                                 className={css.closeModal}
-                                id={props.id && `${props.id}-close-button`}
-                                onClick={props.onClose}
+                                id={id && `${id}-close-button`}
+                                onClick={onClose}
                                 aria-label={ariaLabel}
                                 icon="closeX"
                               />
@@ -153,13 +174,13 @@ const Modal = (props) => {
                       </div>
                     </div>
                   }
-                  <div className={getContentClass()} id={props.id && `${props.id}-content`}>
-                    {props.children}
+                  <div className={getContentClass()} id={id && `${id}-content`}>
+                    {children}
                   </div>
                   {
-                    props.footer && (
-                      <div className={css.modalFooter} id={props.id && `${props.id}-footer`}>
-                        {props.footer}
+                    footer && (
+                      <div className={css.modalFooter} id={id && `${id}-footer`}>
+                        {footer}
                       </div>
                     )
                   }


### PR DESCRIPTION
## Purpose
Related to https://github.com/folio-org/stripes-components/pull/714

We have a `wrappingElement` prop that allows a `<Modal>` to be a `<form>`, but we had no way to set an `onSubmit` for that modal form.

## Approach
Spread any remaining props on the `wrappingElement`. Will also make adding `data-test-*` attributes easier.