### PR TITLE
Improve children prop validation in modal footer

### DIFF
--- a/lib/ModalFooter/ModalFooter.js
+++ b/lib/ModalFooter/ModalFooter.js
@@ -34,15 +34,10 @@ const ModalFooter = ({ children, primaryButton, secondaryButton }) => {
 };
 
 ModalFooter.propTypes = {
-  children: (props) => {
-    let error = null;
-    React.Children.forEach(props.children, (child) => {
-      if (child.type !== Button) {
-        error = new Error('`ModalFooter` children should be of type `Button`.');
-      }
-    });
-    return error;
-  },
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(Button),
+    PropTypes.objectOf(Button),
+  ]),
   primaryButton: deprecated(PropTypes.shape({
     ...buttonPropTypes,
     label: PropTypes.node,


### PR DESCRIPTION
The previous check was failing for me because we can't compare two functions with `===`. This PR uses what react provides for us. 