### PR TITLE
STCOM-546: increase ModalFooter code coverage

### DIFF
--- a/lib/ModalFooter/tests/ModalFooter-test.js
+++ b/lib/ModalFooter/tests/ModalFooter-test.js
@@ -15,32 +15,67 @@ describe('ModalFooter', () => {
   const secondaryButtonLabel = 'Secondary Button';
   const secondaryButtonId = 'modalFooterSecondaryButton';
 
-  beforeEach(async () => {
-    await mount(
-      <ModalFooter>
-        <Button id={primaryButtonId} buttonStyle="primary">
-          {primaryButtonLabel}
-        </Button>
-        <Button id={secondaryButtonId}>
-          {secondaryButtonLabel}
-        </Button>
-      </ModalFooter>
-    );
+  describe('when buttons are passed as children', () => {
+    beforeEach(async () => {
+      await mount(
+        <ModalFooter>
+          <Button id={primaryButtonId} buttonStyle="primary">
+            {primaryButtonLabel}
+          </Button>
+          <Button id={secondaryButtonId}>
+            {secondaryButtonLabel}
+          </Button>
+        </ModalFooter>
+      );
+    });
+
+    it('renders a primary button', () => {
+      expect(modalFooter.primaryButton.rendersPrimary).to.be.true;
+    });
+
+    it('renders a default button', () => {
+      expect(modalFooter.secondaryButton.rendersDefault).to.be.true;
+    });
+
+    it(`renders a button with a label of "${secondaryButtonLabel}"`, () => {
+      expect(modalFooter.secondaryButton.label).to.equal(secondaryButtonLabel);
+    });
+
+    it(`renders a button with a label of "${primaryButtonLabel}"`, () => {
+      expect(modalFooter.primaryButton.label).to.equal(primaryButtonLabel);
+    });
   });
 
-  it('renders a primary button', () => {
-    expect(modalFooter.primaryButton.rendersPrimary).to.be.true;
-  });
+  describe('when buttons are configured using props', () => {
+    beforeEach(async () => {
+      await mount(
+        <ModalFooter
+          primaryButton={{
+            id: primaryButtonId,
+            label: primaryButtonLabel
+          }}
+          secondaryButton={{
+            id: secondaryButtonId,
+            label: secondaryButtonLabel
+          }}
+        />
+      );
+    });
 
-  it('renders a default button', () => {
-    expect(modalFooter.secondaryButton.rendersDefault).to.be.true;
-  });
+    it('renders a primary button', () => {
+      expect(modalFooter.primaryButton.rendersPrimary).to.be.true;
+    });
 
-  it(`renders a button with a label of "${secondaryButtonLabel}"`, () => {
-    expect(modalFooter.secondaryButton.label).to.equal(secondaryButtonLabel);
-  });
+    it('renders a default button', () => {
+      expect(modalFooter.secondaryButton.rendersDefault).to.be.true;
+    });
 
-  it(`renders a button with a label of "${primaryButtonLabel}"`, () => {
-    expect(modalFooter.primaryButton.label).to.equal(primaryButtonLabel);
+    it(`renders a button with a label of "${secondaryButtonLabel}"`, () => {
+      expect(modalFooter.secondaryButton.label).to.equal(secondaryButtonLabel);
+    });
+
+    it(`renders a button with a label of "${primaryButtonLabel}"`, () => {
+      expect(modalFooter.primaryButton.label).to.equal(primaryButtonLabel);
+    });
   });
 });


### PR DESCRIPTION
`ModalFooter` can receive buttons either via `children` or with `primaryButton` and `secondaryButton` props.  `primaryButton` and `secondaryButton` props are deprecated and not covered by tests. If someone is sure that they are not used anywhere and can be removed, please let me know. For now, I'm adding some more tests covering the case when those deprecated props are used.