### PR TITLE
Resolve propTypes warnings for filterGroup

### DIFF
--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -63,7 +63,7 @@ FilterGroup.propTypes = {
   disabled: PropTypes.bool,
   filters: PropTypes.object.isRequired,
   groupName: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
+  label: PropTypes.node.isRequired,
   names: PropTypes.arrayOf(PropTypes.string).isRequired,
   onChangeFilter: PropTypes.func.isRequired,
 };
@@ -286,7 +286,7 @@ FilterGroups.propTypes = {
   config: PropTypes.arrayOf(
     PropTypes.shape({
       cql: PropTypes.string.isRequired,
-      label: PropTypes.string.isRequired,
+      label: PropTypes.node.isRequired,
       name: PropTypes.string.isRequired,
       values: PropTypes.arrayOf(
         PropTypes.oneOfType([


### PR DESCRIPTION
 ## Purpose
As deprecated pattern `formatMessage` was replaced with `<FormattedMessage/>`, currently it sends warnings to console relating to wrong propTypes for a label in `<FilterGroup/>` and `<FilterGroup/>`.

## Approach
- the label in propTypes was changed from 'string' to 'node'