### PR TITLE
Fixed 'spinner-ellipsis' icon

### DIFF
--- a/lib/Icon/DotSpinner.css
+++ b/lib/Icon/DotSpinner.css
@@ -1,18 +1,16 @@
 @import "../variables";
 
 .spinner {
-  width: inherit;
-  height: inherit;
   display: flex;
   align-items: center;
+  width: 2.5em;
+  height: 1.25em;
 
   & .bounce1 {
-    -webkit-animation-delay: -0.32s;
     animation-delay: -0.32s;
   }
 
   & .bounce2 {
-    -webkit-animation-delay: -0.16s;
     animation-delay: -0.16s;
   }
 
@@ -21,30 +19,20 @@
     height: 33%;
     margin: 0 8%;
     background-color: var(--color-icon);
-    border-radius: 100%;
+    border-radius: 999px;
     display: inline-block;
-    -webkit-animation: sk-bouncedelay 1.4s infinite ease-in-out both;
     animation: sk-bouncedelay 1.4s infinite ease-in-out both;
   }
-}
-
-@-webkit-keyframes sk-bouncedelay {
-  0%,
-  80%,
-  100% { -webkit-transform: scale(0); }
-  40% { -webkit-transform: scale(1); }
 }
 
 @keyframes sk-bouncedelay {
   0%,
   80%,
   100% {
-    -webkit-transform: scale(0);
     transform: scale(0);
   }
 
   40% {
-    -webkit-transform: scale(1);
     transform: scale(1);
   }
 }

--- a/lib/Icon/Icon.css
+++ b/lib/Icon/Icon.css
@@ -51,15 +51,6 @@
 }
 
 /**
- * Specific styling for spinner
- * (Spinner is likely to be deprecated later on)
- */
-.iconSpinner {
-  width: 1em;
-  height: 0.5em;
-}
-
-/**
  * Label
  */
 

--- a/lib/Icon/Icon.js
+++ b/lib/Icon/Icon.js
@@ -64,8 +64,6 @@ class Icon extends React.Component {
       { [css[`icon-position-${iconPosition}`]]: children && iconPosition },
       // If a status is defined
       { [css[`status-${status}`]]: status },
-      // Icon is spinner (this is going to be deprecated later on)
-      { [css.iconSpinner]: icon === 'spinner-ellipsis' },
       // Icons that contains "left" or "right should flip on dir="rtl"
       { [css.flippable]: typeof icon === 'string' && icon.match(/(right|left)/) },
       // Apply icon style


### PR DESCRIPTION
**Ticket: https://issues.folio.org/browse/STCOM-570**

In this PR I have made some adjustments for the `spinner-ellipsis`-icon because it had some odd flickering. I also increased the size of the icon a little bit.

We should probably extract the spinner icon into its own component later on.

## Before
![ellipsis-before](https://user-images.githubusercontent.com/640976/62868451-fee69d00-bd15-11e9-926d-01d583d36571.gif)

<img width="150" src="https://user-images.githubusercontent.com/640976/62868680-77e5f480-bd16-11e9-817e-09138d3a2067.png" />

## After
![ellipsis-after](https://user-images.githubusercontent.com/640976/62868462-0443e780-bd16-11e9-8d75-a772b9ba1195.gif)
