### PR TITLE
ButtonGroup: Remove propTypes check

### DIFF
--- a/lib/ButtonGroup/ButtonGroup.js
+++ b/lib/ButtonGroup/ButtonGroup.js
@@ -1,19 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import Button from '../Button';
 import css from './ButtonGroup.css';
 
 const propTypes = {
-  children: (props) => {
-    let error = null;
-    React.Children.forEach(props.children, (child) => {
-      if (child.type !== Button) {
-        error = new Error('`ButtonGroup` children should be of type `Button`.');
-      }
-    });
-    return error;
-  },
   className: PropTypes.string,
   fullWidth: PropTypes.bool,
   tagName: PropTypes.string,


### PR DESCRIPTION
Checking `.type` doesn't work when using `webpack-dev-server` since all components get wrapped in an HOC.