### PR TITLE
MultiSelectOptionsList: Support node proptype for emptyMessage

### DIFF
--- a/lib/MultiSelection/MultiSelectOptionsList.js
+++ b/lib/MultiSelection/MultiSelectOptionsList.js
@@ -18,7 +18,7 @@ class MultiSelectOptionsList extends React.Component {
     containerWidth: PropTypes.number,
     controlRef: PropTypes.object,
     downshiftActions: PropTypes.object,
-    emptyMessage: PropTypes.string,
+    emptyMessage: PropTypes.node,
     error: PropTypes.node,
     exactMatch: PropTypes.bool,
     formatter: PropTypes.func,


### PR DESCRIPTION
By default, `MultiSelection` passes a react-intl `FormattedMessage` to `MultiSelectOptionsList` which then throws proptype warnings. This correctly sets a `node` proptype instead.