### PR TITLE
Updated deprecated warning for actionMenuItems-prop

### DIFF
--- a/lib/Pane/Pane.js
+++ b/lib/Pane/Pane.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
+import { deprecated } from 'prop-types-extra';
 import uniqueId from 'lodash/uniqueId';
 import css from './Pane.css';
 import PaneHeader from '../PaneHeader';
@@ -9,7 +10,7 @@ import { withPaneset } from '../Paneset/PanesetContext';
 const propTypes = {
   actionMenu: PropTypes.func,
   actionMenuAutoFocus: PropTypes.bool,
-  actionMenuItems: PropTypes.arrayOf(PropTypes.object),
+  actionMenuItems: deprecated(PropTypes.arrayOf(PropTypes.object), 'Use `actionMenu` instead.'),
   appIcon: PropTypes.shape({
     app: PropTypes.string.isRequired,
     key: PropTypes.string,

--- a/lib/PaneHeader/PaneHeader.js
+++ b/lib/PaneHeader/PaneHeader.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
+import { deprecated } from 'prop-types-extra';
 import classNames from 'classnames';
 
 import css from './PaneHeader.css';
@@ -16,7 +17,7 @@ import AppIcon from '../AppIcon';
 class PaneHeader extends Component {
   static propTypes = {
     actionMenu: PropTypes.func,
-    actionMenuItems: PropTypes.arrayOf(PropTypes.object),
+    actionMenuItems: deprecated(PropTypes.arrayOf(PropTypes.object), 'Use `actionMenu` instead.'),
     appIcon: PropTypes.shape({
       app: PropTypes.string.isRequired,
       key: PropTypes.string,
@@ -135,7 +136,6 @@ class PaneHeader extends Component {
      * (Deprecation in progress)
      */
     if (actionMenuItems && actionMenuItems.length) {
-      console.warn('[DEPRECATED] actionMenuItems will be removed soon. Use "actionMenu" instead.');
       return (
         <NavList>
           <NavListSection activeLink="">

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "moment-timezone": "^0.5.14",
     "normalize.css": "^7.0.0",
     "prop-types": "^15.5.10",
-    "prop-types-extra": "^1.0.1",
+    "prop-types-extra": "^1.1.0",
     "query-string": "^6.1.0",
     "react-flexbox-grid": "1.1.3",
     "react-highlighter": "^0.4.2",


### PR DESCRIPTION
The deprecation console.warn was shown a lot of times in console.

Now using the 'deprecated' function from prop-types-extra to indicate that the `actionMenuItems`-prop is deprecated which only warns once pr. instance.