### PR TITLE
Fix proptype for FilterGroup.names

### DIFF
--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -66,10 +66,7 @@ FilterGroup.propTypes = {
   filters: PropTypes.object.isRequired,
   groupName: PropTypes.string.isRequired,
   label: PropTypes.node.isRequired,
-  names: PropTypes.arrayOf(PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.object,
-  ])).isRequired,
+  names: PropTypes.arrayOf(PropTypes.object).isRequired,
   onChangeFilter: PropTypes.func.isRequired,
 };
 

--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -66,7 +66,10 @@ FilterGroup.propTypes = {
   filters: PropTypes.object.isRequired,
   groupName: PropTypes.string.isRequired,
   label: PropTypes.node.isRequired,
-  names: PropTypes.arrayOf(PropTypes.string).isRequired,
+  names: PropTypes.arrayOf(PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+  ])).isRequired,
   onChangeFilter: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
`<FilterGroup>` names prop should be an array of objects not strings. 