### PR TITLE
add missing prop

### DIFF
--- a/lib/Button/Button.js
+++ b/lib/Button/Button.js
@@ -27,6 +27,7 @@ export const propTypes = {
   onClick: PropTypes.func,
   paddingSide0: PropTypes.bool,
   role: PropTypes.string,
+  to: PropTypes.string,
   type: PropTypes.string,
 };
 

--- a/lib/Button/Button.js
+++ b/lib/Button/Button.js
@@ -27,7 +27,7 @@ export const propTypes = {
   onClick: PropTypes.func,
   paddingSide0: PropTypes.bool,
   role: PropTypes.string,
-  to: PropTypes.string,
+  to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   type: PropTypes.string,
 };
 


### PR DESCRIPTION
`props.to` wasn't defined, until now. 