### PR TITLE
STCOM-517: Create common WYSIWYG editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change history for stripes-components
 
+* Create common WYSIWYG editor. STSMACOM-190
+
 ## [5.2.0](https://github.com/folio-org/stripes-components/tree/v5.2.0) (2019-04-25)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.1.0...v5.2.0)
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ export { default as Select } from './lib/Select';
 export { default as TextArea } from './lib/TextArea';
 export { default as TextField } from './lib/TextField';
 export { default as Timepicker } from './lib/Timepicker';
+export { default as Editor } from './lib/Editor';
 export { default as MultiSelection } from './lib/MultiSelection';
 export { default as RepeatableField } from './lib/RepeatableField';
 

--- a/lib/Editor/Editor.css
+++ b/lib/Editor/Editor.css
@@ -3,10 +3,10 @@
 .editor {
   position: relative;
   max-width: 100%;
-	display: flex;
-	flex-direction: column;
-	flex-wrap: nowrap;
-	justify-content: flex-start;
-	align-items: stretch;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+  align-items: stretch;
   align-content: stretch;
 }

--- a/lib/Editor/Editor.css
+++ b/lib/Editor/Editor.css
@@ -1,0 +1,12 @@
+@import '../variables.css';
+
+.editor {
+  position: relative;
+  max-width: 100%;
+	display: flex;
+	flex-direction: column;
+	flex-wrap: nowrap;
+	justify-content: flex-start;
+	align-items: stretch;
+  align-content: stretch;
+}

--- a/lib/Editor/Editor.js
+++ b/lib/Editor/Editor.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import className from 'classnames';
 import ReactQuill from 'react-quill';
+import merge from 'lodash/merge';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import '!style-loader!css-loader!react-quill/dist/quill.snow.css';
 
@@ -18,6 +19,7 @@ class Editor extends Component {
     className: PropTypes.string,
     defaultValue: PropTypes.string,
     dirty: PropTypes.bool,
+    disableEditorTab: PropTypes.bool,
     editorClassName: PropTypes.string,
     editorRef: PropTypes.oneOfType([
       PropTypes.func,
@@ -52,6 +54,8 @@ class Editor extends Component {
     validStylesEnabled: false,
     required: false,
     readOnly: false,
+    disableEditorTab: true,
+    modules: {},
   };
 
   getRootStyle() {
@@ -69,6 +73,28 @@ class Editor extends Component {
     );
   }
 
+  handleTab = () => true;
+
+  getModules() {
+    if (this.props.disableEditorTab) {
+      const tabBinding = {
+        keyboard: {
+          bindings: {
+            tab: {
+              key: 9,
+              handler: () => true,
+            }
+          }
+        }
+      };
+      const modulesWithTabBindings = merge({}, this.props.modules, tabBinding);
+
+      return modulesWithTabBindings;
+    }
+
+    return this.props.modules;
+  }
+
   render() {
     const {
       error,
@@ -77,7 +103,6 @@ class Editor extends Component {
       readOnly,
       required,
       warning,
-      modules,
       formats,
       ...restProps
     } = this.props;
@@ -85,7 +110,7 @@ class Editor extends Component {
     const component = (
       <ReactQuill
         className={this.getEditorStyle()}
-        modules={modules}
+        modules={this.getModules()}
         formats={formats}
         ref={editorRef}
         readOnly={readOnly}
@@ -93,6 +118,7 @@ class Editor extends Component {
         {...omitProps(restProps, [
           'validationEnabled',
           'validStylesEnabled',
+          'modules',
         ])}
       />
     );

--- a/lib/Editor/Editor.js
+++ b/lib/Editor/Editor.js
@@ -1,0 +1,134 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import className from 'classnames';
+import ReactQuill from 'react-quill';
+// eslint-disable-next-line import/no-webpack-loader-syntax
+import '!style-loader!css-loader!react-quill/dist/quill.snow.css';
+
+import formField from '../FormField';
+import css from './Editor.css';
+import omitProps from '../../util/omitProps';
+import sharedInputStylesHelper from '../sharedStyles/sharedInputStylesHelper';
+import formStyles from '../sharedStyles/form.css';
+import Label from '../Label';
+
+
+class Editor extends Component {
+  static propTypes = {
+    className: PropTypes.string,
+    defaultValue: PropTypes.string,
+    dirty: PropTypes.bool,
+    editorClassName: PropTypes.string,
+    editorRef: PropTypes.func,
+    error: PropTypes.node,
+    formats: PropTypes.arrayOf(PropTypes.string),
+    id: PropTypes.string,
+    label: PropTypes.node,
+    modules: PropTypes.object,
+    onBlur: PropTypes.func,
+    onChange: PropTypes.func,
+    onFocus: PropTypes.func,
+    onKeyDown: PropTypes.func,
+    onKeyPress: PropTypes.func,
+    onKeyUp: PropTypes.func,
+    placeholder: PropTypes.string,
+    preserveWhitespace: PropTypes.bool,
+    readOnly: PropTypes.bool,
+    required: PropTypes.bool,
+    style: PropTypes.object,
+    tabIndex: PropTypes.number,
+    valid: PropTypes.bool,
+    validationEnabled: PropTypes.bool,
+    validStylesEnabled: PropTypes.bool,
+    value: PropTypes.string,
+    warning: PropTypes.node,
+  };
+
+  static defaultProps = {
+    validationEnabled: true,
+    validStylesEnabled: false,
+    required: false,
+    readOnly: false,
+  };
+
+  getRootStyle() {
+    return className(
+      formStyles.inputGroup,
+      this.props.className,
+    );
+  }
+
+  getEditorStyle() {
+    return className(
+      sharedInputStylesHelper(this.props),
+      css.editor,
+      this.props.editorClassName,
+    );
+  }
+
+  render() {
+    const {
+      error,
+      editorRef,
+      label,
+      readOnly,
+      required,
+      warning,
+      modules,
+      formats,
+      ...restProps
+    } = this.props;
+
+    const component = (
+      <ReactQuill
+        className={this.getEditorStyle()}
+        modules={modules}
+        formats={formats}
+        ref={editorRef}
+        readOnly={readOnly}
+        theme="snow"
+        {...omitProps(restProps, [
+          'validationEnabled',
+          'validStylesEnabled',
+        ])}
+      />
+    );
+
+    const warningElement = warning ?
+      <div className={formStyles.feedbackWarning}>{warning}</div> : null;
+
+    const errorElement = error ?
+      <div className={formStyles.feedbackError}>{error}</div> : null;
+
+    const labelElement = label ?
+      <Label
+        htmlFor={this.props.id}
+        required={required}
+        readOnly={readOnly}
+      >
+        {label}
+      </Label>
+      : null;
+
+    return (
+      <div className={this.getRootStyle()}>
+        {labelElement}
+        {component}
+        <div role="alert">
+          {warningElement}
+          {errorElement}
+        </div>
+      </div>
+    );
+  }
+}
+
+export default formField(
+  Editor,
+  ({ meta }) => ({
+    dirty: meta.dirty,
+    error: (meta.touched && meta.error ? meta.error : ''),
+    valid: meta.valid,
+    warning: (meta.touched && meta.warning ? meta.warning : ''),
+  })
+);

--- a/lib/Editor/Editor.js
+++ b/lib/Editor/Editor.js
@@ -19,7 +19,10 @@ class Editor extends Component {
     defaultValue: PropTypes.string,
     dirty: PropTypes.bool,
     editorClassName: PropTypes.string,
-    editorRef: PropTypes.func,
+    editorRef: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.object
+    ]),
     error: PropTypes.node,
     formats: PropTypes.arrayOf(PropTypes.string),
     id: PropTypes.string,

--- a/lib/Editor/index.js
+++ b/lib/Editor/index.js
@@ -1,0 +1,1 @@
+export { default } from './Editor';

--- a/lib/Editor/readme.md
+++ b/lib/Editor/readme.md
@@ -1,5 +1,7 @@
 # Editor
-WYSIWYG HTML Editor component with label and validation controls.
+
+WYSIWYG HTML Editor component to wrap the react-quill (see https://github.com/zenoamaro/react-quill#the-unprivileged-editor) with label and validation controls.
+
 
 ## Common Usage with a form framework...
 Form state frameworks such as `react-final-form` provide `<Field>` components that manage form state. `<Field>` components often automatically apply particular props such as `onChange` and `value` under the hood, so you don't have to.
@@ -60,7 +62,7 @@ Name | type | description | default | required
 `dirty` | bool | Mark 'true' when value has changes. | |
 `error` | node | Error string to display after textfield in case of validation error. | |
 `valid` | bool | Applies success validation style to `<Editor>` | | 
-`validStylesEnabled` | bool | When set to false, `<Editor>` will not display validation styles. | `true` | 
+`validStylesEnabled` | bool | When set to false, `<Editor>` will not display validation styles. | `false` | 
 `warning` | node | Validation warning. Renders node below `<Editor>` with warning styling. | | 
 
 ## Style Props

--- a/lib/Editor/readme.md
+++ b/lib/Editor/readme.md
@@ -1,0 +1,72 @@
+# Editor
+WYSIWYG HTML Editor component with label and validation controls.
+
+## Common Usage with a form framework...
+Form state frameworks such as `react-final-form` provide `<Field>` components that manage form state. `<Field>` components often automatically apply particular props such as `onChange` and `value` under the hood, so you don't have to.
+```
+import { Editor } from '@folio/stripes/components';
+import { Field } from 'react-final-form';
+...
+<Field component={Editor} />
+```
+
+## Basic vanilla usage (controlled)
+If used without a form state manager, you will have to supply your own state and handlers.
+```
+import { Editor } from '@folio/stripes/components';
+...
+<Editor
+  value={this.state.html}
+  onChange={this.handleChange}
+/>
+```
+
+## Basic Props
+Name | type | description | default | required
+--- | --- | --- | --- | ---
+`id` | string | ID to be applied to the DOM element | | 
+`className` | string | Classes to be applied to the DOM element. | |
+`value` | string | Value for the editor as a controlled component. Can be a string containing HTML, a Quill Delta instance, or a plain object representing a Delta. Note that due to limitations in Quill, this is actually a semi-controlled mode, meaning that the edit is not prevented, but changing value will still replace the contents. Also note that passing a Quill Delta here, and then an HTML string, or vice-versa, will always trigger a change, regardless of whether they represent the same document. ⚠️ Do not pass the delta object from the onChange event as value, as it will cause a loop. See https://github.com/zenoamaro/react-quill#using-deltas  | |
+`defaultValue` | string |  Initial value for the editor as an uncontrolled component. Can be a string containing HTML, a Quill Delta, or a plain object representing a Delta. | |
+`readOnly` | bool | If true, the editor won't allow changing its contents. Wraps the Quill disable API. | false |
+`placeholder` | string | The default value for the empty editor. | | 
+`modules` | object | An object specifying which modules are enabled, and their configuration. The editor toolbar is a commonly customized module. See the http://quilljs.com/docs/modules/ | |
+`formats` | array | An array of formats to be enabled during editing. All implemented formats are enabled by default. See http://quilljs.com/docs/formats/ for a list of availible formats. | |
+
+`inputRef` | object or func | Supplies a ref to the rendered `<Editor>` | | 
+`tabIndex` | number | The order in which the editor becomes focused, among other controls in the page, during keyboard navigation. | |
+`style` | object | An object with custom CSS rules to apply on the editor's container. Rules should be in React's "camelCased" naming style. | | 
+
+
+`required` | bool | Apply `required` attribute to `<input>` | | 
+`startControl` | element |  Element to render as a leading control to the textfield. | | 
+`type` | string | Type attribute of `<input>` | "text" | 
+
+
+## Callback Props
+Name | type | description | default | required
+--- | --- | --- | --- | ---
+`onBlur` | func | Called when the editor loses focus. It will receive the selection range it had right before losing focus. | | 
+`onChange` | func | Called back with the new contents of the editor after change. | | 
+`onChangeSelection` | func |  Called back with the new selected range, or null when unfocused.  | | 
+`onFocus` | func | Called when the editor becomes focused. It will receive the new selection range | |
+`onKeyPress` | func | Called after a key has been pressed and released. | | 
+`onKeyDown` | func | Called after a key has been pressed, but before it is released. | | 
+`onKeyUp` | func | Called after a key has been released. | |  
+
+## Validation Props
+Name | type | description | default | required
+--- | --- | --- | --- | ---
+`dirty` | bool | Mark 'true' when value has changes. | |
+`error` | node | Error string to display after textfield in case of validation error. | |
+`valid` | bool | Applies success validation style to `<Editor>` | | 
+`validStylesEnabled` | bool | When set to false, `<Editor>` will not display validation styles. | `true` | 
+`warning` | node | Validation warning. Renders node below `<Editor>` with warning styling. | | 
+
+## Style Props
+Name | type | description | default | required
+--- | --- | --- | --- | ---
+`className` | string | Apply a custom class name to the root element that wraps the  <Editor>`. | |
+`style` | object | An object with custom CSS rules to apply on the `<Editor>` container. Rules should be in React's "camelCased" naming style. | | 
+`editorClassName` | string | Apply a custom class name to the `<Editor>`. | | 
+

--- a/lib/Editor/readme.md
+++ b/lib/Editor/readme.md
@@ -37,9 +37,7 @@ Name | type | description | default | required
 
 `inputRef` | object or func | Supplies a ref to the rendered `<Editor>` | | 
 `tabIndex` | number | The order in which the editor becomes focused, among other controls in the page, during keyboard navigation. | |
-`style` | object | An object with custom CSS rules to apply on the editor's container. Rules should be in React's "camelCased" naming style. | | 
-
-
+`disableEditorTab` | bool | Disable editor tab handling to improve accessibility. | true |
 `required` | bool | Apply `required` attribute to `<input>` | | 
 `startControl` | element |  Element to render as a leading control to the textfield. | | 
 `type` | string | Type attribute of `<input>` | "text" | 

--- a/lib/Editor/stories/BasicUsage.js
+++ b/lib/Editor/stories/BasicUsage.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import Editor from '../Editor';
+import modules from './EditorModules';
+import formats from './EditorFormats';
+
+
+const BasicUsage = () => (
+  <div>
+    <Editor
+      label="field with custom toolbar"
+      placeholder="Placeholder Text"
+      modules={modules}
+      formats={formats}
+    />
+    <Editor
+      value="This field is read only"
+      label="Read only field"
+      readOnly
+    />
+    <Editor
+      value="This field is required"
+      label="Required field"
+      required
+    />
+    <Editor
+      validStylesEnabled
+      valid
+      dirty
+      label="Field with validation success"
+    />
+    <Editor
+      value="Wrong value.."
+      error="Here is an error message"
+      label="Field with a validation error"
+    />
+    <Editor
+      value="Not entirely valid value.."
+      warning="Here is a warning"
+      dirty
+      label="Field with validation warning"
+    />
+  </div>
+);
+
+export default BasicUsage;

--- a/lib/Editor/stories/Editor.stories.js
+++ b/lib/Editor/stories/Editor.stories.js
@@ -1,5 +1,8 @@
 import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
 import BasicUsage from './BasicUsage';
+import Readme from '../readme.md';
 
 storiesOf('Editor', module)
+  .addDecorator(withReadme(Readme))
   .add('Basic Usage', BasicUsage);

--- a/lib/Editor/stories/Editor.stories.js
+++ b/lib/Editor/stories/Editor.stories.js
@@ -1,0 +1,5 @@
+import { storiesOf } from '@storybook/react';
+import BasicUsage from './BasicUsage';
+
+storiesOf('Editor', module)
+  .add('Basic Usage', BasicUsage);

--- a/lib/Editor/stories/EditorFormats.js
+++ b/lib/Editor/stories/EditorFormats.js
@@ -1,0 +1,7 @@
+const formats = [
+  'header',
+  'bold', 'italic', 'underline', 'strike', 'blockquote',
+  'list', 'bullet', 'indent',
+  'link'
+];
+export default formats;

--- a/lib/Editor/stories/EditorModules.js
+++ b/lib/Editor/stories/EditorModules.js
@@ -1,0 +1,10 @@
+const modules = {
+  toolbar: [
+    [{ 'header': [1, 2, false] }],
+    ['bold', 'italic', 'underline', 'strike', 'blockquote'],
+    [{ 'list': 'ordered' }, { 'list': 'bullet' }, { 'indent': '-1' }, { 'indent': '+1' }],
+    ['link'],
+    ['clean']
+  ]
+};
+export default modules;

--- a/lib/Editor/tests/Editor.js
+++ b/lib/Editor/tests/Editor.js
@@ -6,7 +6,7 @@ import { mount } from '../../../tests/helpers';
 import Editor from '../Editor';
 import EditorInteractor from './interactor';
 
-describe('TextArea', () => {
+describe('Editor', () => {
   const editor = new EditorInteractor();
 
   describe('rendering a basic Editor', async () => {

--- a/lib/Editor/tests/Editor.js
+++ b/lib/Editor/tests/Editor.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { mount } from '../../../tests/helpers';
+import Editor from '../Editor';
+import EditorInteractor from './interactor';
+
+describe('TextArea', () => {
+  const editor = new EditorInteractor();
+
+  describe('rendering a basic Editor', async () => {
+    beforeEach(async () => {
+      await mount(
+        <Editor id="test" />
+      );
+    });
+
+    it('renders an editor element', () => {
+      expect(editor.hasEditor).to.be.true;
+    });
+
+    it('renders no label tag by default', () => {
+      expect(editor.hasLabel).to.be.false;
+    });
+
+    it('applies the id to the editor', () => {
+      expect(editor.id).to.equal('test');
+    });
+  });
+
+  describe('supplying an error', () => {
+    beforeEach(async () => {
+      await mount(
+        <Editor error="This is an error." />
+      );
+    });
+
+    it('renders an error element', () => {
+      expect(editor.errorText).to.equal('This is an error.');
+    });
+
+    it('applies an error style', () => {
+      expect(editor.hasErrorStyle).to.be.true;
+    });
+  });
+
+  describe('supplying a warning', () => {
+    beforeEach(async () => {
+      await mount(
+        <Editor warning="This is a warning." />
+      );
+    });
+
+    it('renders a warning element', () => {
+      expect(editor.warningText).to.equal('This is a warning.');
+    });
+
+    it('applies a warning style', () => {
+      expect(editor.hasWarningStyle).to.be.true;
+    });
+  });
+});

--- a/lib/Editor/tests/interactor.js
+++ b/lib/Editor/tests/interactor.js
@@ -1,0 +1,22 @@
+import {
+  attribute,
+  hasClass,
+  interactor,
+  isPresent,
+  text,
+} from '@bigtest/interactor';
+
+import formCss from '../../sharedStyles/form.css';
+import { selectorFromClassnameString } from '../../../tests/helpers';
+
+export default interactor(class TextAreaInteractor {
+  hasEditor = isPresent('.quill');
+  id = attribute('.quill', 'id');
+  label = text('label');
+  hasLabel = isPresent('label');
+  errorText = text(selectorFromClassnameString(`.${formCss.feedbackError}`));
+  warningText = text(selectorFromClassnameString(`.${formCss.feedbackWarning}`));
+  hasWarningStyle = hasClass('.quill', formCss.hasWarning);
+  hasErrorStyle = hasClass('.quill', formCss.hasError);
+  hasValidStyle = hasClass('.quill', formCss.isValid);
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",
-  "sideEffects": ["*.css"],
+  "sideEffects": [
+    "*.css"
+  ],
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"
   },
@@ -98,6 +100,7 @@
     "react-highlighter": "^0.4.2",
     "react-intl": "^2.5.0",
     "react-overlays": "^0.8.3",
+    "react-quill": "^1.3.3",
     "react-router-dom": "^4.1.1",
     "react-tether": "^1.0.1",
     "react-transition-group": "^2.2.1",


### PR DESCRIPTION
## Purpose

The purpose of this PR is to create the reusable  WYSIWYG editor component. 
Currently it is planned to be used in the notes create/update forms.

This component wraps the react-quill library  (see https://github.com/zenoamaro/react-quill#the-unprivileged-editor) with label and validation controls.

## Approach

The react-quill library was used for the Editor and in the PR wrapped with with label and validation controls.
react-quill was chosen as the base  as is it has good support and stars on gitHub and also iut was used for in the circulation module.
 
#### TODOS and Open Questions
Add the preview functionality to apply it to the circulation module


## Screenshots
![Screen Shot 2019-05-01 at 20 33 54](https://user-images.githubusercontent.com/15856488/57031507-9553ee80-6c50-11e9-9e11-540a236c2009.png)

