### PR TITLE
use static column label for sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-components
 
+## 5.1.0 (IN PROGRESS)
+
+* In `<MultiColumnList>`, use columns' static keys, not translated aliases, for sorting. Refs STSMACOM-93.
+
 ## [5.0.2](https://github.com/folio-org/stripes-components/tree/v5.0.2) (2019-01-17)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.0.1...v5.0.2)
 

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -552,9 +552,7 @@ class MCLRenderer extends React.Component {
   }
 
   getHeaderClassName(column) {
-    const isSortHeader = (this.props.sortOrder === this.getMappedColumnName(column) ||
-      this.props.sortedColumn === this.getMappedColumnName(column));
-
+    const isSortHeader = (this.props.sortOrder === column || this.props.sortedColumn === column);
     return classnames(
       css.header,
       { [`${css.clickable}`]: (Object.prototype.hasOwnProperty.call(this.props, 'onHeaderClick')) },


### PR DESCRIPTION
Use columns' static labels, i.e. the keys from `props.columnMapping`,
rather than their translated labels, i.e. the values from
`props.columnMapping`. This means the sort parameter in the querystring
will remain constant regardless of locale.

Refs [STSMACOM-93](https://issues.folio.org/browse/STSMACOM-93), [UIU-479](https://issues.folio.org/browse/UIU-479), [UIU-864](https://issues.folio.org/browse/UIU-864)