### PR TITLE
STCOM-421 Add deprecation warning for TabButton

### DIFF
--- a/lib/TabButton/TabButton.js
+++ b/lib/TabButton/TabButton.js
@@ -10,6 +10,11 @@ const propTypes = {
 function TabButton(props) {
   const { children, selected, ...buttonProps } = props;
 
+  console.warn(
+    'Warning: <TabButton> is deprecated and will be removed in the\n' +
+    'next major version of @folio/stripes-components.\n\n'
+  );
+
   return (
     <Button
       buttonStyle={selected ? 'paneHeaderButton tab selected' : 'paneHeaderButton tab'}

--- a/lib/TabButton/TabButton.js
+++ b/lib/TabButton/TabButton.js
@@ -1,3 +1,7 @@
+/**
+ * Deprecated - will be removed in next major release
+ */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '../Button';


### PR DESCRIPTION
The `<TabButton>` component is being phased out.

Searching the FOLIO organization on GitHub showed no trace of this component being used anywhere. As far as I know, the tab layout design pattern in which this component was used in, is no longer used and it's not planned to be implemented again.

This change should prevent anyone from using it in any new code – and should there be other repos out there using it they will be notified so that they can remove it.

I will follow up with a PR against the next major release (5.0.0) to remove it completely.