### PR TITLE
UX-324 + UX-327: Font-weight updates + minor <Headline> refactor

### DIFF
--- a/lib/Accordion/Accordion.css
+++ b/lib/Accordion/Accordion.css
@@ -61,9 +61,9 @@
 .labelArea {
   display: flex;
   flex-grow: 2;
-  font-weight: var(--text-weight-bold);
+  font-weight: var(--text-weight-black);
   justify-content: flex-start;
-  color: var(--color-text-p2);
+  color: var(--color-text);
 }
 
 /**
@@ -158,7 +158,7 @@
 
   & .labelArea {
     padding-left: 0.25em;
-    color: var(--color-text-p2);
+    color: var(--color-text);
   }
 }
 
@@ -185,8 +185,8 @@
 }
 
 .filterSetlabel {
-  font-weight: var(--text-weight-bold);
-  color: var(--color-text-p2);
+  font-weight: var(--text-weight-black);
+  color: var(--color-text);
   pointer-events: none;
   user-select: none;
 }

--- a/lib/Accordion/Accordion.css
+++ b/lib/Accordion/Accordion.css
@@ -61,7 +61,7 @@
 .labelArea {
   display: flex;
   flex-grow: 2;
-  font-weight: var(--text-weight-black);
+  font-weight: var(--text-weight-bold);
   justify-content: flex-start;
   color: var(--color-text);
 }
@@ -185,7 +185,6 @@
 }
 
 .filterSetlabel {
-  font-weight: var(--text-weight-black);
   color: var(--color-text);
   pointer-events: none;
   user-select: none;

--- a/lib/Accordion/Accordion.css
+++ b/lib/Accordion/Accordion.css
@@ -61,7 +61,7 @@
 .labelArea {
   display: flex;
   flex-grow: 2;
-  font-weight: 600;
+  font-weight: var(--text-weight-bold);
   justify-content: flex-start;
   color: var(--color-text-p2);
 }
@@ -185,7 +185,7 @@
 }
 
 .filterSetlabel {
-  font-weight: 600;
+  font-weight: var(--text-weight-bold);
   color: var(--color-text-p2);
   pointer-events: none;
   user-select: none;

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -86,7 +86,6 @@
   &.primary {
     background-color: var(--primary);
     border: 1px solid var(--primary);
-    font-weight: var(--text-weight-button-primary);
     color: #fff;
 
     &:hover {

--- a/lib/DropdownMenu/DropdownLayout.css
+++ b/lib/DropdownMenu/DropdownLayout.css
@@ -4,7 +4,7 @@
   padding: 0 1rem;
   height: 44px;
   border-bottom: 1px solid #ccc;
-  font-weight: 600;
+  font-weight: var(--text-weight-bold);
   display: flex;
   align-items: center;
 }

--- a/lib/Headline/Headline.css
+++ b/lib/Headline/Headline.css
@@ -18,11 +18,6 @@
     color: var(--color-text-p2);
   }
 
-  /* Bold */
-  &.isBold {
-    font-weight: var(--text-weight-headline);
-  }
-
   /* Flex */
   &.flex {
     display: flex;
@@ -95,4 +90,24 @@
 
 .marginXxLarge {
   margin-bottom: 2.33rem;
+}
+
+/**
+ * Font weight
+ */
+
+.font-weight-regular {
+  font-weight: var(--text-weight-regular);
+}
+
+.font-weight-medium {
+  font-weight: var(--text-weight-medium);
+}
+
+.font-weight-bold {
+  font-weight: var(--text-weight-bold);
+}
+
+.font-weight-black {
+  font-weight: var(--text-weight-black);
 }

--- a/lib/Headline/Headline.css
+++ b/lib/Headline/Headline.css
@@ -7,7 +7,6 @@
 /**
  * Root styling
  */
-
 .headline {
   margin-top: 0;
   font-weight: var(--text-weight-headline);
@@ -35,24 +34,23 @@
  * Follows HTML5 headline specs
  * https://www.w3.org/TR/html5/rendering.html#sections-and-headings
  */
-
-.sizeSmall { /* default browser h5 proportion */
+.size-small { /* default browser h5 proportion */
   font-size: var(--font-size-small);
 }
 
-.sizeMedium { /* default browser h4 proportion */
+.size-medium { /* default browser h4 proportion */
   font-size: var(--font-size-medium);
 }
 
-.sizeLarge { /* default browser h3 proportion */
+.size-large { /* default browser h3 proportion */
   font-size: var(--font-size-large);
 }
 
-.sizeXLarge { /* default browser h2 proportion */
+.size-x-large { /* default browser h2 proportion */
   font-size: var(--font-size-x-large);
 }
 
-.sizeXxLarge { /* default browser h1 proportion */
+.size-xx-large { /* default browser h1 proportion */
   font-size: var(--font-size-xx-large);
 }
 
@@ -60,42 +58,41 @@
  * Margin
  */
 
-.marginNone {
+.margin-none {
   margin-bottom: 0;
 }
 
-.marginXxSmall {
+.margin-xx-small {
   margin-bottom: 0.67rem;
 }
 
-.marginXSmall {
+.margin-x-small {
   margin-bottom: 0.83rem;
 }
 
-.marginSmall {
+.margin-small {
   margin-bottom: 1rem;
 }
 
-.marginMedium {
+.margin-medium {
   margin-bottom: 1.33rem;
 }
 
-.marginLarge {
+.margin-large {
   margin-bottom: 1.67rem;
 }
 
-.marginXLarge {
+.margin-x-large {
   margin-bottom: 2rem;
 }
 
-.marginXxLarge {
+.margin-xx-large {
   margin-bottom: 2.33rem;
 }
 
 /**
  * Font weight
  */
-
 .font-weight-regular {
   font-weight: var(--text-weight-regular);
 }

--- a/lib/Headline/Headline.js
+++ b/lib/Headline/Headline.js
@@ -3,7 +3,6 @@
  */
 
 import React, { forwardRef } from 'react';
-import { camelCase } from 'lodash';
 import { deprecated } from 'prop-types-extra';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
@@ -17,9 +16,9 @@ const Headline = forwardRef((
     // Base styling
     css.headline,
     // Size
-    css[camelCase(`size ${size}`)],
+    css[`size-${size}`],
     // Margin
-    css[camelCase(`margin ${margin || size}`)],
+    css[`margin-${margin || size}`],
     // Faded
     { [css.isFaded]: faded },
     // Fallback for deprecated "bold"-prop

--- a/lib/Headline/Headline.js
+++ b/lib/Headline/Headline.js
@@ -4,12 +4,13 @@
 
 import React, { forwardRef } from 'react';
 import { camelCase } from 'lodash';
+import { deprecated } from 'prop-types-extra';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import css from './Headline.css';
 
 const Headline = forwardRef((
-  { size, margin, tag: Element, faded, bold, flex, block, children, className, ...rest },
+  { bold, size, margin, tag: Element, faded, flex, block, children, className, weight, ...rest },
   ref
 ) => {
   const classes = classNames(
@@ -21,8 +22,11 @@ const Headline = forwardRef((
     css[camelCase(`margin ${margin || size}`)],
     // Faded
     { [css.isFaded]: faded },
-    // Bold
-    { [css.isBold]: bold },
+    // Fallback for deprecated "bold"-prop
+    { [css['font-weight-regular']]: bold === false },
+    { [css['font-weight-bold']]: bold === true },
+    // Define font-weight
+    { [css[`font-weight-${weight}`]]: weight && typeof bold === 'undefined' },
     // Display: flex
     { [css.flex]: flex },
     // Display: block
@@ -44,8 +48,8 @@ const Headline = forwardRef((
 });
 
 Headline.defaultProps = {
-  bold: true,
   faded: false,
+  weight: 'bold',
   margin: '', // If nothing is set it will default to the value of size
   size: 'medium',
   tag: 'div',
@@ -53,7 +57,8 @@ Headline.defaultProps = {
 
 Headline.propTypes = {
   block: PropTypes.bool,
-  bold: PropTypes.bool,
+  bold: deprecated(PropTypes.bool, `Use the "weight"-prop for setting font-weight instead. 
+  Options: regular, medium, bold & black`),
   children: PropTypes.node,
   className: PropTypes.string,
   faded: PropTypes.bool,
@@ -71,6 +76,9 @@ Headline.propTypes = {
   ]),
   size: PropTypes.oneOf(['small', 'medium', 'large', 'x-large', 'xx-large']),
   tag: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'div', 'legend']),
+  weight: PropTypes.oneOf(['regular', 'medium', 'bold', 'black']),
 };
+
+Headline.displayName = 'Headline';
 
 export default Headline;

--- a/lib/Headline/readme.md
+++ b/lib/Headline/readme.md
@@ -18,4 +18,4 @@ size | string | The size of the headline | xx-small, x-small, small, medium, lar
 margin | string | The bottom margin of the component. Automatically matches the size-prop. | xx-small, x-small, small, medium, large, x-large, xx-large, none | medium
 tag | string | The tag of the headline | h1, h2, h3, h4, h5, h6, p, div, legend | div
 faded | boolean | Adds faded style to headline (gray color) | true/false | false
-bold | boolean | Adds bold style to headline | true/false | true
+weight | string | Changes the font-weight of the `<Headline>` | regular, medium, bold, black | bold

--- a/lib/Headline/stories/BasicUsage.js
+++ b/lib/Headline/stories/BasicUsage.js
@@ -30,10 +30,22 @@ const BasicUsage = () => (
     <Headline size="medium" margin="small">
       Here is a nice medium headline with a small margin
     </Headline>
-    <Headline size="small" faded bold={false} tag="h3" aria-label="My headline">
+    <Headline size="small" faded tag="h3" aria-label="My headline">
       With a nice small faded non-bold sub headline
     </Headline>
     <hr />
+    <Headline size="large" weight="regular">
+      Regular font-weight
+    </Headline>
+    <Headline size="large" weight="medium">
+      Medium font-weight
+    </Headline>
+    <Headline size="large" weight="bold">
+      Bold font-weight
+    </Headline>
+    <Headline size="large" weight="black">
+      Black font-weight
+    </Headline>
   </div>
 );
 

--- a/lib/Headline/tests/Headline-test.js
+++ b/lib/Headline/tests/Headline-test.js
@@ -9,7 +9,7 @@ import { mount } from '../../../tests/helpers';
 import Headline from '../Headline';
 import HeadlineInteractor, { sizes } from './interactor';
 
-describe('Headline', () => {
+describe.only('Headline', () => {
   const headline = new HeadlineInteractor();
 
   beforeEach(async () => {
@@ -17,7 +17,6 @@ describe('Headline', () => {
       <Headline
         flex
         block
-        bold
         faded
         tag="h1"
         className="my-custom-class"
@@ -33,10 +32,6 @@ describe('Headline', () => {
 
   it('has a custom class name', () => {
     expect(headline.class).to.include('my-custom-class');
-  });
-
-  it('has bold font weight class', () => {
-    expect(headline.isBold).to.be.true;
   });
 
   it('has faded text color class', () => {
@@ -99,6 +94,50 @@ describe('Headline', () => {
       it(`has a margin of ${size}`, () => {
         expect(headline[`has-margin-${size}`]).to.be.true;
       });
+    });
+  });
+
+  /**
+   * Font weights
+   */
+
+  describe('Setting weight="regular"', () => {
+    beforeEach(async () => {
+      await mount(<Headline weight="regular">My label</Headline>);
+    });
+
+    it('Should have a font weight regular class', () => {
+      expect(headline.hasRegularFontWeight).to.be.true;
+    });
+  });
+
+  describe('Setting weight="medium"', () => {
+    beforeEach(async () => {
+      await mount(<Headline weight="medium">My label</Headline>);
+    });
+
+    it('Should have a font weight medium class', () => {
+      expect(headline.hasMediumFontWeight).to.be.true;
+    });
+  });
+
+  describe('Setting weight="bold"', () => {
+    beforeEach(async () => {
+      await mount(<Headline weight="bold">My label</Headline>);
+    });
+
+    it('Should have a font weight bold class', () => {
+      expect(headline.hasBoldFontWeight).to.be.true;
+    });
+  });
+
+  describe('Setting weight="black"', () => {
+    beforeEach(async () => {
+      await mount(<Headline weight="black">My label</Headline>);
+    });
+
+    it('Should have a font weight black class', () => {
+      expect(headline.hasBlackFontWeight).to.be.true;
     });
   });
 });

--- a/lib/Headline/tests/interactor.js
+++ b/lib/Headline/tests/interactor.js
@@ -19,8 +19,8 @@ export default interactor(class HeadlineInteractor {
 
   constructor() {
     sizes.forEach(size => {
-      this[`has-size-${size}`] = hasClass(css[camelCase(`size ${size}`)]);
-      this[`has-margin-${size}`] = hasClass(css[camelCase(`margin ${size}`)]);
+      this[`has-size-${size}`] = hasClass(css[`size-${size}`]);
+      this[`has-margin-${size}`] = hasClass(css[`margin-${size}`]);
     });
   }
 

--- a/lib/Headline/tests/interactor.js
+++ b/lib/Headline/tests/interactor.js
@@ -29,7 +29,11 @@ export default interactor(class HeadlineInteractor {
   tagName = tagName();
 
   isFaded = hasClass(css.isFaded);
-  isBold = hasClass(css.isBold);
   isFlex = hasClass(css.flex);
   isBlock = hasClass(css.block);
+
+  hasRegularFontWeight = hasClass(css['font-weight-regular']);
+  hasMediumFontWeight = hasClass(css['font-weight-medium']);
+  hasBoldFontWeight = hasClass(css['font-weight-bold']);
+  hasBlackFontWeight = hasClass(css['font-weight-black']);
 });

--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -84,7 +84,7 @@
   flex-shrink: 0;
   flex-grow: 0;
   padding: var(--gutter-static-two-thirds) var(--gutter-static-one-third) var(--gutter-static-one-third) var(--gutter-static-one-third);
-  font-weight: var(--text-weight-black);
+  font-weight: var(--text-weight-bold);
   font-size: var(--font-size-medium);
   color: var(--color-text);
 

--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -84,9 +84,9 @@
   flex-shrink: 0;
   flex-grow: 0;
   padding: var(--gutter-static-two-thirds) var(--gutter-static-one-third) var(--gutter-static-one-third) var(--gutter-static-one-third);
-  font-weight: var(--text-weight-bold);
+  font-weight: var(--text-weight-black);
   font-size: var(--font-size-medium);
-  color: var(--color-text-p2);
+  color: var(--color-text);
 
   &.mclClickable {
     cursor: pointer;

--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -84,7 +84,7 @@
   flex-shrink: 0;
   flex-grow: 0;
   padding: var(--gutter-static-two-thirds) var(--gutter-static-one-third) var(--gutter-static-one-third) var(--gutter-static-one-third);
-  font-weight: 600;
+  font-weight: var(--text-weight-bold);
   font-size: var(--font-size-medium);
   color: var(--color-text-p2);
 

--- a/lib/PaneHeader/PaneHeader.css
+++ b/lib/PaneHeader/PaneHeader.css
@@ -70,7 +70,7 @@
 /* Pane title */
 .paneTitle {
   font-size: var(--font-size-medium);
-  font-weight: 600;
+  font-weight: var(--text-weight-bold);
   align-items: center;
   letter-spacing: 0.04em;
   color: var(--color-text);

--- a/lib/global.css
+++ b/lib/global.css
@@ -85,7 +85,7 @@ a {
 }
 
 strong {
-  font-weight: 600;
+  font-weight: var(--text-weight-bold);
 }
 
 fieldset {

--- a/lib/variables.css
+++ b/lib/variables.css
@@ -53,7 +53,7 @@
    */
   --text-weight-black: 900;
   --text-weight-bold: 700;
-  --text-weight-medium: 500;
+  --text-weight-medium: 600;
   --text-weight-regular: 400;
   --text-weights-are-bolder: 0;
   --text-weight-basis: var(--text-weight-regular);

--- a/lib/variables.css
+++ b/lib/variables.css
@@ -51,7 +51,8 @@
   /**
    * Font-weights
    */
-  --text-weight-bold: 900;
+  --text-weight-black: 900;
+  --text-weight-bold: 700;
   --text-weight-medium: 500;
   --text-weight-regular: 400;
   --text-weights-are-bolder: 0;

--- a/lib/variables.css
+++ b/lib/variables.css
@@ -62,8 +62,7 @@
   --text-weight-headline-addition-factor: 100;
   --text-weight: calc(var(--text-weight-basis) + ( var(--text-weight-addition-factor) * var(--text-weights-are-bolder)));
   --text-weight-headline: var(--text-weight-bold);
-  --text-weight-button: var(--text-weight);
-  --text-weight-button-primary: calc(var(--text-weight-headline-basis) + ( var(--text-weight-headline-addition-factor) * var(--text-weights-are-bolder)));
+  --text-weight-button: var(--text-weight-bold);
 }
 
 /* Lean on min-width queries to create mobile-first CSS. */


### PR DESCRIPTION
## Tickets
https://issues.folio.org/browse/UX-324
https://issues.folio.org/browse/UX-327

## Changes
- Updated the bold font-weight variable to `700`
- Added a new black (`900`) font-weight
- Updated various components that still was using a hardcoded font-weight
- Deprecated "bold"-prop on `<Headline>`
- Added `weight`-prop for `<Headline>` with options: regular, medium, bold & black
- Removed unnecessary camelCase function in `<Headline>` code and updated class names accordingly
- Updated `<Headline>` tests
- Update Accordion, filter set and MCL header labels font-weight and text opaqueness (UX-327)

![image](https://user-images.githubusercontent.com/640976/62425774-62047e00-b6dd-11e9-9c37-4a107a8d5fa9.png)
