### PR TITLE
Selection: Remove special handling of small screens

### DIFF
--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -761,24 +761,25 @@ class SingleSelect extends React.Component {
       />
     );
 
-    if (atSmallMedia) {
-      return (
-        <div ref={this.container}>
-          {uiInput}
-          {this.state.showList &&
-            <Portal container={document.getElementById('root')}>
-              <div
-                role="presentation"
-                className={css.selectionMobileBackdrop}
-                onClick={() => { this.hideList(); }}
-              >
-                {selectList}
-              </div>
-            </Portal>
-          }
-        </div>
-      );
-    }
+    // if (atSmallMedia) {
+    //   console.log('showList', this.state.showList);
+    //   return (
+    //     <div ref={this.container}>
+    //       {uiInput}
+    //       {this.state.showList &&
+    //         <Portal container={document.getElementById('root')}>
+    //           <div
+    //             role="presentation"
+    //             className={css.selectionMobileBackdrop}
+    //             onClick={() => { this.hideList(); }}
+    //           >
+    //             {selectList}
+    //           </div>
+    //         </Portal>
+    //       }
+    //     </div>
+    //   );
+    // }
 
     const mergedTetherProps = Object.assign({}, SingleSelect.defaultProps.tether, tether);
 


### PR DESCRIPTION
The `Selection` component is currently crashing when the dropdown is brought up when the browser window is small (<800px), with an error stating "ERROR: Cannot read property 'focus' of null". This is an immediate issue because it breaks any integration tests that rely on functionality provided by a `Selection` component. In particular, it breaks the Basket tests for ui-agreements.

The error is due to an unassigned `ref`, which is what's being attempted to be `focus`()ed in [`componentDidUpdate`](https://github.com/folio-org/stripes-components/blob/master/lib/Selection/SingleSelect.js#L180)

The ref appears to be unset because [rendering for small screens appears to be different](https://github.com/folio-org/stripes-components/blob/master/lib/Selection/SingleSelect.js#L764).

[JIRA has been filed for better handling,](https://issues.folio.org/browse/STCOM-433) but I figured I'd create this temporary hotfix until that gets handled. Feel free to disagree and suggest we should handle this properly immediately. 😄 