### PR TITLE
STCOM-427: Added examples and readme for <ErrorBoundary>

### DIFF
--- a/lib/ErrorBoundary/readme.md
+++ b/lib/ErrorBoundary/readme.md
@@ -1,0 +1,21 @@
+# ErrorBoundary
+Catches JavaScript errors in child components and renders an error message instead of the actual content.
+
+## Basic Usage
+```js
+  import { ErrorBoundary } from '@folio/stripes/components';
+
+  <ErrorBoundary>
+    <MyComponent />
+  </ErrorBoundary>
+```
+
+## Where to place error boundaries
+The granularity of error boundaries is up to you. You may wrap top-level route components to display a “Something went wrong” message to the user. You may also wrap individual components in an error boundary to protect them from crashing the rest of the application.
+
+**Note:** The FOLIO system wraps the app's root in an `ErrorBoundary` which will catch errors on a top-level.
+
+## Props
+Name | type | description
+--- | --- | ---
+children | node | Pass any component as a child to ErrorBoundary to enable error catching

--- a/lib/ErrorBoundary/stories/BasicUsage.js
+++ b/lib/ErrorBoundary/stories/BasicUsage.js
@@ -1,5 +1,5 @@
 /**
- * Avatar: Basic Usage
+ * ErrorBoundary: Basic Usage
  */
 
 import React, { Component } from 'react';

--- a/lib/ErrorBoundary/stories/BasicUsage.js
+++ b/lib/ErrorBoundary/stories/BasicUsage.js
@@ -1,0 +1,25 @@
+/**
+ * Avatar: Basic Usage
+ */
+
+import React, { Component } from 'react';
+import ErrorBoundary from '../ErrorBoundary';
+import Button from '../../Button';
+
+const ComponentWithError = () => <div>{kapooow}</div>; /* eslint-disable-line no-undef */
+
+export default class BasicUsage extends Component {
+  state = {
+    triggered: false,
+  }
+
+  render() {
+    const { triggered } = this.state;
+    return (
+      <ErrorBoundary>
+        <Button onClick={() => this.setState({ triggered: true })}>Clicking me will trigger an error</Button>
+        { triggered && <ComponentWithError /> }
+      </ErrorBoundary>
+    );
+  }
+}

--- a/lib/ErrorBoundary/stories/ErrorBoundary.stories.js
+++ b/lib/ErrorBoundary/stories/ErrorBoundary.stories.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
+import readme from '../readme.md';
+import BasicUsage from './BasicUsage';
+
+storiesOf('ErrorBoundary', module)
+  .addDecorator(withReadme(readme))
+  .add('Basic Usage', () => <BasicUsage />);


### PR DESCRIPTION
Added storybook example and readme for `<ErrorBoundary>`

**Ticket:** https://issues.folio.org/browse/STCOM-427

I think we could improve this component in the future by updating the styles a bit. And maybe also provide a prop for a fallback UI.