### PR TITLE
Release v5.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for stripes-components
 
+## [5.7.1](https://github.com/folio-org/stripes-components/tree/v5.7.1) (2019-09-11)
+[Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.7.0...v5.7.1)
+
+* Provide more render options within `<PaneFooter>`. Refs STCOM-571.
+
 ## [5.7.0](https://github.com/folio-org/stripes-components/tree/v5.7.0) (2019-09-09)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.6.0...v5.7.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
Patch release to address failing unit tests in ui-users, e.g. 
```
  ItemEditPage
    visiting the edit user page
      clicking on cancel button
        ✖ "before each" hook for "should redirect to view users page after click"
          Chrome 76.0.3809 (Mac OS X 10.14.6)
        Error: unable to find "[data-test-user-form-cancel-button]"
            at $ (test/bigtest/index.js:948:11)
            at CustomInteractor.get (test/bigtest/index.js:1579:18)
            at CustomInteractor.$$$1 (test/bigtest/index.js:1594:31)
            at CustomInteractor.<anonymous> (test/bigtest/index.js:992:22)
            at CustomInteractor.<anonymous> (test/bigtest/index.js:1208:18)
            at loop (test/bigtest/index.js:663:23)

    validating user barcode
      ✖ "before each" hook for "should display validation error"
        Chrome 76.0.3809 (Mac OS X 10.14.6)
      Error: unable to find "[data-test-user-form-submit-button]"
          at $ (test/bigtest/index.js:948:11)
          at CustomInteractor.get (test/bigtest/index.js:1579:18)
          at CustomInteractor.$$$1 (test/bigtest/index.js:1594:31)
          at CustomInteractor.<anonymous> (test/bigtest/index.js:992:22)
          at CustomInteractor.<anonymous> (test/bigtest/index.js:1208:18)
          at loop (test/bigtest/index.js:663:23)
```