### PR TITLE
Fix group filter checkbox id

### DIFF
--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -1,3 +1,4 @@
+import { kebabCase } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import FilterControlGroup from '../FilterControlGroup';
@@ -16,7 +17,7 @@ const FilterCheckbox = (props) => {
   const fullName = `${groupName}.${name}`;
 
   return (<Checkbox
-    id={`clickable-filter-${fullName.replace('.', '-')}`}
+    id={`clickable-filter-${kebabCase(fullName)}`}
     label={name}
     name={fullName}
     checked={checked}

--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -1,4 +1,4 @@
-import { kebabCase } from 'lodash';
+import kebabCase from 'lodash/kebabCase';
 import React from 'react';
 import PropTypes from 'prop-types';
 import FilterControlGroup from '../FilterControlGroup';


### PR DESCRIPTION
The previous id was similar to `clickable-filter-active-Include inactive users` which is invalid. It's impossible to reference it via dom queries. This PR changes:

`clickable-filter-active-Include inactive users`

to:

`clickable-filter-active-include-inactive-users`
