### PR TITLE
STCOM-411: Setup deprecation message for <AppIcon>

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stripes-components
 
-Copyright (C) 2016-2018 The Open Library Foundation
+Copyright (C) 2016-2019 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.

--- a/lib/AppIcon/AppIcon.js
+++ b/lib/AppIcon/AppIcon.js
@@ -12,21 +12,27 @@ import classNames from 'classnames';
 import { withStripes } from '@folio/stripes-core/src/StripesContext';
 import css from './AppIcon.css';
 
-const AppIcon = ({
-  iconAriaHidden,
-  size,
-  icon,
-  alt,
-  src,
-  style,
-  children,
-  className,
-  tag,
-  app,
-  iconKey,
-  stripes,
-}) => {
-  const getIcon = () => {
+class AppIcon extends React.Component {
+  constructor(props) {
+    super(props);
+
+    console.warn(
+      `[DEPRECATION] The "AppIcon" component from "stripes-components" is deprecated.
+      Use "AppIcon" component from "stripes-core" instead.`
+    );
+  }
+
+  getIcon() {
+    const {
+      stripes,
+      app,
+      iconKey,
+      size,
+      icon,
+      src,
+      alt,
+    } = this.props;
+
     let appIconProps;
 
     /**
@@ -78,37 +84,47 @@ const AppIcon = ({
         alt={typeof alt !== 'undefined' ? alt : appIconProps.alt}
       />
     );
-  };
+  }
 
-  /**
-   * Root CSS styles
-   */
-  const rootStyles = classNames(
-    /* Base app icon styling */
-    css.appIcon,
-    /* Icon size */
-    css[size],
-    /* Custom ClassName */
-    className,
-  );
+  render() {
+    const {
+      size,
+      tag,
+      className,
+      style,
+      iconAriaHidden,
+      children,
+    } = this.props;
+    /**
+     * Root CSS styles
+    */
+    const rootStyles = classNames(
+      /* Base app icon styling */
+      css.appIcon,
+      /* Icon size */
+      css[size],
+      /* Custom ClassName */
+      className,
+    );
 
-  /**
-   * Element - changeable by prop
-   */
-  const Element = tag;
+    /**
+     * Element - changeable by prop
+     */
+    const Element = tag;
 
-  /**
-   * Render
-   */
-  return (
-    <Element className={rootStyles} style={style}>
-      <span className={css.icon} aria-hidden={iconAriaHidden}>
-        {getIcon()}
-      </span>
-      { children && <span className={css.label}>{children}</span> }
-    </Element>
-  );
-};
+    /**
+     * Render
+     */
+    return (
+      <Element className={rootStyles} style={style}>
+        <span className={css.icon} aria-hidden={iconAriaHidden}>
+          {this.getIcon()}
+        </span>
+        {children && <span className={css.label}>{children}</span>}
+      </Element>
+    );
+  }
+}
 
 AppIcon.propTypes = {
   alt: PropTypes.string,

--- a/lib/PaneHeader/PaneHeader.js
+++ b/lib/PaneHeader/PaneHeader.js
@@ -3,12 +3,14 @@ import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import css from './PaneHeader.css';
+import AppIcon from '@folio/stripes-core/src/components/AppIcon';
+
 import IconButton from '../IconButton';
 import { Dropdown } from '../Dropdown';
 import DropdownMenu from '../DropdownMenu';
 import Icon from '../Icon';
-import AppIcon from '../AppIcon';
+
+import css from './PaneHeader.css';
 
 class PaneHeader extends Component {
   static propTypes = {

--- a/lib/PaneHeader/PaneHeader.js
+++ b/lib/PaneHeader/PaneHeader.js
@@ -3,7 +3,7 @@ import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import AppIcon from '@folio/stripes-core/src/components/AppIcon';
+import AppIcon from '../AppIcon';
 
 import IconButton from '../IconButton';
 import { Dropdown } from '../Dropdown';


### PR DESCRIPTION
### Purpose
`<AppIcon>` is the last place in `stripes-components` which relies on `withStripes`. That's why we want to move it to `stripes-core`.
### Approach 
* `<AppIcon>` was refactored to a class component in order to be able to show a deprecation message in its constructor
* `<PaneHeader>` component was changed to use `stripes-core`'s `<AppIcon>`

This PR can only be merged after [this one](https://github.com/folio-org/stripes-core/pull/567) (since currently there is no `AppIcon` in `stripes-core`, which can also make tests fail)
[JIRA issue link](https://issues.folio.org/browse/STCOM-411)