### PR TITLE
Fix issue with TextField focusing outside of itself when Clear pressed

### DIFF
--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -160,7 +160,6 @@ class TextField extends Component {
 
   static defaultProps = {
     hasClearIcon: true,
-    inputRef: React.createRef(),
     type: 'text',
     validationEnabled: true,
     value: ''
@@ -169,7 +168,6 @@ class TextField extends Component {
   constructor(props) {
     super(props);
 
-    this.input = React.createRef();
     this.startControl = React.createRef();
     this.endControl = React.createRef();
 
@@ -189,7 +187,7 @@ class TextField extends Component {
         this.input.current = ref;
       };
     } else {
-      this.input = props.inputRef;
+      this.input = props.inputRef || React.createRef();
     }
 
     // if no id has been supplied, generate a unique one


### PR DESCRIPTION
**Problem**
If no inputRef prop is applied, TextField currently focuses *the last TextField instance rendered when the 'clear' button is clicked... This is due to the createRef call happening in static default props rather than the constructor. 
**Approach** 
Modify ref conditional so that the ref stays local to the component. I knew the clean implementation that existed before was too good to be true 😭