### PR TITLE
Disabled variable fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added asterisk for required form fields. STCOM-469
 * Add EndOfList component to MCL component. Part of UIDATIMP-105
 * Handle on blur issue for `MultiSelect` when it is part of `redux-form`. See [docs](lib/MultiSelection/readme.md#usage-as-a-part-of-the-field-for-redux-form). Part of UIDATIMP-56
+* Disable variable fonts. Fixes STCOM-461 and STCOM-434
 
 ## [5.0.2](https://github.com/folio-org/stripes-components/tree/v5.0.2) (2019-01-17)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.0.1...v5.0.2)

--- a/lib/fonts.css
+++ b/lib/fonts.css
@@ -1,4 +1,9 @@
-@font-face {
+/**
+ * Note: Variable fonts disabled for now 
+ * due to causing multiple rendering problems
+ */
+
+/* @font-face {
   font-family: 'Source Sans Pro Variable';
   font-style: normal;
   src: url('../assets/fonts/SourceSansPro/SourceSansVariable-Roman.woff2') format('woff2-variations');
@@ -80,7 +85,7 @@
   font-style: italic;
   src: url('../assets/fonts/SourceSansPro/SourceSansVariable-Italic.woff2') format('woff2-variations');
   font-weight: 900;
-}
+} */
 
 /* fallbacks */
 @font-face {

--- a/lib/fonts.css
+++ b/lib/fonts.css
@@ -1,7 +1,7 @@
 /**
- * Note: Variable fonts disabled for now 
+ * Note: Variable fonts disabled for now
  * because it's causing several problems
- * 
+ *
  * https://issues.folio.org/browse/STCOM-461
  * https://issues.folio.org/browse/STCOM-434
  */

--- a/lib/fonts.css
+++ b/lib/fonts.css
@@ -1,6 +1,9 @@
 /**
  * Note: Variable fonts disabled for now 
- * due to causing multiple rendering problems
+ * because it's causing several problems
+ * 
+ * https://issues.folio.org/browse/STCOM-461
+ * https://issues.folio.org/browse/STCOM-434
  */
 
 /* @font-face {

--- a/lib/global.css
+++ b/lib/global.css
@@ -15,7 +15,7 @@ html {
   height: 100%;
   margin: 0;
   font-family:
-    'Source Sans Pro Variable',
+    'Source Sans Pro',
     -apple-system,
     BlinkMacSystemFont,
     "Segoe UI",


### PR DESCRIPTION
The variable version of our main font "Source Sans Pro" are causing multiple issues.

I have looked into how we could fix this – without completely removing the variable font – but without luck. If anyone has an idea of how we can fix the variable fonts I would appreciate a comment or a PM =)

The main advantage of a variable font is the reduced file size which is great. But if it's at the cost of having multiple issues around the app then I think we should disable it (as my PR suggests) – and maybe get back to it at a later point.

**Issues that I know of:**
- Select fields are crashing in Safari on Mac (https://issues.folio.org/browse/STCOM-434)
- Multiple scrollbars appearing when opening the app list dropdown (PC/Chrome) (https://issues.folio.org/browse/STCOM-461)
- Wrong line heights in most places on Chrome on PC (see screenshot below)

## Screenshots

### Before
![with-source-sans-pro-variable](https://user-images.githubusercontent.com/640976/52345697-2171c380-2a1e-11e9-9c4c-c11ae5bb9118.PNG)

### After
![without-source-sans-pro-variable](https://user-images.githubusercontent.com/640976/52345705-2767a480-2a1e-11e9-9ca9-430a841ec8ff.PNG)


