### PR TITLE
STCOM-439: Add multi selection filter

### DIFF
--- a/lib/MultiSelectionFilter/MultiSelectionFilter.js
+++ b/lib/MultiSelectionFilter/MultiSelectionFilter.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import MultiSelection from '../MultiSelection';
+
+export default class MultiSelectionFilter extends React.Component {
+  static propTypes = {
+    name: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+    options: PropTypes.arrayOf(PropTypes.shape({
+      label: PropTypes.node,
+      value: PropTypes.any,
+    })).isRequired,
+    selectedValues: PropTypes.arrayOf(PropTypes.string),
+  };
+
+  static defaultProps = {
+    selectedValues: [],
+  }
+
+  onChangeHandler = (selectedOptions) => {
+    const {
+      name,
+      onChange,
+    } = this.props;
+
+    onChange({
+      name,
+      values: selectedOptions.map((option) => option.value),
+    });
+  };
+
+  getSelectedOptions() {
+    const {
+      selectedValues,
+      options,
+    } = this.props;
+
+    return selectedValues
+      .map((curValue) => options.find((curAvailableValue) => curAvailableValue.value === curValue));
+  }
+
+  render() {
+    const {
+      options,
+    } = this.props;
+
+    return (
+      <MultiSelection
+        {...this.props}
+        dataOptions={options}
+        value={this.getSelectedOptions()}
+        onChange={this.onChangeHandler}
+      />
+    );
+  }
+}

--- a/lib/MultiSelectionFilter/MultiSelectionFilter.stories.js
+++ b/lib/MultiSelectionFilter/MultiSelectionFilter.stories.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+import withReadme from 'storybook-readme/with-readme';
+import { storiesOf } from '@storybook/react';
+import readme from './readme.md';
+import MultiSelectionFilter from './MultiSelectionFilter';
+
+const options = [
+  { value: 'en', label: 'English' },
+  { value: 'fr', label: 'French' },
+  { value: 'ge', label: 'German' },
+  { value: 'it', label: 'Italian' },
+];
+
+const styles = { maxWidth: '300px' };
+
+
+const renderAddTag = ({ filterValue, exactMatch }) => {
+  if (exactMatch) {
+    return null;
+  } else {
+    return (
+      <div>
+        Add tag for
+        <strong>
+          &quot;
+          {`${filterValue}`}
+          &quot;
+        </strong>
+      </div>
+    );
+  }
+};
+
+storiesOf('MultiSelectionFilter', module)
+  .addDecorator(withReadme(readme))
+  .add('Basic Usage', () => (
+    <div style={styles}>
+      <MultiSelectionFilter
+        name="language"
+        options={options}
+        onChange={action}
+      />
+    </div>
+  ))
+  .add('With label', () => (
+    <div style={styles}>
+      <MultiSelectionFilter
+        name="language"
+        options={options}
+        onChange={action}
+        label="Languages"
+      />
+    </div>
+  ))
+  .add('With placeholder', () => (
+    <div style={styles}>
+      <MultiSelectionFilter
+        name="language"
+        options={options}
+        onChange={action}
+        placeholder="Choose a language!"
+      />
+    </div>
+  ))
+  .add('With selected value', () => (
+    <div style={styles}>
+      <MultiSelectionFilter
+        name="language"
+        selectedValues={['en']}
+        options={options}
+        onChange={action}
+      />
+    </div>
+  ))
+  .add('With custom formatter', () => (
+    <div style={styles}>
+      <MultiSelectionFilter
+        name="language"
+        selectedValues={['en']}
+        options={options}
+        onChange={action}
+        formatter={({ option, searchTerm }) => `${option.label}(${option.value} )`}
+      />
+    </div>
+  ));

--- a/lib/MultiSelectionFilter/index.js
+++ b/lib/MultiSelectionFilter/index.js
@@ -1,0 +1,1 @@
+export { default } from './MultiSelectionFilter';

--- a/lib/MultiSelectionFilter/readme.md
+++ b/lib/MultiSelectionFilter/readme.md
@@ -1,0 +1,128 @@
+# MultiSelectionFilter
+
+It's an extended version of `MultiSelection` component. Created to be used as reusable filter element. Allows filtering for long lists of options via a text field. The behavior of filtering is similar to a type-ahead or suggestion list. The value is returned as an array. Selected values are displayed as value 'chips' - they can be removed by clicking their "X" button -or- simply be toggled off in the options list. The control is fully navigable via keyboard, without use of any modifier keys. 
+
+## Basic Usage
+```
+import { MultiSelectionFilter } from '@folio/stripes/components';
+
+const options = [
+  { value: 'en', label: 'English' },
+  { value: 'fr', label: 'French' },
+  { value: 'ge', label: 'German' },
+  // ...
+];
+
+/* ... later in JSX */
+<MultiSelectionFilter
+  name="language"
+  options={options}
+  onChange={({name, values}) => {}}
+/>      
+```
+
+## Common Props
+Name | type | description | default | required
+--- | --- | --- | --- | ---
+`actions` | array of objects | array of non-selectable actions that would be present in the list - for example, an 'add tag' functionality where a user can add their entered filter word to the list of available values. See the **actions** section below | [] |
+`asyncFiltering` | bool | if true, it's up to the surrounding app to apply a filter handler and pass its resulting list through to the `dataOptions` prop. | false |
+`options` | array of objects | A set of options to be rendered in a dropdown list. Set up to treat objects with the shape of {value<any>, label:<string>} |
+`backspaceDeletes` | bool | if true, the user can press the backspace key when the option filter is empty to remove the last selected item in the value list | true |
+`emptyMessage` | string | feedback message for user when options list is empty (they've entered an option filter with no results,) | 'No matching items found!' |
+`filter` | func | a custom filter function. If you're not using `asyncFiltering` It should return an object with the shape of `{renderedItems:<array>}` This object can include additional properties that can be used for conditional rendering of `action`s. | the default filter is via reg-ex on the items' `label` field |
+`formatter` | func | Render function that accepts an object with keys for the option and the current filter string. The function is called to display values in the options dropdown and in the selected values list. A default `formatter` is provided. | [DefaultOptionFormatter](../Selection/DefaultOptionFormatter.md) |
+`id` | string | Sets the `id` attribute for the control. Other interior id's are generated using this string as a prefix. | |
+`itemToString` | <string>func | Function used to return a single string representation of its value. For example, option objects with a shape of `{label:<string>, value:<object>}` would use `item => (item ? item.label : '')` for their toString function. This is used to generate strings so that values can accurately be announced for screen readers. | `item => (item ? item.label : '')` |
+`label` | string | Used as the form label for the field. Appropriate label/field relationship for accessibility is automatically set up by the component. | |
+`maxHeight` | number | The maximum height of the options menu in pixels. This does not include the heigh of any validation messages that may also appear with the menu. | `168` |
+`name` | string | Filter name |
+`onBlur` | func | Blur event handler for when the user blurs the filter field | |
+`onChange` | func | Callback to be called when a filter value changes. Receives `{name:<string>, values:<array>}`, where the name is a filter name and values is all selected values of the filter. | |
+`onRemove` | func | Event handler specifically called when an item is removed from the selection. The removed item is passed to the handler. | |
+`placeholder` | string | Rendered as a placeholder for the control when no value is present. | |
+`renderToOverlay` | bool | For use in situations where the dropdown may be cut off due to a containing dom element's `overflow: hidden/auto` css attribute. | false |
+`selectedValues` | array of strings | A list of selected filter values |
+`tether` | object | Override settings for the tether when `renderToOverlay` is used. | default tether object provided. |
+
+## Validation props
+These are props that could be applicable if setting up your own validation system. These would probably best be handled within `onChange` and `onBlur` event handlers.
+
+Name | type | description | default | required
+--- | --- | --- | --- | ---
+`dirty` | bool | Apply a specific style when the value has changed. | false |
+`error` | string | Text to display as inline validation feedback for the user. A truthy value here will also apply validation styling to the control. | |
+`isValid` | bool | Whether or not field is valid. When true, specific styles are applied. | |
+`validationEnabled` | bool | Controls whether or not validation styles are rendered. | false |
+`warning` | string | Text to display as inline validation feedback for the user. A truthy value here will also apply validation styling to the control. | |
+
+## Shape of dataOptions
+The shape of the items in your dataOptions array may require you to pass additional props. The default props are set up to handle dataOptions with `label` and `value` keys. If your options do not have label and value keys, here are some other props to be sure you're setting:
+
+* `itemToString` - string for accessible announcement of the item's status. "<item> has been removed"
+* `filter` - function to use when filtering the options list. Should return an object with renderedItems holding the resulting array as a key.
+* `formatter` - function for rendering the options in the dropdown and selected items list.
+
+### Example
+```
+// if the data options are an array of strings instead of objects
+
+dataOptions = [ 'one', 'two', 'three' ];
+toString = (option) => option;
+formatter = ({option}) => <div>{option}</div>;
+
+filterItems = (filterOptions = (filterText, list) => {
+  const filterRegExp = new RegExp(`^${filterText}`, 'i');
+  const renderedItems = filterText ? list.filter(item => item.search(filterRegExp) !== -1) : list;
+  return { renderedItems };
+};
+
+<MultiSelect
+  itemToString={this.toString}
+  formatter={this.formatter}
+  filter={this.filterItems}
+/>
+```
+## Formatting with `<OptionSegment>`
+We provide an `<OptionSegment>` component for use in formatters to enable nice features like the bolding of filter values in results - so a filter of 'in' will display resulting options like '**in**put', '**in**dustry','**in**novation'.
+```
+import { OptionSegment } from '@folio/stripes/components';
+
+formatter= ({option, searchTerm}) => <OptionSegment searchTerm={searchTerm} >{option}</OptionSegment>;
+
+//...rest of code...
+```
+## Actions
+Some use cases may require an item in the options list to perform a function rather than simply set/toggle a value. An example of this would be for a tagging system to add the string that a user has entered as a search term as a new tag.
+```
+addTag = ({ renderedItems, exactMatch, filterText }) => {
+    ... logic to push new option with 'filterText' as its `label` key.
+}
+
+renderAddTag = ({ filterValue, exactMatch }) => {
+    if (exactMatch) {
+      return null;
+    } else {
+      return <div>Add tag for &quot;{`${filterValue}`}&quot;</div>;
+    }
+}
+
+addAction = { onSelect: this.addTag, render: this.renderAddTag }
+
+actions = [this.addAction];
+
+/* later in JSX */
+<MultiSelection
+  dataOptions={listOptions}
+  actions={actions}
+/>
+```
+
+## Async Filtering
+Sometimes if a list of potential options is very large, it may be handled by the server. The `asyncFiltering` prop can be used along with your own `filter` function that controls the `dataOptions` prop. In this scenario, if dataOptions is left undefined or null, the dropdown list will render a loading spinner.
+```
+  <MultiSelect
+    asyncFiltering
+    filter={this.handleFilter}
+    dataOptions={this.state.options}
+  />
+```

--- a/lib/MultiSelectionFilter/tests/MultiSelectionFilter-test.js
+++ b/lib/MultiSelectionFilter/tests/MultiSelectionFilter-test.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { mountWithContext } from '../../../tests/helpers';
+import MultiSelectionFilter from '../MultiSelectionFilter';
+
+import MultiSelectionInteractor from '../../MultiSelection/tests/interactor';
+
+const multiSelectionFilter = new MultiSelectionInteractor();
+
+const options = [
+  { value: 'en', label: 'English' },
+  { value: 'fr', label: 'French' },
+  { value: 'ge', label: 'German' },
+  { value: 'it', label: 'Italian' },
+];
+
+describe('MultiSelectionFilter', () => {
+  const onChangeHandler = sinon.spy();
+
+  beforeEach(async () => {
+    await mountWithContext(
+      <MultiSelectionFilter
+        name="language"
+        options={options}
+        onChange={onChangeHandler}
+      />
+    );
+
+    onChangeHandler.resetHistory();
+  });
+
+  it('should not render any selected values by default', () => {
+    expect(multiSelectionFilter.values()).to.deep.equal([]);
+  });
+
+  describe('when there are selected values', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <MultiSelectionFilter
+          name="language"
+          selectedValues={['en', 'fr', 'ge']}
+          options={options}
+          onChange={onChangeHandler}
+        />
+      );
+    });
+
+    it('should display selected values', () => {
+      expect(multiSelectionFilter.values(0).valLabel).to.equal('English');
+      expect(multiSelectionFilter.values(1).valLabel).to.equal('French');
+      expect(multiSelectionFilter.values(2).valLabel).to.equal('German');
+    });
+
+    describe('after click on a value delete button', () => {
+      beforeEach(async () => {
+        await multiSelectionFilter.values(0).clickRemoveButton();
+      });
+
+      it('should call onChange callback with filter name and rest values', () => {
+        expect(onChangeHandler.args[0]).to.deep.equal([{
+          name: 'language',
+          values: ['fr', 'ge'],
+        }]);
+      });
+    });
+
+    describe('after click on selected option', () => {
+      beforeEach(async () => {
+        await multiSelectionFilter.options(1).clickOption();
+      });
+
+      it('should call onChange callback with filter name and rest values', () => {
+        expect(onChangeHandler.args[0]).to.deep.equal([{
+          name: 'language',
+          values: ['en', 'ge']
+        }]);
+      });
+    });
+
+    describe('after click on unselected option', () => {
+      beforeEach(async () => {
+        await multiSelectionFilter.options(3).clickOption();
+      });
+
+      it('should pass filter name and all selected values to onChange callback', () => {
+        expect(onChangeHandler.args[0]).to.deep.equal([{
+          name: 'language',
+          values: ['en', 'fr', 'ge', 'it'],
+        }]);
+      });
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "react-redux": "^5.0.2",
     "redux": "^3.6.0",
     "redux-form": "^7.0.3",
+    "sinon": "^7.2.2",
     "storybook-addon-intl": "^2.3.2",
     "storybook-addon-rtl": "^0.1.2",
     "storybook-readme": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1448,6 +1448,29 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.2.tgz#54c5a964462be3d4d78af631363c18d6fa91ac26"
   integrity sha512-yprFYuno9FtNsSHVlSWd+nRlmGoAbqbeCwOryP6sC/zoCjhpArcRMYp19EvpSUSizJAlsXEwJv+wcWS9XaXdMw==
 
+"@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.2.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.3.0.tgz#50a2754016b6f30a994ceda6d9a0a8c36adda849"
+  integrity sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/formatio@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.1.0.tgz#6ac9d1eb1821984d84c4996726e45d1646d8cce5"
+  integrity sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==
+  dependencies:
+    "@sinonjs/samsam" "^2 || ^3"
+
+"@sinonjs/samsam@^2 || ^3", "@sinonjs/samsam@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.0.2.tgz#304fb33bd5585a0b2df8a4c801fcb47fa84d8e43"
+  integrity sha512-m08g4CS3J6lwRQk1pj1EO+KEVWbrbXsmi9Pw0ySmrIbcVxVaedoFgLvFsV8wHLwh01EpROVz3KvVcD1Jmks9FQ==
+  dependencies:
+    "@sinonjs/commons" "^1.0.2"
+    array-from "^2.1.1"
+    lodash.get "^4.4.2"
+
 "@storybook/addon-actions@^4.0.12":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-4.1.1.tgz#c8f939ddf75d61a25c907544b35f8793769f5084"
@@ -2521,6 +2544,11 @@ array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
+
+array-from@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
+  integrity sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
 
 array-includes@^3.0.3:
   version "3.0.3"
@@ -5637,7 +5665,7 @@ diff@3.2.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
   integrity sha1-yc45Okt8vQsFinJck98pkCeGj/k=
 
-diff@3.5.0:
+diff@3.5.0, diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
@@ -8946,6 +8974,11 @@ jsx-ast-utils@^2.0.1:
   dependencies:
     array-includes "^3.0.3"
 
+just-extend@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
+  integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
+
 just-kebab-case@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/just-kebab-case/-/just-kebab-case-1.1.0.tgz#ebe854fde84b0afa4e597fcd870b12eb3c026755"
@@ -9521,6 +9554,16 @@ loglevelnext@^1.0.1:
   dependencies:
     es6-symbol "^3.1.1"
     object.assign "^4.1.0"
+
+lolex@^2.3.2:
+  version "2.7.5"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
+  integrity sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==
+
+lolex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-3.0.0.tgz#f04ee1a8aa13f60f1abd7b0e8f4213ec72ec193e"
+  integrity sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==
 
 longest-streak@^2.0.1:
   version "2.0.2"
@@ -10190,6 +10233,17 @@ nightmare@^2.10.0:
     rimraf "^2.4.3"
     sliced "1.0.1"
     split2 "^2.0.1"
+
+nise@^1.4.7:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.4.8.tgz#ce91c31e86cf9b2c4cac49d7fcd7f56779bfd6b0"
+  integrity sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==
+  dependencies:
+    "@sinonjs/formatio" "^3.1.0"
+    just-extend "^4.0.2"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
 
 no-case@^2.2.0:
   version "2.3.2"
@@ -13300,6 +13354,19 @@ single-line-log@^1.1.2:
   dependencies:
     string-width "^1.0.1"
 
+sinon@^7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.2.2.tgz#388ecabd42fa93c592bfc71d35a70894d5a0ca07"
+  integrity sha512-WLagdMHiEsrRmee3jr6IIDntOF4kbI6N2pfbi8wkv50qaUQcBglkzkjtoOEbeJ2vf1EsrHhLI+5Ny8//WHdMoA==
+  dependencies:
+    "@sinonjs/commons" "^1.2.0"
+    "@sinonjs/formatio" "^3.1.0"
+    "@sinonjs/samsam" "^3.0.2"
+    diff "^3.5.0"
+    lolex "^3.0.0"
+    nise "^1.4.7"
+    supports-color "^5.5.0"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -14180,6 +14247,11 @@ tether@^1.4.3:
   resolved "https://registry.yarnpkg.com/tether/-/tether-1.4.5.tgz#8efd7b35572767ba502259ba9b1cc167fcf6f2c1"
   integrity sha512-fysT1Gug2wbRi7a6waeu39yVDwiNtvwj5m9eRD+qZDSHKNghLo6KqP/U3yM2ap6TNUL2skjXGJaJJTJqoC31vw==
 
+text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+  integrity sha1-45mpgiV6J22uQou5KEXLcb3CbRk=
+
 text-table@0.2.0, text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -14393,7 +14465,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-439

## Purpose
Create a reusable multiselection filter, based on MultiSelection component, to be used in SearchAndSort side panel.

## Approach
- create `onChangeHandler` which will raise filter name and selected values after a filter change.
- add a couple of props
- add storybook
- add tests only specific for this component
