### PR TITLE
Fixed vertical centering of a <Button>'s children

### DIFF
--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -247,6 +247,11 @@
   }
 }
 
+.inner {
+  display: flex;
+  align-items: center;
+}
+
 /**
  * Dropdown Item style
  */

--- a/lib/Button/Button.js
+++ b/lib/Button/Button.js
@@ -125,7 +125,7 @@ function Button(props) {
       type={type}
       {...sharedProps}
     >
-      <span>
+      <span className={css.inner}>
         {children}
       </span>
     </button>


### PR DESCRIPTION
I noticed that the vertical centering was a bit off after I added the inner-element for the Button-component.

To fix this I added `display: flex;` and `align-items: center;` for the inner element to ensure proper vertical centering of the children of a `<Button>`.

## Before
<img width="250" alt="Screenshot 2019-04-26 15 04 41" src="https://user-images.githubusercontent.com/640976/56810062-adcd9e80-6835-11e9-855b-24fea5ae9de7.png">

## After
<img width="240" alt="Screenshot 2019-04-26 15 05 27" src="https://user-images.githubusercontent.com/640976/56810056-aad2ae00-6835-11e9-8318-eb21fd9dc36c.png">
