### PR TITLE
STCOM-558 - Fix accordion for ui-data-import module

### DIFF
--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -1,7 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import uniqueId from 'lodash/uniqueId';
 import classNames from 'classnames';
+import {
+  isBoolean,
+  uniqueId,
+} from 'lodash';
+
 import { DefaultAccordionHeader } from './headers';
 import css from './Accordion.css';
 import { HotKeys } from '../HotKeys';
@@ -95,27 +99,30 @@ class Accordion extends React.Component {
 
   componentDidUpdate(prevProps, prevState) {
     // prop/state changes to open status set off the animation callbacks.
-    let shouldAdjust = false;
     // if using state...
-    if ((this.state.isOpen !== prevState.isOpen) || this.props.open !== prevProps.open) {
-      if (this.state.isOpen || this.props.open) {
-        this.transitioningOpen = true;
-        this.syncedHeight = false;
-        this.expandRaf();
-      } else {
-        shouldAdjust = true;
-        this.transitioningClosed = true;
-        this.collapseRaf();
+    if (isBoolean(this.state.isOpen)) {
+      if (this.state.isOpen !== prevState.isOpen) {
+        this.setAnimationCallbacks(this.state.isOpen);
       }
-    }
-
-    if (shouldAdjust) {
-      this.syncMaxHeight();
+    } else if (this.props.open !== prevProps.open) {
+      this.setAnimationCallbacks(this.props.open);
     }
   }
 
   componentWillUnmount() {
     this.tearDownHandlers();
+  }
+
+  setAnimationCallbacks(isOpen) {
+    if (isOpen) {
+      this.transitioningOpen = true;
+      this.syncedHeight = false;
+      this.expandRaf();
+    } else {
+      this.transitioningClosed = true;
+      this.collapseRaf();
+      this.syncMaxHeight();
+    }
   }
 
   syncMaxHeight() {


### PR DESCRIPTION
# Purpose
- fix incorrect displaying in ui-data-import module
- leave coverage for accordion.js file more than 80%

# Link
https://issues.folio.org/browse/STCOM-558

# Screenshots
<img width="1426" alt="Screen Shot 2019-07-31 at 14 54 47" src="https://user-images.githubusercontent.com/43472449/62210058-e4223900-b3a3-11e9-880c-f964ed488c3b.png">
<img width="1101" alt="Screen Shot 2019-07-31 at 15 00 27" src="https://user-images.githubusercontent.com/43472449/62210090-f4d2af00-b3a3-11e9-826b-42c9b82dd09e.png">


