### PR TITLE
Revert "STCOM-492: change filter search to use == not ="

### DIFF
--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -185,7 +185,7 @@ export function filters2cql(config, filters = '') {
       let joinedValues = mappedValues.map(v => `"${v}"`).join(' or ');
       if (values.length > 1) joinedValues = `(${joinedValues})`;
 
-      conds.push(`${cqlIndex}==${joinedValues}`);
+      conds.push(`${cqlIndex}=${joinedValues}`);
     }
   }
 


### PR DESCRIPTION
Reverts folio-org/stripes-components#925

Given the current state of CQL-to-SQL translation in cql2pgsjon-java, detailed in [CQLPG-81](https://issues.folio.org/browse/CQLPG-81), #925 inadvertently broke searching for array fields. Once query translation is updated, we'll consider reinstating this PR. 