### PR TITLE
Removed icons regex

### DIFF
--- a/lib/Icon/icons.js
+++ b/lib/Icon/icons.js
@@ -10,7 +10,7 @@ import omitProps from '../../util/omitProps';
  */
 const req = require.context('!!react-svg-loader!./icons/', true, /\.svg$/);
 const icons = req.keys().reduce((images, path) => Object.assign(images, {
-  [path.match(/(?<=.\/)(.*)(?=.svg)/g)]: req(path).default,
+  [path.slice(2, path.length - 4)]: req(path).default,
 }), {});
 
 export default {


### PR DESCRIPTION
Replaced regex that is supposed to get the name of an icon from the path with a simple .slice – 
e.g. ./`my-icon`.svg -> `my-icon`. The regex was not working in Firefox.