### PR TITLE
spread data- elements onto paneset container

### DIFF
--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import { pickBy, uniqueId } from 'lodash';
 import parseCSSUnit from '../../util/parseCSSUnit';
 import css from './Paneset.css';
 
@@ -47,7 +47,7 @@ class Paneset extends React.Component {
     };
 
     this.container = React.createRef();
-    this.id = _.uniqueId();
+    this.id = uniqueId();
     this.removePane = this.removePane.bind(this);
     this.handleClose = this.handleClose.bind(this);
     this.getContainer = this.getContainer.bind(this);
@@ -253,12 +253,15 @@ class Paneset extends React.Component {
   render() {
     const {
       id,
-      children
+      children,
     } = this.props;
+
+    // pull any data-test-* props into a spreadable object
+    const dataProps = pickBy(this.props, (val, key) => /^data-test/.test(key));
 
     return (
       <PanesetContext.Provider value={this.state.paneManager}>
-        <div className={this.getClassName()} id={id} style={this.state.style} ref={this.container}>
+        <div className={this.getClassName()} id={id} style={this.state.style} ref={this.container} {...dataProps}>
           {children}
         </div>
       </PanesetContext.Provider>

--- a/lib/Paneset/tests/Paneset-test.js
+++ b/lib/Paneset/tests/Paneset-test.js
@@ -35,6 +35,18 @@ describe('Paneset', () => {
     expect(paneset.panes().length).to.equal(4);
   });
 
+  describe.only('Testable Paneset', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <Paneset data-test />
+      );
+    });
+
+    it('has a "data-test" attribute', () => {
+      expect(paneset.testElement.isPresent).to.be.true;
+    });
+  });
+
   describe('Child Paneset', () => {
     beforeEach(async () => {
       await mountWithContext(

--- a/lib/Paneset/tests/interactor.js
+++ b/lib/Paneset/tests/interactor.js
@@ -1,6 +1,7 @@
 import {
   interactor,
-  collection
+  collection,
+  Interactor,
 } from '@bigtest/interactor';
 
 import paneInteractor from '../../Pane/tests/interactor';
@@ -10,4 +11,5 @@ import paneCss from '../../Pane/Pane.css';
 export default interactor(class PaneSetInteractor {
   static defaultScope = `.${css.paneset}`;
   panes = collection(`.${paneCss.pane}`, paneInteractor);
+  testElement = new Interactor('[data-test]');
 });


### PR DESCRIPTION
The paneset container element now spreads `data-*` props.

Refs [STCOM-527](https://issues.folio.org/browse/STCOM-527), [UIORG-166](https://issues.folio.org/browse/UIORG-166)