### PR TITLE
Bugfix: non-interactive MCL's rendering with <buttons> for rows

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -174,7 +174,7 @@
   overflow: hidden;
   border-right: 1px solid rgba(0, 0, 0, 0.1);
   text-align: left;
-  
+
   &:last-child {
     border-right: 0;
   }

--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -173,7 +173,8 @@
   min-height: var(--control-min-size-desktop);
   overflow: hidden;
   border-right: 1px solid rgba(0, 0, 0, 0.1);
-
+  text-align: left;
+  
   &:last-child {
     border-right: 0;
   }

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -675,6 +675,7 @@ class MCLRenderer extends React.Component {
       interactive,
       rowFormatter,
       virtualize,
+      onRowClick,
     } = this.props;
 
     const {
@@ -697,9 +698,10 @@ class MCLRenderer extends React.Component {
     */
     const defaultStyle = { minWidth: `${Math.max((widthVar - rowMargin), rowWidthVar)}px` };
 
+    const onClick = onRowClick ? (e) => { this.handleRowClick(e, this.getRowData(rowIndex)); } : undefined;
     const defaultRowProps = {
       // eslint-disable-next-line
-      'onClick': (e) => { this.handleRowClick(e, this.getRowData(rowIndex)); },
+      onClick,
       'style': defaultStyle,
       'aria-rowindex': rowIndex + 2,
       'role': 'row',


### PR DESCRIPTION
Approach: Only pass defined onClick to rowFormatteron if onRowClick prop is provided.