### PR TITLE
Select: Update readme

### DIFF
--- a/lib/Select/readme.md
+++ b/lib/Select/readme.md
@@ -21,7 +21,7 @@ label | string | Adds an html `<label>` tag container a string to the element. |
 id | string | HTML id attribute applied to input - will also set the HtmlFor attribute of the label. |  | false
 dataOptions | array | Array of objects for options in the shape of `{value:<string>, label: <string>, disabled:<bool>}` |  | required
 autoFocus | bool | If this prop is `true`, `<select>` will automatically focus on mount | `false` | false
-placeHolder | string | Sets a disabled first option in the options list. |  | false
+placeholder | string | Sets a disabled first option in the options list. |  | false
 required | bool | Sets the required attribute on the select field. | false | false
 readOnly | bool | Sets the select field as read only. | false | false
 marginBottom0 | bool | Styles the input with no bottom margin. | false | false


### PR DESCRIPTION
Select uses `placeholder`, not `placeHolder`