### PR TITLE
STCOM-589 row height issue.

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -46,7 +46,7 @@ import RowPositioner from './RowPositioner';
 */
 function comparison(obj, oth) {
   if (obj === oth) return true;
-  if (obj === undefined || oth === undefined) return true;
+  if (obj === undefined || oth === undefined) return false;
   const objType = typeof obj;
   const othType = typeof oth;
   if (objType !== othType) return false;

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -46,7 +46,7 @@ import RowPositioner from './RowPositioner';
 */
 function comparison(obj, oth) {
   if (obj === oth) return true;
-  if (obj === undefined || oth === undefined) return false;
+  if (obj === undefined || oth === undefined) return true;
   const objType = typeof obj;
   const othType = typeof oth;
   if (objType !== othType) return false;
@@ -67,18 +67,18 @@ function comparison(obj, oth) {
 
 export function dataChangedOrLess(previous, current) {
   // Filtering... smaller data always a change
-  if (previous.length > current.length) return true;
+  if (current.length < previous.length) return true;
 
   /* greater data length could be paging... so check to see the data is the same,
   * keeping in mind those array order changes that can happen using the comparison function.
   */
   for (let i = 0; i < previous.length - 1; i += 4) {
-    const notEqual = !isEqualWith(previous[i], current[i], comparison);
+    const notEqual = !isEqualWith(previous[i] || {}, current[i], comparison);
     if (notEqual) return true;
   }
   // finally, compare the last item...
-  const currentLast = current.length - 1;
-  if (!isEqualWith(current[currentLast], previous[currentLast], comparison)) return true;
+  const prevLast = previous.length - 1;
+  if (!isEqualWith(current[prevLast], previous[prevLast], comparison)) return true;
   return false;
 }
 

--- a/lib/MultiColumnList/tests/MultiColumnList-test.js
+++ b/lib/MultiColumnList/tests/MultiColumnList-test.js
@@ -23,7 +23,7 @@ const data100 = generate(100);
 
 let headerClicked = false;
 
-describe.only('MultiColumnList', () => {
+describe('MultiColumnList', () => {
   const mcl = new MultiColumnListInteractor();
   const clicker = new Interactor();
 

--- a/lib/MultiColumnList/tests/MultiColumnList-test.js
+++ b/lib/MultiColumnList/tests/MultiColumnList-test.js
@@ -23,7 +23,7 @@ const data100 = generate(100);
 
 let headerClicked = false;
 
-describe('MultiColumnList', () => {
+describe.only('MultiColumnList', () => {
   const mcl = new MultiColumnListInteractor();
   const clicker = new Interactor();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "5.7.1",
+  "version": "5.7.2",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
## Problem
Overlapping Rows in MCL if results filtered increases the count.

## Approach
Equality of `contentData` was erroneously passing the equality check, so the check is set up to fail if either item is `undefined`

## Before:
![image](https://user-images.githubusercontent.com/20704067/65459810-43398280-de16-11e9-8a3c-656a412db50f.png)

## After:
![image](https://user-images.githubusercontent.com/20704067/65443876-84b93600-ddf4-11e9-8492-cf1ed69daf2a.png)
