### PR TITLE
Added 'innerClass' to <Checkbox> propTypes

### DIFF
--- a/lib/Checkbox/Checkbox.js
+++ b/lib/Checkbox/Checkbox.js
@@ -24,6 +24,7 @@ class Checkbox extends React.Component {
     fullWidth: PropTypes.bool,
     id: PropTypes.string,
     inline: PropTypes.bool,
+    innerClass: PropTypes.string,
     inputRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     label: PropTypes.node,
     labelClass: PropTypes.string,


### PR DESCRIPTION
The missing prop-type was causing the 'innerClass'-prop to be spread onto the `<input>`.