### PR TITLE
Minor style updates for button

### DIFF
--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -28,10 +28,10 @@
   font-size: var(--font-size-medium);
   min-height: var(--control-min-size-desktop);
 
-  /* Minor update to avoid a small gap between 
+  /* Minor update to avoid a small gap between
     the button and the focus/active styles */
-  &:before {
-    border-radius: calc(var(--radius) -1px);
+  &::before {
+    border-radius: calc(var(--radius) - 1px);
   }
 
   &.block {

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -28,6 +28,12 @@
   font-size: var(--font-size-medium);
   min-height: var(--control-min-size-desktop);
 
+  /* Minor update to avoid a small gap between 
+    the button and the focus/active styles */
+  &:before {
+    border-radius: calc(var(--radius) -1px);
+  }
+
   &.block {
     display: flex;
   }

--- a/lib/Button/Button.js
+++ b/lib/Button/Button.js
@@ -125,7 +125,9 @@ function Button(props) {
       type={type}
       {...sharedProps}
     >
-      {children}
+      <span>
+        {children}
+      </span>
     </button>
   );
 }


### PR DESCRIPTION
I noticed a few minor issues with the button styling that I decided to fix.

### The label disappears on the secondary button when the :active style is applied
This happens because of the way the focus/active/hover styles are made so when there's no inner element of the button that a z-index can be applied to, the label ends up behind the active styles. Wrapping the content in a span fixes this issue.

**Before:**
![image](https://user-images.githubusercontent.com/640976/56206460-c3c8ab80-604c-11e9-96ba-e1fb10a3df69.png)

**After:**
![image](https://user-images.githubusercontent.com/640976/56206344-6df40380-604c-11e9-90ac-83d98170a406.png)


### A small gap appears when the focus/active style is applied
This is fixed by making the active/hover/focus style border-radius overlay 1px smaller (5px) than the button's border-radius (6px).

**Before:**
![image](https://user-images.githubusercontent.com/640976/56206548-f672a400-604c-11e9-9428-2ad995ae132c.png)

**After:**
![image](https://user-images.githubusercontent.com/640976/56207038-0d65c600-604e-11e9-8bd1-e3774619a3a3.png)
