### PR TITLE
use moment.tz instead of moment to show the presented value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.1.0 (IN-PROGRESS)
 
+* Use `moment.tz()` to display the presentedValue in Datepicker, fixes UIREQ-207.
 * Update ARIA roles for MCL. STCOM-365
 * Add EndOfList component to MCL component. Part of UIDATIMP-105.
 * Added asterisk for required form fields. STCOM-469

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -107,8 +107,7 @@ class Datepicker extends React.Component {
       presentedValue = '';
       inputValue = moment.tz(parseTimeZone).format(this._dateFormat);
     } else if (this.props.input.value !== '') {
-      inputValue = moment(this.props.input.value, this._dateFormat)
-        .tz(parseTimeZone)
+      inputValue = moment.tz(this.props.input.value, this._dateFormat, parseTimeZone)
         .format(this._dateFormat);
       presentedValue = inputValue;
     }


### PR DESCRIPTION
The issue here was the logic we were using with  _moment()_  instead of _moment.tz()_ wasn't considering the timezone while presenting the value. For example: we have numerous sites across users, requests and the checkin app where this wasn't functioning properly:

Example: With me in Eastern time zone and  _America/LosAngeles_ set as my tenant timezone:

In users app: the **userExpirationDate** had different dates showing up on the view vs edit page

Requests app: the **requestExpirationDate** showing the date by 1 day offset similar to the **userExpirationDate**

Also, in the checkin app, the checkin date shows a different day when the **datePicker** is opened up with default as _today_

All of these should be resolved by this PR

