### PR TITLE
Release v4.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-components
 
-## 4.5.0 (IN PROGRESS)
+## [4.5.0](https://github.com/folio-org/stripes-components/tree/v4.5.0) (2018-11-29)
+[Full Changelog](https://github.com/folio-org/stripes-components/compare/v4.4.0...v4.5.0)
 
 * Deprecate `<EntrySelector>`
 * Introduce `showUserLink` prop on `<MetaSection>`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
* Deprecate `<EntrySelector>`
* Introduce `showUserLink` prop on `<MetaSection>`
* Deprecate `<IfInterface>` and `<IfPermission>`, STCOM-357
* Extend InfoPopover with new props (UIDATIMP-5).