### PR TITLE
allow PropTypes.node for labels

### DIFF
--- a/lib/Accordion/ExpandAllButton.js
+++ b/lib/Accordion/ExpandAllButton.js
@@ -6,8 +6,8 @@ import Button from '../Button';
 
 const propTypes = {
   accordionStatus: PropTypes.object.isRequired,
-  collapseLabel: PropTypes.string,
-  expandLabel: PropTypes.string,
+  collapseLabel: PropTypes.node,
+  expandLabel: PropTypes.node,
   onToggle: PropTypes.func.isRequired,
 };
 

--- a/lib/ConfirmationModal/ConfirmationModal.js
+++ b/lib/ConfirmationModal/ConfirmationModal.js
@@ -12,7 +12,7 @@ const propTypes = {
   cancelButtonStyle: PropTypes.string,
   cancelLabel: PropTypes.node,
   confirmLabel: PropTypes.node,
-  heading: PropTypes.string.isRequired,
+  heading: PropTypes.node.isRequired,
   id: PropTypes.string,
   message: PropTypes.oneOfType([
     PropTypes.node,

--- a/lib/IconButton/IconButton.js
+++ b/lib/IconButton/IconButton.js
@@ -82,7 +82,7 @@ const IconButton = React.forwardRef(({
 });
 
 IconButton.propTypes = {
-  ariaLabel: PropTypes.node,
+  ariaLabel: PropTypes.string,
   autoFocus: PropTypes.bool,
   badgeColor: PropTypes.string,
   badgeCount: PropTypes.oneOfType([

--- a/lib/IconButton/IconButton.js
+++ b/lib/IconButton/IconButton.js
@@ -5,6 +5,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
+import { deprecated } from 'prop-types-extra';
 import Link from 'react-router-dom/Link';
 import Icon from '../Icon';
 import css from './IconButton.css';
@@ -81,7 +82,7 @@ const IconButton = React.forwardRef(({
 });
 
 IconButton.propTypes = {
-  ariaLabel: PropTypes.string,
+  ariaLabel: PropTypes.node,
   autoFocus: PropTypes.bool,
   badgeColor: PropTypes.string,
   badgeCount: PropTypes.oneOfType([
@@ -105,7 +106,7 @@ IconButton.propTypes = {
   ]),
   style: PropTypes.object,
   tabIndex: PropTypes.string,
-  title: PropTypes.node,
+  title: deprecated(PropTypes.string, 'Use ariaLabel instead'),
   to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   type: PropTypes.string,
 };

--- a/lib/IconButton/IconButton.js
+++ b/lib/IconButton/IconButton.js
@@ -105,7 +105,7 @@ IconButton.propTypes = {
   ]),
   style: PropTypes.object,
   tabIndex: PropTypes.string,
-  title: PropTypes.string,
+  title: PropTypes.node,
   to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   type: PropTypes.string,
 };

--- a/lib/InfoPopover/InfoPopover.js
+++ b/lib/InfoPopover/InfoPopover.js
@@ -11,7 +11,7 @@ import css from './InfoPopover.css';
 
 const propTypes = {
   buttonHref: PropTypes.string,
-  buttonLabel: PropTypes.string,
+  buttonLabel: PropTypes.node,
   buttonTarget: PropTypes.string,
   content: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 };

--- a/lib/Layer/Layer.js
+++ b/lib/Layer/Layer.js
@@ -22,7 +22,7 @@ class Layer extends React.Component {
       PropTypes.arrayOf(PropTypes.node),
     ]),
     container: componentOrElement,
-    contentLabel: PropTypes.node,
+    contentLabel: PropTypes.string,
     enforceFocus: PropTypes.bool,
     isOpen: PropTypes.bool.isRequired,
     paneset: PropTypes.shape({

--- a/lib/Layer/Layer.js
+++ b/lib/Layer/Layer.js
@@ -22,7 +22,7 @@ class Layer extends React.Component {
       PropTypes.arrayOf(PropTypes.node),
     ]),
     container: componentOrElement,
-    contentLabel: PropTypes.string,
+    contentLabel: PropTypes.node,
     enforceFocus: PropTypes.bool,
     isOpen: PropTypes.bool.isRequired,
     paneset: PropTypes.shape({


### PR DESCRIPTION
Follow on to #693, expanding prop type validation for various button
labels and other labels to make internationalization easier, using
`<FormattedMessage />` in favor of `formatMessage`.