### PR TITLE
STCOM-429: Fixed footer for Save and Cancel buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Correctly set `<Accordion>`'s `id`. Refs STCOM-551. 
 * `<MetaSection>` elegantly handles missing metadata. Refs STCOM-538.
 * `<Datepicker>` cleanup: better i18n, issues with untouched fields.
+* Add an optional `footer` prop for `Pane` component for fixed footer feature. Refs STCOM-429.
 
 ## [5.4.2](https://github.com/folio-org/stripes-components/tree/v5.4.2) (2019-06-12)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.4.1...v5.4.2)

--- a/lib/Pane/Pane.js
+++ b/lib/Pane/Pane.js
@@ -20,6 +20,7 @@ const propTypes = {
   ),
   firstMenu: PropTypes.element,
   fluidContentWidth: PropTypes.bool,
+  footer: PropTypes.element,
   height: PropTypes.string,
   lastMenu: PropTypes.element,
   noOverflow: PropTypes.bool,
@@ -165,6 +166,7 @@ class Pane extends React.Component {
       dismissible,
       firstMenu,
       fluidContentWidth, // eslint-disable-line no-unused-vars
+      footer,
       height, // eslint-disable-line no-unused-vars
       lastMenu,
       noOverflow, // eslint-disable-line no-unused-vars
@@ -204,6 +206,7 @@ class Pane extends React.Component {
         <div key={`${this.id}-content`} className={this.getContentClass()} onFocus={this.setLatestFocused}>
           {children}
         </div>
+        {footer}
       </Element>
     );
   }

--- a/lib/Pane/readme.md
+++ b/lib/Pane/readme.md
@@ -47,6 +47,7 @@ defaultWidth | string percentage or `"fill"` | Tells the pane the percentage of 
 height | string | css-value representation of a custom pane height. The maximum height of a Pane is 100% of the viewport (vh unit) - the height of the universal FOLIO header. A situation where you may need this is if the Pane (or Paneset) is wrapped in an unstyled element without any width/max-width set.  |  |
 dismissible | bool or "last"| If true, pane will render a close (&times;) button in its firstMenu. If "last" is supplied, the button will render in the lastMenu. | false |
 firstMenu | node | Component (typically an instance of `<PaneMenu>`) to render buttons or icons at the beginning of the header. |  |
+footer | node | Render a component at the bottom of the Pane containing a form. |  |
 lastMenu | node | Component (typically an instance of `<PaneMenu>`) to render buttons or icons at the far end of the header. |  |
 onClose | func | Callback fired when the pane is closed using its dismiss button. |  |
 paneTitle | string or node | Text or text-rendering elements to appear in the pane header. |  |

--- a/lib/Pane/stories/Pane.stories.js
+++ b/lib/Pane/stories/Pane.stories.js
@@ -19,10 +19,14 @@ import PaneHeaderIconButtonBasicUsage from '../../PaneHeaderIconButton/stories/B
 
 import PaneMenuReadme from '../../PaneMenu/readme.md';
 
+import WithPaneFooterReadme from '../../PaneFooter/readme.md';
+import WithPaneFooter from '../../PaneFooter/stories/BasicUsage';
+
 storiesOf('Pane', module)
   .add('Basic Usage', withReadme(readme, () => <BasicUsage />))
   .add('PaneHeader', withReadme(PaneHeaderReadme, () => <PaneHeaderBasicUsage />))
   .add('PaneMenu', withReadme(PaneMenuReadme, () => <PaneHeaderBasicUsage />))
   .add('PaneHeaderIconButton', withReadme(PaneHeaderIconButtonReadme, () => <PaneHeaderIconButtonBasicUsage />))
   .add('PaneBackLink', withReadme(PaneBackLinkReadme, () => <PaneBackLinkBasicUsage />))
-  .add('PaneCloseLink', withReadme(PaneCloseLinkReadme, () => <PaneCloseLinkBasicUsage />));
+  .add('PaneCloseLink', withReadme(PaneCloseLinkReadme, () => <PaneCloseLinkBasicUsage />))
+  .add('PaneFooter', withReadme(WithPaneFooterReadme, () => <WithPaneFooter />));

--- a/lib/PaneFooter/PaneFooter.css
+++ b/lib/PaneFooter/PaneFooter.css
@@ -1,0 +1,20 @@
+@import '../variables.css';
+
+.paneFooter {
+  overflow: auto;
+  display: flex;
+  justify-content: center;
+  border-top: 1px solid var(--color-border);
+  box-shadow: var(--shadow);
+  min-height: var(--control-min-size-touch);
+  padding: var(--gutter-static);
+}
+
+.paneFooterButtons {
+  width: 50em;
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  padding-top: var(--gutter-static-one-third);
+  margin-right: var(--gutter-static);
+}

--- a/lib/PaneFooter/PaneFooter.js
+++ b/lib/PaneFooter/PaneFooter.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Button from '../Button/Button';
+
+import css from './PaneFooter.css';
+
+const PaneFooter = ({ children }) => (
+  <div className={css.paneFooter}>
+    <div className={css.paneFooterButtons}>
+      {children}
+    </div>
+  </div>
+);
+
+PaneFooter.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(Button),
+    PropTypes.objectOf(Button),
+  ]),
+};
+
+export default PaneFooter;

--- a/lib/PaneFooter/index.js
+++ b/lib/PaneFooter/index.js
@@ -1,0 +1,1 @@
+export { default } from './PaneFooter';

--- a/lib/PaneFooter/readme.md
+++ b/lib/PaneFooter/readme.md
@@ -1,0 +1,30 @@
+# PaneFooter
+Render pane footer at the bottom of the `<Pane>`-component containing a form.
+
+### Usage
+```js
+import { Pane, PaneFooter, Button } from '@folio/stripes/components';
+
+const footer = (
+  <PaneFooter>
+    <Button onClick={() => {...}}>
+      Cancel
+    </Button>
+    <Button
+      buttonStyle="primary"
+      type="submit"
+    >
+      Save
+    </Button>
+  </PaneFooter>
+);
+
+<Pane footer={footer} ... >
+  Pane Content
+</Pane>
+```
+
+### Props
+Name | type | description | default | required
+--- | --- | --- | --- | ---
+children | | Set of `<Button>`s. |  |

--- a/lib/PaneFooter/stories/BasicUsage.js
+++ b/lib/PaneFooter/stories/BasicUsage.js
@@ -1,0 +1,40 @@
+/**
+ * Pane: With PaneFooter component
+ */
+
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+import Paneset from '../../Paneset';
+import PaneFooter from '../PaneFooter';
+import Pane from '../../Pane';
+import Button from '../../Button';
+
+export default () => {
+  const footer = (
+    <PaneFooter>
+      <Button onClick={action('You clicked cancel')}>
+        Cancel
+      </Button>
+      <Button
+        buttonStyle="primary"
+        onClick={action('You clicked save')}
+      >
+        Save
+      </Button>
+    </PaneFooter>
+  );
+
+  return (
+    <div style={{ margin: '-1rem' }}>
+      <Paneset>
+        <Pane
+          dismissible
+          paneTitle="Pane with a footer"
+          footer={footer}
+        >
+          Pane Content
+        </Pane>
+      </Paneset>
+    </div>
+  );
+};

--- a/lib/PaneFooter/tests/PaneFooter-test.js
+++ b/lib/PaneFooter/tests/PaneFooter-test.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import {
+  describe,
+  beforeEach,
+  it,
+} from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import PaneFooterInteractor from './interactor';
+import { mount } from '../../../tests/helpers';
+
+import Button from '../../Button';
+import PaneFooter from '../PaneFooter';
+
+describe('PaneFooter', () => {
+  const paneFooter = new PaneFooterInteractor();
+  const primaryButtonLabel = 'Primary Button';
+  const primaryButtonId = 'paneFooterPrimaryButton';
+  const primaryButtonStyle = 'primary mega';
+  const secondaryButtonLabel = 'Secondary Button';
+  const secondaryButtonId = 'paneFooterSecondaryButton';
+  const secondaryButtonStyle = 'default mega';
+
+  const renderPaneFooter = ({ primaryButtonDisabled }) => async () => {
+    await mount(
+      <PaneFooter>
+        <Button
+          data-test-pane-footer-primary-button
+          id={primaryButtonId}
+          buttonStyle={primaryButtonStyle}
+          disabled={primaryButtonDisabled}
+        >
+          {primaryButtonLabel}
+        </Button>
+        <Button
+          data-test-pane-footer-secondary-button
+          id={secondaryButtonId}
+          buttonStyle={secondaryButtonStyle}
+        >
+          {secondaryButtonLabel}
+        </Button>
+      </PaneFooter>
+    );
+  };
+
+  beforeEach(
+    renderPaneFooter({ primaryButtonDisabled: true })
+  );
+
+  it('renders a primary button', () => {
+    expect(paneFooter.primaryButton.rendersPrimary).to.be.true;
+  });
+
+  it('primary button is disabled', () => {
+    expect(paneFooter.primaryButtonDisabled).to.be.true;
+  });
+
+  it(`renders a button with id "${primaryButtonId}"`, () => {
+    expect(paneFooter.primaryButton.id).to.equal(primaryButtonId);
+  });
+
+  it(`renders a button with a label of "${primaryButtonLabel}"`, () => {
+    expect(paneFooter.primaryButton.label).to.equal(primaryButtonLabel);
+  });
+
+  it('renders a default button', () => {
+    expect(paneFooter.secondaryButton.rendersDefault).to.be.true;
+  });
+
+  it(`renders a button with id "${secondaryButtonId}"`, () => {
+    expect(paneFooter.secondaryButton.id).to.equal(secondaryButtonId);
+  });
+
+  it(`renders a button with a label of "${secondaryButtonLabel}"`, () => {
+    expect(paneFooter.secondaryButton.label).to.equal(secondaryButtonLabel);
+  });
+
+  describe('renders a primary button', () => {
+    beforeEach(
+      renderPaneFooter({ primaryButtonDisabled: false })
+    );
+
+    it('primary button is not disabled', () => {
+      expect(paneFooter.primaryButtonDisabled).to.be.false;
+    });
+  });
+});

--- a/lib/PaneFooter/tests/interactor.js
+++ b/lib/PaneFooter/tests/interactor.js
@@ -1,0 +1,12 @@
+import {
+  interactor,
+  property,
+} from '@bigtest/interactor';
+
+import ButtonInteractor from '../../Button/tests/interactor';
+
+export default interactor(class PaneFooterInteractor {
+  primaryButton = new ButtonInteractor('[data-test-pane-footer-primary-button]');
+  secondaryButton = new ButtonInteractor('[data-test-pane-footer-secondary-button]');
+  primaryButtonDisabled = property('[data-test-pane-footer-primary-button]', 'disabled');
+});

--- a/translations/stripes-components/en.json
+++ b/translations/stripes-components/en.json
@@ -32,6 +32,7 @@
   "addressSection": "Address Section",
   "cancel": "Cancel",
   "submit": "Submit",
+  "saveAndClose": "Save & close",
   "saveChangesToThisItem": "Save changes to this item",
   "cancelEditingThisItem": "Cancel editing this item",
   "editThisItem": "Edit this item",


### PR DESCRIPTION
### Purpose
Create element with Save and Cancel buttons, fixed to the bottom of a pane containing a form, with styling as shown on [link](https://xd.adobe.com/view/395087a8-d2cf-42cf-643b-e2a5ba6b4728-4f61/?fullscreen) with changes according to [story](https://issues.folio.org/browse/STCOM-429).

![Image_1](https://user-images.githubusercontent.com/49517355/62361057-e1018700-b522-11e9-9adf-735ec814318c.png)

![Image_2](https://user-images.githubusercontent.com/49517355/62361068-e78ffe80-b522-11e9-86f6-00573241b24b.png)

![Storybook](https://user-images.githubusercontent.com/49517355/62553645-63b67900-b878-11e9-8fbe-0756385c4ed8.png)
