### PR TITLE
fix issue with blur, add marginBottom0 prop

### DIFF
--- a/lib/MultiSelection/MultiDownshift.js
+++ b/lib/MultiSelection/MultiDownshift.js
@@ -85,7 +85,7 @@ class MultiDownshift extends React.Component {
     cb(newValue);
   }
 
-  getSelectedItems = () => this.state.selectedItems;
+  getSelectedItems = () => this.props.value;
 
   getRemoveButtonProps = ({
     onClick,

--- a/lib/MultiSelection/MultiSelect.css
+++ b/lib/MultiSelection/MultiSelect.css
@@ -14,6 +14,9 @@
   width: 100%;
   display: flex;
   justify-content: space-between;
+  &.marginBottom0{
+    margin-bottom: 0;
+  }
 }
 
 .multiSelectFocused {
@@ -43,6 +46,7 @@
   padding: 0 4px;
   border-width: 0;
   outline: 0;
+  width: 100%;
 }
 
 .multiSelectValueListContainer {

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -40,6 +40,7 @@ class MultiSelection extends React.Component {
     isValid: PropTypes.bool,
     itemToString: PropTypes.func,
     label: PropTypes.node,
+    marginBottom0: PropTypes.bool,
     maxHeight: PropTypes.number,
     onBlur: PropTypes.func,
     onChange: PropTypes.func,
@@ -198,6 +199,7 @@ class MultiSelection extends React.Component {
     return classnames(
       css.multiSelectControl,
       { [`${css.multiSelectFocused}`]: this.state.focused },
+      { [`${css.marginBottom0}`]: this.props.marginBottom0 },
       sharedInputStylesHelper(this.props),
     );
   }

--- a/lib/MultiSelection/readme.md
+++ b/lib/MultiSelection/readme.md
@@ -34,6 +34,7 @@ Name | type | description | default | required
 `id` | string | Sets the `id` attribute for the control. Other interior id's are generated using this string as a prefix. | |
 `itemToString` | <string>func | Function used to return a single string representation of its value. For example, option objects with a shape of `{label:<string>, value:<object>}` would use `item => (item ? item.label : '')` for their toString function. This is used to generate strings so that values can accurately be announced for screen readers. | `item => (item ? item.label : '')` |
 `label` | string | Used as the form label for the field. Appropriate label/field relationship for accessibility is automatically set up by the component. | |
+`marginBottom0` | bool | Applies a style with zero-bottom-margin to the control | | 
 `maxHeight` | number | The maximum height of the options menu in pixels. This does not include the heigh of any validation messages that may also appear with the menu. | `168` |
 `onBlur` | func | Blur event handler for when the user blurs the filter field | |
 `onChange` | func | Change event handler for when internal state changes. `selectedItems` is passed as parameter to function. | |


### PR DESCRIPTION
`<MultiSelection>`'s onBlur event wasn't firing properly due to a regression from removing the localState of its internal MultiDownshift component. 
Also, usage of the component has been on the ugly side due to the lingering bottom margins... added the `marginBottom0` prop to resolve.