### PR TITLE
STCOM-445: Fix minor AppIcon bug

### DIFF
--- a/lib/AppIcon/AppIcon.css
+++ b/lib/AppIcon/AppIcon.css
@@ -52,6 +52,7 @@
     width: 100%;
     border-radius: 25%;
     height: auto;
+    vertical-align: top;
   }
 }
 


### PR DESCRIPTION
Fixed AppIcon img offset bug when browser font-size is set to larger than default.

**Issue:** https://issues.folio.org/browse/STCOM-445

## Before
<img width="898" alt="screenshot 2019-01-05 14 32 51" src="https://user-images.githubusercontent.com/640976/50725017-883a4f00-10f7-11e9-8986-935a23b526f8.png">

## After
<img width="839" alt="screenshot 2019-01-05 14 35 26" src="https://user-images.githubusercontent.com/640976/50725019-8a041280-10f7-11e9-862c-ff6b2c375f91.png">
