### PR TITLE
STCOM-433 Selection focus management.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add [documentation](lib/TextField/Readme.md) for `<TextField>`.
 * Add `document` icon
 * Replace `<SegmentedControl>` with `<ButtonGroup>`
+* Fix broken focus management of `<Selection>` on small screens. Fixes STCOM-433.
 
 ## [4.5.0](https://github.com/folio-org/stripes-components/tree/v4.5.0) (2018-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v4.4.0...v4.5.0)

--- a/lib/Selection/SelectList.js
+++ b/lib/Selection/SelectList.js
@@ -89,6 +89,8 @@ class SelectList extends React.Component {
     if (this.props.selected && !this.props.filtered) {
       this.scrollToCursor(true);
     }
+
+    this.props.filterRef.current.focus();
   }
 
   shouldComponentUpdate(nextProps) {

--- a/lib/Selection/Selection.css
+++ b/lib/Selection/Selection.css
@@ -85,6 +85,7 @@
   background-color: rgba(0, 0, 0, 0.2);
   padding-top: 48px;
   align-items: flex-start;
+  pointer-events: all;
 }
 
 .singleValue {

--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -177,12 +177,6 @@ class SingleSelect extends React.Component {
     }
   }
 
-  componentDidUpdate(prevProps, prevState) {
-    if (this.state.showList && !prevState.showList) {
-      this.filterTextInput.current.focus();
-    }
-  }
-
   componentWillUnmount() {
     clearTimeout(this._filterFocusTimeout);
     this._filterFocusTimeout = null;
@@ -766,7 +760,7 @@ class SingleSelect extends React.Component {
         <div ref={this.container}>
           {uiInput}
           {this.state.showList &&
-            <Portal container={document.getElementById('root')}>
+            <Portal container={document.getElementById('OverlayContainer')}>
               <div
                 role="presentation"
                 className={css.selectionMobileBackdrop}


### PR DESCRIPTION
On small screens, Selection misbehaves since the ref for its filter field doesn't quite get reconciled before the state of its root updates.
Having the SelectList component actually focus its own filter input on mount assures the presence of the ref rather than leaning on the parent component's state update.