### PR TITLE
validate props.width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-components
 
+## 5.3.0 (IN PROGRESS)
+
+* Additional props validation in `<MultiColumnList>`. Fixes STCOM-515.
+
 ## [5.2.0](https://github.com/folio-org/stripes-components/tree/v5.2.0) (2019-04-25)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.1.0...v5.2.0)
 

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -828,7 +828,7 @@ class MCLRenderer extends React.Component {
       return null;
     }
 
-    const endOfListWidth = Math.max(width, 200);
+    const endOfListWidth = Math.max(width || 0, 200);
 
     return (
       <div


### PR DESCRIPTION
MCLRenderer did not validate the presence of props.width which would
lead to NaN warnings in the JS console when it was undefined.

Fixes [STCOM-515](https://issues.folio.org/browse/STCOM-515)