### PR TITLE
STCOM-415 Deprecate SegmentedControl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Deprecate `getInput()` and `focusInput()` methods of `TextField`. Part of STCOM-372.
 * Add [documentation](lib/TextField/Readme.md) for `<TextField>`.
 * Add `document` icon
+* Replace `<SegmentedControl>` with `<ButtonGroup>`
 
 ## [4.5.0](https://github.com/folio-org/stripes-components/tree/v4.5.0) (2018-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v4.4.0...v4.5.0)

--- a/lib/SegmentedControl/SegmentedControl.js
+++ b/lib/SegmentedControl/SegmentedControl.js
@@ -27,6 +27,8 @@ const SegmentedControl = ({
   onActivate,
   tag: Tag,
 }) => {
+  console.warn('<SegmentedControl> is deprecated. Instead use <ButtonGroup> instead.');
+
   const renderedChildren = React.Children.map(children, (child) => {
     const childDecoration = child.props.id === activeId ? 'primary' : 'default';
     const childStyle = `${childDecoration}`;

--- a/lib/SegmentedControl/readme.md
+++ b/lib/SegmentedControl/readme.md
@@ -1,4 +1,4 @@
-# Segmented Control
+# Segmented Control (DEPRECATED)
 Creates a split button set that can be used for filters, tabs, and other subnavigation.
 
 ## Usage


### PR DESCRIPTION
The consensus from https://github.com/folio-org/stripes-components/pull/761 was that we'd deprecate `<SegmentedControl>`.

Least path of resistance: existing modules using it can clone `<SegmentedControl>` to their own repos. In most cases it'll make sense to just use `<ButtonGroup>` with `buttonStyle` coming from state or the router.

Closes https://issues.folio.org/browse/STCOM-415