### PR TITLE
Prevent :visited styles from being applied to IconButton

### DIFF
--- a/lib/IconButton/IconButton.css
+++ b/lib/IconButton/IconButton.css
@@ -21,6 +21,11 @@
   }
 }
 
+/* To avoid global :visited color on anchor tags */
+a.iconButton {
+  color: var(--color-icon);
+}
+
 .iconButtonInner {
   composes: interactionStyles from "../sharedStyles/interactionStyles.css";
   display: flex;


### PR DESCRIPTION
Updated color for IconButtons that renders as anchor tags to prevent the global `:visisted` style from being applied.

## Before
![image](https://user-images.githubusercontent.com/640976/52871782-23890000-314b-11e9-9428-2f0fabbe4e4c.png)

## After
![image](https://user-images.githubusercontent.com/640976/52871716-f89eac00-314a-11e9-8c3b-00cddf52eb6a.png)