### PR TITLE
UIDATIMP-200: Handle horizontal scroll issue for mac os when scrolls …

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -153,7 +153,7 @@
 
 .mclEndOfList {
   color: var(--color-text-p2);
-  padding: 7px 0;
-  position: absolute;
+  padding: var(--gutter-static-two-thirds) 0;
+  position: relative;
   left: 0;
 }

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -2,7 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import classnames from 'classnames';
-import isEqual from 'lodash/isEqual';
+import {
+  isEqual,
+  isFinite,
+} from 'lodash';
 
 import Icon from '../Icon';
 import EmptyMessage from '../EmptyMessage';
@@ -321,7 +324,8 @@ class MCLRenderer extends React.Component {
 
   setEndOfListOffset = () => {
     if (this.endOfListRef) {
-      this.endOfListRef.style.left = `${this.scrollContainer.scrollLeft}px`;
+      // 5 pixels are needed to allow recalculation of the list row items when details pane is closed
+      this.endOfListRef.style.left = `${Math.max(this.headerRow.scrollLeft - 5, 0)}px`;
     }
   };
 
@@ -836,7 +840,7 @@ class MCLRenderer extends React.Component {
       return null;
     }
 
-    const endOfListWidth = Math.max(width || 0, 200);
+    const endOfListWidth = isFinite(width) ? Math.max(width, 200) : '100%';
 
     return (
       <div


### PR DESCRIPTION
…are always displayed.

<img width="663" alt="Screen Shot 2019-05-20 at 12 46 19" src="https://user-images.githubusercontent.com/40821852/58012524-569daf80-7afd-11e9-8f58-bd28638798c1.png">

It turned out that when the scroll is always shown the `scollContainer` is continued to accumulate its scroll value even when it reached the most right end, so it is not the right element for endOfList element for calculation its position whereas table header row is a proper one as it does not do accumulation.

![chrome-capture](https://user-images.githubusercontent.com/40821852/58013710-e0e71300-7aff-11e9-9e63-0fdd3fa35fec.jpg)