### PR TITLE
STCOM-554 apply ref correctly to avoid React stacktrace

### DIFF
--- a/lib/MultiSelection/MultiSelectOptionsList.js
+++ b/lib/MultiSelection/MultiSelectOptionsList.js
@@ -134,7 +134,7 @@ class MultiSelectOptionsList extends React.Component {
       internalChangeCallback,
       backspaceDeletes: false,
       getInputProps,
-      ref: inputRef,
+      inputRef,
       placeholder,
     };
 

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -393,14 +393,14 @@ class MultiSelection extends React.Component {
               ...filterResults,
             };
 
-            const handleControlClick = (e) => {
+            const handleControlClick = () => {
               if (disabled) {
                 return;
               }
 
               toggleMenu();
               if (!isOpen && this.input.current) {
-                e.target.focus();
+                this.input.current.focus();
               }
             };
 

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -393,14 +393,14 @@ class MultiSelection extends React.Component {
               ...filterResults,
             };
 
-            const handleControlClick = () => {
+            const handleControlClick = (e) => {
               if (disabled) {
                 return;
               }
 
               toggleMenu();
               if (!isOpen && this.input.current) {
-                this.input.current.focus();
+                e.target.focus();
               }
             };
 


### PR DESCRIPTION
When the pane was narrow, the ref was incorrectly created on the component
rather than the DOM element. `<MultiSelectFilterField>` expects to receive
`props.inputRef`, but `<MultiSelectOptionsList>` was passing `props.ref` 
instead.

Refs [STCOM-554](https://issues.folio.org/browse/STCOM-554)