### PR TITLE
KeyValue: Support data-test props

### DIFF
--- a/lib/KeyValue/KeyValue.js
+++ b/lib/KeyValue/KeyValue.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { pickBy } from 'lodash';
+
 import css from './KeyValue.css';
 
 const propTypes = {
@@ -12,8 +14,11 @@ const propTypes = {
 };
 
 function KeyValue(props) {
+  // pull any data-test-* props into a spreadable object
+  const dataProps = pickBy(props, (_, key) => /^data-test/.test(key));
+
   return (
-    <div className={css.kvRoot}>
+    <div className={css.kvRoot} {...dataProps}>
       <div className={css.kvLabel}>
         {props.label}
       </div>

--- a/lib/KeyValue/tests/KeyValue-test.js
+++ b/lib/KeyValue/tests/KeyValue-test.js
@@ -12,7 +12,7 @@ import KeyValue from '../KeyValue';
 import { mount } from '../../../tests/helpers';
 import KeyValueInteractor from './interactor';
 
-describe.only('KeyValue', () => {
+describe('KeyValue', () => {
   const keyValue = new KeyValueInteractor();
 
   describe('without children', () => {

--- a/lib/KeyValue/tests/KeyValue-test.js
+++ b/lib/KeyValue/tests/KeyValue-test.js
@@ -12,13 +12,14 @@ import KeyValue from '../KeyValue';
 import { mount } from '../../../tests/helpers';
 import KeyValueInteractor from './interactor';
 
-describe('KeyValue', () => {
+describe.only('KeyValue', () => {
   const keyValue = new KeyValueInteractor();
 
   describe('without children', () => {
     beforeEach(async () => {
       await mount(
         <KeyValue
+          data-test-foo="bar"
           label="Label"
           value="Value"
         />
@@ -29,16 +30,20 @@ describe('KeyValue', () => {
       expect(keyValue.label.isPresent).to.be.true;
     });
 
-    it('should diplay correct label', () => {
+    it('should display correct label', () => {
       expect(keyValue.label.text).to.equal('Label');
     });
 
-    it('should dispaly value', () => {
+    it('should display value', () => {
       expect(keyValue.value.isPresent).to.be.true;
     });
 
-    it('should diplay correct value', () => {
+    it('should display correct value', () => {
       expect(keyValue.value.text).to.equal('Value');
+    });
+
+    it('should have correct data-test attribute', () => {
+      expect(keyValue.dataTestFoo).to.equal('bar');
     });
   });
 
@@ -51,7 +56,7 @@ describe('KeyValue', () => {
       );
     });
 
-    it('should diplay correct value', () => {
+    it('should display correct value', () => {
       expect(keyValue.value.text).to.equal('Children');
     });
   });

--- a/lib/KeyValue/tests/interactor.js
+++ b/lib/KeyValue/tests/interactor.js
@@ -1,4 +1,5 @@
 import {
+  attribute,
   interactor,
   scoped,
 } from '@bigtest/interactor';
@@ -14,4 +15,6 @@ export default interactor(class KeyValueInteractor {
 
   label = scoped(`.${css.kvLabel}`);
   value = scoped('[data-test-kv-value]');
+
+  dataTestFoo = attribute('data-test-foo');
 });


### PR DESCRIPTION
It's super helpful to be able to set `data-test-` on KeyValue to avoid having to render unnecessary `<span>`s around the value. I assumed we didn't want to support passing absolutely anything to the children so this PR is tightly scoped.