### PR TITLE
UIDATIMP-163: Make `EndOfList` component within MCLRenderer to be centered

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -834,11 +834,10 @@ class MCLRenderer extends React.Component {
       <div
         key="end-of-list"
         ref={(ref) => { this.endOfListRef = ref; }}
+        className={css.mclEndOfList}
+        style={{ width: endOfListWidth }}
       >
-        <Layout
-          className={classnames('textCentered', css.mclEndOfList)}
-          style={{ width: endOfListWidth }}
-        >
+        <Layout className="textCentered">
           <Icon icon="end-mark">
             <FormattedMessage id="stripes-components.endOfList" />
           </Icon>


### PR DESCRIPTION
Additional changes were made for the EndOfList component within MCL in order to handle the centering issue within data-import app. It turned out that centering feature was worked just fine only for the `SearchAndSort` component, but not just for the MCL outside of `SearchAndSort`.
![EndOfList](https://user-images.githubusercontent.com/40821852/57101599-3f537980-6d2a-11e9-8637-0fb1a1bf5f81.gif)
