### PR TITLE
Add tagName-prop for <Label>

### DIFF
--- a/lib/Label/Label.js
+++ b/lib/Label/Label.js
@@ -10,27 +10,41 @@ import Icon from '../Icon';
 import Asterisk from './components/Asterisk';
 import css from './Label.css';
 
-const Label = ({ children, className, htmlFor, id, readOnly, required, ...rest }) => (
-  <label
-    htmlFor={htmlFor}
-    id={id}
-    {...rest}
-    className={classnames(css.label, className)}
-  >
-    {children}
-    {required && <Asterisk />}
-    {readOnly && (
-      <Icon size="small" icon="lock">
-        <span className="sr-only">
-          <FormattedMessage id="stripes-components.readonly" />
-        </span>
-      </Icon>
-    )}
-  </label>
-);
+const Label = ({ children, className, htmlFor, id, readOnly, required, tagName, ...rest }) => {
+  const Element = tagName;
+
+  return (
+    <Element
+      htmlFor={htmlFor}
+      id={id}
+      {...rest}
+      className={classnames(css.label, className)}
+    >
+      {children}
+      {required && <Asterisk />}
+      {readOnly && (
+        <Icon size="small" icon="lock">
+          <span className="sr-only">
+            <FormattedMessage id="stripes-components.readonly" />
+          </span>
+        </Icon>
+      )}
+    </Element>
+  );
+};
 
 Label.propTypes = {
   children: PropTypes.node,
+  className: PropTypes.string,
+  htmlFor: PropTypes.string,
+  id: PropTypes.string,
+  readOnly: PropTypes.bool,
+  required: PropTypes.bool,
+  tagName: PropTypes.string,
+};
+
+Label.defaultProps = {
+  tagName: 'label',
 };
 
 export default Label;

--- a/lib/Label/readme.md
+++ b/lib/Label/readme.md
@@ -23,3 +23,4 @@ htmlFor | Adds a "for"-attribute on the label-element
 id | string | Adds an ID on the label-element
 readOnly | boolean | Renders a lock-icon next to the label (indicating that the assosiated field is read-only)
 required | boolean | Renders an asterisk next to the label (indicating that the assosiated field is required)
+tagName | string | Change the tag name of the component. Renders a label-element as default.


### PR DESCRIPTION
Addded tagName-prop for `<Label>` – for cases where you want the styles and functionality of the `<Label>` but don't want to render a label-element (for semantic reasons etc.).

I also added some missing propTypes.