### PR TITLE
STCOM-437: Remove controls from Timepicker inputs + minor style updates

### DIFF
--- a/lib/Timepicker/TimeDropdown.css
+++ b/lib/Timepicker/TimeDropdown.css
@@ -17,6 +17,10 @@
     -webkit-appearance: none; 
     margin: 0;
   }
+
+  & input {
+    text-align: center;
+  }
 }
 
 .center {

--- a/lib/Timepicker/TimeDropdown.css
+++ b/lib/Timepicker/TimeDropdown.css
@@ -27,8 +27,13 @@
   text-align: center;
 }
 
+.submitButton {
+  margin-top: 0.35rem;
+}
+
 .colon {
-  vertical-align: middle;
+  height: 100%;
+  font-weight: bold;
 }
 
 .srOnly {

--- a/lib/Timepicker/TimeDropdown.css
+++ b/lib/Timepicker/TimeDropdown.css
@@ -9,6 +9,14 @@
   width: 230px;
   box-shadow: var(--shadow);
   z-index: 9999;
+
+  /* WebKit desktop browsers add little up down arrows 
+  to number inputs called spinners. Here we remove them. */
+  & input[type=number]::-webkit-inner-spin-button,
+  & input[type=number]::-webkit-outer-spin-button {
+    -webkit-appearance: none; 
+    margin: 0;
+  }
 }
 
 .center {
@@ -26,4 +34,9 @@
   height: 1px;
   width: 1px;
   overflow: hidden;
+}
+
+.input {
+  background-color: green;
+  width: 200px;
 }

--- a/lib/Timepicker/TimeDropdown.css
+++ b/lib/Timepicker/TimeDropdown.css
@@ -10,11 +10,11 @@
   box-shadow: var(--shadow);
   z-index: 9999;
 
-  /* WebKit desktop browsers add little up down arrows 
-  to number inputs called spinners. Here we remove them. */
+  /* WebKit desktop browsers add little up down arrows
+  to number inputs called spinners. Here we remove them to preserve space. */
   & input[type=number]::-webkit-inner-spin-button,
   & input[type=number]::-webkit-outer-spin-button {
-    -webkit-appearance: none; 
+    -webkit-appearance: none;
     margin: 0;
   }
 
@@ -43,9 +43,4 @@
   height: 1px;
   width: 1px;
   overflow: hidden;
-}
-
-.input {
-  background-color: green;
-  width: 200px;
 }

--- a/lib/Timepicker/TimeDropdown.js
+++ b/lib/Timepicker/TimeDropdown.js
@@ -9,6 +9,7 @@ import classNames from 'classnames';
 import { extendMoment } from 'moment-range';
 import Button from '../Button';
 import IconButton from '../IconButton';
+import Layout from '../Layout';
 import { Row, Col } from '../LayoutGrid';
 import TextField from '../TextField';
 import css from './TimeDropdown.css';
@@ -362,7 +363,7 @@ class TimeDropdown extends React.Component {
             />
           </Col>
           <Col xs={1}>
-            <strong className={css.colon}>:</strong>
+            <Layout className={`display-flex flex-align-items-center ${css.colon}`}>:</Layout>
           </Col>
           <Col xs={4}>
             <TextField
@@ -419,6 +420,7 @@ class TimeDropdown extends React.Component {
           <Col xs={12}>
             <Button
               buttonStyle="primary"
+              buttonClass={css.submitButton}
               onKeyDown={this.setTimeHandleKeyDown}
               tabIndex={this.props.visible ? '0' : '-1'}
               fullWidth


### PR DESCRIPTION
**Ticket:** https://issues.folio.org/browse/STCOM-437

Webkit desktop browsers add little up/down arrows to number inputs. This caused the input values to be pushed out when focusing the inputs within the Timepicker dropdown.

In this PR I removed those controls since we already have arrow controls for these inputs. I also made some minor style adjustments: Centering number in inputs and properly vertically aligned the colon between the inputs.

## Before
![dec-29-2018 16-46-04](https://user-images.githubusercontent.com/640976/50540103-f75df380-0b8b-11e9-996a-40f49b36dde0.gif)

## After
![dec-29-2018 16-45-41](https://user-images.githubusercontent.com/640976/50540102-f331d600-0b8b-11e9-8673-35c9e8530e36.gif)
