### PR TITLE
Commander Tests - trigger cross-platform keyboard events

### DIFF
--- a/lib/Commander/tests/Commander-test.js
+++ b/lib/Commander/tests/Commander-test.js
@@ -30,7 +30,7 @@ const innerHandler = () => { innerHandled = true; };
 const innerSaveHandler = () => { innerSaveHandled = true; };
 const scopedHandler = () => { scopedHandled = true; };
 
-describe.only('CommandList, HasCommand', () => {
+describe('CommandList, HasCommand', () => {
   const focusableInteractor = new Interactor('[data-test-focusable]');
   const innerInteractor = new Interactor('[data-test-inner-focusable]');
 

--- a/lib/Commander/tests/Commander-test.js
+++ b/lib/Commander/tests/Commander-test.js
@@ -30,7 +30,7 @@ const innerHandler = () => { innerHandled = true; };
 const innerSaveHandler = () => { innerSaveHandled = true; };
 const scopedHandler = () => { scopedHandled = true; };
 
-describe('CommandList, HasCommand', () => {
+describe.only('CommandList, HasCommand', () => {
   const focusableInteractor = new Interactor('[data-test-focusable]');
   const innerInteractor = new Interactor('[data-test-inner-focusable]');
 
@@ -92,6 +92,8 @@ describe('CommandList, HasCommand', () => {
         scopedHandled = false;
         await focusableInteractor.focus();
         await focusableInteractor.trigger('keydown', { ctrlKey: true, char: 'i', keyCode: 73 });
+        // Safari equivalent for the "mod+i" shortcut
+        await focusableInteractor.trigger('keydown', { metaKey: true, char: 'i', keyCode: 73 });
       });
 
       it('calls the globally scoped handler', () => {
@@ -124,6 +126,8 @@ describe('CommandList, HasCommand', () => {
         beforeEach(async () => {
           await innerInteractor.focus();
           await innerInteractor.trigger('keydown', { ctrlKey: true, char: 's', keyCode: 83 });
+          // Safari equivalent with Mac's Command Key used by the "mod+s" shortcut
+          await innerInteractor.trigger('keydown', { metaKey: true, char: 's', keyCode: 83 });
         });
 
         it('calls the assigned handler', () => {
@@ -135,6 +139,8 @@ describe('CommandList, HasCommand', () => {
             innerSaveHandled = false;
             await focusableInteractor.focus();
             await focusableInteractor.trigger('keydown', { ctrlKey: true, char: 's', keyCode: 83 });
+            // Safari equivalent with Mac's Command Key used by the "mod+s" shortcut
+            await focusableInteractor.trigger('keydown', { metaKey: true, char: 's', keyCode: 83 });
           });
 
           it('does not call the assigned handler', () => {


### PR DESCRIPTION
It appears that Safari looks for a 'metaKey' property on keydown events to indicate the Command key is pressed, so in order to test shortcuts that use the "mod+*" string, the event has to be triggered with the appropriate properties. (`ctrlKey` for the Windows version, `metaKey` for the Mac version).
