### PR TITLE
Fix calendar aria labels

### DIFF
--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -329,7 +329,7 @@ class Calendar extends React.Component {
                       data-test-date={titleFormattedDay}
                       onFocus={this.props.buttonFocus}
                       className={dayClasses}
-                      ariaLabel={ariaLabel}
+                      aria-label={ariaLabel}
                       onDayClick={this.handleDayClick}
                       day={day}
                       onKeyDown={isExcluded ? this.keyDownOnExcluded : this.props.onKeyDown}
@@ -385,7 +385,7 @@ class Calendar extends React.Component {
                         onKeyDown={this.props.onKeyDown}
                         tabIndex="-1"
                         style={arrowStyle}
-                        ariaLabel={ariaLabel}
+                        aria-label={ariaLabel}
                       >
                         <Icon icon="left-double-chevron" />
                       </button>
@@ -406,7 +406,7 @@ class Calendar extends React.Component {
                         onKeyDown={this.props.onKeyDown}
                         tabIndex="-1"
                         style={arrowStyle}
-                        ariaLabel={ariaLabel}
+                        aria-label={ariaLabel}
                       >
                         <Icon icon="left-arrow" />
                       </button>
@@ -431,7 +431,7 @@ class Calendar extends React.Component {
                         onKeyDown={this.props.onKeyDown}
                         tabIndex="-1"
                         style={arrowStyle}
-                        ariaLabel={ariaLabel}
+                        aria-label={ariaLabel}
                       >
                         <Icon icon="right-arrow" />
                       </button>
@@ -451,7 +451,7 @@ class Calendar extends React.Component {
                         onKeyDown={this.props.onKeyDown}
                         tabIndex="-1"
                         style={arrowStyle}
-                        title={ariaLabel}
+                        aria-label={ariaLabel}
                       >
                         <Icon icon="right-double-chevron" />
                       </button>

--- a/lib/Datepicker/DayButton.js
+++ b/lib/Datepicker/DayButton.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const propTypes = {
-  ariaLabel: PropTypes.string,
   children: PropTypes.node,
   className: PropTypes.string,
   day: PropTypes.object,


### PR DESCRIPTION
Prevents:
```
Warning: Invalid ARIA attribute `ariaLabel`. Did you mean `aria-label`?
    in button (created by FormattedMessage)
```

Regression introduced in https://github.com/folio-org/stripes-components/pull/703.