### PR TITLE
STCOM-571: Make PaneFooter flexible enough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Display `<Button>`s as pills (circular/rounded sides). Refs STCOM-564.
 * Correctly pass `ref`s to `<MultiSelection>` internal components. Refs STCOM-554.
 * Better `<KeyValue>` test infrastructure.
+* Update `<PaneFooter>`: consolidate into a single div with adding CSS classes. Refs STCOM-521.
 
 ## [5.5.0](https://github.com/folio-org/stripes-components/tree/v5.5.0) (2019-07-22)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.4.2...v5.5.0)

--- a/lib/PaneFooter/DefaultPaneFooter.css
+++ b/lib/PaneFooter/DefaultPaneFooter.css
@@ -1,0 +1,10 @@
+.paneFooterContent {
+  width: 50em;
+  display: flex;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.renderStart {
+  flex: 1;
+}

--- a/lib/PaneFooter/DefaultPaneFooter.js
+++ b/lib/PaneFooter/DefaultPaneFooter.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import css from './DefaultPaneFooter.css';
+
+const DefaultPaneFooter = ({ renderStart, renderEnd, className }) => (
+  <div className={classNames(css.paneFooterContent, className)}>
+    <span
+      data-test-pane-footer-start
+      className={css.renderStart}
+    >
+      {renderStart}
+    </span>
+    {renderEnd && <span data-test-pane-footer-end>{renderEnd}</span>}
+  </div>
+);
+
+DefaultPaneFooter.propTypes = {
+  className: PropTypes.string,
+  renderEnd: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]),
+  renderStart: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]),
+};
+
+export default DefaultPaneFooter;

--- a/lib/PaneFooter/PaneFooter.css
+++ b/lib/PaneFooter/PaneFooter.css
@@ -1,20 +1,11 @@
 @import '../variables.css';
 
 .paneFooter {
-  overflow: auto;
   display: flex;
   justify-content: center;
+  align-items: center;
   border-top: 1px solid var(--color-border);
   box-shadow: var(--shadow);
   min-height: var(--control-min-size-touch);
   padding: var(--gutter-static);
-}
-
-.paneFooterButtons {
-  width: 50em;
-  display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  padding-top: var(--gutter-static-one-third);
-  margin-right: var(--gutter-static);
 }

--- a/lib/PaneFooter/PaneFooter.js
+++ b/lib/PaneFooter/PaneFooter.js
@@ -1,23 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
-import Button from '../Button/Button';
+import DefaultPaneFooter from './DefaultPaneFooter';
 
 import css from './PaneFooter.css';
 
-const PaneFooter = ({ children }) => (
-  <div className={css.paneFooter}>
-    <div className={css.paneFooterButtons}>
-      {children}
-    </div>
-  </div>
-);
+const PaneFooter = React.forwardRef(({ element: Element, children, className, innerClassName, ...rest }, ref) => (
+  <Element
+    ref={ref}
+    className={classNames(css.paneFooter, className)}
+  >
+    {children || <DefaultPaneFooter className={innerClassName} {...rest} />}
+  </Element>
+));
 
 PaneFooter.propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(Button),
-    PropTypes.objectOf(Button),
-  ]),
+  children: PropTypes.node,
+  className: PropTypes.string,
+  element: PropTypes.string,
+  innerClassName: PropTypes.string,
 };
+
+PaneFooter.defaultProps = {
+  element: 'div',
+};
+
+PaneFooter.displayName = 'PaneFooter';
 
 export default PaneFooter;

--- a/lib/PaneFooter/readme.md
+++ b/lib/PaneFooter/readme.md
@@ -1,21 +1,45 @@
 # PaneFooter
-Render pane footer at the bottom of the `<Pane>`-component containing a form.
+Renders pane footer at the bottom of the `<Pane>`-component containing a form.
 
-### Usage
+### Basic (Default) Usage
+
+The component itself only sets up the styling of the footer and the contents (`renderStart` and `renderEnd` props) are completely up to the developer.
+```js
+import { Pane, PaneFooter } from '@folio/stripes/components';
+
+const footer = (
+  <PaneFooter
+    renderStart={<Button>Cancel</Button>}
+    renderEnd={<Button>Save</Button>}
+    className={css.paneFooterClass}
+    innerClassName={css.paneFooterContentClass}
+  />
+);
+
+<Pane footer={footer} ... >
+  Pane Content
+</Pane>
+```
+
+### Advanced (Customized) Usage
+
+The component styling and content are completely up to the developer.
 ```js
 import { Pane, PaneFooter, Button } from '@folio/stripes/components';
 
 const footer = (
-  <PaneFooter>
-    <Button onClick={() => {...}}>
-      Cancel
-    </Button>
-    <Button
-      buttonStyle="primary"
-      type="submit"
-    >
-      Save
-    </Button>
+  <PaneFooter footerClass={css.paneFooter}>
+    <div className={css.paneFooterContent}>
+      <Button onClick={() => {...}}>
+        Cancel
+      </Button>
+      <Button
+        buttonStyle="primary"
+        type="submit"
+      >
+        Save
+      </Button>
+    </div>
   </PaneFooter>
 );
 
@@ -27,4 +51,8 @@ const footer = (
 ### Props
 Name | type | description | default | required
 --- | --- | --- | --- | ---
-children | | Set of `<Button>`s. |  |
+children | node |  |  |
+className | string | Adds a className to the `PaneFooter`. Optional. |  |
+innerClassName | string | Adds a className to the `PaneFooter` content. Optional. |  |
+renderEnd | node |  |  |
+renderStart | node |  |  |

--- a/lib/PaneFooter/stories/BasicUsage.js
+++ b/lib/PaneFooter/stories/BasicUsage.js
@@ -10,20 +10,28 @@ import Pane from '../../Pane';
 import Button from '../../Button';
 
 export default () => {
+  const startButton = (
+    <Button onClick={action('You clicked cancel')}>
+
+      Cancel
+    </Button>
+  );
+
+  const endButton = (
+    <Button
+      buttonStyle="primary"
+      onClick={action('You clicked save')}
+    >
+
+    Save
+    </Button>
+  );
+
   const footer = (
-    <PaneFooter>
-      <Button onClick={action('You clicked cancel')}>
-
-        Cancel
-      </Button>
-      <Button
-        buttonStyle="primary"
-        onClick={action('You clicked save')}
-      >
-
-        Save
-      </Button>
-    </PaneFooter>
+    <PaneFooter
+      renderStart={startButton}
+      renderEnd={endButton}
+    />
   );
 
   return (

--- a/lib/PaneFooter/tests/PaneFooter-test.js
+++ b/lib/PaneFooter/tests/PaneFooter-test.js
@@ -21,67 +21,127 @@ describe('PaneFooter', () => {
   const secondaryButtonId = 'paneFooterSecondaryButton';
   const secondaryButtonStyle = 'default mega';
 
-  const renderPaneFooter = ({ primaryButtonDisabled }) => async () => {
-    await mount(
-      <PaneFooter>
-        <Button
-          data-test-pane-footer-primary-button
-          id={primaryButtonId}
-          buttonStyle={primaryButtonStyle}
-          disabled={primaryButtonDisabled}
-        >
-          {primaryButtonLabel}
-        </Button>
-        <Button
-          data-test-pane-footer-secondary-button
-          id={secondaryButtonId}
-          buttonStyle={secondaryButtonStyle}
-        >
-          {secondaryButtonLabel}
-        </Button>
-      </PaneFooter>
-    );
-  };
+  describe('rendering PaneFooter', () => {
+    const renderPaneFooter = ({ primaryButtonDisabled }) => async () => {
+      await mount(
+        <PaneFooter>
+          <Button
+            data-test-pane-footer-primary-button
+            id={primaryButtonId}
+            buttonStyle={primaryButtonStyle}
+            disabled={primaryButtonDisabled}
+          >
+            {primaryButtonLabel}
+          </Button>
+          <Button
+            data-test-pane-footer-secondary-button
+            id={secondaryButtonId}
+            buttonStyle={secondaryButtonStyle}
+          >
+            {secondaryButtonLabel}
+          </Button>
+        </PaneFooter>
+      );
+    };
 
-  beforeEach(
-    renderPaneFooter({ primaryButtonDisabled: true })
-  );
-
-  it('renders a primary button', () => {
-    expect(paneFooter.primaryButton.rendersPrimary).to.be.true;
-  });
-
-  it('primary button is disabled', () => {
-    expect(paneFooter.primaryButtonDisabled).to.be.true;
-  });
-
-  it(`renders a button with id "${primaryButtonId}"`, () => {
-    expect(paneFooter.primaryButton.id).to.equal(primaryButtonId);
-  });
-
-  it(`renders a button with a label of "${primaryButtonLabel}"`, () => {
-    expect(paneFooter.primaryButton.label).to.equal(primaryButtonLabel);
-  });
-
-  it('renders a default button', () => {
-    expect(paneFooter.secondaryButton.rendersDefault).to.be.true;
-  });
-
-  it(`renders a button with id "${secondaryButtonId}"`, () => {
-    expect(paneFooter.secondaryButton.id).to.equal(secondaryButtonId);
-  });
-
-  it(`renders a button with a label of "${secondaryButtonLabel}"`, () => {
-    expect(paneFooter.secondaryButton.label).to.equal(secondaryButtonLabel);
-  });
-
-  describe('renders a primary button', () => {
     beforeEach(
-      renderPaneFooter({ primaryButtonDisabled: false })
+      renderPaneFooter({ primaryButtonDisabled: true })
     );
 
-    it('primary button is not disabled', () => {
-      expect(paneFooter.primaryButtonDisabled).to.be.false;
+    it('should render a primary button', () => {
+      expect(paneFooter.primaryButton.rendersPrimary).to.be.true;
+    });
+
+    it('should disable the primary button', () => {
+      expect(paneFooter.primaryButtonDisabled).to.be.true;
+    });
+
+    it(`should render a button with id "${primaryButtonId}"`, () => {
+      expect(paneFooter.primaryButton.id).to.equal(primaryButtonId);
+    });
+
+    it(`should render a button with a label of "${primaryButtonLabel}"`, () => {
+      expect(paneFooter.primaryButton.label).to.equal(primaryButtonLabel);
+    });
+
+    it('should render a default button', () => {
+      expect(paneFooter.secondaryButton.rendersDefault).to.be.true;
+    });
+
+    it(`should render a button with id "${secondaryButtonId}"`, () => {
+      expect(paneFooter.secondaryButton.id).to.equal(secondaryButtonId);
+    });
+
+    it(`should render a button with a label of "${secondaryButtonLabel}"`, () => {
+      expect(paneFooter.secondaryButton.label).to.equal(secondaryButtonLabel);
+    });
+
+    describe('rendering a primary button', () => {
+      beforeEach(
+        renderPaneFooter({ primaryButtonDisabled: false })
+      );
+
+      it('should not disable the primary button', () => {
+        expect(paneFooter.primaryButtonDisabled).to.be.false;
+      });
+    });
+  });
+
+  describe('rendering DefaultPaneFooter', () => {
+    const renderStart = isDisabled => (
+      <Button
+        data-test-pane-footer-primary-button
+        id={primaryButtonId}
+        buttonStyle={primaryButtonStyle}
+        disabled={isDisabled}
+      >
+        {primaryButtonLabel}
+      </Button>
+    );
+
+    const renderEnd = (
+      <Button
+        data-test-pane-footer-secondary-button
+        id={secondaryButtonId}
+        buttonStyle={secondaryButtonStyle}
+      >
+        {secondaryButtonLabel}
+      </Button>
+    );
+
+    const renderDefaultPaneFooter = ({ primaryButtonDisabled }) => async () => {
+      await mount(
+        <PaneFooter
+          renderStart={renderStart(primaryButtonDisabled)}
+          renderEnd={renderEnd}
+        />
+      );
+    };
+
+    beforeEach(
+      renderDefaultPaneFooter({ primaryButtonDisabled: true })
+    );
+
+    it('should render a primary button', () => {
+      expect(paneFooter.primaryButton.rendersPrimary).to.be.true;
+    });
+
+    it('should disable the primary button', () => {
+      expect(paneFooter.primaryButtonDisabled).to.be.true;
+    });
+
+    it('should render a default button', () => {
+      expect(paneFooter.secondaryButton.rendersDefault).to.be.true;
+    });
+
+    describe('rendering a primary button', () => {
+      beforeEach(
+        renderDefaultPaneFooter({ primaryButtonDisabled: false })
+      );
+
+      it('should not disable the primary button', () => {
+        expect(paneFooter.primaryButtonDisabled).to.be.false;
+      });
     });
   });
 });


### PR DESCRIPTION
### Purpose
Support the ability to add CSS properties to the PaneFooter via the parent component according the [story](https://issues.folio.org/browse/STCOM-571).

**Screenshot**
![View_6](https://user-images.githubusercontent.com/49517355/64125342-4c54a800-cdb2-11e9-9a23-050f69424bc6.png)
