### PR TITLE
Accept nodes for renderable EntrySelector props

### DIFF
--- a/lib/EntrySelector/EntrySelector.js
+++ b/lib/EntrySelector/EntrySelector.js
@@ -25,7 +25,7 @@ class EntrySelector extends React.Component {
       PropTypes.object,
     ).isRequired,
     detailComponent: PropTypes.func.isRequired,
-    detailPaneTitle: PropTypes.string,
+    detailPaneTitle: PropTypes.node,
     editable: PropTypes.bool,
     history: PropTypes.shape({
       push: PropTypes.func.isRequired,
@@ -40,7 +40,7 @@ class EntrySelector extends React.Component {
     onClone: PropTypes.func,
     onEdit: PropTypes.func,
     paneSetWidth: PropTypes.string,
-    paneTitle: PropTypes.string,
+    paneTitle: PropTypes.node,
     paneWidth: PropTypes.string.isRequired,
     parentMutator: PropTypes.object.isRequired,
     parentResources: PropTypes.object,


### PR DESCRIPTION
Makes passing in a `<FormattedMessage>` less chatty.