### PR TITLE
Make <Button> align-prop great again

### DIFF
--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -263,3 +263,19 @@
     outline: none;
   }
 }
+
+/**
+ * Alignment
+ */
+
+.align-start {
+  justify-content: flex-start;
+}
+
+.align-center {
+  justify-content: center;
+}
+
+.align-end {
+  justify-content: flex-end;
+}

--- a/lib/Button/Button.js
+++ b/lib/Button/Button.js
@@ -52,7 +52,6 @@ function Button(props) {
       { [`${css.marginBottom0}`]: props.bottomMargin0 },
       { [`${css.paddingSide0}`]: props.paddingSide0 },
       { [`${css.fullWidth}`]: props.fullWidth },
-      { [`${css.floatEnd}`]: props.align === 'end' },
       { [`${css[`align-${props.align}`]}`]: props.align },
       props.buttonClass,
     );

--- a/lib/Button/Button.js
+++ b/lib/Button/Button.js
@@ -53,6 +53,7 @@ function Button(props) {
       { [`${css.paddingSide0}`]: props.paddingSide0 },
       { [`${css.fullWidth}`]: props.fullWidth },
       { [`${css.floatEnd}`]: props.align === 'end' },
+      { [`${css[`align-${props.align}`]}`]: props.align },
       props.buttonClass,
     );
   }

--- a/lib/Button/stories/styles.js
+++ b/lib/Button/stories/styles.js
@@ -16,6 +16,11 @@ export default () => (
     <Button fullWidth buttonStyle="primary">Primary</Button>
     <Button fullWidth buttonStyle="danger">Danger</Button>
     <hr />
+    <h3>Alignment</h3>
+    <Button align="start" fullWidth buttonStyle="primary">Start</Button>
+    <Button align="center" fullWidth buttonStyle="primary">Center (default)</Button>
+    <Button align="end" fullWidth buttonStyle="primary">End</Button>
+    <hr />
     <h3>Dropdown Item</h3>
     <Button buttonStyle="dropdownItem">
       <Icon icon="trash">Delete</Icon>


### PR DESCRIPTION
While working on something else I needed a way to left align the content of a `<Button>`. I looked in the readme and found that there already was a prop for this – great!

 _The problem:_ the align-prop wasn't really doing anything.

In this PR I added alignment functionality for the `<Button>`-component. I also removed a reference for `css.floatEnd` which aren't defined in `Button.css` anymore and probably has not been for a while.