### PR TITLE
Fixed selected styles on odd rows

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -40,7 +40,7 @@
   }
 
   /* Different bg on odd rows */
-  &.mclIsOdd:not(.selected) {
+  &.mclIsOdd:not(.mclSelected) {
     background-color: var(--color-fill-table-row-odd);
   }
 


### PR DESCRIPTION
I noticed a minor visual bug with selected odd rows. The odd row styles were overwriting the selected-styles.

## Before
<img width="420" alt="screenshot 2019-02-05 16 30 47" src="https://user-images.githubusercontent.com/640976/52284244-50c3fa00-2964-11e9-95b5-14d23db0c01e.png">

## After
![image](https://user-images.githubusercontent.com/640976/52284276-6507f700-2964-11e9-99e9-f7d20dbb1ce5.png)
