### PR TITLE
STCOM-440: Add checkbox filter

### DIFF
--- a/lib/CheckboxFilter/CheckboxFilter.js
+++ b/lib/CheckboxFilter/CheckboxFilter.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Checkbox from '../Checkbox';
+
+export default class CheckboxFilter extends React.Component {
+  static propTypes = {
+    name: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+    options: PropTypes.arrayOf(PropTypes.shape({
+      disabled: PropTypes.bool,
+      label: PropTypes.node,
+      readOnly: PropTypes.bool,
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    })).isRequired,
+    selectedValues: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
+  };
+
+  static defaultProps = {
+    selectedValues: [],
+  }
+
+  createOnChangeHandler = (filterValue) => (e) => {
+    const {
+      name,
+      selectedValues,
+      onChange,
+    } = this.props;
+
+    const newValues = e.target.checked
+      ? [...selectedValues, filterValue]
+      : selectedValues.filter((value) => value !== filterValue);
+
+    onChange({
+      name,
+      values: newValues,
+    });
+  };
+
+  render() {
+    const {
+      options,
+      selectedValues,
+    } = this.props;
+
+    return (
+      options.map(({ value, label, disabled, readOnly }) => {
+        return (
+          <Checkbox
+            {...this.props}
+            data-test-checkbox-filter-option={value}
+            key={value}
+            label={label}
+            disabled={disabled}
+            readOnly={readOnly}
+            checked={selectedValues.includes(value)}
+            onChange={this.createOnChangeHandler(value)}
+          />
+        );
+      })
+    );
+  }
+}

--- a/lib/CheckboxFilter/CheckboxFilter.stories.js
+++ b/lib/CheckboxFilter/CheckboxFilter.stories.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+import withReadme from 'storybook-readme/with-readme';
+import { storiesOf } from '@storybook/react';
+import readme from './readme.md';
+import CheckboxFilter from './CheckboxFilter';
+
+const options = [
+  { value: 'en', label: 'English' },
+  { value: 'fr', label: 'French' },
+  { value: 'ge', label: 'German' },
+  { value: 'it', label: 'Italian' },
+];
+
+const styles = { maxWidth: '300px' };
+
+storiesOf('CheckboxFilter', module)
+  .addDecorator(withReadme(readme))
+  .add('Basic Usage', () => (
+    <div style={styles}>
+      <CheckboxFilter
+        name="language"
+        options={options}
+        onChange={action}
+      />
+    </div>
+  ))
+  .add('With selected values', () => (
+    <div style={styles}>
+      <CheckboxFilter
+        name="language"
+        selectedValues={['en', 'fr']}
+        options={options}
+        onChange={action}
+      />
+    </div>
+  ))
+  .add('With readOnly option', () => (
+    <div style={styles}>
+      <CheckboxFilter
+        name="language"
+        selectedValues={['en', 'fr']}
+        options={[
+          { value: 'en', label: 'English', readOnly: true },
+          { value: 'fr', label: 'French' },
+          { value: 'ge', label: 'German' },
+          { value: 'it', label: 'Italian' },
+        ]}
+        onChange={action}
+      />
+    </div>
+  ))
+  .add('With disabled option', () => (
+    <div style={styles}>
+      <CheckboxFilter
+        name="language"
+        options={[
+          { value: 'en', label: 'English', disabled: true },
+          { value: 'fr', label: 'French' },
+          { value: 'ge', label: 'German' },
+          { value: 'it', label: 'Italian' },
+        ]}
+        onChange={action}
+      />
+    </div>
+  ));

--- a/lib/CheckboxFilter/index.js
+++ b/lib/CheckboxFilter/index.js
@@ -1,0 +1,1 @@
+export { default } from './CheckboxFilter';

--- a/lib/CheckboxFilter/readme.md
+++ b/lib/CheckboxFilter/readme.md
@@ -1,0 +1,30 @@
+# CheckboxFilter
+
+A stateless component. Represents a set of Checkbox components working like one filter. 
+
+## Basic Usage
+```
+import { CheckboxFilter } from '@folio/stripes/components';
+
+const options = [
+  { value: 'en', label: 'English' },
+  { value: 'fr', label: 'French' },
+  { value: 'ge', label: 'German' },
+  // ...
+];
+
+/* ... later in JSX */
+<CheckboxFilter
+  name="language"
+  options={options}
+  onChange={({name, values}) => {}}
+/>      
+```
+
+## Common Props
+Name | type | description | default | required
+--- | --- | --- | --- | ---
+`name` | string | Filter name |
+`options` | array of objects | A set of filter options to be rendered as checkboxes. Set up to treat objects with the shape of `{value:<any>, label:<string>, disabled:<boolean>, readOnly:<boolean>}` |
+`onChange` | func | Callback to be called when a filter value changes. Receives `{name:<string>, values:<array>}`, where the name is a filter name and values is all selected values of the filter. Values is an array of strings. | |
+`selectedValues` | array of strings | A list of selected filter values |

--- a/lib/CheckboxFilter/tests/CheckboxFilter-test.js
+++ b/lib/CheckboxFilter/tests/CheckboxFilter-test.js
@@ -1,0 +1,119 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { mountWithContext } from '../../../tests/helpers';
+
+import CheckboxFilter from '../CheckboxFilter';
+import CheckboxFilterInteractor from './interactor';
+
+
+describe('CheckboxFilter', () => {
+  const checkboxFilter = new CheckboxFilterInteractor();
+  const onChangeHandler = sinon.spy();
+
+  const renderComponent = (props) => {
+    return mountWithContext(
+      <CheckboxFilter
+        name="language"
+        onChange={onChangeHandler}
+        options={[
+          { value: 'en', label: 'English' },
+          { value: 'fr', label: 'French' },
+          { value: 'ge', label: 'German' },
+          { value: 'it', label: 'Italian' },
+        ]}
+        {...props}
+      />
+    );
+  };
+
+  beforeEach(async () => {
+    await renderComponent();
+
+    onChangeHandler.resetHistory();
+  });
+
+  it('should render all filter options', () => {
+    expect(checkboxFilter.optionsCount).to.equal(4);
+  });
+
+
+  describe('after click on readonly option', () => {
+    beforeEach(async () => {
+      await renderComponent({
+        options: [
+          {
+            value: 'en',
+            label: 'English',
+            readOnly: true,
+          },
+        ]
+      });
+      await checkboxFilter.options(0).click();
+    });
+
+    it('should not call onChange callback', () => {
+      expect(onChangeHandler.called).to.equal(false);
+    });
+  });
+
+  describe('after click on disabled option', () => {
+    beforeEach(async () => {
+      await renderComponent({
+        options: [
+          {
+            value: 'en',
+            label: 'English',
+            disabled: true,
+          },
+        ]
+      });
+      await checkboxFilter.options(0).click();
+    });
+
+    it('should not call onChange callback', () => {
+      expect(onChangeHandler.called).to.equal(false);
+    });
+  });
+
+  describe('when there are selected options', () => {
+    beforeEach(async () => {
+      await renderComponent({
+        selectedValues: ['fr', 'ge'],
+      });
+    });
+
+    it('should render selected options', () => {
+      expect(checkboxFilter.options(1).isSelected).to.equal(true);
+      expect(checkboxFilter.options(2).isSelected).to.equal(true);
+    });
+
+    describe('after click on unselected option', () => {
+      beforeEach(async () => {
+        await checkboxFilter.options(0).click();
+      });
+
+      it('should raise filter name and new selected values to onChange callback', () => {
+        expect(onChangeHandler.args[0]).to.deep.equal([{
+          name: 'language',
+          values: ['fr', 'ge', 'en'],
+        }]);
+      });
+    });
+
+    describe('after click on selected option', () => {
+      beforeEach(async () => {
+        await checkboxFilter.options(1).click();
+      });
+
+      it('should raise filter name with the remaining selected values to onChange callback', () => {
+        expect(onChangeHandler.args[0]).to.deep.equal([{
+          name: 'language',
+          values: ['ge'],
+        }]);
+      });
+    });
+  });
+});

--- a/lib/CheckboxFilter/tests/interactor.js
+++ b/lib/CheckboxFilter/tests/interactor.js
@@ -1,0 +1,19 @@
+import {
+  count,
+  clickable,
+  interactor,
+  collection,
+  is
+} from '@bigtest/interactor';
+
+const Option = interactor(class OptionInteractor {
+  click = clickable();
+  isSelected = is('[checked]');
+  isDisabled = is('disabled');
+  isReadOnly = is('readonly')
+});
+
+export default interactor(class CheckboxFilterInteractor {
+  optionsCount = count('[data-test-checkbox-filter-option]');
+  options = collection('[data-test-checkbox-filter-option]', Option);
+});

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "react-router-dom": "^4.1.1",
     "react-tether": "^1.0.1",
     "react-transition-group": "^2.2.1",
+    "sinon": "^7.2.2",
     "tai-password-strength": "^1.1.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1448,6 +1448,29 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.2.tgz#54c5a964462be3d4d78af631363c18d6fa91ac26"
   integrity sha512-yprFYuno9FtNsSHVlSWd+nRlmGoAbqbeCwOryP6sC/zoCjhpArcRMYp19EvpSUSizJAlsXEwJv+wcWS9XaXdMw==
 
+"@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.2.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.3.0.tgz#50a2754016b6f30a994ceda6d9a0a8c36adda849"
+  integrity sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/formatio@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.1.0.tgz#6ac9d1eb1821984d84c4996726e45d1646d8cce5"
+  integrity sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==
+  dependencies:
+    "@sinonjs/samsam" "^2 || ^3"
+
+"@sinonjs/samsam@^2 || ^3", "@sinonjs/samsam@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.0.2.tgz#304fb33bd5585a0b2df8a4c801fcb47fa84d8e43"
+  integrity sha512-m08g4CS3J6lwRQk1pj1EO+KEVWbrbXsmi9Pw0ySmrIbcVxVaedoFgLvFsV8wHLwh01EpROVz3KvVcD1Jmks9FQ==
+  dependencies:
+    "@sinonjs/commons" "^1.0.2"
+    array-from "^2.1.1"
+    lodash.get "^4.4.2"
+
 "@storybook/addon-actions@^4.0.12":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-4.1.1.tgz#c8f939ddf75d61a25c907544b35f8793769f5084"
@@ -2521,6 +2544,11 @@ array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
+
+array-from@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
+  integrity sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
 
 array-includes@^3.0.3:
   version "3.0.3"
@@ -5637,7 +5665,7 @@ diff@3.2.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
   integrity sha1-yc45Okt8vQsFinJck98pkCeGj/k=
 
-diff@3.5.0:
+diff@3.5.0, diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
@@ -8946,6 +8974,11 @@ jsx-ast-utils@^2.0.1:
   dependencies:
     array-includes "^3.0.3"
 
+just-extend@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
+  integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
+
 just-kebab-case@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/just-kebab-case/-/just-kebab-case-1.1.0.tgz#ebe854fde84b0afa4e597fcd870b12eb3c026755"
@@ -9521,6 +9554,16 @@ loglevelnext@^1.0.1:
   dependencies:
     es6-symbol "^3.1.1"
     object.assign "^4.1.0"
+
+lolex@^2.3.2:
+  version "2.7.5"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
+  integrity sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==
+
+lolex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-3.0.0.tgz#f04ee1a8aa13f60f1abd7b0e8f4213ec72ec193e"
+  integrity sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==
 
 longest-streak@^2.0.1:
   version "2.0.2"
@@ -10190,6 +10233,17 @@ nightmare@^2.10.0:
     rimraf "^2.4.3"
     sliced "1.0.1"
     split2 "^2.0.1"
+
+nise@^1.4.7:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.4.8.tgz#ce91c31e86cf9b2c4cac49d7fcd7f56779bfd6b0"
+  integrity sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==
+  dependencies:
+    "@sinonjs/formatio" "^3.1.0"
+    just-extend "^4.0.2"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
 
 no-case@^2.2.0:
   version "2.3.2"
@@ -13300,6 +13354,19 @@ single-line-log@^1.1.2:
   dependencies:
     string-width "^1.0.1"
 
+sinon@^7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.2.2.tgz#388ecabd42fa93c592bfc71d35a70894d5a0ca07"
+  integrity sha512-WLagdMHiEsrRmee3jr6IIDntOF4kbI6N2pfbi8wkv50qaUQcBglkzkjtoOEbeJ2vf1EsrHhLI+5Ny8//WHdMoA==
+  dependencies:
+    "@sinonjs/commons" "^1.2.0"
+    "@sinonjs/formatio" "^3.1.0"
+    "@sinonjs/samsam" "^3.0.2"
+    diff "^3.5.0"
+    lolex "^3.0.0"
+    nise "^1.4.7"
+    supports-color "^5.5.0"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -14180,6 +14247,11 @@ tether@^1.4.3:
   resolved "https://registry.yarnpkg.com/tether/-/tether-1.4.5.tgz#8efd7b35572767ba502259ba9b1cc167fcf6f2c1"
   integrity sha512-fysT1Gug2wbRi7a6waeu39yVDwiNtvwj5m9eRD+qZDSHKNghLo6KqP/U3yM2ap6TNUL2skjXGJaJJTJqoC31vw==
 
+text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+  integrity sha1-45mpgiV6J22uQou5KEXLcb3CbRk=
+
 text-table@0.2.0, text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -14393,7 +14465,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-440

## Purpose
Create a reusable checkbox filter, based on Checkbox component, to be used in SearchAndSort side panel. Presents a set of checkboxes working like one filter.

## Approach
- create `onChangeHandler` which will raise filter name and selected values after a filter change.
- add a couple of props
- add storybook
- add tests only specific for this component
- add Sinon to test the parameters passed to the onChange callback from the filter
