### PR TITLE
STCOM-492: change filter search to use == not =

### DIFF
--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -185,7 +185,7 @@ export function filters2cql(config, filters = '') {
       let joinedValues = mappedValues.map(v => `"${v}"`).join(' or ');
       if (values.length > 1) joinedValues = `(${joinedValues})`;
 
-      conds.push(`${cqlIndex}=${joinedValues}`);
+      conds.push(`${cqlIndex}==${joinedValues}`);
     }
   }
 


### PR DESCRIPTION
The "=" syntax is translated to ~ regex search on database side and is very slow. Since filters search the exact key, we should use "==" syntax that translates to LIKE (equivalent to exact in most cases) and that is way faster. For example in location filtered instance search MODINVSTOR-273, we see performance improved about 30x.