### PR TITLE
Updated EmptyMessage children prop-type to 'node'

### DIFF
--- a/lib/EmptyMessage/EmptyMessage.js
+++ b/lib/EmptyMessage/EmptyMessage.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import css from './EmptyMessage.css';
 
 const propTypes = {
-  children: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  children: PropTypes.node,
 };
 
 const EmptyMessage = ({ children }) => (

--- a/lib/EmptyMessage/readme.md
+++ b/lib/EmptyMessage/readme.md
@@ -11,4 +11,4 @@ A uniform way of rendering an empty state - e.g. no results found in a list.
 ## Props
 Name | Type | Description
 -- | -- | --
-children | element, string | Render the empty message by passing it as a child
+children | node | Render the empty message by passing it as a child


### PR DESCRIPTION
Updated EmptyMessage to simply allow for children of type 'node' instead of strings/elements.