### PR TITLE
Updated storybook-addon-rtl to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "redux": "^3.6.0",
     "redux-form": "^7.0.3",
     "storybook-addon-intl": "^2.3.2",
-    "storybook-addon-rtl": "^0.1.2",
+    "storybook-addon-rtl": "^0.2.1",
     "storybook-readme": "^4.0.2",
     "stylelint": "^9.5.0",
     "stylelint-config-standard": "^18.2.0",


### PR DESCRIPTION
This fixes the issue of the RTL toggle showing on all tabs when viewing stories.