### PR TITLE
Selection: Added support for emptyMessages of node proptypes

### DIFF
--- a/lib/Selection/SelectList.js
+++ b/lib/Selection/SelectList.js
@@ -14,7 +14,7 @@ const propTypes = {
   activeId: PropTypes.string,
   controlRef: PropTypes.object,
   cursoredValue: PropTypes.string,
-  emptyMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.node]),
+  emptyMessage: PropTypes.node,
   filtered: PropTypes.bool,
   filterRef: PropTypes.object,
   formatter: PropTypes.func,

--- a/lib/Selection/SelectList.js
+++ b/lib/Selection/SelectList.js
@@ -14,7 +14,7 @@ const propTypes = {
   activeId: PropTypes.string,
   controlRef: PropTypes.object,
   cursoredValue: PropTypes.string,
-  emptyMessage: PropTypes.string,
+  emptyMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.node]),
   filtered: PropTypes.bool,
   filterRef: PropTypes.object,
   formatter: PropTypes.func,

--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -27,7 +27,7 @@ const propTypes = {
   })).isRequired,
   dirty: PropTypes.bool,
   disabled: PropTypes.bool,
-  emptyMessage: PropTypes.string,
+  emptyMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.node]),
   error: PropTypes.node,
   formatter: PropTypes.func,
   hasChanged: PropTypes.bool,

--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -27,7 +27,7 @@ const propTypes = {
   })).isRequired,
   dirty: PropTypes.bool,
   disabled: PropTypes.bool,
-  emptyMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.node]),
+  emptyMessage: PropTypes.node,
   error: PropTypes.node,
   formatter: PropTypes.func,
   hasChanged: PropTypes.bool,


### PR DESCRIPTION
`SelectList` was already complaining that `SingleSelect` was passing it a node by default for the `emptyMessage` prop, so this gets rid of that warning. Additionally, it adds propType support for passing `emptyMessage` nodes directly into `Selection`.