### PR TITLE
Consistently declare redux form field mappings

### DIFF
--- a/lib/AutoSuggest/AutoSuggest.js
+++ b/lib/AutoSuggest/AutoSuggest.js
@@ -177,7 +177,6 @@ export default reduxFormField(
     dirty: meta.dirty,
     error: (meta.touched && meta.error ? meta.error : ''),
     loading: meta.asyncValidating,
-    touched: meta.touched,
     valid: meta.valid,
     warning: (meta.touched && meta.warning ? meta.warning : ''),
   })

--- a/lib/AutoSuggest/AutoSuggest.js
+++ b/lib/AutoSuggest/AutoSuggest.js
@@ -176,7 +176,6 @@ export default reduxFormField(
   ({ meta }) => ({
     dirty: meta.dirty,
     error: (meta.touched && meta.error ? meta.error : ''),
-    loading: meta.asyncValidating,
     valid: meta.valid,
     warning: (meta.touched && meta.warning ? meta.warning : ''),
   })

--- a/lib/Checkbox/Checkbox.js
+++ b/lib/Checkbox/Checkbox.js
@@ -210,7 +210,7 @@ class Checkbox extends React.Component {
 export default reduxFormField(
   Checkbox,
   ({ meta }) => ({
+    error: (meta.touched && meta.error ? meta.error : ''),
     warning: (meta.touched && meta.warning ? meta.warning : ''),
-    error: (meta.touched && meta.error ? meta.error : '')
   })
 );

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -450,7 +450,7 @@ class MultiSelection extends React.Component {
 export default ReduxFormField(
   MultiSelection,
   ({ meta }) => ({
-    error: meta.error,
-    warning: meta.warning
+    error: (meta.touched && meta.error ? meta.error : ''),
+    warning: (meta.touched && meta.warning ? meta.warning : ''),
   })
 );

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -47,7 +47,6 @@ class MultiSelection extends React.Component {
     placeholder: PropTypes.string,
     renderToOverlay: PropTypes.bool,
     tether: PropTypes.object,
-    touched: PropTypes.bool,
     validationEnabled: PropTypes.bool,
     value: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.object),
@@ -451,7 +450,6 @@ class MultiSelection extends React.Component {
 export default ReduxFormField(
   MultiSelection,
   ({ meta }) => ({
-    touched: meta.touched,
     error: meta.error,
     warning: meta.warning
   })

--- a/lib/MultiSelection/readme.md
+++ b/lib/MultiSelection/readme.md
@@ -51,7 +51,6 @@ Name | type | description | default | required
 `dirty` | bool | Apply a specific style when the value has changed. | false |
 `error` | string | Text to display as inline validation feedback for the user. A truthy value here will also apply validation styling to the control. | |
 `isValid` | bool | Whether or not field is valid. When true, specific styles are applied. | |
-`touched` | bool | Prop that controls application of validation styles. Redux-form applies this prop automatically. This defaults to false. | false |
 `validationEnabled` | bool | Controls whether or not validation styles are rendered. | false |
 `warning` | string | Text to display as inline validation feedback for the user. A truthy value here will also apply validation styling to the control. | |
 

--- a/lib/RadioButton/RadioButton.js
+++ b/lib/RadioButton/RadioButton.js
@@ -199,7 +199,7 @@ class RadioButton extends React.Component {
 export default reduxFormField(
   RadioButton,
   ({ meta }) => ({
+    error: (meta.touched && meta.error ? meta.error : ''),
     warning: (meta.touched && meta.warning ? meta.warning : ''),
-    error: (meta.touched && meta.error ? meta.error : '')
   })
 );

--- a/lib/RadioButtonGroup/RadioButtonGroup.js
+++ b/lib/RadioButtonGroup/RadioButtonGroup.js
@@ -51,6 +51,6 @@ export default ReduxFormField(
   RadioButtonGroup,
   ({ meta }) => ({
     error: (meta.touched && meta.error ? meta.error : ''),
-    warning: (meta.touched && meta.warning ? meta.warning : '')
+    warning: (meta.touched && meta.warning ? meta.warning : ''),
   })
 );

--- a/lib/Select/Select.js
+++ b/lib/Select/Select.js
@@ -29,7 +29,6 @@ class Select extends Component {
     readOnly: PropTypes.bool,
     required: PropTypes.bool,
     selectClass: PropTypes.string,
-    touched: PropTypes.bool,
     valid: PropTypes.bool,
     validationEnabled: PropTypes.bool,
     validStylesEnabled: PropTypes.bool,
@@ -90,7 +89,6 @@ class Select extends Component {
       name,
       placeholder,
       readOnly,
-      touched,
       valid,
       validationEnabled,
       validStylesEnabled,
@@ -189,7 +187,6 @@ export default reduxFormField(
     dirty: meta.dirty,
     error: (meta.touched && meta.error ? meta.error : ''),
     loading: meta.asyncValidating,
-    touched: meta.touched,
     valid: meta.valid,
     warning: (meta.touched && meta.warning ? meta.warning : ''),
   })

--- a/lib/Select/Select.js
+++ b/lib/Select/Select.js
@@ -186,7 +186,6 @@ export default reduxFormField(
   ({ meta }) => ({
     dirty: meta.dirty,
     error: (meta.touched && meta.error ? meta.error : ''),
-    loading: meta.asyncValidating,
     valid: meta.valid,
     warning: (meta.touched && meta.warning ? meta.warning : ''),
   })

--- a/lib/Select/stories/BasicUsage.js
+++ b/lib/Select/stories/BasicUsage.js
@@ -64,7 +64,6 @@ class BasicUsage extends Component {
           onChange={e => this.changeValue(e, 'select-with-valid-styles')}
           value={this.state.selectedValues['select-with-valid-styles']}
           dataOptions={options}
-          touched
           dirty
           valid
           validStylesEnabled
@@ -76,7 +75,6 @@ class BasicUsage extends Component {
           value={this.state.selectedValues['select-with-warning-styles']}
           dataOptions={options}
           warning="Here is a warning"
-          touched
           id="select-with-warning-styles"
         />
         <Select
@@ -85,7 +83,6 @@ class BasicUsage extends Component {
           value={this.state.selectedValues['select-with-error-styles']}
           dataOptions={options}
           error="Here is an error"
-          touched
           id="select-with-error-styles"
         />
         <Select

--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -25,13 +25,13 @@ const propTypes = {
     label: PropTypes.node,
     value: PropTypes.string,
   })).isRequired,
+  dirty: PropTypes.bool,
   disabled: PropTypes.bool,
   emptyMessage: PropTypes.string,
   error: PropTypes.node,
   formatter: PropTypes.func,
   hasChanged: PropTypes.bool,
   id: PropTypes.string,
-  isValid: PropTypes.bool,
   label: PropTypes.node,
   listMaxHeight: PropTypes.string,
   marginBottom0: PropTypes.bool,
@@ -46,13 +46,13 @@ const propTypes = {
   required: PropTypes.bool,
   tether: PropTypes.object,
   useValidStyle: PropTypes.bool,
+  valid: PropTypes.bool,
   value: PropTypes.string,
   warning: PropTypes.node,
 };
 
 const defaultProps = {
   formatter: DefaultOptionFormatter,
-  isValid: false,
   useValidStyle: false,
   multiple: false,
   tether: {
@@ -72,6 +72,7 @@ const defaultProps = {
     },
     ],
   },
+  valid: false,
 };
 
 class SingleSelect extends React.Component {
@@ -604,11 +605,11 @@ class SingleSelect extends React.Component {
       { [`${formStyles.hasFeedback}`]: this.props.error || this.props.warning },
       { [`${formStyles.hasWarning}`]: this.props.warning },
       { [`${formStyles.hasError}`]: this.props.error },
-      { [`${formStyles.isChanged}`]: this.props.hasChanged },
+      { [`${formStyles.isChanged}`]: this.props.dirty },
       {
         [`${formStyles.isValid}`]:
           this.props.useValidStyle &&
-          this.props.isValid &&
+          this.props.valid &&
           !this.props.error &&
           !this.props.warning
       },
@@ -798,9 +799,9 @@ SingleSelect.propTypes = propTypes;
 export default reduxFormField(
   SingleSelect,
   ({ meta }) => ({
-    warning: (meta.touched ? meta.warning : undefined),
-    error: (meta.touched ? meta.error : undefined),
-    isValid: (meta.touched ? meta.valid : undefined),
-    hasChanged: (meta.dirty)
+    dirty: meta.dirty,
+    error: (meta.touched && meta.error ? meta.error : ''),
+    valid: meta.valid,
+    warning: (meta.touched && meta.warning ? meta.warning : ''),
   })
 );

--- a/lib/TextArea/TextArea.js
+++ b/lib/TextArea/TextArea.js
@@ -145,7 +145,6 @@ export default reduxFormField(
   ({ meta }) => ({
     dirty: meta.dirty,
     error: (meta.touched && meta.error ? meta.error : ''),
-    loading: meta.asyncValidating,
     valid: meta.valid,
     warning: (meta.touched && meta.warning ? meta.warning : ''),
   })

--- a/lib/TextArea/TextArea.js
+++ b/lib/TextArea/TextArea.js
@@ -34,7 +34,6 @@ class TextArea extends Component {
     readOnly: PropTypes.bool,
     required: PropTypes.bool,
     startControl: PropTypes.element,
-    touched: PropTypes.bool,
     /**
      * Can be "type" or "number". Standard html attribute.
      */
@@ -96,7 +95,6 @@ class TextArea extends Component {
       noBorder,
       required,
       startControl,
-      touched,
       valid,
       validStylesEnabled,
       warning,
@@ -148,7 +146,6 @@ export default reduxFormField(
     dirty: meta.dirty,
     error: (meta.touched && meta.error ? meta.error : ''),
     loading: meta.asyncValidating,
-    touched: meta.touched,
     valid: meta.valid,
     warning: (meta.touched && meta.warning ? meta.warning : '')
   })

--- a/lib/TextArea/TextArea.js
+++ b/lib/TextArea/TextArea.js
@@ -147,6 +147,6 @@ export default reduxFormField(
     error: (meta.touched && meta.error ? meta.error : ''),
     loading: meta.asyncValidating,
     valid: meta.valid,
-    warning: (meta.touched && meta.warning ? meta.warning : '')
+    warning: (meta.touched && meta.warning ? meta.warning : ''),
   })
 );

--- a/lib/TextArea/stories/BasicUsage.js
+++ b/lib/TextArea/stories/BasicUsage.js
@@ -26,7 +26,6 @@ const BasicUsage = () => (
     <br />
     <TextArea
       validStylesEnabled
-      touched
       valid
       dirty
       label="Field with validation success"
@@ -34,14 +33,12 @@ const BasicUsage = () => (
     <TextArea
       value="Wrong value.."
       onChange={() => {}}
-      touched
       error="Here is an error message"
       label="Field with a validation error"
     />
     <TextArea
       value="Not entirely valid value.."
       onChange={() => {}}
-      touched
       warning="Here is a warning"
       dirty
       label="Field with validation warning"

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -122,10 +122,6 @@ class TextField extends Component {
      */
     startControl: PropTypes.element,
     /**
-     * Has the input been touched?
-     */
-    touched: PropTypes.bool,
-    /**
      * Can be "text" or "number". Standard html attribute.
      */
     type: PropTypes.string,
@@ -309,7 +305,6 @@ class TextField extends Component {
         'onFocus',
         'required',
         'startControl',
-        'touched',
         'valid',
         'validationEnabled',
         'validStylesEnabled'
@@ -480,7 +475,6 @@ export default reduxFormField(
     dirty: meta.dirty,
     error: (meta.touched && meta.error ? meta.error : ''),
     loading: meta.asyncValidating,
-    touched: meta.touched,
     valid: meta.valid,
     warning: (meta.touched && meta.warning ? meta.warning : ''),
   })

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -474,7 +474,6 @@ export default reduxFormField(
   ({ meta }) => ({
     dirty: meta.dirty,
     error: (meta.touched && meta.error ? meta.error : ''),
-    loading: meta.asyncValidating,
     valid: meta.valid,
     warning: (meta.touched && meta.warning ? meta.warning : ''),
   })

--- a/lib/TextField/stories/BasicUsage.js
+++ b/lib/TextField/stories/BasicUsage.js
@@ -36,7 +36,6 @@ const BasicUsage = () => (
       validStylesEnabled
       value="Good value"
       label="Field with validation success"
-      touched
       valid
       dirty
     />
@@ -44,13 +43,11 @@ const BasicUsage = () => (
       label="Field with a validation error"
       value="Wrong value.."
       error="Here is an error message"
-      touched
     />
     <TextField
       label="Field with validation warning"
       value="Not entirely valid value.."
       warning="Here is a warning"
-      touched
     />
     <TextField
       label="Loading field"

--- a/lib/TextField/tests/TextField-ReduxForm-test.js
+++ b/lib/TextField/tests/TextField-ReduxForm-test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 
-import { Field, reduxForm } from 'redux-form';
+import { Field } from 'redux-form';
 import { mountWithContext } from '../../../tests/helpers';
 import TestForm from '../../../tests/TestForm';
 import TextField from '../TextField';
@@ -115,48 +115,6 @@ describe('TextField with ReduxForm', () => {
 
         it('renders an error message', () => {
           expect(textfield.inputError).to.be.true;
-        });
-      });
-    });
-
-    describe('inputting an valid value with asyncValidating', () => {
-      let resolveValidation;
-
-      const AsyncForm = reduxForm({
-        form: 'TextFieldAsyncTest',
-        asyncValidate: () => {
-          return new Promise((resolve) => {
-            resolveValidation = resolve;
-          });
-        }
-      })(() => (
-        <Field
-          name="testField"
-          component={TextField}
-        />
-      ));
-
-      beforeEach(async () => {
-        await mountWithContext(
-          <AsyncForm />
-        );
-      });
-
-      beforeEach(async () => {
-        await textfield.fillInput('valid');
-      });
-
-      it('displays a loading icon', () => {
-        expect(textfield.hasLoadingIcon).to.be.true;
-      });
-
-      describe('finishing the async validation', () => {
-        beforeEach(async () => {
-          resolveValidation();
-        });
-
-        it('removes the loading icon', () => {
-          expect(textfield.hasLoadingIcon).to.be.false;
         });
       });
     });


### PR DESCRIPTION
## Purpose
Move toward the end goal of building our form field components agnostic of any form state library.

## Approach
- The `touched` styles were no longer in effect, so no `touched` props were doing anything.
- Always declare `dirty`, `error`, `valid`, and `warning` mappings in the same way.
- Removed `loading` mapping. `asyncValidating` was part of Redux Form, but is not part of React Final Form. Consumers of those components can still use the `loading` prop as needed.

## Next steps
In the very near future we'll be able to remove the `reduxFormField` HOC completely. Instead, hooking up the form state to form field components would be opt-in. This will provide more expressiveness for composing forms in more use cases. It will be more verbose, but consuming developers will have more options according to the needs of their feature.

What that would look like with React Final Form:
Need to use `TextField` without any validation styles?
```
<Field component={TextField} />
```

Have a field that should show an error when it's been focused, even if it hasn't changed?
```
<Field 
  render={({ input, meta }) => (
    <TextField {...input} error={meta.touched && meta.error ? meta.error : ''} />
  )}
/>
```

Have a field that should show an error only when it's been changed?
```
<Field 
  render={({ input, meta }) => (
    <TextField {...input} error={meta.dirty && meta.error ? meta.error : ''} />
  )}
/>
```

Have a field that should show an error, even if it hasn't been changed?
```
<Field 
  render={({ input, meta }) => (
    <TextField {...input} error={meta.error} />
  )}
/>
```

Have a field that needs to show a valid state?
```
<Field 
  render={({ input, meta }) => (
    <TextField {...input} valid={meta.valid} />
  )}
/>
```

Have a field that should only show a valid state when it's been changed?
```
<Field 
  render={({ input, meta }) => (
    <TextField {...input} valid={meta.dirty && meta.valid} />
  )}
/>
```

Have a field that should always show a warning, regardless of its value?
```
<Field 
  render={({ input, meta }) => (
    <TextField {...input} warning="I am a warning." />
  )}
/>
```