### PR TITLE
STCOM-403 Accessible validation messages

### DIFF
--- a/lib/Checkbox/Checkbox.js
+++ b/lib/Checkbox/Checkbox.js
@@ -173,6 +173,7 @@ class Checkbox extends React.Component {
             ref={(ref) => { this.input = ref; }}
             autoFocus={autoFocus}
             value={value}
+            aria-invalid={!!(this.props.error)}
           />
           <span className={css.labelCheck}>
             <svg height="10" width="10" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14">

--- a/lib/Checkbox/Checkbox.js
+++ b/lib/Checkbox/Checkbox.js
@@ -201,7 +201,9 @@ class Checkbox extends React.Component {
             )
           }
         </label>
-        {this.getFeedbackElement()}
+        <div role="alert">
+          {this.getFeedbackElement()}
+        </div>
       </div>
     );
   }

--- a/lib/RadioButton/RadioButton.js
+++ b/lib/RadioButton/RadioButton.js
@@ -173,6 +173,7 @@ class RadioButton extends React.Component {
             autoFocus={autoFocus}
             value={value}
             readOnly={readOnly}
+            aria-invalid={!!(this.props.error)}
           />
           <span className={css.labelPseudo} />
           { (label || readOnly) &&

--- a/lib/RadioButton/RadioButton.js
+++ b/lib/RadioButton/RadioButton.js
@@ -190,7 +190,9 @@ class RadioButton extends React.Component {
             )
           }
         </label>
-        {this.getFeedbackElement()}
+        <div role="alert">
+          {this.getFeedbackElement()}
+        </div>
       </div>
     );
   }

--- a/lib/RadioButtonGroup/RadioButtonGroup.js
+++ b/lib/RadioButtonGroup/RadioButtonGroup.js
@@ -39,8 +39,10 @@ function RadioButtonGroup(props) {
     <fieldset className={css.groupRoot} {...rest}>
       <legend className={css.groupLabel}>{label}</legend>
       {displayedChildren}
-      {warningElement}
-      {errorElement}
+      <div role="alert">
+        {warningElement}
+        {errorElement}
+      </div>
     </fieldset>
   );
 }

--- a/lib/Select/Select.js
+++ b/lib/Select/Select.js
@@ -176,8 +176,10 @@ class Select extends Component {
           {component}
           <Icon icon="down-triangle" iconRootClass={css.selectIcon} />
         </div>
-        {warningElem}
-        {errorElem}
+        <div role="alert">
+          {warningElem}
+          {errorElem}
+        </div>
       </div>
     );
   }

--- a/lib/Select/Select.js
+++ b/lib/Select/Select.js
@@ -128,6 +128,7 @@ class Select extends Component {
         name={name}
         {...omitProps(selectCustom, ['selectClass'])}
         aria-labelledby={`${this.id}-label ${this.props.readOnly ? `${this.id}-read-only-message` : ''}`.trim()}
+        aria-invalid={!!(this.props.error)}
         id={this.id}
         readOnly={this.props.readOnly}
       >

--- a/lib/TextArea/TextArea.js
+++ b/lib/TextArea/TextArea.js
@@ -135,8 +135,10 @@ class TextArea extends Component {
       <div className={this.getRootStyle()}>
         {labelElement}
         {component}
-        {warningElement}
-        {errorElement}
+        <div role="alert">
+          {warningElement}
+          {errorElement}
+        </div>
       </div>
     );
   }

--- a/lib/TextArea/TextArea.js
+++ b/lib/TextArea/TextArea.js
@@ -107,6 +107,7 @@ class TextArea extends Component {
     const component = (
       <textarea
         aria-required={required}
+        aria-invalid={!!(this.props.error)}
         autoFocus={autoFocus}
         className={this.getInputStyle()}
         name={name}

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -321,6 +321,7 @@ class TextField extends Component {
         {...inputCustom}
         aria-label={this.props.ariaLabel}
         aria-required={required}
+        aria-invalid={!!(this.props.error)}
         autoComplete={this.props.autoComplete}
         autoFocus={this.props.autoFocus}
         name={name}
@@ -467,8 +468,10 @@ class TextField extends Component {
           {component}
           {endControlElement}
         </div>
-        {warningElement}
-        {errorElement}
+        <div role="alert">
+          {warningElement}
+          {errorElement}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
# Problem
Inline validations are not being announced by screen readers.

## Approach
Wrapping error messages in `<div role="alert">` will announce the errors aloud when they appear. Some suggested approaches looked for some focus management, but I would rather wait for feedback before we manipulate focus (seems like it should be the user's choice on whether or not to go back now or wait).
Additionally, `aria-invalid` was added to the fields which AT's will also announce when the field is focused.