### PR TITLE
Exported ButtonGroup from package

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 export { default as AutoSuggest } from './lib/AutoSuggest';
 export { default as Badge } from './lib/Badge';
 export { default as Button } from './lib/Button';
+export { default as ButtonGroup } from './lib/ButtonGroup';
 export { default as Checkbox } from './lib/Checkbox';
 export { default as Datepicker, Calendar } from './lib/Datepicker';
 export { default as DateRangeWrapper } from './lib/DateRangeWrapper';


### PR DESCRIPTION
Exported the `ButtonGroup` component created in https://github.com/folio-org/stripes-components/pull/761

(I'm assuming we didn't _purposely_ skip exporting it for some Q4-release-related reasons.)