### PR TITLE
Minor PaneHeader appIcon tweak to prevent icon from shrinking

### DIFF
--- a/lib/PaneHeader/PaneHeader.js
+++ b/lib/PaneHeader/PaneHeader.js
@@ -160,6 +160,7 @@ class PaneHeader extends Component {
     return React.cloneElement(appIcon, {
       size: 'small',
       iconAriaHidden: true,
+      tag: 'div',
     });
   };
 


### PR DESCRIPTION
I noticed that the AppIcon in the PaneHeader was shrinking and being cut in half when the title became too big.

Changing the AppIcon tag to a `div` fixes this.

## Before
![image](https://user-images.githubusercontent.com/640976/59196573-57bb7d00-8b8f-11e9-9b65-cc2e77c7952b.png)

## After
![image](https://user-images.githubusercontent.com/640976/59196479-14610e80-8b8f-11e9-8840-5c22e5e3a576.png)
