### PR TITLE
STCOM-475: Fix autogenerated ID's in withAccordionSet()

### DIFF
--- a/lib/Accordion/withAccordionSet.js
+++ b/lib/Accordion/withAccordionSet.js
@@ -4,34 +4,40 @@ import uniqueId from 'lodash/uniqueId';
 import { Consumer as AccordionConsumer } from './AccordionContext';
 
 const withAccordionSet = (Component) => {
-  const WrappedAccordion = (props) => {
-    const trackingId = uniqueId('accordion_');
-    return (
-      <AccordionConsumer>
-        {status => {
-          if (status) {
-            const uId = props.id || trackingId;
-            return (<Component
-              accordionSet={status.set}
-              open={status.expanded[uId]}
-              id={uId}
-              onToggle={status.set.handleToggle}
-              toggleRef={status.set.registerAccordion}
-              toggleKeyHandlers={status.set.toggleKeyHandlers}
-              toggleKeyMap={status.set.toggleKeyMap}
-              {...props}
-            />);
-          }
-          return <Component {...props} />;
-        }
-        }
-      </AccordionConsumer>
-    );
-  };
+  class WrappedAccordion extends Component {
+    static propTypes = {
+      id: PropTypes.string,
+    }
 
-  WrappedAccordion.propTypes = {
-    id: PropTypes.string,
-  };
+    constructor(props) {
+      super(props);
+      this.trackingId = uniqueId('accordion_');
+    }
+
+    render() {
+      return (
+        <AccordionConsumer>
+          {status => {
+            if (status) {
+              const uId = this.props.id || this.trackingId;
+              return (<Component
+                accordionSet={status.set}
+                open={status.expanded[uId]}
+                id={uId}
+                onToggle={status.set.handleToggle}
+                toggleRef={status.set.registerAccordion}
+                toggleKeyHandlers={status.set.toggleKeyHandlers}
+                toggleKeyMap={status.set.toggleKeyMap}
+                {...this.props}
+              />);
+            }
+            return <Component {...this.props} />;
+          }
+          }
+        </AccordionConsumer>
+      );
+    }
+  }
 
   return WrappedAccordion;
 };


### PR DESCRIPTION
While working on some things in the `ui-data-import` module I noticed that the accordions were given new incremented ID's every few seconds.

This is caused by the "withAccordionSet" HoC having the automatic generation of accordion ID's (if none is passed a prop) directly in the render which causes it to generate a new ID every time the accordion re-renders.

I fixed this by turning the wrapped component into a class and placed the autogeneration of ID's in the constructor.

![feb-12-2019 12-18-56](https://user-images.githubusercontent.com/640976/52631986-8d41a980-2ec0-11e9-8188-3f2c25e19ade.gif)
