### PR TITLE
Use width of container for sizing panes

### DIFF
--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -200,7 +200,7 @@ class Paneset extends React.Component {
     let staticSpace = 0;
     const dynamics = [];
     const widths = [];
-    const windowWidth = window.innerWidth;
+    const containerWidth = this.container.current.offsetWidth;
 
     panes.forEach((pane, i) => {
       if (pane.staticWidth) {
@@ -218,7 +218,7 @@ class Paneset extends React.Component {
           switch (unit) {
             case 'percent':
             case 'vw':
-              parsedWidth = currentPaneWidth * 0.01 * windowWidth;
+              parsedWidth = currentPaneWidth * 0.01 * containerWidth;
               break;
             case 'px':
               parsedWidth = currentPaneWidth;
@@ -236,7 +236,7 @@ class Paneset extends React.Component {
         }
       }
     });
-    const staticPercent = ((windowWidth - staticSpace) / windowWidth) * 100;
+    const staticPercent = ((containerWidth - staticSpace) / containerWidth) * 100;
     const basePercentage = staticPercent / Math.max(dynamics.length, 1);
 
     panes.forEach((pane, i) => {


### PR DESCRIPTION
This component was using the width of window for the original fix, but in reality, it isn't always full-screen - it's often nested or used within a modal. This PR uses the size of the paneset's container for adjusting the child panes.