### PR TITLE
ClassNames in MCL use 'mcl' prefix

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -6,11 +6,11 @@
   }
 }
 
-.heightSpacer {
+.mclHeightSpacer {
   position: relative;
 }
 
-.rowContainer {
+.mclRowContainer {
   position: absolute;
   min-width: 100%;
 
@@ -21,11 +21,11 @@
 }
 
 /* Row is interactive (clickable, hoverable and focusable etc.) */
-.isInteractive {
+.mclIsInteractive {
   composes: interactionStyles hasDot focusDotPositionStart from "../sharedStyles/interactionStyles.css";
 }
 
-.row {
+.mclRow {
   display: flex;
   justify-content: flex-start;
   align-items: stretch;
@@ -40,12 +40,12 @@
   }
 
   /* Different bg on odd rows */
-  &.isOdd:not(.selected) {
+  &.mclIsOdd:not(.selected) {
     background-color: var(--color-fill-table-row-odd);
   }
 
   /* Selected style */
-  &.selected {
+  &.mclSelected {
     color: #fff;
     background-color: var(--color-fill-current);
 
@@ -56,7 +56,7 @@
   }
 }
 
-.rowsBody {
+.mclRowsBody {
   padding: 0 6px 3px;
 
   /* Use monospaced numbers, aka Tabular Numerals (tnum) */
@@ -65,19 +65,19 @@
   -moz-font-feature-settings: 'tnum';
 }
 
-.headerRow {
+.mclHeaderRow {
   display: flex;
   justify-content: flex-start;
   margin: 0 calc(var(--gutter) / 2);
   overflow: hidden;
   width: 100%;
 
-  &.hScroll {
+  &.mclHScroll {
     overflow: auto;
   }
 }
 
-.header {
+.mclHeader {
   display: flex;
   align-items: center;
   flex-shrink: 0;
@@ -87,24 +87,24 @@
   font-size: var(--font-size-medium);
   color: var(--color-text-p2);
 
-  &.clickable {
+  &.mclClickable {
     cursor: pointer;
   }
 
-  &.sorted {
+  &.mclSorted {
     text-decoration: underline;
   }
 
-  &.ascending::after {
+  &.mclAscending::after {
     content: "↑";
   }
 
-  &.descending::after {
+  &.mclDescending::after {
     content: "↓";
   }
 }
 
-.cell {
+.mclCell {
   display: flex;
   align-items: center;
   flex-shrink: 0;
@@ -118,13 +118,13 @@
   }
 }
 
-.scrollable {
+.mclScrollable {
   position: relative;
   overflow: auto;
   width: 100%;
 }
 
-.contentLoadingRow {
+.mclContentLoadingRow {
   width: 100%;
   display: flex;
   position: absolute;
@@ -134,7 +134,7 @@
   pointer-events: none;
 }
 
-.contentLoading {
+.mclContentLoading {
   display: flex;
   justify-content: center;
   align-content: center;
@@ -144,11 +144,11 @@
   background-color: rgba(255, 255, 255, 0.5);
 }
 
-.emptyMessage {
+.mclEmptyMessage {
   padding: 1rem;
 }
 
-.endOfList {
+.mclEndOfList {
   padding: 7px 0;
   position: sticky;
   left: 0;

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -67,7 +67,7 @@ const defaultProps = {
   rowFormatter: defaultRowFormatter,
   rowProps: {},
   scrollToIndex: 0,
-  selectedClass: css.selected,
+  selectedClass: css.mclSelected,
   striped: true,
   totalCount: 0,
 };
@@ -423,16 +423,16 @@ class MCLRenderer extends React.Component {
   };
 
   getRowClass = (rowIndex) => {
-    const selectedClass = this.props.selectedClass ? this.props.selectedClass : css.selected;
+    const selectedClass = this.props.selectedClass ? this.props.selectedClass : css.mclSelected;
 
     return classnames(
-      css.row,
+      css.mclRow,
       // Striped rows
-      { [css.isOdd]: this.props.striped && (rowIndex % 2 === 0) },
+      { [css.mclIsOdd]: this.props.striped && (rowIndex % 2 === 0) },
       // Is selected
       { [`${selectedClass}`]: this.maybeSelected(this.props.selectedRow, rowIndex) },
       // whether the table contains interactive rows
-      { [css.isInteractive]: this.props.interactive },
+      { [css.mclIsInteractive]: this.props.interactive },
     );
   };
 
@@ -502,12 +502,12 @@ class MCLRenderer extends React.Component {
         cellStyle = { flex: `0 0 ${cellWidth}`, width: `${cellWidth}` };
       }
 
-      const showOverflow = (columnOverflow[col]) ? css.showOverflow : '';
+      const showOverflow = (columnOverflow[col]) ? css.mclShowOverflow : '';
       cells.push((
         <div
           role="gridcell"
           key={`${col}-${rowIndex}`}
-          className={`${css.cell} ${showOverflow}`}
+          className={`${css.mclCell} ${showOverflow}`}
           style={cellStyle}
         >
           {value}
@@ -540,11 +540,11 @@ class MCLRenderer extends React.Component {
       this.props.sortedColumn === this.getMappedColumnName(column));
 
     return classnames(
-      css.header,
-      { [`${css.clickable}`]: (Object.prototype.hasOwnProperty.call(this.props, 'onHeaderClick')) },
-      { [`${css.sorted}`]: isSortHeader },
-      { [`${css.ascending}`]: (isSortHeader && this.props.sortDirection === 'ascending') },
-      { [`${css.descending}`]: (isSortHeader && this.props.sortDirection === 'descending') },
+      css.mclHeader,
+      { [`${css.mclClickable}`]: (Object.prototype.hasOwnProperty.call(this.props, 'onHeaderClick')) },
+      { [`${css.mclSorted}`]: isSortHeader },
+      { [`${css.mclAscending}`]: (isSortHeader && this.props.sortDirection === 'ascending') },
+      { [`${css.mclDescending}`]: (isSortHeader && this.props.sortDirection === 'descending') },
     );
   };
 
@@ -786,15 +786,15 @@ class MCLRenderer extends React.Component {
       if (element.offsetHeight < element.scrollHeight ||
         element.offsetWidth < element.scrollWidth) {
         return classnames(
-          { [`${css.headerRow}`]: !this.props.headerRowClass },
+          { [`${css.mclHeaderRow}`]: !this.props.headerRowClass },
           this.props.headerRowClass,
-          `${css.headerForScrollable}`,
+          // `${css.mclHeaderForScrollable}`,
         );
-        // return `${css.headerRow} ${css.headerForScrollable}`;
+        // return `${css.mclHeaderRow} ${css.headerForScrollable}`;
       }
     }
     return classnames(
-      { [`${css.headerRow}`]: !this.props.headerRowClass },
+      { [`${css.mclHeaderRow}`]: !this.props.headerRowClass },
       this.props.headerRowClass,
     );
   };
@@ -825,7 +825,7 @@ class MCLRenderer extends React.Component {
         ref={(ref) => { this.endOfListRef = ref; }}
       >
         <Layout
-          className={classnames('textCentered', css.endOfList)}
+          className={classnames('textCentered', css.mclEndOfList)}
           style={{ width: endOfListWidth }}
         >
           <Icon icon="end-mark">
@@ -857,7 +857,7 @@ class MCLRenderer extends React.Component {
     if (contentData.length === 0) {
       return (
         <div
-          className={css.emptyMessage}
+          className={css.mclEmptyMessage}
           style={{ minWidth: width || '200px' }}
           ref={this.serveContainerRef}
         >
@@ -934,18 +934,18 @@ class MCLRenderer extends React.Component {
                 {renderedHeaders}
               </div>
               <div
-                className={css.scrollable}
+                className={css.mclScrollable}
                 style={this.getBodyStyle()}
                 onScroll={virtualize ? this.handleInfiniteScroll : this.handleFiniteScroll}
                 ref={(ref) => { this.scrollContainer = ref; }}
               >
                 {virtualize &&
                   <div
-                    className={css.heightSpacer}
+                    className={css.mclHeightSpacer}
                     style={{ height: heightSpacer }}
                   >
                     <div
-                      className={css.rowContainer}
+                      className={css.mclRowContainer}
                       role="group"
                       style={{ top: this.state.contentTop }}
                       ref={(ref) => { this.rowContainer = ref; this.measureNewRows(); }}
@@ -961,8 +961,8 @@ class MCLRenderer extends React.Component {
               </div>
               {
                 this.props.loading &&
-                <div className={css.contentLoadingRow}>
-                  <div className={css.contentLoading}>
+                <div className={css.mclContentLoadingRow}>
+                  <div className={css.mclContentLoading}>
                     <Icon icon="spinner-ellipsis" width="35px" />
                   </div>
                 </div>

--- a/lib/MultiColumnList/tests/interactor.js
+++ b/lib/MultiColumnList/tests/interactor.js
@@ -17,15 +17,15 @@ const CellInteractor = interactor(class CellInteractor {
 });
 
 const RowInteractor = interactor(class RowInteractor {
-  isSelected = hasClass(`${css.selected}`);
-  cellCount = count(`.${css.cell}`);
-  cells = collection(`.${css.cell}`, CellInteractor);
+  isSelected = hasClass(`${css.mclSelected}`);
+  cellCount = count(`.${css.mclCell}`);
+  cells = collection(`.${css.mclCell}`, CellInteractor);
   click = clickable();
   isAnchor = is('a');
 });
 
 const HeaderInteractor = interactor(class HeaderInteractor {
-  isSortHeader = hasClass(`${css.sorted}`);
+  isSortHeader = hasClass(`${css.mclSorted}`);
   click = clickable('[data-test-clickable-header]');
 });
 
@@ -33,16 +33,16 @@ export default interactor(class MultiColumnListInteractor {
   containerPresent = isPresent(`.${css.mclContainer}`);
   containerWidth = property(`.${css.mclContainer}`, 'offsetWidth');
   containerHeight = property(`.${css.mclContainer}`, 'offsetHeight');
-  rowCount = count(`.${css.row}`);
-  columnCount = count(`.${css.header}`);
-  rows = collection(`.${css.row}`, RowInteractor);
-  headers = collection(`.${css.header}`, HeaderInteractor);
-  scrollbodyTop = property(`.${css.rowContainer}`, 'offsetTop');
-  displaysEmptyMessage = isPresent(`.${css.emptyMessage}`);
-  displaysLoadingIcon = isPresent(`.${css.contentLoading}`);
+  rowCount = count(`.${css.mclRow}`);
+  columnCount = count(`.${css.mclHeader}`);
+  rows = collection(`.${css.mclRow}`, RowInteractor);
+  headers = collection(`.${css.mclHeader}`, HeaderInteractor);
+  scrollbodyTop = property(`.${css.mclRowContainer}`, 'offsetTop');
+  displaysEmptyMessage = isPresent(`.${css.mclEmptyMessage}`);
+  displaysLoadingIcon = isPresent(`.${css.mclContentLoading}`);
 
   scrollBody(amount) {
-    return this.scroll(`.${css.scrollable}`, { top: amount });
+    return this.scroll(`.${css.mclScrollable}`, { top: amount });
   }
 
   contains(selector) {


### PR DESCRIPTION
# Problem

Until we're able to import interactors into ui-modules, we have to stick to selecting around in the rendered DOM in order to build tests.

Testing with MCL currently has some challenges due to indistinct classnames making it difficult to select particular elements to assert on. This PR remedies that by prefixing all of the major class names with "mcl".
