### PR TITLE
Release v5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for stripes-components
 
+## [5.0.1](https://github.com/folio-org/stripes-components/tree/v5.0.1) (2019-01-16)
+[Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.0.0...v5.0.1)
+
+* Bump `stripes-core` peer dependency
+
 ## [5.0.0](https://github.com/folio-org/stripes-components/tree/v5.0.0) (2019-01-15)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v4.4.0...v5.0.0)
 
@@ -17,7 +22,6 @@
 * Remove `<IfPermission>` and `<IfInterface>`
 * Remove deprecated icon names
 * Delete moved `<EntrySelector>`
-
 
 ## [4.5.0](https://github.com/folio-org/stripes-components/tree/v4.5.0) (2018-11-29)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v4.4.0...v4.5.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",
@@ -102,6 +102,6 @@
     "tai-password-strength": "^1.1.1"
   },
   "peerDependencies": {
-    "@folio/stripes-core": "^2.13.0"
+    "@folio/stripes-core": "^3.0.0"
   }
 }


### PR DESCRIPTION
Bumps `stripes-core` peer dependency to `v3.0.0` to prevent unmet peer dependency warnings.