### PR TITLE
UIIN-319 Potential fix for gap below results list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.1.3 (IN-PROGRESS)
 * Fix `<Datepicker>` for non-redux-form usage. Fixes STCOM-493
 * Fix issue with `<AutoSuggest>` not using refs correctly. Fixes STCOM-489
+* Use minimumRowHeight in `<MultiColumnList>` instead of averageHeight for row rendering/loading. Relates to UIIN-319.
 
 ## [5.1.2](https://github.com/folio-org/stripes-components/tree/v5.1.2) (2019-03-20)
 * `<AccordionSet>` consideres `closedByDefault` prop when setting up initial state for child accordions. Fixes STCOM-480.

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -111,6 +111,7 @@ class MCLRenderer extends React.Component {
       averageRowHeight: 0,
       adjustedHeight: null,
       endOfListHeight: null,
+      minimumRowHeight: 24,
     };
 
     this.handlers = Object.assign({
@@ -273,16 +274,16 @@ class MCLRenderer extends React.Component {
     // }
   }
 
-  updateDimensions = (height, data, avgHeight) => {
+  updateDimensions = (height, data, minHeight) => {
     // Base-case to avoid a catastrophic divide-by-zero during a re-render.
-    const averageRowHeight = avgHeight || this.state.averageRowHeight || 10;
+    const minimumRowHeight = this.state.minimumRowHeight;
 
     // if we don't have a height, then we'll just render whatever data we have...
     let newAmount;
     if (!height) {
       newAmount = data.length;
     } else {
-      newAmount = parseInt(height / averageRowHeight, 10) + (this.state.overscanRows * 2);
+      newAmount = parseInt(height / minimumRowHeight, 10) + (this.state.overscanRows * 2);
     }
     let fetching = false;
 
@@ -405,7 +406,7 @@ class MCLRenderer extends React.Component {
       for (let i = 0; i < amountToRender; i += 1) {
         const index = firstIndex + i;
         if (contentData[index]) {
-          if (this.rowCache[index] !== 'undefined') {
+          if (!this.rowCache[index]) {
             // children are c[1] to c[length-1]
             this.rowCache.push(c[index - firstIndex].offsetHeight);
           }

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -141,7 +141,7 @@ class MCLRenderer extends React.Component {
       this.measureNewRows();
       const rowAvg = this.updateAverageHeight();
       newState.averageRowHeight = rowAvg;
-      const dimensions = this.updateDimensions(this.props.height, this.props.contentData, rowAvg);
+      const dimensions = this.updateDimensions(this.props.height, this.props.contentData);
       Object.assign(newState, dimensions);
       // } else {
       if (!this.props.virtualize) {
@@ -232,7 +232,7 @@ class MCLRenderer extends React.Component {
 
         if (this.state.averageRowHeight === 0) {
           const avg = this.updateAverageHeight();
-          const dimensions = this.updateDimensions(this.props.height, this.props.contentData, avg);
+          const dimensions = this.updateDimensions(this.props.height, this.props.contentData);
           this.setState({ averageRowHeight: avg, ...dimensions });
         }
       });
@@ -274,7 +274,7 @@ class MCLRenderer extends React.Component {
     // }
   }
 
-  updateDimensions = (height, data, minHeight) => {
+  updateDimensions = (height, data) => {
     // Base-case to avoid a catastrophic divide-by-zero during a re-render.
     const minimumRowHeight = this.state.minimumRowHeight;
 

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -438,7 +438,7 @@ class MCLRenderer extends React.Component {
   };
 
   handleRowClick = (e, row) => {
-    if (Object.prototype.hasOwnProperty.call(this.props, 'onRowClick')) {
+    if (this.props.onRowClick) {
       e.preventDefault();
       this.props.onRowClick(e, row);
     }


### PR DESCRIPTION
This is a difficult issue to reproduce locally.

Short of a heavier refactor for MCL, an initial approach is to stick to a minimum row-height for rendering rows and determining when more data is needed rather than an averaged row height.

This includes a fix to rowCache logic that might have been the culprit as well as the mentioned minimum row height.
With virtualization, the main goal is to render only a portion of the data in situations where displaying all of the data would be quite slow. Despite the loaded amount being more in some cases due to the height number being lower, it's still in the acceptable realm.

This fix is non-breaking and tests still pass for the component.
