### PR TITLE
STCOM-551 correctly set this.contentId

### DIFF
--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -187,13 +187,9 @@ class Accordion extends React.Component {
     return {};
   }
 
+  // generate unique id if no id is provided.
   initializeContentId() {
-    // generate unique id if no id is provided.
-    if (this.props.contentId === undefined) {
-      this.contentId = uniqueId('accordion');
-    } else {
-      this.contentId = this.props.contentId;
-    }
+    return (this.props.contentId === undefined) ? uniqueId('accordion') : this.props.contentId;
   }
 
   tearDownHandlers() {
@@ -268,7 +264,7 @@ class Accordion extends React.Component {
     const headerElement = React.createElement(this.props.header, headerProps);
 
     return (
-      <section id={this.props.id} className={this.getRootClasses()}>
+      <section id={this.props.id} className={this.getRootClasses()} data-test-accordion-section>
         <HotKeys keyMap={this.props.toggleKeyMap} handlers={this.props.toggleKeyHandlers} noWrapper>
           {headerElement}
         </HotKeys>
@@ -280,6 +276,7 @@ class Accordion extends React.Component {
           onTransitionEnd={this.handleTransitionEnd}
           // effectively hides any tab-able elements within a collapsed accordion...
           hidden={!open}
+          data-test-accordion-wrapper
         >
           {this.props.children}
         </div>

--- a/lib/Accordion/tests/Accordion-test.js
+++ b/lib/Accordion/tests/Accordion-test.js
@@ -8,7 +8,7 @@ import Accordion from '../Accordion';
 import AccordionSet from '../AccordionSet';
 import { AccordionInteractor, AccordionSetInteractor } from './interactor';
 
-describe.only('Accordion', () => {
+describe('Accordion', () => {
   const accordion = new AccordionInteractor();
 
   beforeEach(async () => {
@@ -110,7 +110,7 @@ describe.only('Accordion', () => {
     });
   });
 
-  describe.only('with a content id', () => {
+  describe('with a content id', () => {
     beforeEach(async () => {
       await mountWithContext(
         <Accordion label="test" contentId="content-test">

--- a/lib/Accordion/tests/Accordion-test.js
+++ b/lib/Accordion/tests/Accordion-test.js
@@ -8,7 +8,7 @@ import Accordion from '../Accordion';
 import AccordionSet from '../AccordionSet';
 import { AccordionInteractor, AccordionSetInteractor } from './interactor';
 
-describe('Accordion', () => {
+describe.only('Accordion', () => {
   const accordion = new AccordionInteractor();
 
   beforeEach(async () => {
@@ -107,6 +107,34 @@ describe('Accordion', () => {
     it('is open by default', () => {
       expect(accordion.isOpen).to.be.true;
       expect(accordion.contentHeight).to.equal(100);
+    });
+  });
+
+  describe.only('with a content id', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <Accordion label="test" contentId="content-test">
+          <div style={{ height: 100 }} />
+        </Accordion>
+      );
+    });
+
+    it('has an id on the accordion-wrapper element', () => {
+      expect(accordion.id).to.equal('content-test');
+    });
+  });
+
+  describe('without a content id', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <Accordion label="test">
+          <div style={{ height: 100 }} />
+        </Accordion>
+      );
+    });
+
+    it('creates an id on the accordion-wrapper element', () => {
+      expect(accordion.id).to.match(/accordion[0-9]+/);
     });
   });
 

--- a/lib/Accordion/tests/interactor.js
+++ b/lib/Accordion/tests/interactor.js
@@ -24,6 +24,7 @@ export const AccordionInteractor = interactor(class AccordionInteractor {
   isOpen = hasClass(`.${css.content}`, css.expanded)
   contentHeight = property(`.${css.content}`, 'offsetHeight')
   clickHeader = clickable(triggerCollapse)
+  id = attribute('[data-test-accordion-wrapper]', 'id')
   accordions = scoped(triggerCollapse, {
     gotoNext: triggerable('keydown', { keyCode: 40 }), // down arrow
     gotoPrevious: triggerable('keydown', { keyCode: 38 }), // up arrow
@@ -32,7 +33,7 @@ export const AccordionInteractor = interactor(class AccordionInteractor {
     pressTab: triggerable('keydown', { keyCode: 9 }), // tab
     focusTrigger: focusable(),
     isFocused: is(':focus'),
-  })
+  });
 });
 
 export const AccordionSetInteractor = interactor(class AccordionSetInteractor {


### PR DESCRIPTION
`contentId` was inadvertently initialized to null because `initializeContentId()` set
`this.contentId` and returned undefined, but it was called in a manner
that expected a return value instead. Whoops.

Added some test instrumentation as well.

Fixes [STCOM-551](https://issues.folio.org/browse/STCOM-551)