### PR TITLE
STCOM-489-AutoSuggest-ref-bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 5.1.3 (IN-PROGRESS)
 * Fix `<Datepicker>` for non-redux-form usage. Fixes STCOM-493
-* Fix issue with `<AutoSuggest>` not using refs correctly. Fixes STCOM-498
+* Fix issue with `<AutoSuggest>` not using refs correctly. Fixes STCOM-489
 
 ## [5.1.2](https://github.com/folio-org/stripes-components/tree/v5.1.2) (2019-03-20)
 * `<AccordionSet>` consideres `closedByDefault` prop when setting up initial state for child accordions. Fixes STCOM-480.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.1.3 (IN-PROGRESS)
 * Fix `<Datepicker>` for non-redux-form usage. Fixes STCOM-493
+* Fix issue with `<AutoSuggest>` not using refs correctly. Fixes STCOM-498
 
 ## [5.1.2](https://github.com/folio-org/stripes-components/tree/v5.1.2) (2019-03-20)
 * `<AccordionSet>` consideres `closedByDefault` prop when setting up initial state for child accordions. Fixes STCOM-480.

--- a/lib/AutoSuggest/AutoSuggest.css
+++ b/lib/AutoSuggest/AutoSuggest.css
@@ -1,6 +1,6 @@
 @import '../variables.css';
 
-.AutoSuggest {
+.autoSuggest {
   position: relative;
   top: 100%;
   width: '100%';
@@ -8,8 +8,7 @@
   padding: 0;
   z-index: 1000;
   max-height: 400px;
-  overflow: scroll;
-  margin-top: -7px;
+  overflow: hidden;
   text-align: left;
   list-style: none;
   background-color: #fff;

--- a/lib/AutoSuggest/AutoSuggest.js
+++ b/lib/AutoSuggest/AutoSuggest.js
@@ -55,14 +55,13 @@ class AutoSuggest extends React.Component {
     super(props);
     this.container = React.createRef();
     this.textfield = React.createRef();
-    this.testId = this.props.id || uniqueId('detailname-');
+    this.testId = this.props.id || uniqueId('autoSuggest-');
     this.autoSuggestId = `list-dropdown-${this.testId}`;
   }
 
-  getInputWidth() { // eslint-disable-line consistent-return
-    if (this.textfield.current) {
-      const { input : { current : { offsetWidth } } } = this.textfield.current;
-      return offsetWidth;
+  getInputWidth = () => { // eslint-disable-line consistent-return
+    if (this.container.current) {
+      return this.container.current.offsetWidth;
     }
   }
 
@@ -83,7 +82,6 @@ class AutoSuggest extends React.Component {
       valueKey,
     } = this.props;
 
-    const textfieldRef = this.textfield;
     const mergedTetherProps = { ...AutoSuggest.defaultProps.tether, ...tether };
     const testId = this.testId;
     const autoSuggestId = this.autoSuggestId;
@@ -93,7 +91,7 @@ class AutoSuggest extends React.Component {
       required,
       label,
       validationEnabled,
-      inputRef: textfieldRef,
+      inputRef: this.textfield,
       id: testId,
       error,
     };
@@ -116,11 +114,11 @@ class AutoSuggest extends React.Component {
           isOpen,
           inputValue,
         }) => (
-          <div className={css.downshift}>
+          <div className={css.downshift} data-test-autosuggest>
             <TetherComponent {...mergedTetherProps}>
               <div
-                className={css.TextFieldDiv}
-                ref={(ref) => { this.container = ref; }}
+                className={css.textFieldDiv}
+                ref={this.container}
                 aria-live="assertive"
                 aria-relevant="additions"
               >
@@ -131,10 +129,13 @@ class AutoSuggest extends React.Component {
                 />
               </div>
               <ul
-                className={css.AutoSuggest}
+                className={css.autoSuggest}
                 {...getMenuProps({
                   id: autoSuggestId,
-                  style: { width: `${listWidth}px` }
+                  style: {
+                    width: `${this.getInputWidth()}px`,
+                    display: isOpen ? 'block' : 'none'
+                  }
                 }, { suppressRefError: true })}
               >
                 {isOpen

--- a/lib/AutoSuggest/tests/AutoSuggest-ReduxForm-test.js
+++ b/lib/AutoSuggest/tests/AutoSuggest-ReduxForm-test.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+import { Field } from 'redux-form';
+
+import { mountWithContext } from '../../../tests/helpers';
+import AutoSuggestInteractor from './interactor';
+import AutoSuggest from '../AutoSuggest';
+import TestForm from '../../../tests/TestForm';
+
+const autosuggest = new AutoSuggestInteractor();
+
+const testItems = [
+  {
+    value: 'book',
+    label: 'Book',
+  },
+  {
+    value: 'cd',
+    label: 'CD',
+  },
+  {
+    value: 'ebook',
+    label: 'eBook',
+  },
+  {
+    value: 'vinyl',
+    label: 'Vinyl',
+  },
+  {
+    value: 'audiobook',
+    label: 'Audiobook',
+  },
+];
+
+describe('AutoSuggest in redux-form', () => {
+  describe('rendering', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <TestForm>
+          <Field component={AutoSuggest} name="testfield" label="autoSuggestTest" items={testItems} />
+        </TestForm>
+      );
+    });
+
+    it('renders the component', () => {
+      expect(autosuggest.renders).to.be.true;
+    });
+
+    it('renders a label', () => {
+      expect(autosuggest.labelDisplayed).to.be.true;
+    });
+
+    describe('entering an existing value', () => {
+      beforeEach(async () => {
+        await autosuggest.input.fillValue('b');
+      });
+
+      it('opens the suggestion list', () => {
+        expect(autosuggest.list.isOpen).to.be.true;
+      });
+
+      describe('selecting an option', () => {
+        beforeEach(async () => {
+          await autosuggest.list.items(0).click();
+        });
+
+        it('closes the suggestion list', () => {
+          expect(autosuggest.list.isOpen).to.be.false;
+        });
+
+        it('sets the value of the input to the selected option', () => {
+          expect(autosuggest.input.val).to.equal('book');
+        });
+      });
+    });
+  });
+});

--- a/lib/AutoSuggest/tests/AutoSuggest-test.js
+++ b/lib/AutoSuggest/tests/AutoSuggest-test.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { mountWithContext } from '../../../tests/helpers';
+
+import AutoSuggestInteractor from './interactor';
+import AutoSuggest from '../AutoSuggest';
+
+const autosuggest = new AutoSuggestInteractor();
+
+const testItems = [
+  {
+    value: 'book',
+    label: 'Book',
+  },
+  {
+    value: 'cd',
+    label: 'CD',
+  },
+  {
+    value: 'ebook',
+    label: 'eBook',
+  },
+  {
+    value: 'vinyl',
+    label: 'Vinyl',
+  },
+  {
+    value: 'audiobook',
+    label: 'Audiobook',
+  },
+];
+
+describe('AutoSuggest', () => {
+  describe('rendering', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <AutoSuggest label="autoSuggestTest" items={testItems} />
+      );
+    });
+
+    it('renders the component', () => {
+      expect(autosuggest.renders).to.be.true;
+    });
+
+    it('renders a label', () => {
+      expect(autosuggest.labelDisplayed).to.be.true;
+    });
+
+    describe('entering an existing value', () => {
+      beforeEach(async () => {
+        await autosuggest.input.fillValue('b');
+      });
+
+      it('opens the suggestion list', () => {
+        expect(autosuggest.list.isOpen).to.be.true;
+      });
+
+      describe('selecting an option', () => {
+        beforeEach(async () => {
+          await autosuggest.list.items(0).click();
+        });
+
+        it('closes the suggestion list', () => {
+          expect(autosuggest.list.isOpen).to.be.false;
+        });
+
+        it('sets the value of the input to the selected option', () => {
+          expect(autosuggest.input.val).to.equal('book');
+        });
+      });
+    });
+  });
+});

--- a/lib/AutoSuggest/tests/interactor.js
+++ b/lib/AutoSuggest/tests/interactor.js
@@ -1,0 +1,35 @@
+import {
+  interactor,
+  clickable,
+  collection,
+  scoped,
+  fillable,
+  text,
+  isPresent,
+  isVisible
+} from '@bigtest/interactor';
+
+import css from '../AutoSuggest.css';
+import { selectorFromClassnameString } from '../../../tests/helpers';
+import TextFieldInteractor from '../../TextField/tests/interactor';
+
+@interactor class listItemInteractor {
+  text = text();
+  click = clickable();
+}
+
+@interactor class AutoSuggestListInteractor {
+  defaultScope = 'data-test-autosuggest-list';
+  isOpen = isVisible();
+  items = collection('li', listItemInteractor);
+}
+
+@interactor class AutoSuggestInteractor {
+  defaultScope = 'data-test-autosuggest';
+  labelDisplayed = isPresent('label');
+  renders = isPresent('input');
+  input = scoped(`.${css.textFieldDiv}`, TextFieldInteractor);
+  list = new AutoSuggestListInteractor(`.${css.autoSuggest}`);
+}
+
+export default AutoSuggestInteractor;

--- a/lib/TextField/tests/interactor.js
+++ b/lib/TextField/tests/interactor.js
@@ -60,4 +60,10 @@ export default interactor(class TextFieldInteractor {
       .fill('input', val)
       .blur('input');
   }
+
+  fillValue(val) {
+    return this
+      .focusInput()
+      .fillInput(val);
+  }
 });


### PR DESCRIPTION
Fixed issue with `<AutoSuggest>` improperly accessing refs and adjusted styling.

## Bonus
Added tests for %100 coverage for this component ... bumping us up to 69.25% coverage for the library.
![image](https://user-images.githubusercontent.com/20704067/55890064-ae98dc00-5b77-11e9-8179-250e09889c5c.png)
