### PR TITLE
RadioButton and Checkbox style improvements

### DIFF
--- a/lib/Checkbox/Checkbox.css
+++ b/lib/Checkbox/Checkbox.css
@@ -45,6 +45,18 @@
   }
 }
 
+
+/* Apply spacing between inline checkboxes when stacked */
+.inline + .inline {
+  margin-left: var(--gutter-static-two-thirds);
+  margin-right: 0;
+}
+
+[dir="rtl"] .inline + .inline {
+  margin-right: var(--gutter-static-two-thirds);
+  margin-left: 0;
+}
+
 .labelCheck {
   position: relative;
   width: var(--checkbox-size);
@@ -116,7 +128,7 @@
 }
 
 .checkboxInteractionStyles {
-  composes: interactionStyles boxOffsetStartMedium boxOffsetEndMedium from "../sharedStyles/interactionStyles.css";
+  composes: interactionStyles boxOffsetStartSmall boxOffsetEndSmall from "../sharedStyles/interactionStyles.css";
 }
 
 .labelFocused {
@@ -130,10 +142,14 @@
 }
 
 .labelText {
-  margin: 0 var(--gutter-static-one-third);
+  margin: 0 0 0 var(--gutter-static-one-third);
   display: flex;
   align-items: center;
   min-height: var(--control-min-size-desktop);
+}
+
+[dir="rtl"] .labelText {
+  margin: 0 var(--gutter-static-one-third) 0 0;
 }
 
 /* fix for shrinkage issues with checkbox as a flex-child */

--- a/lib/Checkbox/Checkbox.css
+++ b/lib/Checkbox/Checkbox.css
@@ -103,6 +103,7 @@
   position: relative;
   border-radius: var(--radius);
   font-size: var(--font-size-medium);
+  margin-bottom: 0;
 
   &.disabledLabel {
     cursor: not-allowed;

--- a/lib/Checkbox/Checkbox.css
+++ b/lib/Checkbox/Checkbox.css
@@ -45,7 +45,6 @@
   }
 }
 
-
 /* Apply spacing between inline checkboxes when stacked */
 .inline + .inline {
   margin-left: var(--gutter-static-two-thirds);

--- a/lib/Checkbox/stories/BasicUsage.js
+++ b/lib/Checkbox/stories/BasicUsage.js
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import Checkbox from '../Checkbox';
+import Label from '../../Label';
 
 export default class CheckboxExample extends React.Component {
   constructor() {
@@ -93,6 +94,13 @@ export default class CheckboxExample extends React.Component {
         />
         {' '}
 inline checkbox with no label.
+        <br aria-hidden="true" />
+        <br aria-hidden="true" />
+        <Label>Stacked inline checkboxes</Label>
+        <Checkbox label="JavaScript" inline />
+        <Checkbox label="PHP" inline />
+        <Checkbox label="C++" inline />
+        <Checkbox label="ASP.net" inline />
       </div>
     );
   }

--- a/lib/RadioButton/RadioButton.css
+++ b/lib/RadioButton/RadioButton.css
@@ -7,13 +7,24 @@
 .radioButton {
   display: flex;
   align-items: center;
-
-  &.inline {
-    display: inline-flex;
-  }
-
+  
   &.marginBottom0 {
     margin-bottom: 0;
+  }
+}
+
+/**
+ * Inline radio button
+ */
+.inline {
+  display: inline-flex;
+
+  & .radioLabel {
+    align-items: center;
+  }
+
+  & + .inline {
+    margin-left: var(--gutter-static-two-thirds);
   }
 }
 
@@ -34,6 +45,7 @@
   border-radius: var(--radius);
   font-size: var(--font-size-medium);
   margin-bottom: 0;
+  min-height: var(--control-min-size-desktop);
 
   &.error {
     color: var(--error);

--- a/lib/RadioButton/RadioButton.css
+++ b/lib/RadioButton/RadioButton.css
@@ -23,6 +23,10 @@
     align-items: center;
   }
 
+  & .labelPseudo {
+    top: 0;
+  }
+
   & + .inline {
     margin-left: var(--gutter-static-two-thirds);
   }

--- a/lib/RadioButton/RadioButton.css
+++ b/lib/RadioButton/RadioButton.css
@@ -7,34 +7,10 @@
 .radioButton {
   display: flex;
   align-items: center;
-  
+
   &.marginBottom0 {
     margin-bottom: 0;
   }
-}
-
-/**
- * Inline radio button
- */
-.inline {
-  display: inline-flex;
-
-  & .radioLabel {
-    align-items: center;
-  }
-
-  & .labelPseudo {
-    top: 0;
-  }
-
-  & + .inline {
-    margin-left: var(--gutter-static-two-thirds);
-  }
-}
-
-[dir="rtl"] .inline + .inline {
-  margin-right: var(--gutter-static-two-thirds);
-  margin-left: 0;
 }
 
 .labelText {
@@ -110,6 +86,30 @@
   & .labelPseudo {
     opacity: 0.5;
   }
+}
+
+/**
+ * Inline radio button
+ */
+.inline {
+  display: inline-flex;
+
+  & .radioLabel {
+    align-items: center;
+  }
+
+  & .labelPseudo {
+    top: 0;
+  }
+
+  & + .inline {
+    margin-left: var(--gutter-static-two-thirds);
+  }
+}
+
+[dir="rtl"] .inline + .inline {
+  margin-right: var(--gutter-static-two-thirds);
+  margin-left: 0;
 }
 
 .input {

--- a/lib/RadioButton/RadioButton.css
+++ b/lib/RadioButton/RadioButton.css
@@ -57,7 +57,7 @@
 }
 
 .labelInteractionStyles {
-  composes: interactionStyles boxOffsetStartMedium boxOffsetEndMedium from "../sharedStyles/interactionStyles.css";
+  composes: interactionStyles boxOffsetStartSmall boxOffsetEndSmall from "../sharedStyles/interactionStyles.css";
 }
 
 .labelFocused {

--- a/lib/RadioButton/RadioButton.css
+++ b/lib/RadioButton/RadioButton.css
@@ -33,6 +33,7 @@
   flex-grow: 2;
   border-radius: var(--radius);
   font-size: var(--font-size-medium);
+  margin-bottom: 0;
 
   &.error {
     color: var(--error);

--- a/lib/RadioButton/RadioButton.css
+++ b/lib/RadioButton/RadioButton.css
@@ -32,11 +32,20 @@
   }
 }
 
+[dir="rtl"] .inline + .inline {
+  margin-right: var(--gutter-static-two-thirds);
+  margin-left: 0;
+}
+
 .labelText {
-  margin: 0 var(--gutter-static-one-third);
+  margin: 0 0 0 var(--gutter-static-one-third);
   display: flex;
   align-items: center;
   min-height: var(--control-min-size-desktop);
+}
+
+[dir="rtl"] .labelText {
+  margin: 0 var(--gutter-static-one-third) 0 0;
 }
 
 .radioLabel {

--- a/lib/RadioButton/stories/BasicUsage.js
+++ b/lib/RadioButton/stories/BasicUsage.js
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import RadioButton from '../RadioButton';
+import Label from '../../Label';
 
 export default class BasicUsage extends React.Component {
   constructor() {
@@ -65,9 +66,16 @@ export default class BasicUsage extends React.Component {
         <br />
         <br />
         <RadioButton label="Inline Radio Button 1" name="inline" value="inline1" inline />
-        <RadioButton label="Inline Radio Button 2" name="inline" value="inline1" inline />
-        <RadioButton label="Inline Radio Button 3" name="inline" value="inline1" inline />
-        <RadioButton label="Inline Radio Button 3" name="inline" value="inline1" inline readOnly />
+        <RadioButton label="Inline Radio Button 2" name="inline" value="inline2" inline />
+        <RadioButton label="Inline Radio Button 3" name="inline" value="inline3" inline />
+        <RadioButton label="Inline Radio Button 3" name="inline" value="inline4" inline readOnly />
+        <br />
+        <br />
+        <br />
+        <Label>
+          Inline RadioButton without a label-prop:
+        </Label>
+        <RadioButton name="inline" value="inline5" inline />
       </div>
     );
   }


### PR DESCRIPTION
In this PR I have made some style improvements for the RadioButton and Checkbox components. The motivation for doing so is related to UIIN-503 because we need to separate the label from a RadioButton while still maintaining a decent layout.

While I was making these updates I decided to do some other improvements as well.

## Updates
- Removed unnecessary margin from the `<label>`-element applied by the `<Label>`-component but not needed in this component and it was causing misalignment.
- Added a min-height of 24px which matches the min-height of form elements. This improves the layout when various form elements are placed inline with checkboxes/radio buttons
- Adjusted the margin of the labelText element of both components so that it only has margin on one side instead of both (adjusted for RTL as well)
- Adjusted the box offset of the interactionStyles for both components since it was a bit too big horizontally
- Added horizontal margin for stacked inline checkboxes/radiobuttons
- Added example for stacked checkboxes
- Added example for a single labelless RadioButton with an external `<Label>` instead

![image](https://user-images.githubusercontent.com/640976/56807921-6db7ed00-6830-11e9-85d3-2099b2fe1b4c.png)

![image](https://user-images.githubusercontent.com/640976/56807929-77415500-6830-11e9-88af-824f6fc5c0c9.png)

