### PR TITLE
accept props.dataTest to provide a test hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Create common WYSIWYG editor. STSMACOM-190
 * Additional props validation in `<MultiColumnList>`. Fixes STCOM-515.
 * Panes/Panesets `defaultWidth` supports css-units outside of percent. Fixes STCOM-521.
+* Panes/Panesets `dataTest` provides a test hook without a wrapper div. Fixes STCOM-527, refs UIORG-166.
 
 ## [5.2.0](https://github.com/folio-org/stripes-components/tree/v5.2.0) (2019-04-25)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.1.0...v5.2.0)

--- a/lib/Pane/Pane.js
+++ b/lib/Pane/Pane.js
@@ -11,6 +11,7 @@ const propTypes = {
   actionMenuAutoFocus: PropTypes.bool,
   appIcon: PropTypes.oneOfType([PropTypes.object, PropTypes.element]),
   children: PropTypes.node,
+  dataTest: PropTypes.string,
   defaultWidth: PropTypes.string.isRequired,
   dismissible: PropTypes.oneOfType(
     [
@@ -185,6 +186,7 @@ class Pane extends React.Component {
         className={css.pane}
         style={this.state.style}
         ref={(ref) => { this.el = ref; }}
+        data-test={this.props.dataTest ? this.props.dataTest : undefined}
         {...rest}
       >
         <PaneHeader

--- a/lib/Pane/Pane.js
+++ b/lib/Pane/Pane.js
@@ -162,6 +162,7 @@ class Pane extends React.Component {
       actionMenuAutoFocus, // eslint-disable-line no-unused-vars
       appIcon,
       children,
+      dataTest,
       defaultWidth, // eslint-disable-line no-unused-vars
       dismissible,
       firstMenu,
@@ -186,7 +187,7 @@ class Pane extends React.Component {
         className={css.pane}
         style={this.state.style}
         ref={(ref) => { this.el = ref; }}
-        data-test={this.props.dataTest ? this.props.dataTest : undefined}
+        data-test={dataTest}
         {...rest}
       >
         <PaneHeader

--- a/lib/Pane/tests/Pane-test.js
+++ b/lib/Pane/tests/Pane-test.js
@@ -42,3 +42,22 @@ describe('Dismissible pane', () => {
     expect(pane.isPresent).to.be.true;
   });
 });
+
+describe('Testable pane', () => {
+  const pane = new PaneInteractor();
+
+  beforeEach(async () => {
+    await mountWithContext(
+      <Paneset>
+        <Pane
+          defaultWidth="fill"
+          dataTest="foo"
+        />
+      </Paneset>
+    );
+  });
+
+  it('contains the "data-test" attribute', () => {
+    expect(pane.dataTest).to.equal('foo');
+  });
+});

--- a/lib/Pane/tests/interactor.js
+++ b/lib/Pane/tests/interactor.js
@@ -7,4 +7,5 @@ import css from '../Pane.css';
 export default interactor(class PaneInteractor {
   static defaultScope = `.${css.pane}`;
   style = attribute('style');
+  dataTest = attribute('data-test');
 });

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -14,6 +14,8 @@ class Paneset extends React.Component {
   static propTypes = {
     // panes and other things that render panes..
     children: PropTypes.node,
+    // optional test hook
+    dataTest: PropTypes.string,
     // if necessary, Paneset can be assigned a percentage width.
     defaultWidth: PropTypes.string,
     // id attribute applied to outer <div>.
@@ -258,7 +260,13 @@ class Paneset extends React.Component {
 
     return (
       <PanesetContext.Provider value={this.state.paneManager}>
-        <div className={this.getClassName()} id={id} style={this.state.style} ref={this.container}>
+        <div
+          className={this.getClassName()}
+          id={id}
+          style={this.state.style}
+          ref={this.container}
+          data-test={this.props.dataTest ? this.props.dataTest : undefined}
+        >
           {children}
         </div>
       </PanesetContext.Provider>

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -255,7 +255,8 @@ class Paneset extends React.Component {
   render() {
     const {
       id,
-      children
+      children,
+      dataTest
     } = this.props;
 
     return (
@@ -265,7 +266,7 @@ class Paneset extends React.Component {
           id={id}
           style={this.state.style}
           ref={this.container}
-          data-test={this.props.dataTest ? this.props.dataTest : undefined}
+          data-test={dataTest}
         >
           {children}
         </div>

--- a/lib/Paneset/tests/Paneset-test.js
+++ b/lib/Paneset/tests/Paneset-test.js
@@ -72,6 +72,18 @@ describe('Paneset', () => {
     });
   });
 
+  describe('Testable Paneset', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <Paneset dataTest="foo" />
+      );
+    });
+
+    it('to have "data-test" attribute', () => {
+      expect(paneset.dataTest).to.equal('foo');
+    });
+  });
+
   describe('pane registration/removal', () => {
     beforeEach(async () => {
       await mountWithContext(

--- a/lib/Paneset/tests/interactor.js
+++ b/lib/Paneset/tests/interactor.js
@@ -1,4 +1,5 @@
 import {
+  attribute,
   interactor,
   collection
 } from '@bigtest/interactor';
@@ -10,4 +11,5 @@ import paneCss from '../../Pane/Pane.css';
 export default interactor(class PaneSetInteractor {
   static defaultScope = `.${css.paneset}`;
   panes = collection(`.${paneCss.pane}`, paneInteractor);
+  dataTest = attribute('data-test');
 });


### PR DESCRIPTION
BigTest likes to find things in the DOM with selectors like
`[data-test-foo]` but there has been no way to provide a `data-test-`
prop to a `<Pane>` or `<Paneset>` until now. This caused folks to wrap
them like `<div data-test-foo>` but the extra wrapper div can cause
layout problems.

Fixes [STCOM-527](https://issues.folio.org/browse/STCOM-527). Refs [UIORG-166](https://issues.folio.org/browse/UIORG-166).