### PR TITLE
STCOM-480 `<AccordionSet>` fails to acknowledge 'closedByDefault' prop of child `<Accordions>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change history for stripes-components
+## [5.1.2](https://github.com/folio-org/stripes-components/tree/v5.1.2) (2019-03-20)
+* `<AccordionSet>` consideres `closedByDefault` prop when setting up initial state for child accordions. Fixes STCOM-480.
+
 ## [5.1.1](https://github.com/folio-org/stripes-components/tree/v5.1.1) (2019-03-14)
 * Consider timezone in Datepicker for values containing a time offset. fixes STCOM-484.
 

--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -89,7 +89,7 @@ class Accordion extends React.Component {
     }
 
     if (this.props.accordionSet) {
-      this.props.accordionSet.registerAccordion(this.toggle, this.trackingId);
+      this.props.accordionSet.registerAccordion(this.toggle, this.trackingId, this.props.closedByDefault);
     }
   }
 

--- a/lib/Accordion/AccordionSet.js
+++ b/lib/Accordion/AccordionSet.js
@@ -100,13 +100,13 @@ class AccordionSet extends React.Component {
     this.accordionList[this.accordionList.length - 1].focus();
   }
 
-  registerAccordion(ref, id) {
+  registerAccordion(ref, id, closedByDefault = false) {
     if (indexOf(this.accordionList, ref) === -1 && ref !== null) {
       this.accordionList.push(ref);
       this.setState((curState) => {
         const newState = Object.assign({}, curState);
         if (typeof newState.expanded[id] === 'undefined') {
-          newState.expanded[id] = true;
+          newState.expanded[id] = !closedByDefault;
         }
         return newState;
       });

--- a/lib/Accordion/stories/BasicUsage.js
+++ b/lib/Accordion/stories/BasicUsage.js
@@ -11,7 +11,7 @@ import Button from '../../Button';
 const BasicUsage = () => (
   <AccordionSet>
     <Accordion label="Information" displayWhenOpen={<Button icon="plus-sign">Add</Button>}>
-      This is an example of an AccordionSet. The 2nd of these accordions is closed by default using the "closedByDefault" prop.
+      This is an example of an AccordionSet. The 2nd of these accordions is closed by default using the &quot;closedByDefault&quot; prop.
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas vitae fringilla felis, sed commodo tellus. Sed bibendum mi id lorem sagittis sodales. Quisque ac lectus gravida, viverra ante et, iaculis sapien. Praesent eget ligula tortor. Praesent vitae ipsum placerat, blandit quam quis, tempus tortor. Aliquam erat volutpat. Fusce hendrerit lectus sed ex dictum, in pretium eros vestibulum. Nulla semper vehicula leo at varius. Quisque bibendum mauris sit amet tellus lobortis ultricies. Mauris eleifend sapien vel est posuere tincidunt. Proin ut nunc ut enim rhoncus elementum vitae in mauris. Nullam ultrices dictum nulla in commodo. Suspendisse potenti. Donec et velit ac quam consequat cursus. Pellentesque quis elit magna. Fusce velit libero, mattis ac placerat eget, aliquam a ante.
       <br />
       <br />

--- a/lib/Accordion/stories/BasicUsage.js
+++ b/lib/Accordion/stories/BasicUsage.js
@@ -11,12 +11,13 @@ import Button from '../../Button';
 const BasicUsage = () => (
   <AccordionSet>
     <Accordion label="Information" displayWhenOpen={<Button icon="plus-sign">Add</Button>}>
+      This is an example of an AccordionSet. The 2nd of these accordions is closed by default using the "closedByDefault" prop.
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas vitae fringilla felis, sed commodo tellus. Sed bibendum mi id lorem sagittis sodales. Quisque ac lectus gravida, viverra ante et, iaculis sapien. Praesent eget ligula tortor. Praesent vitae ipsum placerat, blandit quam quis, tempus tortor. Aliquam erat volutpat. Fusce hendrerit lectus sed ex dictum, in pretium eros vestibulum. Nulla semper vehicula leo at varius. Quisque bibendum mauris sit amet tellus lobortis ultricies. Mauris eleifend sapien vel est posuere tincidunt. Proin ut nunc ut enim rhoncus elementum vitae in mauris. Nullam ultrices dictum nulla in commodo. Suspendisse potenti. Donec et velit ac quam consequat cursus. Pellentesque quis elit magna. Fusce velit libero, mattis ac placerat eget, aliquam a ante.
       <br />
       <br />
       Ut eu velit a mi suscipit malesuada. Sed sollicitudin magna sed leo dignissim, vel fringilla quam placerat. Donec tempor id orci et posuere. Nam at erat at urna lobortis congue vitae at mauris. Maecenas rutrum ex tempor felis dignissim, sit amet varius lacus porttitor. Ut imperdiet sapien eu rutrum placerat. Donec eget interdum leo, quis interdum augue. Duis interdum aliquet semper. Donec aliquam molestie ipsum, quis interdum mi ullamcorper id. Vivamus in ligula eu turpis venenatis mattis. Praesent accumsan ultricies ante, nec pulvinar nunc iaculis eu.
     </Accordion>
-    <Accordion label="Extended Information">
+    <Accordion label="Extended Information" closedByDefault>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas vitae fringilla felis, sed commodo tellus. Sed bibendum mi id lorem sagittis sodales. Quisque ac lectus gravida, viverra ante et, iaculis sapien. Praesent eget ligula tortor. Praesent vitae ipsum placerat, blandit quam quis, tempus tortor. Aliquam erat volutpat. Fusce hendrerit lectus sed ex dictum, in pretium eros vestibulum. Nulla semper vehicula leo at varius. Quisque bibendum mauris sit amet tellus lobortis ultricies. Mauris eleifend sapien vel est posuere tincidunt. Proin ut nunc ut enim rhoncus elementum vitae in mauris. Nullam ultrices dictum nulla in commodo. Suspendisse potenti. Donec et velit ac quam consequat cursus. Pellentesque quis elit magna. Fusce velit libero, mattis ac placerat eget, aliquam a ante.
       <br />
       <br />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
# Problem
Rendered as part of an `<AccordionSet>` the "useful" `closedByDefault` prop is rendered "useless" since it fails to be considered as part of the `<AccordionSet>`'s initial state.

# Solution
Pass the `closedByDefault` prop in each `<Accordion>`'s registration function to its `<AccordionSet>` and consider it in the set up of the initial accordion state.