### PR TITLE
Added vertical alignment for accordion buttons

### DIFF
--- a/lib/Accordion/Accordion.css
+++ b/lib/Accordion/Accordion.css
@@ -98,6 +98,8 @@
 }
 
 .headerDefaultContentRight {
+  display: flex;
+  align-items: center;
   flex-grow: 2;
   flex-shrink: 0;
   padding: 0 0 0 1.2rem;


### PR DESCRIPTION
Made sure that the content within the right side of the default accordion header always is centered vertically.

## Before
![image](https://user-images.githubusercontent.com/640976/54129482-a0d42780-440e-11e9-8106-c18066011f11.png)

## After
![image](https://user-images.githubusercontent.com/640976/54129239-1db2d180-440e-11e9-8d9c-7da1636a3136.png)
