### PR TITLE
Minor <RepeatableField> multiple columns documentation udpate

### DIFF
--- a/lib/RepeatableField/readme.md
+++ b/lib/RepeatableField/readme.md
@@ -30,7 +30,7 @@ import { RepeatableField } from '@folio/stripes/components';
   onRemove={this.handleRemove}
   renderField={(field, index) => (
     <Row>
-      <Col xs>
+      <Col xs={6} sm={4}>
         <TextField
           autoFocus
           label="Name"
@@ -40,7 +40,7 @@ import { RepeatableField } from '@folio/stripes/components';
           value={field.name}
         />
       </Col>
-      <Col xs>
+      <Col xs={6} sm={4}>
         <TextField
           label="Age"
           name={`people[${index}].age`}
@@ -49,7 +49,7 @@ import { RepeatableField } from '@folio/stripes/components';
           value={field.age}
         />
       </Col>
-      <Col xs>
+      <Col xs={12} sm={4}>
         <TextField
           label="Occupation"
           name={`people[${index}].occupation`}

--- a/lib/RepeatableField/stories/MultipleColumns.js
+++ b/lib/RepeatableField/stories/MultipleColumns.js
@@ -62,7 +62,7 @@ export default class MultipleCoumnsExample extends Component {
           onRemove={this.handleRemove}
           renderField={(field, index) => (
             <Row>
-              <Col xs>
+              <Col xs={6} sm={4}>
                 <TextField
                   autoFocus
                   label="Name"
@@ -72,7 +72,7 @@ export default class MultipleCoumnsExample extends Component {
                   value={field.name}
                 />
               </Col>
-              <Col xs>
+              <Col xs={6} sm={4}>
                 <TextField
                   label="Age"
                   name={`people[${index}].age`}
@@ -81,7 +81,7 @@ export default class MultipleCoumnsExample extends Component {
                   value={field.age}
                 />
               </Col>
-              <Col xs>
+              <Col xs={12} sm={4}>
                 <TextField
                   label="Occupation"
                   name={`people[${index}].occupation`}


### PR DESCRIPTION
I thought it would be useful to see how a row could be controlled responsively with the LayoutGrid components so I updated the example and the readme.

![Jul-02-2019 17-18-25](https://user-images.githubusercontent.com/640976/60524764-7378f580-9ced-11e9-89b8-f119085b8d0b.gif)
