### PR TITLE
Selection: Update selectedIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-components
 
+## 5.0.3 (IN-PROGRESS)
+
+* Fixed bug where `<Selection>` wouldn't update the selected item when a new `dataOptions` was passed in.
+
 ## [5.0.2](https://github.com/folio-org/stripes-components/tree/v5.0.2) (2019-01-17)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.0.1...v5.0.2)
 

--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -146,8 +146,11 @@ class SingleSelect extends React.Component {
   componentWillReceiveProps(nextProps, nextState) { // eslint-disable-line react/no-deprecated
     if (!isEqual(this.props.dataOptions, nextProps.dataOptions)) {
       this.setState(curState => (
+        // Reinit the selectedIndex in case the newly-received dataOptions
+        // have the selected value in a different position.
         Object.assign({}, curState, {
-          renderedList: nextProps.dataOptions
+          renderedList: nextProps.dataOptions,
+          selectedIndex: nextProps.dataOptions.findIndex(o => o.value === nextProps.value),
         })
       ));
     }

--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -156,7 +156,7 @@ class SingleSelect extends React.Component {
     }
 
     if (nextProps.value !== this.props.value) {
-      const newValue = this.initValue(nextProps.value);
+      const newValue = this.initValue(nextProps.value, nextProps.dataOptions);
       this.setState(curState => (
         Object.assign({}, curState, {
           selectedIndex: newValue.index,
@@ -210,22 +210,25 @@ class SingleSelect extends React.Component {
     return { value: '', index: -1, label: '' };
   }
 
-  initValue(value) {
+  initValue(value, dataOptions) {
     let _value;
     if (isNil(value)) {
       _value = this.props.value;
     } else {
       _value = value;
     }
+
+    const _dataOptions = dataOptions || this.props.dataOptions;
+
     const selectedObject = { value: undefined, index: -1, label: undefined };
     let valueIndex;
-    if (this.props.dataOptions.length > 0) {
+    if (_dataOptions.length > 0) {
       if (typeof _value !== 'undefined') { // in the case of RF, nothing selected, so cursor the 1st...
-        valueIndex = this.props.dataOptions.findIndex(o => o.value === _value);
+        valueIndex = _dataOptions.findIndex(o => o.value === _value);
         if (valueIndex !== -1) {
           selectedObject.value = _value;
           selectedObject.index = valueIndex;
-          selectedObject.label = this.props.dataOptions[valueIndex].label;
+          selectedObject.label = _dataOptions[valueIndex].label;
         }
       }
     }


### PR DESCRIPTION
Basically, if you vary dataOptions, selectedIndex should be recomputed because the position of currently selected value may be different in the new dataOptions.

@doytch did this work in #901, which also updated the package version to 5.0.3. *But* that version was never formally tagged and released. Here, we're cherry picking it onto the v5.0 release branch so we can formally release v5.0.3 without pulling in additional feature work that was done on master in between 5.0.2 and that PR. 