### PR TITLE
use static column label for sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Change history for stripes-components
 
-## [5.0.3](https://github.com/folio-org/stripes-components/tree/v5.0.3) (IN-PROGRESS)
+## 5.1.0 (IN-PROGRESS)
 
 * Update ARIA roles for MCL. STCOM-365
 * Add EndOfList component to MCL component. Part of UIDATIMP-105.
 * Added asterisk for required form fields. STCOM-469
 * Add EndOfList component to MCL component. Part of UIDATIMP-105
 * Handle on blur issue for `MultiSelect` when it is part of `redux-form`. See [docs](lib/MultiSelection/readme.md#usage-as-a-part-of-the-field-for-redux-form). Part of UIDATIMP-56
+* In `<MultiColumnList>`, use columns' static keys, not translated aliases, for sorting. Refs STSMACOM-93.
 
 ## [5.0.2](https://github.com/folio-org/stripes-components/tree/v5.0.2) (2019-01-17)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.0.1...v5.0.2)

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -582,8 +582,7 @@ class MCLRenderer extends React.Component {
         headerStyle = { flex: `0 0 ${headerWidth}`, width: `${headerWidth}` };
       }
 
-      const isSortHeader = (sortOrder === this.getMappedColumnName(header) ||
-      sortedColumn === this.getMappedColumnName(header));
+      const isSortHeader = (sortOrder === header || sortedColumn === header);
 
       let headerInner = this.getMappedColumnName(header);
       if (onHeaderClick) {


### PR DESCRIPTION
Use columns' static labels, i.e. the keys from `props.columnMapping`,
rather than their translated labels, i.e. the values from
`props.columnMapping`. This means the sort parameter in the querystring
will remain constant regardless of locale.

Refs [STSMACOM-93](https://issues.folio.org/browse/STSMACOM-93), [UIU-479](https://issues.folio.org/browse/UIU-479), [UIU-864](https://issues.folio.org/browse/UIU-864)

Replaces #841 