### PR TITLE
Datepicker: Fixed issue where touched wasn't set

### DIFF
--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -546,9 +546,11 @@ class Datepicker extends React.Component {
         meta: this.props.meta,
         input : { ...input, value: this.state.dateString },
         onChange: this.handleFieldChange,
-        onBlur: (e) => { e.preventDefault(); }
+        onBlur: (e) => { input.onBlur(); e.preventDefault(); }
       };
     }
+
+    console.log(this.testId, 'touched', textfieldProps.meta.touched);
 
     return <TextField {...textfieldProps} />;
   }

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -550,8 +550,6 @@ class Datepicker extends React.Component {
       };
     }
 
-    console.log(this.testId, 'touched', textfieldProps.meta.touched);
-
     return <TextField {...textfieldProps} />;
   }
 


### PR DESCRIPTION
This fixes an issue where `meta.touched` wasn't being set to `true` after a date was set.