### PR TITLE
UIEH-574: Resolve scrolling bug

### DIFF
--- a/lib/Accordion/Accordion.css
+++ b/lib/Accordion/Accordion.css
@@ -23,6 +23,7 @@
   width: 100%;
   display: flex;
   align-items: center;
+  border-top: 1px solid transparent;
 
   /* transition: background-color 0.3s; */
 


### PR DESCRIPTION
## Purpose
According to [UIEH-574](https://issues.folio.org/browse/UIEH-574), there was a bug with scrolling in the eHoldings app. It also impeded the looking of the whole list of packages ([UIEH-576](https://issues.folio.org/browse/UIEH-576)).

## Approach
Accordion wrapper had a border, which disappeared when the title of the accordion was becoming sticky. The problem was resolved with adding border to not only the sticky mode, but in the usual either. 

## Additional
This PR also resolves [UIEH-576](https://issues.folio.org/browse/UIEH-576).

## Screenshot
![2018-12-03 15 38 29](https://user-images.githubusercontent.com/43647240/49376972-8acd1180-f711-11e8-8945-d99762dc9727.gif)
