### PR TITLE
STCOM-485 Check internal multiselection refs before calling focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-components
 ## [5.1.1](https://github.com/folio-org/stripes-components/tree/v5.1.1) (2019-03-14)
 * Consider timezone in Datepicker for values containing a time offset. fixes STCOM-484.
+* Check for ref existence within MultiSelection before calling `focus()`. fixes STCOM-485.
 
 ## [5.1.0](https://github.com/folio-org/stripes-components/tree/v5.1.0) (2019-03-14)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.0.2...v5.1.0)

--- a/lib/MultiSelection/MultiSelectOptionsList.js
+++ b/lib/MultiSelection/MultiSelectOptionsList.js
@@ -54,8 +54,10 @@ class MultiSelectOptionsList extends React.Component {
     if (this.props.atSmallMedia) {
       if (prevProps.isOpen !== this.props.isOpen) {
         if (this.props.isOpen) {
-          this.props.inputRef.current.focus();
-        } else {
+          if (this.props.inputRef && this.props.inputRef.current) {
+            this.props.inputRef.current.focus();
+          }
+        } else if (this.props.controlRef && this.props.controlRef.current) {
           this.props.controlRef.current.focus();
         }
       }

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -117,7 +117,9 @@ class MultiSelection extends React.Component {
 
   componentDidUpdate(prevProps, prevState) {
     if (prevState.atSmallMedia !== this.state.atSmallMedia && this.state.filterFocused) {
-      this.input.current.focus();
+      if (this.input.current) {
+        this.input.current.focus();
+      }
     }
   }
 
@@ -397,7 +399,7 @@ class MultiSelection extends React.Component {
               }
 
               toggleMenu();
-              if (!isOpen) {
+              if (!isOpen && this.input.current) {
                 this.input.current.focus();
               }
             };

--- a/lib/MultiSelection/SelectedValuesList.js
+++ b/lib/MultiSelection/SelectedValuesList.js
@@ -43,7 +43,9 @@ class SelectedValuesList extends React.Component {
 
   handleFocusAfterRemoval = (index, remaining) => {
     if (remaining === 0 && !this.props.atSmallMedia) {
-      this.props.inputRef.current.focus();
+      if (this.props.inputRef.current) {
+        this.props.inputRef.current.focus();
+      }
     } else {
       setTimeout(() => {
         let neighbor = index;


### PR DESCRIPTION
Calling `focus()` prematurely could result in an app crash. This particularly affects small screen widths.
