### PR TITLE
A11y clean-up - aria button roles, color contrast issues.

### DIFF
--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -7,7 +7,6 @@
 .buttonInner {
   display: flex;
   align-items: center;
-  pointer-events: none;
 }
 
 .button {

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -4,11 +4,6 @@
 * Default styling
 */
 
-.buttonInner {
-  display: flex;
-  align-items: center;
-}
-
 .button {
   composes: interactionStyles from "../sharedStyles/interactionStyles.css";
   padding: 0.125rem var(--gutter);

--- a/lib/Button/Button.js
+++ b/lib/Button/Button.js
@@ -33,7 +33,6 @@ export const propTypes = {
 
 const defaultProps = {
   buttonStyle: 'default',
-  role: 'button',
   type: 'button',
 };
 

--- a/lib/Button/Button.js
+++ b/lib/Button/Button.js
@@ -83,7 +83,6 @@ function Button(props) {
   ]);
   const { children, onClick, type, to, buttonRef } = props;
 
-  const buttonInner = <span className={css.buttonInner}>{children}</span>;
   const sharedProps = {
     ...inputCustom,
     onClick,
@@ -100,7 +99,7 @@ function Button(props) {
         role="button"
         {...sharedProps}
       >
-        {buttonInner}
+        {children}
       </Link>
     );
   }
@@ -115,7 +114,7 @@ function Button(props) {
         {...sharedProps}
         onClick={handleAnchorClick}
       >
-        {buttonInner}
+        {children}
       </a>
     );
   }
@@ -126,7 +125,7 @@ function Button(props) {
       type={type}
       {...sharedProps}
     >
-      {buttonInner}
+      {children}
     </button>
   );
 }

--- a/lib/PaneHeader/PaneHeader.css
+++ b/lib/PaneHeader/PaneHeader.css
@@ -46,7 +46,6 @@
   display: flex;
   justify-content: center;
   position: relative;
-  pointer-events: none;
 
   /*  If paneTitle is wrapped in a div
       we add display:flex and vertcially centers the content */

--- a/lib/PaneHeader/PaneHeader.js
+++ b/lib/PaneHeader/PaneHeader.js
@@ -184,20 +184,15 @@ class PaneHeader extends Component {
     const paneActionMenu = getActionMenu();
 
     const content = (
-      <div>
+      <React.Fragment>
         { paneTitle && (
-          <h2 className={css.paneTitle} aria-describedby={paneSub && `${this._id}-subtitle`}>
+        <h2 className={css.paneTitle}>
             { appIcon &&
               <AppIcon iconAriaHidden size="small" app={appIcon.app} appIconKey={appIcon.key} />
             }
-            <span
-              tabIndex="-1"
-              ref={this.props.paneTitleRef}
-              autoFocus={this.props.paneTitleAutoFocus}
-              className={css.paneTitleLabel}
-            >
-              {paneTitle}
-            </span>
+          <span className={css.paneTitleLabel}>
+            {paneTitle}
+          </span>
             { paneActionMenu &&
               <Icon
                 icon={actionMenuOpen ? 'caret-up' : 'caret-down'}
@@ -205,13 +200,13 @@ class PaneHeader extends Component {
                 iconRootClass={css.paneActionMenuIcon}
               />
             }
-          </h2>
+        </h2>
         )
         }
         { paneSub && (
           <p id={`${this._id}-subtitle`} className={css.paneSub}><span>{paneSub}</span></p>
         ) }
-      </div>
+      </React.Fragment>
     );
     /**
      * Action Menu
@@ -241,7 +236,10 @@ class PaneHeader extends Component {
 
     return (
       <div className={css.paneHeaderCenter} style={this.getCenteredContentAreaStyle()}>
-        <div className={css.paneHeaderCenterInner}>
+        <div
+          className={css.paneHeaderCenterInner}
+          id={`${this._id}-pane-title`}
+        >
           { paneActionMenu ? contentWithActionMenu : content }
         </div>
       </div>
@@ -317,8 +315,20 @@ class PaneHeader extends Component {
       return (<div className={css.paneHeader}>{header}</div>);
     }
 
+    /**
+     * App can obtain a ref to the pane header for focus management (paneTitleRef).
+     * The header is labeled by the title which will announce on focus.
+     * This focus can only be achieved programmatically.
+     */
+
     return (
-      <div className={css.paneHeader}>
+      <div
+        className={css.paneHeader}
+        autoFocus={this.props.paneTitleAutoFocus}
+        tabIndex="-1"
+        ref={this.props.paneTitleRef}
+        aria-labelledby={`${this._id}-pane-title`}
+      >
         { getFirstContentArea() }
         { getCenteredContentArea() }
         { getLastContentArea() }


### PR DESCRIPTION
# Problem
Axe-reported issues in color contrast issues led me to investigate - based on the Axe project's issues/PR's these reports are often flags for deeper issues. It turns out that the CSS rule `pointer-events: none` can cause textual elements to not be accurately compared with their backgrounds. Buttons and Pane headers/dropdowns have `pointer-events: none` applied to keep inner elements from stealing focus as part of the way that focus styling is set up in the system.  This only appears to be an issue in the case that an inner element of a `<button>` is actually focusable (has a tab index, implicit or otherwise.) Testing on Chrome and Firefox for Windows, non-focusable elements didn't affect the appearance of interaction styles and, more importantly, clicks were not blocked from the interactive elements. Buttons have high potential for contrast issues if the primary colors , so it's best to not give any reason for tooling not to see them.

## Approach

Removed `pointer-events: none` from styles within `Button.css` and `PaneHeader.css`. Modified the focus behavior of pane headers so that instead of the `<h2>` being focused directly, it's mapped as a label to the header's outermost element. This results in a better focus order, since all pane menus will be in the focus path in front of the user.

## Additionally
Button was applying a redundant 'button' role to its rendered `<button>`. Fixed it.