### PR TITLE
UIORGS-71 use `placeholder`, removed console warning

### DIFF
--- a/lib/AutoSuggest/AutoSuggest.js
+++ b/lib/AutoSuggest/AutoSuggest.js
@@ -42,6 +42,7 @@ const propTypes = {
   onChange: PropTypes.func,
   onFocus: PropTypes.func,
   onSelect: PropTypes.func,
+  placeholder: PropTypes.string,
   renderOption: PropTypes.func,
   renderValue: PropTypes.func,
   required: PropTypes.bool,
@@ -81,6 +82,7 @@ class AutoSuggest extends React.Component {
       onChange,
       onFocus,
       onSelect,
+      placeholder,
       renderOption,
       renderValue,
       required,
@@ -103,6 +105,9 @@ class AutoSuggest extends React.Component {
       id: testId,
       error,
     };
+    if (placeholder) {
+      inputProps.placeholder = placeholder;
+    }
 
     return (
       <Downshift

--- a/lib/AutoSuggest/AutoSuggest.js
+++ b/lib/AutoSuggest/AutoSuggest.js
@@ -154,7 +154,7 @@ class AutoSuggest extends React.Component {
                     .map((item, index) => (
                       <li
                         {...getItemProps({
-                          key: item[valueKey],
+                          key: `${index}_${item[valueKey]}`,
                           index,
                           item,
                           style: {


### PR DESCRIPTION
* added an optional `placeholder` prop;
* remove console warning of `React repeatable key`, value can't be `key`, since it migth not be unique