### PR TITLE
STCOM-493 Datepicker not working without redux-form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change history for stripes-components
+
+## 5.1.3 (IN-PROGRESS)
+* Fix `<Datepicker>` for non-redux-form usage. Fixes STCOM-493
+
 ## [5.1.2](https://github.com/folio-org/stripes-components/tree/v5.1.2) (2019-03-20)
 * `<AccordionSet>` consideres `closedByDefault` prop when setting up initial state for child accordions. Fixes STCOM-480.
 
@@ -12,7 +16,7 @@
 * Use `moment.tz()` to display the presentedValue in Datepicker, fixes UIREQ-207.
 * Update ARIA roles for MCL. STCOM-365
 * Add EndOfList component to MCL component. Part of UIDATIMP-105.
-* Added asterisk for required form fields. STCOM-469
+* Added asterisk for required form fields. STCOM-46
 * Add EndOfList component to MCL component. Part of UIDATIMP-105
 * Handle on blur issue for `MultiSelect` when it is part of `redux-form`. See [docs](lib/MultiSelection/readme.md#usage-as-a-part-of-the-field-for-redux-form). Part of UIDATIMP-56
 * Disable variable fonts. Fixes STCOM-461 and STCOM-434

--- a/lib/DateRangeWrapper/DateRangeWrapper.js
+++ b/lib/DateRangeWrapper/DateRangeWrapper.js
@@ -24,8 +24,8 @@ class DateRangeWrapper extends React.Component {
   static defaultProps = {
     endExcluder: (day, startDate) => day.isBefore(startDate, ISOFormat),
     startExcluder: (day, endDate) => day.isAfter(endDate, ISOFormat),
-    startValueGetter: (value) => value,
-    endValueGetter: (value) => value,
+    startValueGetter: (e) => e.target.value,
+    endValueGetter: (e) => e.target.value,
   }
 
   constructor(props) {

--- a/lib/DateRangeWrapper/tests/DateRangeWrapper-ReduxForm-test.js
+++ b/lib/DateRangeWrapper/tests/DateRangeWrapper-ReduxForm-test.js
@@ -17,8 +17,8 @@ describe('DateRangeWrapper with Redux Form', () => {
   let startChanged = false;
   let endChanged = false;
 
-  const handleChange = (e, value) => {
-    return value;
+  const handleChange = (e) => {
+    return e.target.value;
   };
 
   const initialDates = {

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -13,6 +13,21 @@ import TextField from '../TextField';
 import Calendar from './Calendar';
 import css from './Calendar.css';
 
+const defaultParser = (value, timeZone, dateFormat) => {
+  if (!value || value === '') { return value; }
+
+  const offsetRegex = /T[\d.:]+[+-][\d]+$/;
+  let inputMoment;
+  // if date string contains a utc offset, we can parse it as utc time and convert it to selected timezone.
+  if (offsetRegex.test(value)) {
+    inputMoment = moment.tz(value, timeZone);
+  } else {
+    inputMoment = moment.tz(value, dateFormat, timeZone);
+  }
+  const inputValue = inputMoment.format(dateFormat);
+  return inputValue;
+};
+
 const propTypes = {
   autoFocus: PropTypes.bool,
   backendDateStandard: PropTypes.string,
@@ -29,6 +44,7 @@ const propTypes = {
   meta: PropTypes.object,
   onChange: PropTypes.func,
   onSetDate: PropTypes.func,
+  parser: PropTypes.func,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
   screenReaderMessage: PropTypes.string,
@@ -47,6 +63,7 @@ const defaultProps = {
   autoFocus: false,
   backendDateStandard: 'ISO8601',
   hideOnChoose: true,
+  parser: defaultParser,
   screenReaderMessage: '',
   tether: {
     attachment: 'top center',
@@ -83,37 +100,20 @@ class Datepicker extends React.Component {
 
     this.dbhideCalendar = debounce(this.hideCalendar, 10);
 
-    // Set time zone
-    this.timeZone = props.timeZone || context.intl.timeZone;
-    const parseTimeZone = this.timeZone;
+    const timeZone = props.timeZone || context.intl.timeZone;
+    const locale = props.locale || context.intl.locale;
+    moment.locale(locale);
 
-    this.locale = props.locale || context.intl.locale;
-
-    moment.locale(this.locale);
-
-    if (this.props.dateFormat) {
-      this._dateFormat = this.props.dateFormat;
-    } else {
-      this._dateFormat = moment.localeData()._longDateFormat.L;
-    }
-
-    let inputValue = '';
-
-    // if we aren't using redux form...
-    if (!props.input && !props.date) {
-      inputValue = this.parseInputString(this.props.value);
-    } else {
-      inputValue = this.parseInputString(this.props.input.value);
-    }
+    const dateFormat = props.dateFormat || moment.localeData()._longDateFormat.L;
 
     this.state = {
-      dateString: inputValue,
+      dateString: '',
       showCalendar: this.props.showCalendar || false,
       srMessage: '',
-      parseTimeZone,
-      _dateFormat: this._dateFormat,
-      prevValue: this.props.input ? this.props.input.value : this.props.value,
-      hiddenValue: this.props.input ? this.props.input.value : '',
+      dateFormat,
+      timeZone,
+      prevValue: '',
+      locale,
     };
 
     if (props.id) {
@@ -121,6 +121,30 @@ class Datepicker extends React.Component {
     } else {
       this.testId = uniqueId('dp-');
     }
+  }
+
+  /* gDSFP handles instances where the value is transitioning from an empty string
+  * to some value.
+  */
+  static getDerivedStateFromProps(props, state) {
+    if (!state.prevValue) {
+      const timeZone = props.timeZone || state.timeZone;
+      const dateFormat = props.dateFormat || state.dateFormat;
+
+      let inputValue = '';
+      if (!props.input && !props.date) {
+        inputValue = props.parser(props.value, timeZone, dateFormat, state.locale);
+      } else {
+        inputValue = props.parser(props.input.value, timeZone, dateFormat, state.locale);
+      }
+      return {
+        dateString: inputValue,
+        prevValue: props.input ? props.input.value : props.value,
+        hiddenValue: props.input ? props.input.value : '',
+      };
+    }
+
+    return null;
   }
 
   componentDidUpdate() {
@@ -143,22 +167,8 @@ class Datepicker extends React.Component {
           { target: this.textfield.current }
         );
       }
-      this.internalSetState({}, undefined);
+      this.internalSetState({ changeType: undefined });
     }
-  }
-
-  parseInputString = (value) => {
-    if (!value || value === '') { return value; }
-    const offsetRegex = /T[\d.:]+[+-][\d]+$/;
-    let inputMoment;
-    // if date string contains a utc offset, we can parse it as utc time and convert it to selected timezone.
-    if (offsetRegex.test(value)) {
-      inputMoment = moment.tz(value, this.timeZone);
-    } else {
-      inputMoment = moment.tz(value, this._dateFormat, this.timeZone);
-    }
-    const inputValue = inputMoment.format(this._dateFormat);
-    return inputValue;
   }
 
   textfield = React.createRef();
@@ -210,7 +220,7 @@ class Datepicker extends React.Component {
   handleKeyDown = (e) => {
     if (this.picker) {
       const curDate = this.picker.getCursorDate();
-      const formattedDate = curDate.format(this._dateFormat);
+      const formattedDate = curDate.format(this.state.dateFormat);
       let dateString;
       switch (e.keyCode) {
         case 40: // down
@@ -295,7 +305,7 @@ class Datepicker extends React.Component {
   }
 
   handleSetDate = (e, date, stringDate) => {
-    const isValidDate = moment(stringDate, this._dateFormat, true).isValid();
+    const isValidDate = moment(stringDate, this.state.dateFormat, true).isValid();
     let standardizedDate;
 
     if (e.type === 'click' || e.type === 'keydown') {
@@ -311,6 +321,7 @@ class Datepicker extends React.Component {
           {
             dateString: stringDate,
             hiddenValue: standardizedDate,
+            prevValue: stringDate,
           },
           'calendar',
           [this.dbhideCalendar]
@@ -321,12 +332,13 @@ class Datepicker extends React.Component {
       // be sure that value is parseable as a date in the required format...
       // the boolean parameter suppresses moment's deprecation warning,
       // preventing it from attempting a parse using independable js Date object.
-      if (moment(tempString, this._dateFormat, true).isValid()) {
+      if (moment(tempString, this.state.dateFormat, true).isValid()) {
         standardizedDate = this.standardizeDate(e.target.value);
         this.internalSetState(
           {
             dateString: e.target.value,
             hiddenValue: standardizedDate,
+            prevValue: e.target.value,
           },
           'validEntry',
         );
@@ -398,7 +410,7 @@ class Datepicker extends React.Component {
   standardizeDate(date) {
     const DATE_RFC2822 = 'ddd, MM MMM YYYY HH:mm:ss ZZ';
     const { backendDateStandard } = this.props;
-    const parsed = moment.tz(date, this._dateFormat, true, this.timeZone);
+    const parsed = moment.tz(date, this.state.dateFormat, this.state.timeZone);
 
     if (/8601/.test(backendDateStandard)) {
       return parsed.toISOString();
@@ -419,7 +431,7 @@ class Datepicker extends React.Component {
         <Calendar
           onSetDate={this.handleSetDate}
           selectedDate={this.state.dateString}
-          dateFormat={this._dateFormat}
+          dateFormat={this.state.dateFormat}
           ref={(ref) => { this.picker = ref; }}
           onKeyDown={this.handleKeyDown}
           onBlur={this.hideCalendar}
@@ -477,7 +489,11 @@ class Datepicker extends React.Component {
       autoFocus
     } = this.props;
 
-    const screenReaderFormat = this.cleanForScreenReader(this._dateFormat);
+    const {
+      dateFormat,
+    } = this.state;
+
+    const screenReaderFormat = this.cleanForScreenReader(this.state.dateFormat);
 
     let ariaLabel;
     if (readOnly || disabled) {
@@ -502,7 +518,7 @@ class Datepicker extends React.Component {
       'onChange': this.handleSetDate,
       'value': this.state.dateString,
       'aria-label': ariaLabel,
-      'placeholder': `${this._dateFormat}`,
+      'placeholder': `${dateFormat}`,
       'onBlur': this.hideOnBlur,
       'hasClearIcon': false,
       'autoComplete': 'off',

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -79,6 +79,7 @@ class Datepicker extends React.Component {
     this.container = null;
     this.srSpace = null;
     this.textfield = props.inputRef || React.createRef();
+    this.hiddenInput = React.createRef();
 
     this.dbhideCalendar = debounce(this.hideCalendar, 10);
 
@@ -96,32 +97,23 @@ class Datepicker extends React.Component {
       this._dateFormat = moment.localeData()._longDateFormat.L;
     }
 
-    // non-null presentedValue will eventually be rendered as the value of the TextField.
     let inputValue = '';
-    let presentedValue = null;
 
     // if we aren't using redux form...
-    if ((typeof this.props.input === 'undefined' && typeof this.props.date === 'undefined')
-      || this.props.input.value === '') {
-      presentedValue = '';
-      inputValue = moment.tz(parseTimeZone).format(this._dateFormat);
-      if (this.props.value && this.props.value !== '') {
-        inputValue = this.parseInputString(this.props.value);
-        presentedValue = inputValue;
-      }
-    } else if (this.props.input.value !== '') {
+    if (!props.input && !props.date) {
+      inputValue = this.parseInputString(this.props.value);
+    } else {
       inputValue = this.parseInputString(this.props.input.value);
-      presentedValue = inputValue;
     }
 
     this.state = {
-      presentedValue,
       dateString: inputValue,
       showCalendar: this.props.showCalendar || false,
       srMessage: '',
       parseTimeZone,
       _dateFormat: this._dateFormat,
       prevValue: this.props.input ? this.props.input.value : this.props.value,
+      hiddenValue: this.props.input ? this.props.input.value : '',
     };
 
     if (props.id) {
@@ -131,45 +123,32 @@ class Datepicker extends React.Component {
     }
   }
 
-  static getDerivedStateFromProps(nextProps, prevState) {
-    // When the selected date has changed, update the state with it
-    let inputValue;
-    const _dateFormat = prevState._dateFormat;
-    let checkedVal;
-    if (nextProps.input) {
-      checkedVal = nextProps.input.value;
-    } else {
-      checkedVal = nextProps.value;
-    }
+  componentDidUpdate() {
+    const {
+      input,
+      onChange
+    } = this.props;
 
-    if (checkedVal) {
-      if (checkedVal !== '' && checkedVal !== prevState.prevValue) {
-        inputValue = moment.tz(checkedVal, prevState.parseTimeZone).format(_dateFormat);
-        return {
-          presentedValue: inputValue,
-          dateString: inputValue,
-          prevValue: checkedVal
-        };
-      } else if (checkedVal === '' && checkedVal !== prevState.prevValue) {
-        inputValue = '';
-        return {
-          presentedValue: '',
-          dateString: inputValue,
-          prevValue: checkedVal
-        };
+    const {
+      changeType,
+    } = this.state;
+
+    if (changeType && changeType !== 'invalid') {
+      if (input && this.hiddenInput.current) {
+        input.onChange(
+          { target: this.hiddenInput.current }
+        );
+      } else if (onChange && this.textfield.current) {
+        onChange(
+          { target: this.textfield.current }
+        );
       }
-    } else if (prevState.prevValue !== '' && prevState.date !== nextProps.date) {
-      inputValue = moment.tz(prevState.parseTimeZone).format(_dateFormat);
-      return {
-        dateString: inputValue,
-        value: nextProps.value,
-        date: nextProps.date,
-      };
+      this.internalSetState({}, undefined);
     }
-    return null;
   }
 
   parseInputString = (value) => {
+    if (!value || value === '') { return value; }
     const offsetRegex = /T[\d.:]+[+-][\d]+$/;
     let inputMoment;
     // if date string contains a utc offset, we can parse it as utc time and convert it to selected timezone.
@@ -302,71 +281,66 @@ class Datepicker extends React.Component {
     }
   }
 
+  internalSetState = (state, changeType, callbacks) => {
+    this.setState(curState => {
+      return Object.assign({}, curState, state, { changeType });
+    },
+    () => {
+      if (callbacks) {
+        callbacks.forEach((cb) => {
+          cb(this.state);
+        });
+      }
+    });
+  }
+
   handleSetDate = (e, date, stringDate) => {
+    const isValidDate = moment(stringDate, this._dateFormat, true).isValid();
+    let standardizedDate;
+
     if (e.type === 'click' || e.type === 'keydown') {
       e.preventDefault();
-
-      // if (e.type === 'keydown' && this.props.onChange) { this.props.onChange(e); }
       this.textfield.current.focus();
 
-      if (this.props.input) {
-        if (moment(stringDate, this._dateFormat, true).isValid()) {
-          // convert date to ISO 8601 format for backend
-          const standardizedDate = this.standardizeDate(stringDate);
-          // redux-form handlers take the value rather than the event...
-          if (this.props.input.onChange) {
-            this.props.input.onChange(standardizedDate);
-          }
-          if (this.props.input.onBlur) {
-            this.props.input.onBlur(standardizedDate);
-          }
-        }
-      } else if (moment(stringDate, this._dateFormat, true).isValid()) {
+      if (isValidDate) {
         // convert date to ISO 8601 format for backend
-        const standardizedDate = this.standardizeDate(stringDate);
-        // redux-form handlers take the value rather than the event...
-        if (this.props.onChange) {
-          this.props.onChange(standardizedDate);
-        }
-      }
+        standardizedDate = this.standardizeDate(stringDate);
 
-      if (this.props.hideOnChoose) {
-        // hiding calendar is debounced to wait for focus to properly catch up.
-        this.dbhideCalendar();
+        // handlers take the value rather than the event...
+        this.internalSetState(
+          {
+            dateString: stringDate,
+            hiddenValue: standardizedDate,
+          },
+          'calendar',
+          [this.dbhideCalendar]
+        );
       }
-
-      this.setState({ dateString: stringDate });
-    }
-    if (e.type === 'change') {
+    } else if (e.type === 'change') {
       const tempString = e.target.value;
       // be sure that value is parseable as a date in the required format...
       // the boolean parameter suppresses moment's deprecation warning,
       // preventing it from attempting a parse using independable js Date object.
       if (moment(tempString, this._dateFormat, true).isValid()) {
-        this.setState({
-          presentedValue: null,
-          dateString: e.target.value,
-        });
+        standardizedDate = this.standardizeDate(e.target.value);
+        this.internalSetState(
+          {
+            dateString: e.target.value,
+            hiddenValue: standardizedDate,
+          },
+          'validEntry',
+        );
       } else {
         // if it's not a valid date, update field value only so that
         // we can still see what we typed in the field...
-        this.setState({
-          dateString: e.target.value,
-        });
+        this.internalSetState(
+          {
+            dateString: e.target.value,
+            hiddenValue: '',
+          },
+          'invalid'
+        );
       }
-      if (this.props.onChange) { this.props.onChange(e); }
-      if (this.props.input) {
-        if (moment(e.target.value, this._dateFormat, true).isValid()) {
-          // convert date to ISO 8601 format for backend
-          const standardizedDate = this.standardizeDate(e.target.value);
-
-          // redux-form handlers take the value rather than the event...
-          if (this.props.input.onChange) {
-            this.props.input.onChange(standardizedDate);
-          }
-        }
-      }
-      if (this.props.onSetDate) { this.props.onSetDate(); }
     }
   }
 
@@ -379,19 +353,13 @@ class Datepicker extends React.Component {
   }
 
   clearDate = () => {
-    const {
-      input,
-      onChange
-    } = this.props;
-
-    this.setState({
-      presentedValue: null,
-      dateString: '',
-    });
-    const changeHandler = input ? input.onChange : onChange;
-    if (changeHandler) {
-      changeHandler('');
-    }
+    this.internalSetState(
+      {
+        dateString: '',
+        hiddenValue: '',
+      },
+      'clear',
+    );
   }
 
   cleanForScreenReader(str) {
@@ -414,9 +382,13 @@ class Datepicker extends React.Component {
   }
 
   hideOnBlur = (e) => {
+    const {
+      input
+    } = this.props;
+
     if (this.datePickerIsFocused()) {
-      if (this.props.input.onBlur) {
-        this.props.input.onBlur(e);
+      if (input && input.onBlur) {
+        input.onBlur(e);
       }
       this.hideCalendar();
       this.setState({ srMessage: '' });
@@ -437,13 +409,6 @@ class Datepicker extends React.Component {
     }
 
     return parsed.format(this.props.backendDateStandard);
-  }
-
-  getPresentedValue() {
-    if (this.state.presentedValue !== null) {
-      return this.state.presentedValue;
-    }
-    return this.state.dateString;
   }
 
   renderCalendar() {
@@ -535,7 +500,7 @@ class Datepicker extends React.Component {
       'id': this.testId,
       'inputRef': this.textfield,
       'onChange': this.handleSetDate,
-      'value': this.getPresentedValue(),
+      'value': this.state.dateString,
       'aria-label': ariaLabel,
       'placeholder': `${this._dateFormat}`,
       'onBlur': this.hideOnBlur,
@@ -557,8 +522,9 @@ class Datepicker extends React.Component {
       textfieldProps = {
         ...textfieldProps,
         meta: this.props.meta,
-        input : { ...input, value: this.getPresentedValue() },
-        onChange: this.handleFieldChange
+        input : { ...input, value: this.state.dateString },
+        onChange: this.handleFieldChange,
+        onBlur: (e) => { e.preventDefault(); }
       };
     }
 
@@ -578,6 +544,7 @@ class Datepicker extends React.Component {
             <div>{this.state.srMessage}</div>
           </div>
           {this.renderInput()}
+          <input type="hidden" hidden value={this.state.hiddenValue} ref={this.hiddenInput} />
         </div>
         {this.state.showCalendar && this.renderCalendar()}
       </TetherComponent>

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -48,7 +48,6 @@ const defaultProps = {
   backendDateStandard: 'ISO8601',
   hideOnChoose: true,
   screenReaderMessage: '',
-  inputRef: React.createRef(),
   tether: {
     attachment: 'top center',
     targetAttachment: 'bottom center',
@@ -79,7 +78,7 @@ class Datepicker extends React.Component {
     this.picker = null;
     this.container = null;
     this.srSpace = null;
-    this.textField = props.inputRef;
+    this.textfield = props.inputRef || React.createRef();
 
     this.dbhideCalendar = debounce(this.hideCalendar, 10);
 
@@ -122,7 +121,7 @@ class Datepicker extends React.Component {
       srMessage: '',
       parseTimeZone,
       _dateFormat: this._dateFormat,
-      input: this.props.input,
+      prevValue: this.props.input ? this.props.input.value : this.props.value,
     };
 
     if (props.id) {
@@ -136,23 +135,30 @@ class Datepicker extends React.Component {
     // When the selected date has changed, update the state with it
     let inputValue;
     const _dateFormat = prevState._dateFormat;
+    let checkedVal;
     if (nextProps.input) {
-      if (nextProps.input.value !== '' && nextProps.input.value !== prevState.input.value) {
-        inputValue = moment.tz(nextProps.input.value, prevState.parseTimeZone).format(_dateFormat);
+      checkedVal = nextProps.input.value;
+    } else {
+      checkedVal = nextProps.value;
+    }
+
+    if (checkedVal) {
+      if (checkedVal !== '' && checkedVal !== prevState.prevValue) {
+        inputValue = moment.tz(checkedVal, prevState.parseTimeZone).format(_dateFormat);
         return {
           presentedValue: inputValue,
           dateString: inputValue,
-          input: nextProps.input
+          prevValue: checkedVal
         };
-      } else if (nextProps.input.value === '' && nextProps.input.value !== prevState.input.value) {
+      } else if (checkedVal === '' && checkedVal !== prevState.prevValue) {
         inputValue = '';
         return {
           presentedValue: '',
           dateString: inputValue,
-          input: nextProps.input
+          prevValue: checkedVal
         };
       }
-    } else if (prevState.value !== '' && prevState.date !== nextProps.date) {
+    } else if (prevState.prevValue !== '' && prevState.date !== nextProps.date) {
       inputValue = moment.tz(prevState.parseTimeZone).format(_dateFormat);
       return {
         dateString: inputValue,
@@ -300,7 +306,7 @@ class Datepicker extends React.Component {
     if (e.type === 'click' || e.type === 'keydown') {
       e.preventDefault();
 
-      if (this.props.onChange) { this.props.onChange(e); }
+      // if (e.type === 'keydown' && this.props.onChange) { this.props.onChange(e); }
       this.textfield.current.focus();
 
       if (this.props.input) {
@@ -315,7 +321,15 @@ class Datepicker extends React.Component {
             this.props.input.onBlur(standardizedDate);
           }
         }
+      } else if (moment(stringDate, this._dateFormat, true).isValid()) {
+        // convert date to ISO 8601 format for backend
+        const standardizedDate = this.standardizeDate(stringDate);
+        // redux-form handlers take the value rather than the event...
+        if (this.props.onChange) {
+          this.props.onChange(standardizedDate);
+        }
       }
+
       if (this.props.hideOnChoose) {
         // hiding calendar is debounced to wait for focus to properly catch up.
         this.dbhideCalendar();
@@ -364,14 +378,19 @@ class Datepicker extends React.Component {
     }
   }
 
-  clearDate = (e) => {
+  clearDate = () => {
+    const {
+      input,
+      onChange
+    } = this.props;
+
     this.setState({
       presentedValue: null,
       dateString: '',
     });
-    if (this.props.onChange) { this.props.onChange(e); }
-    if (this.props.input.onChange) {
-      this.props.input.onChange('');
+    const changeHandler = input ? input.onChange : onChange;
+    if (changeHandler) {
+      changeHandler('');
     }
   }
 

--- a/lib/Datepicker/readme.md
+++ b/lib/Datepicker/readme.md
@@ -27,6 +27,46 @@ Name | type | description | default | required
 
 <!-- dateFormat | string | system formatting for date. [Moment.js formats](https://momentjs.com/docs/#/displaying/format/) are supported | "MM/DD/YYYY" | false-->
 
+## Controlled Datepicker example
+```
+...
+state = {
+  day1: 11/03/1980
+}
+...
+
+handleDateChange = (e) => {
+  const newDate = e.target.value;
+  this.setState({
+    day1: newDate,
+  });
+}
+
+<Datepicker
+  label="Date"
+  value={this.state.day1}
+  onChange={handleDateChange}
+/>
+```
+
+## Redux-form/Final Form usage
+
+```
+<Field component={Datepicker} name="date" label="date" />
+```
+### Value manipulation into/out of the field...
+To adjust the value from the redux store before passing it to the component, use the `<Field>`'s `format` prop:
+```
+const formatField = value => (value ? moment.utc(value) : '');
+<Field component={Datepicker} name="date" label="date" format={formatField} />
+```
+To adjust the set value, prior to storing it in the redux-store, use `parse`
+```
+const parseField = value => (value ? moment.utc(value) : '');
+<Field component={Datepicker} name="date" label="date" parse={parseField} />
+```
+You can read more about value lifecycles in `redux-form` here: https://redux-form.com/7.4.2/docs/valuelifecycle.md/
+
 ## Working with Dates
 
 Using a `value` that does not include any time or timezone

--- a/lib/Datepicker/stories/BasicUsage.js
+++ b/lib/Datepicker/stories/BasicUsage.js
@@ -3,29 +3,11 @@
  */
 
 import React from 'react';
-import Datepicker from '../Datepicker';
 import DatepickerDemo from './DatepickerDemo';
+
 const BasicUsage = () => (
   <div>
     <DatepickerDemo />
-    {/* <Datepicker
-      label="Date"
-    />
-    <br />
-    <Datepicker
-      label="Date (read only)"
-      readOnly
-    />
-    <br />
-    <Datepicker
-      label="Date (disabled)"
-      disabled
-    />
-    <br />
-    <Datepicker
-      label="Date (required)"
-      required
-    /> */}
   </div>
 );
 

--- a/lib/Datepicker/stories/BasicUsage.js
+++ b/lib/Datepicker/stories/BasicUsage.js
@@ -4,10 +4,11 @@
 
 import React from 'react';
 import Datepicker from '../Datepicker';
-
+import DatepickerDemo from './DatepickerDemo';
 const BasicUsage = () => (
   <div>
-    <Datepicker
+    <DatepickerDemo />
+    {/* <Datepicker
       label="Date"
     />
     <br />
@@ -24,7 +25,7 @@ const BasicUsage = () => (
     <Datepicker
       label="Date (required)"
       required
-    />
+    /> */}
   </div>
 );
 

--- a/lib/Datepicker/stories/DatepickerDemo.js
+++ b/lib/Datepicker/stories/DatepickerDemo.js
@@ -29,13 +29,13 @@ class DatepickerDemo extends React.Component {
         <Datepicker
           label="Date"
           value={this.state.day1}
-          onChange={(v) => { this.onChangeDate(v, 'day1'); }}
+          onChange={(e) => { this.onChangeDate(e.target.value, 'day1'); }}
         />
         <br />
         <Datepicker
           label="Date (read only)"
           value={this.state.day3}
-          onChange={(v) => { this.onChangeDate(v, 'day3'); }}
+          onChange={(e) => { this.onChangeDate(e.target.value, 'day3'); }}
           readOnly
         />
         <br />
@@ -47,7 +47,7 @@ class DatepickerDemo extends React.Component {
         <Datepicker
           label="Date (required)"
           value={this.state.day2}
-          onChange={(v) => { this.onChangeDate(v, 'day2'); }}
+          onChange={(e) => { this.onChangeDate(e.target.value, 'day2'); }}
           required
         />
       </div>

--- a/lib/Datepicker/stories/DatepickerDemo.js
+++ b/lib/Datepicker/stories/DatepickerDemo.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import moment from 'moment';
-import PropTypes from 'prop-types';
 import Datepicker from '../Datepicker';
 
 class DatepickerDemo extends React.Component {

--- a/lib/Datepicker/stories/DatepickerDemo.js
+++ b/lib/Datepicker/stories/DatepickerDemo.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import moment from 'moment';
+import PropTypes from 'prop-types';
+import Datepicker from '../Datepicker';
+
+class DatepickerDemo extends React.Component {
+  state = {
+    day1: '12/10/1980',
+    day2: '11/03/1982',
+    day3: '02/09/2019',
+  }
+
+  onChangeDate = (value, name) => {
+    let nextDate;
+    if (value !== '') {
+      nextDate = moment.utc(value).format('MM/DD/YYYY');
+    } else {
+      nextDate = value;
+    }
+
+    this.setState({
+      [name]: nextDate,
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        <Datepicker
+          label="Date"
+          value={this.state.day1}
+          onChange={(v) => { this.onChangeDate(v, 'day1'); }}
+        />
+        <br />
+        <Datepicker
+          label="Date (read only)"
+          value={this.state.day3}
+          onChange={(v) => { this.onChangeDate(v, 'day3'); }}
+          readOnly
+        />
+        <br />
+        <Datepicker
+          label="Date (disabled)"
+          disabled
+        />
+        <br />
+        <Datepicker
+          label="Date (required)"
+          value={this.state.day2}
+          onChange={(v) => { this.onChangeDate(v, 'day2'); }}
+          required
+        />
+      </div>
+    );
+  }
+}
+
+export default DatepickerDemo;

--- a/lib/Datepicker/tests/Datepicker-ReduxForm-test.js
+++ b/lib/Datepicker/tests/Datepicker-ReduxForm-test.js
@@ -33,7 +33,7 @@ describe('Datepicker with Redux Form integration', () => {
     });
 
     it('returns an ISO 8601 datetime string at UTC', () => {
-      expect(onChange.mock.calls[0][1]).to.equal('2018-04-01T00:00:00.000Z');
+      expect(onChange.mock.calls[0][1].target.value).to.equal('2018-04-01T00:00:00.000Z');
     });
 
     describe('clearing the input', () => {
@@ -42,7 +42,7 @@ describe('Datepicker with Redux Form integration', () => {
         expect(onChange.mock.calls.length).to.equal(2);
       });
       it('sends empty value to onChange', () => {
-        expect(onChange.mock.calls[1][1]).to.equal('');
+        expect(onChange.mock.calls[1][1].target.value).to.equal('');
       });
     });
   });
@@ -67,7 +67,7 @@ describe('Datepicker with Redux Form integration', () => {
       expect(datepicker.inputValue).to.equal('');
     });
     it('called onChange with empty value', () => {
-      expect(onChange.mock.calls[0][1]).to.equal('');
+      expect(onChange.mock.calls[0][1].target.value).to.equal('');
     });
   });
 
@@ -346,7 +346,7 @@ describe('Datepicker with Redux Form integration', () => {
     });
 
     it('returns an ISO 8601 datetime string for specific time zone', () => {
-      expect(onChange.mock.calls[0][1]).to.equal('2018-04-01T07:00:00.000Z');
+      expect(onChange.mock.calls[0][1].target.value).to.equal('2018-04-01T07:00:00.000Z');
     });
   });
 
@@ -396,7 +396,7 @@ describe('Datepicker with Redux Form integration', () => {
       });
 
       it('returns an RFC2822 datetime string for specific time zone', () => {
-        expect(onChange.mock.calls[0][1]).to.equal('Sun, 04 Apr 2018 00:00:00 -0700');
+        expect(onChange.mock.calls[0][1].target.value).to.equal('Sun, 04 Apr 2018 00:00:00 -0700');
       });
     });
 
@@ -422,7 +422,7 @@ describe('Datepicker with Redux Form integration', () => {
       });
 
       it('returns an RFC2822 datetime string for specific time zone', () => {
-        expect(onChange.mock.calls[0][1]).to.equal('2018');
+        expect(onChange.mock.calls[0][1].target.value).to.equal('2018');
       });
     });
   });

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -100,11 +100,11 @@ describe('Datepicker', () => {
         />
       );
 
-      await datepicker.fillInput('04/01/2018');
+      await datepicker.fillInput('01.04.2018');
     });
 
     it('emits an event with the date formatted as displayed', () => {
-      expect(dateOutput).to.equal('04/01/2018');
+      expect(dateOutput).to.equal('01.04.2018');
     });
   });
 

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -2,10 +2,12 @@ import React from 'react';
 import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 import mock from 'jest-mock';
+import { Interactor } from '@bigtest/interactor';
 
 import { mountWithContext } from '../../../tests/helpers';
 
 import Datepicker from '../Datepicker';
+import DatepickerAppHarness from './DatepickerAppHarness';
 import DatepickerInteractor from './interactor';
 
 describe('Datepicker', () => {
@@ -24,6 +26,29 @@ describe('Datepicker', () => {
 
     it('has a placeholder in the input', () => {
       expect(datepicker.placeholder).to.equal('MM/DD/YYYY');
+    });
+  });
+
+  describe('value set after initial render', () => {
+    const datepickerAppInteractor = new Interactor();
+    beforeEach(async () => {
+      await mountWithContext(
+        <DatepickerAppHarness lateValue="04/01/2019" />
+      );
+    });
+
+    it('does not have a value in the input', () => {
+      expect(datepicker.inputValue).to.equal('');
+    });
+
+    describe('applying late value', () => {
+      beforeEach(async () => {
+        await datepickerAppInteractor.click('button#applylatevalue');
+      });
+
+      it('displays the late-applied value', () => {
+        expect(datepicker.inputValue).to.equal('04/01/2019');
+      });
     });
   });
 

--- a/lib/Datepicker/tests/DatepickerAppHarness.js
+++ b/lib/Datepicker/tests/DatepickerAppHarness.js
@@ -1,0 +1,32 @@
+/* a basic harness meant to set up scenarios for datepicker within an actual application
+* where its props are fed to it by potentially dynamic sources.
+*/
+import React from 'react';
+import Datepicker from '../Datepicker';
+
+class DatepickerAppHarness extends React.Component {
+  static defaultProps = {
+    lateValue: '04/01/2019'
+  }
+
+  state = {
+    value: '',
+  }
+
+  setValue = () => {
+    this.setState({
+      value: this.props.lateValue,
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        <Datepicker value={this.state.value} {...this.props} />
+        <button type="button" onClick={this.setValue} id="applylatevalue">set test value</button>
+      </div>
+    )
+  }
+}
+
+export default DatepickerAppHarness;

--- a/lib/Datepicker/tests/DatepickerAppHarness.js
+++ b/lib/Datepicker/tests/DatepickerAppHarness.js
@@ -25,7 +25,7 @@ class DatepickerAppHarness extends React.Component {
         <Datepicker value={this.state.value} {...this.props} />
         <button type="button" onClick={this.setValue} id="applylatevalue">set test value</button>
       </div>
-    )
+    );
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
# Problems
Numerous ones within Datepicker... logic that's passed through a few hands without really fixing very much - along with a completely neglected non-redux-form mode.

## Approach
Changehandlers are now called after the input field is updated. The parameter has similar shape to the event object... this appeases typical changeHandler conventions of accepting an event object with a present `target.value`
Redux-form still receives the ISO formatted value, while non-redux-form receives the input value of the textField.

Additionally - this removed a large chunk from numerous parts of the code, including `handleSetDate()` method, the constructor, ~the entire `gDSFP()` method~. *Edit*: I brought back `gDSFP()` after thinking about it. it's good for handling situations where initial values land after the component's initial render. With this, I transfered parsing logic from the constructor to `gDSFP()` instead.

There is no of usage of Datepicker in a non-redux-form-y way among ui-modules I'm aware of (it really didn't work - so we would have heard about it, surely)

## Future work
Conforming even handlers also means that maybe this can use the `formField` HOC now... that'll take more effort but it won't be quite as difficult.
Additionally, an accessibility overhaul is necessary on this component (JIRAS exist for this)