### PR TITLE
Set sideEffects to false to enable tree-shaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fix `<Datepicker>` for non-redux-form usage. Fixes STCOM-493
 * Fix issue with `<AutoSuggest>` not using refs correctly. Fixes STCOM-489
 * Use minimumRowHeight in `<MultiColumnList>` instead of averageHeight for row rendering/loading. Relates to UIIN-319.
+* Turned off sideEffects to enable tree-shaking for production builds. Refs STRIPES-564 and STRIPES-581.
 
 ## [5.1.2](https://github.com/folio-org/stripes-components/tree/v5.1.2) (2019-03-20)
 * `<AccordionSet>` consideres `closedByDefault` prop when setting up initial state for child accordions. Fixes STCOM-480.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",
+  "sideEffects": ["*.css"],
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"
   },


### PR DESCRIPTION
- Tested output with simple "hello world" UI app

Before:

![Screen Shot 2019-04-23 at 10 06 18 AM](https://user-images.githubusercontent.com/28395235/56587608-d04e8600-65af-11e9-924b-dd021817fda1.png)

After:

![Screen Shot 2019-04-23 at 10 06 35 AM](https://user-images.githubusercontent.com/28395235/56587629-d7759400-65af-11e9-993a-b49f42c5e2af.png)
