### PR TITLE
UIDATIMP-5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Deprecate `<EntrySelector>`
 * Introduce `showUserLink` prop on `<MetaSection>`
 * Deprecate `<IfInterface>` and `<IfPermission>`, STCOM-357
+* Extend InfoPopover with new props (UIDATIMP-5).
 
 ## [4.4.0](https://github.com/folio-org/stripes-components/tree/v4.4.0) (2018-11-19)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v4.3.1...v4.4.0)

--- a/lib/InfoPopover/InfoPopover.js
+++ b/lib/InfoPopover/InfoPopover.js
@@ -4,50 +4,67 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { FormattedMessage } from 'react-intl';
+
 import Popover from '../Popover';
 import Button from '../Button';
 import IconButton from '../IconButton';
+
 import css from './InfoPopover.css';
 
 const propTypes = {
+  allowAnchorClick: PropTypes.bool,
   buttonHref: PropTypes.string,
   buttonLabel: PropTypes.node,
   buttonTarget: PropTypes.string,
-  content: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  content: PropTypes.node,
+  contentClass: PropTypes.string,
+  iconSize: PropTypes.oneOf(['small', 'medium']),
 };
 
 const defaultProps = {
-  buttonLabel: 'Read more',
+  allowAnchorClick: false,
+  buttonLabel: <FormattedMessage id="stripes-components.readMore" />,
   buttonTarget: '_blank',
+  iconSize: 'small',
 };
 
-const InfoPopover = ({ content, buttonLabel, buttonHref, buttonTarget }) => (
-  <Popover activeClass={css.activeClass}>
-    <IconButton
-      className={css.icon}
-      data-role="target"
-      icon="info"
-      size="small"
-      iconSize="small"
-    />
-    <div data-role="popover" className={css.wrap}>
-      <div className={css.content}>{content}</div>
-      { buttonHref &&
-        <Button
-          href={buttonHref}
-          target={buttonTarget}
-          buttonStyle="primary"
-          fullWidth
-          paddingSide0
-          marginBottom0
-          buttonClass={css.button}
-        >
-          {buttonLabel}
-        </Button>
-      }
-    </div>
-  </Popover>
-);
+const InfoPopover = ({ content, contentClass, allowAnchorClick, iconSize, buttonLabel, buttonHref, buttonTarget }) => {
+  const getContentClass = () => classNames(
+    css.content,
+    contentClass,
+  );
+
+  return (
+    <Popover activeClass={css.activeClass}>
+      <IconButton
+        className={css.icon}
+        data-role="target"
+        icon="info"
+        size={iconSize}
+        iconSize={iconSize}
+      />
+      <div data-role="popover" className={css.wrap}>
+        <div className={getContentClass()}>{content}</div>
+        {buttonHref &&
+          <Button
+            allowAnchorClick={allowAnchorClick}
+            href={buttonHref}
+            target={buttonTarget}
+            buttonStyle="primary"
+            fullWidth
+            paddingSide0
+            marginBottom0
+            buttonClass={css.button}
+          >
+            {buttonLabel}
+          </Button>
+        }
+      </div>
+    </Popover>
+  );
+};
 
 InfoPopover.propTypes = propTypes;
 InfoPopover.defaultProps = defaultProps;

--- a/lib/InfoPopover/readme.md
+++ b/lib/InfoPopover/readme.md
@@ -15,7 +15,10 @@ Display a small information icon which can be toggled by clicking on it.
 ## Props
 Name | Type | Description | default
 -- | -- | --
-content | string, node | The content of the information popover |
-buttonLabel | string | The label of the button inside the information popover | "Read more"
+content | node | The content of the information popover |
+buttonLabel | node | The label of the button inside the information popover | "Read more"
 buttonHref | string | The destination for the button inside the information popover |
-buttonTarget | string | The target for the button  | _blank
+buttonTarget | string | The target for the button | _blank
+contentClass | string | `className` for content inside popover |
+allowAnchorClick | boolean | Whether to allow the link button to be clicked | false
+iconSize | string | The size of the icon (`small` or `medium`) | small

--- a/translations/stripes-components/en.json
+++ b/translations/stripes-components/en.json
@@ -65,6 +65,7 @@
   "multiSelection.removeSelectedButtonLabel": "remove value",
   "readonly": "Read-only",
   "endOfList": "End of list",
+  "readMore": "Read more",
   "passwordStrength.veryWeak": "Your password is very weak.",
   "passwordStrength.weak": "Your password is too weak.",
   "passwordStrength.reasonable": "Your password is reasonable.",


### PR DESCRIPTION
1. Extend `InfoPopover` component to make it more flexible. Add new props `contentClass`, `iconSize` and `allowAnchorClick `.