### PR TITLE
UIEH-728: use AppIcon from stripes-core in PaneHeader

### DIFF
--- a/lib/PaneHeader/PaneHeader.js
+++ b/lib/PaneHeader/PaneHeader.js
@@ -3,9 +3,9 @@ import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import has from 'lodash/has';
+import { AppIcon } from '@folio/stripes-core';
 
 import PaneHeaderIconButton from '../PaneHeaderIconButton';
-import AppIcon from '../AppIcon';
 import PaneMenu from '../PaneMenu';
 import { Dropdown } from '../Dropdown';
 import DropdownMenu from '../DropdownMenu';


### PR DESCRIPTION
To get rid of the deprecation messages in the console, I've made PaneHeader use an AppIcon from stripes-core, not from stripes-components