### PR TITLE
UIOR-387 wrap long text value

### DIFF
--- a/lib/KeyValue/KeyValue.css
+++ b/lib/KeyValue/KeyValue.css
@@ -13,3 +13,7 @@
   margin-bottom: var(--control-margin-bottom);
   font-size: var(--font-size-medium);
 }
+
+.kvValue {
+  overflow-wrap: break-word;
+}

--- a/lib/KeyValue/KeyValue.js
+++ b/lib/KeyValue/KeyValue.js
@@ -22,7 +22,10 @@ function KeyValue(props) {
       <div className={css.kvLabel}>
         {props.label}
       </div>
-      <div data-test-kv-value>
+      <div
+        className={css.kvValue}
+        data-test-kv-value
+      >
         {props.children || props.value}
       </div>
     </div>


### PR DESCRIPTION
*Purpose*:
Fix for https://issues.folio.org/browse/UIOR-387
I think it's a good idea to wrap any long text value
![fixed](https://user-images.githubusercontent.com/43577432/65316412-96a39a80-dba2-11e9-8f66-8a79d1185d8a.png)
