### PR TITLE
Fix bug on blurring <Editor /> component

### DIFF
--- a/lib/Editor/Editor.js
+++ b/lib/Editor/Editor.js
@@ -58,6 +58,26 @@ class Editor extends Component {
     modules: {},
   };
 
+  constructor(props) {
+    super(props);
+
+    if (props.disableEditorTab) {
+      const tabBinding = {
+        keyboard: {
+          bindings: {
+            tab: {
+              key: 9,
+              handler: () => true,
+            }
+          }
+        }
+      };
+      this.modules = merge({}, this.props.modules, tabBinding);
+    } else {
+      this.modules = props.modules;
+    }
+  }
+
   getRootStyle() {
     return className(
       formStyles.inputGroup,
@@ -71,28 +91,6 @@ class Editor extends Component {
       css.editor,
       this.props.editorClassName,
     );
-  }
-
-  handleTab = () => true;
-
-  getModules() {
-    if (this.props.disableEditorTab) {
-      const tabBinding = {
-        keyboard: {
-          bindings: {
-            tab: {
-              key: 9,
-              handler: () => true,
-            }
-          }
-        }
-      };
-      const modulesWithTabBindings = merge({}, this.props.modules, tabBinding);
-
-      return modulesWithTabBindings;
-    }
-
-    return this.props.modules;
   }
 
   render() {
@@ -110,7 +108,7 @@ class Editor extends Component {
     const component = (
       <ReactQuill
         className={this.getEditorStyle()}
-        modules={this.getModules()}
+        modules={this.modules}
         formats={formats}
         ref={editorRef}
         readOnly={readOnly}


### PR DESCRIPTION
## Purpose
This small PR fixes a not responding page after blurring the `<Editor />` component.
## Approach
Now tab bindings are created on component instantiation, not inside of render method