### PR TITLE
STCOM-269 Generically rename to formField()

### DIFF
--- a/lib/AutoSuggest/AutoSuggest.js
+++ b/lib/AutoSuggest/AutoSuggest.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import uniqueId from 'lodash/uniqueId';
 import TetherComponent from 'react-tether';
 import TextField from '../TextField';
-import reduxFormField from '../ReduxFormField';
+import formField from '../FormField';
 import css from './AutoSuggest.css';
 
 const defaultProps = {
@@ -171,7 +171,7 @@ class AutoSuggest extends React.Component {
   }
 }
 
-export default reduxFormField(
+export default formField(
   AutoSuggest,
   ({ meta }) => ({
     dirty: meta.dirty,

--- a/lib/Checkbox/Checkbox.js
+++ b/lib/Checkbox/Checkbox.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import uniqueId from 'lodash/uniqueId';
 import { FormattedMessage } from 'react-intl';
 
-import reduxFormField from '../ReduxFormField';
+import formField from '../FormField';
 import Icon from '../Icon';
 import separateComponentProps from '../../util/separateComponentProps';
 import css from './Checkbox.css';
@@ -210,7 +210,7 @@ class Checkbox extends React.Component {
   }
 }
 
-export default reduxFormField(
+export default formField(
   Checkbox,
   ({ meta }) => ({
     error: (meta.touched && meta.error ? meta.error : ''),

--- a/lib/FormField/FormField.js
+++ b/lib/FormField/FormField.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const reduxFormField = (WrappedComponent, config) => {
+const formField = (WrappedComponent, config) => {
   function fieldWithRef({ input, meta, ...rest }, ref) {
     if (input || meta) {
       return (
@@ -23,14 +23,14 @@ const reduxFormField = (WrappedComponent, config) => {
   }
 
   const componentName = WrappedComponent.displayName || WrappedComponent.name || 'Component';
-  fieldWithRef.displayName = `ReduxFormField(${componentName})`;
+  fieldWithRef.displayName = `FormField(${componentName})`;
 
   return forwardRef(fieldWithRef);
 };
 
-reduxFormField.propTypes = {
+formField.propTypes = {
   config: PropTypes.func,
   WrappedComponent: PropTypes.element.isRequired,
 };
 
-export default reduxFormField;
+export default formField;

--- a/lib/FormField/index.js
+++ b/lib/FormField/index.js
@@ -1,0 +1,1 @@
+export { default } from './FormField';

--- a/lib/FormField/readme.md
+++ b/lib/FormField/readme.md
@@ -1,7 +1,7 @@
-# Redux Form Field
-Higher-order component for making a component easy to use in a [Redux Form](https://redux-form.com/7.3.0/) [`Field`](https://redux-form.com/7.3.0/docs/api/field.md/).
+# Form Field
+Higher-order component for making a component easy to use in a [Redux Form](https://github.com/erikras/redux-form) or [React Final Form](https://github.com/final-form/react-final-form) `<Field>`.
 
-When passing a component into the `component` prop of a `Field`, Redux Form will inject `input` and `meta` props.
+When passing a component into the `component` prop of a `Field`, React Final Form and Redux Form will inject `input` and `meta` props.
 
 When doing this:
 ```jsx
@@ -11,16 +11,16 @@ When doing this:
 `input` is mostly events, and `meta` is mostly computed properties of the form field.
 
 ## Usage
-`reduxFormField()` will pass along the `input` props as-is. To normalize the `meta` props injected by Redux Form:
+`formField()` will pass along the `input` props as-is. To normalize the `meta` props:
 ```jsx
 function ExampleComponent({ value, onChange, warning, error }) => (
   <div>{warning}</div>
 );
 
-export default reduxFormField(
+export default formField(
   ExampleComponent,
   ({ meta }) => ({
-    warning: (meta.touched && meta.warning ? meta.warning : ''),
+    dirty: meta.dirty,
     error: (meta.touched && meta.error ? meta.error : '')
   })
 );
@@ -36,4 +36,5 @@ Name | type | description | required
 
 ## Learning
 - [React Higher-Order Components](https://reactjs.org/docs/higher-order-components.html)
-- [Redux Form `Field`](https://redux-form.com/7.3.0/docs/api/field.md/#instance-api)
+- [Redux Form `Field`](https://github.com/erikras/redux-form/blob/master/docs/api/Field.md)
+- [React Final Form `Field`](https://github.com/final-form/react-final-form#fieldprops)

--- a/lib/FormFieldArray/FormFieldArray.js
+++ b/lib/FormFieldArray/FormFieldArray.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const reduxFormFieldArray = (WrappedComponent, config) => {
+const formFieldArray = (WrappedComponent, config) => {
   function fieldArrayWithRef({ fields, meta, ...rest }, ref) {
     if (meta !== undefined) {
       return (
@@ -23,14 +23,14 @@ const reduxFormFieldArray = (WrappedComponent, config) => {
   }
 
   const componentName = WrappedComponent.displayName || WrappedComponent.name;
-  fieldArrayWithRef.displayName = `reduxFormFieldArray(${componentName})`;
+  fieldArrayWithRef.displayName = `FormFieldArray(${componentName})`;
 
   return forwardRef(fieldArrayWithRef);
 };
 
-reduxFormFieldArray.propTypes = {
+formFieldArray.propTypes = {
   config: PropTypes.func,
   WrappedComponent: PropTypes.element.isRequired,
 };
 
-export default reduxFormFieldArray;
+export default formFieldArray;

--- a/lib/FormFieldArray/index.js
+++ b/lib/FormFieldArray/index.js
@@ -1,0 +1,1 @@
+export { default } from './FormFieldArray';

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -15,7 +15,7 @@ import SRStatus from '../SRStatus';
 import DefaultOptionFormatter from '../Selection/DefaultOptionFormatter';
 import TextFieldIcon from '../TextField/TextFieldIcon';
 import sharedInputStylesHelper from '../sharedStyles/sharedInputStylesHelper';
-import ReduxFormField from '../ReduxFormField';
+import formField from '../FormField';
 import css from './MultiSelect.css';
 
 const filterOptions = (filterText, list) => {
@@ -447,7 +447,7 @@ class MultiSelection extends React.Component {
   }
 }
 
-export default ReduxFormField(
+export default formField(
   MultiSelection,
   ({ meta }) => ({
     error: (meta.touched && meta.error ? meta.error : ''),

--- a/lib/RadioButton/RadioButton.js
+++ b/lib/RadioButton/RadioButton.js
@@ -5,7 +5,7 @@ import uniqueId from 'lodash/uniqueId';
 import { FormattedMessage } from 'react-intl';
 
 import Icon from '../Icon';
-import reduxFormField from '../ReduxFormField';
+import formField from '../FormField';
 import separateComponentProps from '../../util/separateComponentProps';
 import css from './RadioButton.css';
 
@@ -199,7 +199,7 @@ class RadioButton extends React.Component {
   }
 }
 
-export default reduxFormField(
+export default formField(
   RadioButton,
   ({ meta }) => ({
     error: (meta.touched && meta.error ? meta.error : ''),

--- a/lib/RadioButtonGroup/RadioButtonGroup.js
+++ b/lib/RadioButtonGroup/RadioButtonGroup.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ReduxFormField from '../ReduxFormField';
+import formField from '../FormField';
 import css from './RadioButtonGroup.css';
 
 const propTypes = {
@@ -49,7 +49,7 @@ function RadioButtonGroup(props) {
 
 RadioButtonGroup.propTypes = propTypes;
 
-export default ReduxFormField(
+export default formField(
   RadioButtonGroup,
   ({ meta }) => ({
     error: (meta.touched && meta.error ? meta.error : ''),

--- a/lib/ReduxFormField/index.js
+++ b/lib/ReduxFormField/index.js
@@ -1,1 +1,0 @@
-export { default } from './ReduxFormField';

--- a/lib/ReduxFormFieldArray/index.js
+++ b/lib/ReduxFormFieldArray/index.js
@@ -1,1 +1,0 @@
-export { default } from './ReduxFormFieldArray';

--- a/lib/RepeatableField/RepeatableField.js
+++ b/lib/RepeatableField/RepeatableField.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import reduxFormFieldArray from '../ReduxFormFieldArray';
+import formFieldArray from '../FormFieldArray';
 import Button from '../Button';
 import Headline from '../Headline';
 import IconButton from '../IconButton';
@@ -99,7 +99,7 @@ class RepeatableField extends Component {
   }
 }
 
-export default reduxFormFieldArray(
+export default formFieldArray(
   RepeatableField,
   ({ fields }) => ({
     fields,

--- a/lib/Select/Select.js
+++ b/lib/Select/Select.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import uniqueId from 'lodash/uniqueId';
 
-import reduxFormField from '../ReduxFormField';
+import formField from '../FormField';
 import css from './Select.css';
 import formStyles from '../sharedStyles/form.css';
 import sharedInputStylesHelper from '../sharedStyles/sharedInputStylesHelper';
@@ -184,7 +184,7 @@ class Select extends Component {
   }
 }
 
-export default reduxFormField(
+export default formField(
   Select,
   ({ meta }) => ({
     dirty: meta.dirty,

--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -15,7 +15,7 @@ import TextFieldIcon from '../TextField/TextFieldIcon';
 import SRStatus from '../SRStatus';
 import SelectList from './SelectList';
 import DefaultOptionFormatter from './DefaultOptionFormatter';
-import reduxFormField from '../ReduxFormField';
+import formField from '../FormField';
 import css from './Selection.css';
 import formStyles from '../sharedStyles/form.css';
 
@@ -796,7 +796,7 @@ class SingleSelect extends React.Component {
 SingleSelect.defaultProps = defaultProps;
 SingleSelect.propTypes = propTypes;
 
-export default reduxFormField(
+export default formField(
   SingleSelect,
   ({ meta }) => ({
     dirty: meta.dirty,

--- a/lib/TextArea/TextArea.js
+++ b/lib/TextArea/TextArea.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import className from 'classnames';
 
-import reduxFormField from '../ReduxFormField';
+import formField from '../FormField';
 import css from './TextArea.css';
 import omitProps from '../../util/omitProps';
 import sharedInputStylesHelper from '../sharedStyles/sharedInputStylesHelper';
@@ -143,7 +143,7 @@ class TextArea extends Component {
   }
 }
 
-export default reduxFormField(
+export default formField(
   TextArea,
   ({ meta }) => ({
     dirty: meta.dirty,

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import uniqueId from 'lodash/uniqueId';
 import classNames from 'classnames';
 
-import reduxFormField from '../ReduxFormField';
+import formField from '../FormField';
 import TextFieldIcon from './TextFieldIcon';
 import css from './TextField.css';
 import formStyles from '../sharedStyles/form.css';
@@ -472,7 +472,7 @@ class TextField extends Component {
   }
 }
 
-export default reduxFormField(
+export default formField(
   TextField,
   ({ meta }) => ({
     dirty: meta.dirty,


### PR DESCRIPTION
## Purpose
I have a branch of `ui-eholdings` where I've completely replaced `redux-form` with `react-final-form`. With `redux-form`'s project health in doubt, we should be actively encouraging use of alternative form state management solutions that meet our needs better. Related to https://issues.folio.org/browse/STCOM-269

## Approach
- Rename `reduxFormField()` and `reduxFormFieldArray()` to `formField()` and `formFieldArray()`
- Updated `formField()` readme to add links to React Final Form docs.