### PR TITLE
Prevent <Icon> from shrinking

### DIFF
--- a/lib/Icon/Icon.css
+++ b/lib/Icon/Icon.css
@@ -13,6 +13,7 @@
 }
 
 :global .stripes__icon {
+  flex-shrink: 0;
   fill: currentColor;
   height: 1.1429em;
   width: 1.1429em;


### PR DESCRIPTION
Added flex-shrink: 0; for svg inside of <Icon> to prevent it from shrinking.