### PR TITLE
row measuring should overwrite 0-height rows

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -423,6 +423,9 @@ class MCLRenderer extends React.Component {
           if (this.rowCache[index] !== 'undefined') {
             // children are c[1] to c[length-1]
             this.rowCache.push(c[index - firstIndex].offsetHeight);
+          } else if (this.rowCache[index] === 0) {
+            // overwrite 0-height rows.
+            this.rowCache[index] = c[index - firstIndex].offsetHeight;
           }
         }
       }


### PR DESCRIPTION
Row heights can register as 0 if an MCL is initially hidden. Once the MCL is visible accurate heights can be obtained again.