### PR TITLE
STCOM-416: Fix Keyboard navigation issues

### DIFF
--- a/lib/RadioButton/RadioButton.js
+++ b/lib/RadioButton/RadioButton.js
@@ -156,7 +156,12 @@ class RadioButton extends React.Component {
     const [, inputCustom] = separateComponentProps(this.props, RadioButton.propTypes);
 
     return (
-      <div className={this.getRootStyle()}>
+      <div
+        className={this.getRootStyle()}
+        role="radio"
+        aria-checked={checked}
+        tabIndex={checked ? 0 : -1}
+      >
         <label htmlFor={this.id} className={this.getLabelStyle()}>
           <input
             id={this.id}
@@ -176,17 +181,17 @@ class RadioButton extends React.Component {
             aria-invalid={!!(this.props.error)}
           />
           <span className={css.labelPseudo} />
-          { (label || readOnly) &&
+          {(label || readOnly) &&
             (
               <span className={css.labelText}>
-                { label }
-                { readOnly && (
+                {label}
+                {readOnly && (
                   <Icon size="small" icon="lock">
                     <span className="sr-only">
                       <FormattedMessage id="stripes-components.readonly" />
                     </span>
                   </Icon>
-                ) }
+                )}
               </span>
             )
           }

--- a/lib/RadioButton/RadioButton.js
+++ b/lib/RadioButton/RadioButton.js
@@ -158,11 +158,14 @@ class RadioButton extends React.Component {
     return (
       <div
         className={this.getRootStyle()}
-        role="radio"
-        aria-checked={checked}
-        tabIndex={checked ? 0 : -1}
       >
-        <label htmlFor={this.id} className={this.getLabelStyle()}>
+        <label
+          htmlFor={this.id}
+          className={this.getLabelStyle()}
+          role="radio"
+          aria-checked={checked}
+          tabIndex={checked ? 0 : -1}
+        >
           <input
             id={this.id}
             type="radio"


### PR DESCRIPTION
## Purpose
Regarding [STCOM-416](https://issues.folio.org/browse/STCOM-416), when a user clicks filter options the whole form shouldn't be highlighted. Only the the current option should be outlined.

## Approach
- eHoldings App uses <RadioButton/> for filter options, so this component should be updated with a few additional attributes.

## Screenshots BEFORE
![2018-12-04 11 13 43](https://user-images.githubusercontent.com/43647240/49431369-041e4000-f7b6-11e8-8434-ff707e4c4f4b.gif)

## Screenshots NOW
![2018-12-04 11 09 34](https://user-images.githubusercontent.com/43647240/49431072-42ffc600-f7b5-11e8-8f0b-1302c6e74479.gif)