### PR TITLE
Removed gray background color for disabled 'dropdownItem' styled butt…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.3.0 (IN PROGRESS)
 
 * Additional props validation in `<MultiColumnList>`. Fixes STCOM-515.
+* Removed gray background color for disabled Buttons with the "dropdownItem"-style. Fixes STCOM-516.
 
 ## [5.2.0](https://github.com/folio-org/stripes-components/tree/v5.2.0) (2019-04-25)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.1.0...v5.2.0)

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -209,17 +209,17 @@
     padding-right: 0;
   }
 
+  &[disabled] {
+    &:hover {
+      cursor: initial;
+    }
+  }
+
   &[disabled]:not(.dropdownItem) {
     background-color: #ccc;
     border-color: #ccc;
     color: var(--color-text-p2);
     transition: opacity ease-in-out 500ms;
-  }
-
-  &[disabled] {
-    &:hover {
-      cursor: initial;
-    }
   }
 
   &.mega {

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -214,10 +214,7 @@
     border-color: #ccc;
     color: var(--color-text-p2);
     transition: opacity ease-in-out 500ms;
-
-    &:hover {
-      cursor: initial;
-    }
+    pointer-events: none;
   }
 
   &.mega {
@@ -250,7 +247,6 @@
 .inner {
   display: flex;
   align-items: center;
-  pointer-events: none;
 }
 
 /**

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -250,6 +250,7 @@
 .inner {
   display: flex;
   align-items: center;
+  pointer-events: none;
 }
 
 /**

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -210,16 +210,14 @@
   }
 
   &[disabled] {
-    &:hover {
-      cursor: initial;
-    }
-  }
-
-  &[disabled]:not(.dropdownItem) {
     background-color: #ccc;
     border-color: #ccc;
     color: var(--color-text-p2);
     transition: opacity ease-in-out 500ms;
+
+    &:hover {
+      cursor: initial;
+    }
   }
 
   &.mega {
@@ -271,6 +269,11 @@
   display: flex;
   align-items: center;
   justify-content: flex-start;
+
+  &[disabled] {
+    background-color: transparent;
+    border: 0;
+  }
 
   &:hover,
   &:focus {

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -209,12 +209,14 @@
     padding-right: 0;
   }
 
-  &[disabled] {
+  &[disabled]:not(.dropdownItem) {
     background-color: #ccc;
     border-color: #ccc;
     color: var(--color-text-p2);
     transition: opacity ease-in-out 500ms;
+  }
 
+  &[disabled] {
     &:hover {
       cursor: initial;
     }

--- a/lib/Button/stories/styles.js
+++ b/lib/Button/stories/styles.js
@@ -34,5 +34,8 @@ export default () => (
     <Button buttonStyle="dropdownItem">
       <Icon icon="duplicate">Duplicate</Icon>
     </Button>
+    <Button buttonStyle="dropdownItem" disabled>
+      <Icon icon="select-all">Select all (disabled)</Icon>
+    </Button>
   </div>
 );

--- a/lib/sharedStyles/interactionStyles.css
+++ b/lib/sharedStyles/interactionStyles.css
@@ -179,9 +179,9 @@
 /**
  * Active
  */
-.isActive:not(:disabled),
-.interactionStylesControl:active:not(:disabled) > .interactionStyles,
-.interactionStyles:active:not(:disabled) {
+.isActive,
+.interactionStylesControl:active > .interactionStyles,
+.interactionStyles:active {
   color: #fff;
   & * { color: #fff; }
   & svg { fill: #fff; }

--- a/lib/sharedStyles/interactionStyles.css
+++ b/lib/sharedStyles/interactionStyles.css
@@ -179,9 +179,9 @@
 /**
  * Active
  */
-.isActive,
-.interactionStylesControl:active > .interactionStyles,
-.interactionStyles:active {
+.isActive:not(:disabled),
+.interactionStylesControl:active:not(:disabled) > .interactionStyles,
+.interactionStyles:active:not(:disabled) {
   color: #fff;
   & * { color: #fff; }
   & svg { fill: #fff; }


### PR DESCRIPTION
**Ticket:** https://issues.folio.org/browse/STCOM-516

- Removed the gray background on disabled Buttons with a buttonStyle of "dropdownItem". 
- Added an example for a disabled "dropdownItem" Button
- Ensured that iterationStyles :active style isn't applied on :disabled buttons

## Before
![image](https://user-images.githubusercontent.com/640976/57089180-1fa95a80-6d04-11e9-95be-c32ea80ea4b2.png)

## After
![image](https://user-images.githubusercontent.com/640976/57089193-259f3b80-6d04-11e9-972d-ffa480e31b49.png)
