### PR TITLE
Render ModalFooter children

### DIFF
--- a/lib/ConfirmationModal/ConfirmationModal.js
+++ b/lib/ConfirmationModal/ConfirmationModal.js
@@ -3,6 +3,7 @@ import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import uniqueId from 'lodash/uniqueId';
 
+import Button from '../Button';
 import Modal from '../Modal';
 import ModalFooter from '../ModalFooter';
 import css from './ConfirmationModal.css';
@@ -34,22 +35,24 @@ const ConfirmationModal = (props) => {
   const confirmLabel = props.confirmLabel || <FormattedMessage id="stripes-components.submit" />;
 
   const footer = (
-    <ModalFooter
-      secondaryButton={{
-        'label': cancelLabel,
-        'onClick': props.onCancel,
-        'id': `clickable-${testId}-cancel`,
-        'buttonStyle': props.cancelButtonStyle,
-        'data-test-confirmation-modal-cancel-button': true,
-      }}
-      primaryButton={{
-        'label': confirmLabel,
-        'onClick': props.onConfirm,
-        'id': `clickable-${testId}-confirm`,
-        'buttonStyle': props.buttonStyle,
-        'data-test-confirmation-modal-confirm-button': true,
-      }}
-    />
+    <ModalFooter>
+      <Button
+        data-test-confirmation-modal-confirm-button
+        buttonStyle={props.buttonStyle}
+        id={`clickable-${testId}-confirm`}
+        onClick={props.onConfirm}
+      >
+        {confirmLabel}
+      </Button>
+      <Button
+        data-test-confirmation-modal-cancel-button
+        buttonStyle={props.cancelButtonStyle}
+        id={`clickable-${testId}-cancel`}
+        onClick={props.onCancel}
+      >
+        {cancelLabel}
+      </Button>
+    </ModalFooter>
   );
 
   return (

--- a/lib/ModalFooter/ModalFooter.css
+++ b/lib/ModalFooter/ModalFooter.css
@@ -4,19 +4,15 @@
   align-items: center;
   display: flex;
   flex-flow: row-reverse wrap;
-  margin: calc((var(--control-margin-bottom) / 2) * -1) 0;
+  margin: calc((var(--control-margin-bottom) / 4) * -1) 0;
   width: 100%;
-}
 
-.modalFooterButton {
-  flex: 1 1 auto;
-  margin: calc(var(--control-margin-bottom) / 2) 4px;
+  & > * {
+    flex: 1 1 auto;
+    margin: calc(var(--control-margin-bottom) / 4);
 
-  & + .modalFooterButton {
-    margin: calc(var(--control-margin-bottom) / 2) 4px;
-  }
-
-  @media (--medium-up) {
-    flex: 0 1 auto;
+    @media (--medium-up) {
+      flex: 0 1 auto;
+    }
   }
 }

--- a/lib/ModalFooter/ModalFooter.js
+++ b/lib/ModalFooter/ModalFooter.js
@@ -6,18 +6,18 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { deprecated } from 'prop-types-extra';
 import Button, { propTypes as buttonPropTypes } from '../Button/Button';
 import css from './ModalFooter.css';
 
-const ModalFooter = ({ primaryButton, secondaryButton }) => {
+const ModalFooter = ({ children, primaryButton, secondaryButton }) => {
   // Rendered buttons are identical except for the label and buttonStyle
   const renderButton = (buttonStyle, props) => {
-    const { label, ...rest } = props; // eslint-disable-line react/prop-types
+    const { label, ...buttonProps } = props;
     return (
       <Button
-        {...rest}
+        {...buttonProps}
         buttonStyle={buttonStyle}
-        buttonClass={css.modalFooterButton}
       >
         {label}
       </Button>
@@ -28,19 +28,29 @@ const ModalFooter = ({ primaryButton, secondaryButton }) => {
     <div className={css.modalFooterButtons}>
       {primaryButton ? renderButton('primary', primaryButton) : null}
       {secondaryButton ? renderButton('default', secondaryButton) : null}
+      {children}
     </div>
   );
 };
 
 ModalFooter.propTypes = {
-  primaryButton: PropTypes.shape({
+  children: (props) => {
+    let error = null;
+    React.Children.forEach(props.children, (child) => {
+      if (child.type !== Button) {
+        error = new Error('`ModalFooter` children should be of type `Button`.');
+      }
+    });
+    return error;
+  },
+  primaryButton: deprecated(PropTypes.shape({
     ...buttonPropTypes,
     label: PropTypes.node,
-  }),
-  secondaryButton: PropTypes.shape({
+  }), 'Pass in children instead.'),
+  secondaryButton: deprecated(PropTypes.shape({
     ...buttonPropTypes,
     label: PropTypes.node,
-  }),
+  }), 'Pass in children instead.'),
 };
 
 export default ModalFooter;

--- a/lib/ModalFooter/examples/ModalFooterExample.js
+++ b/lib/ModalFooter/examples/ModalFooterExample.js
@@ -6,19 +6,21 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import ModalFooter from '../ModalFooter';
 import Modal from '../../Modal';
+import Button from '../../Button';
 
 export default () => {
   const footer = (
-    <ModalFooter
-      primaryButton={{
-        label: 'Save',
-        onClick: action('You clicked save')
-      }}
-      secondaryButton={{
-        label: 'Cancel',
-        onClick: action('You clicked cancel')
-      }}
-    />
+    <ModalFooter>
+      <Button
+        buttonStyle="primary"
+        onClick={action('You clicked save')}
+      >
+        Save
+      </Button>
+      <Button onClick={action('You clicked cancel')}>
+        Cancel
+      </Button>
+    </ModalFooter>
   );
 
   return (

--- a/lib/ModalFooter/readme.md
+++ b/lib/ModalFooter/readme.md
@@ -3,19 +3,20 @@ The default modal footer for the Modal-component.
 
 ### Usage
 ```js
-import { Modal, ModalFooter } from '@folio/stripes/components';
+import { Modal, ModalFooter, Button } from '@folio/stripes/components';
 
 const footer = (
-  <ModalFooter
-    primaryButton={{
-      label: 'Save',
+  <ModalFooter>
+    <Button
+      buttonStyle="primary"
       onClick={() => {...}}
-    }}
-    secondaryButton={{
-      label: 'Cancel',
-      onClick={() => {...}}
-    }}
-  />
+    >
+      Save
+    </Button>
+    <Button onClick={() => {...}}>
+      Cancel
+    </Button>
+  </ModalFooter>
 );
 
 <Modal
@@ -30,5 +31,4 @@ const footer = (
 ### Props
 Name | type | description | default | required
 --- | --- | --- | --- | ---
-primaryButton | object | Props for the primary button. In addition to the "label"-key it will accept all available [`<Button>`](/?selectedKind=Button) props. | undefined | false
-secondaryButton | object | Props for the secondary button. In addition to the "label"-key it will accept all available [`<Button>`](/?selectedKind=Button) props. | undefined | false
+children | | Set of `<Button>`s. |  |

--- a/lib/ModalFooter/tests/ModalFooter-test.js
+++ b/lib/ModalFooter/tests/ModalFooter-test.js
@@ -1,7 +1,3 @@
-/**
- * ModalFooter test
- */
-
 import React from 'react';
 
 import { expect } from 'chai';
@@ -9,6 +5,7 @@ import { describe, beforeEach, it } from '@bigtest/mocha';
 import { mount } from '../../../tests/helpers';
 
 import ModalFooter from '../ModalFooter';
+import Button from '../../Button';
 import ModalFooterInteractor from './interactor';
 
 describe('ModalFooter', () => {
@@ -20,40 +17,29 @@ describe('ModalFooter', () => {
 
   beforeEach(async () => {
     await mount(
-      <ModalFooter
-        primaryButton={{
-          label: primaryButtonLabel,
-          id: primaryButtonId,
-        }}
-        secondaryButton={{
-          label: secondaryButtonLabel,
-          id: secondaryButtonId,
-        }}
-      />
+      <ModalFooter>
+        <Button id={primaryButtonId} buttonStyle="primary">
+          {primaryButtonLabel}
+        </Button>
+        <Button id={secondaryButtonId}>
+          {secondaryButtonLabel}
+        </Button>
+      </ModalFooter>
     );
   });
 
-  /**
-   * The "primaryButton"-prop should render a primary <Button>  with the primary button style
-   */
-  it('renders a primary button when using the primaryButton-prop', () => {
+  it('renders a primary button', () => {
     expect(modalFooter.primaryButton.rendersPrimary).to.be.true;
   });
 
-  /**
-   * The "secondaryButton"-prop should render a <Button> with the default button style
-   */
-  it('renders a default button when using the secondaryButton-prop', () => {
+  it('renders a default button', () => {
     expect(modalFooter.secondaryButton.rendersDefault).to.be.true;
   });
 
-  /**
-   * Passing a label-key to either the secondaryButton- or primaryButton-prop
-   * should render a button with the label value passed
-   */
   it(`renders a button with a label of "${secondaryButtonLabel}"`, () => {
     expect(modalFooter.secondaryButton.label).to.equal(secondaryButtonLabel);
   });
+
   it(`renders a button with a label of "${primaryButtonLabel}"`, () => {
     expect(modalFooter.primaryButton.label).to.equal(primaryButtonLabel);
   });


### PR DESCRIPTION
Changes the ergonomics of `<ModalFooter>` to accept children instead of prop objects.
- Makes adding `data-test-*` attributes less awkward.
- Makes it possible to construct a `<ModalFooter>` with more than two buttons. I don't know of any current cases of that, but it'll probably come up.
- Makes it possible to change order of the buttons - that might be desired for modals asking to confirm destructive actions.
- Adjusted button margins a hair to look better on narrow screens.

Very similar to https://github.com/folio-org/stripes-components/pull/761

We probably want to leave the deprecations for `primaryButton` and `secondaryButton` in until `stripes` `v3.0.0`.