### PR TITLE
Remove stripes-util dependency

### DIFF
--- a/lib/ExportCsv/ExportCsv.js
+++ b/lib/ExportCsv/ExportCsv.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { deprecated } from 'prop-types-extra';
-import exportToCsv from '@folio/stripes-util/lib/exportCsv';
+import exportToCsv from './exportToCsv';
 import Button from '../Button';
 
 class ExportCsv extends React.Component {

--- a/lib/ExportCsv/exportToCsv.js
+++ b/lib/ExportCsv/exportToCsv.js
@@ -1,0 +1,88 @@
+import { Parser } from 'json2csv';
+
+function triggerDownload(csv, fileTitle) {
+  const exportedFilename = fileTitle ? fileTitle + '.csv' : 'export.csv';
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  if (navigator.msSaveBlob) { // IE 10+
+    navigator.msSaveBlob(blob, exportedFilename);
+  } else {
+    const link = document.createElement('a');
+    if (link.download !== undefined) { // feature detection
+      // Browsers that support HTML5 download attribute
+      const url = URL.createObjectURL(blob);
+      link.setAttribute('href', url);
+      link.setAttribute('download', exportedFilename);
+      link.style.visibility = 'hidden';
+      document.body.appendChild(link);
+      window.setTimeout(() => {
+        link.click();
+        document.body.removeChild(link);
+      }, 50); // Need to debounce this click event from others (Pane actionMenuItems dropdown)
+    } else {
+      console.error('Failed to trigger download for CSV data'); // eslint-disable-line no-console
+    }
+  }
+}
+
+// Returns an array of all nested keys in an object
+const keyify = (obj, prefix = '') => Object.keys(obj).reduce((res, el) => {
+  if (Array.isArray(obj[el])) {
+    return res;
+  } else if (typeof obj[el] === 'object' && obj[el] !== null) {
+    return [...res, ...keyify(obj[el], prefix + el + '.')];
+  } else {
+    return [...res, prefix + el];
+  }
+}, []);
+
+class FieldList {
+  constructor(objectArray, onlyFields = []) {
+    this.list = onlyFields.length ? onlyFields : keyify(objectArray[0]);
+  }
+
+  omit = (excludedFields = []) => {
+    excludedFields.forEach((field) => {
+      const index = this.list.indexOf(field);
+      if (index !== -1) {
+        this.list.splice(index, 1);
+      }
+    });
+    return this;
+  }
+
+  ensureToInclude = (includedFields = []) => {
+    includedFields.forEach((field) => {
+      const index = this.list.indexOf(field);
+      if (index === -1) {
+        this.list.push(field);
+      }
+    });
+    return this;
+  }
+}
+
+export default function exportToCsv(objectArray, opts) {
+  if (!(objectArray && objectArray.length > 0)) {
+    // console.debug('No data to export');
+    return;
+  }
+  let options = opts;
+  if (opts.isArray) { // backwards-compatiblity
+    options = { excludeFields: opts };
+  }
+
+  const {
+    excludeFields,           // do not include these fields
+    explicitlyIncludeFields, // ensure to include these fields
+    onlyFields,              // Only Fields to be included
+  } = options;
+
+  // The default behavior is to use the keys on the first object as the list of fields
+  const fields = new FieldList(objectArray, onlyFields)
+    .omit(excludeFields)
+    .ensureToInclude(explicitlyIncludeFields).list;
+
+  const parser = new Parser({ fields, flatten: true });
+  const csv = parser.parse(objectArray);
+  triggerDownload(csv);
+}

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
   },
   "dependencies": {
     "@folio/stripes-react-hotkeys": "^2.0.0",
-    "@folio/stripes-util": "^1.0.0",
     "classnames": "^2.2.5",
     "dom-helpers": "^3.2.1",
     "downshift": "^2.0.16",


### PR DESCRIPTION
## Purpose
Moves `exportToCsv()` from `stripes-util` into `stripes-components` itself.

## Next steps
Refactor `ui-requests` to use the `<ExportCsv>` component instead of the `stripes-util` function: https://issues.folio.org/browse/STUTL-3