### PR TITLE
STSMACOM-255: Add global class to reset all margins for editor markup in preview mode

### DIFF
--- a/lib/Editor/Editor.js
+++ b/lib/Editor/Editor.js
@@ -14,6 +14,11 @@ import formStyles from '../sharedStyles/form.css';
 import parseMeta from '../FormField/parseMeta';
 import Label from '../Label';
 
+const defaultModulesConfig = {
+  clipboard: {
+    matchVisual: false,
+  },
+};
 
 class Editor extends Component {
   static propTypes = {
@@ -62,6 +67,8 @@ class Editor extends Component {
   constructor(props) {
     super(props);
 
+    this.modules = merge({}, defaultModulesConfig, props.modules);
+
     if (props.disableEditorTab) {
       const tabBinding = {
         keyboard: {
@@ -70,12 +77,10 @@ class Editor extends Component {
               key: 9,
               handler: () => true,
             }
-          }
-        }
+          },
+        },
       };
-      this.modules = merge({}, this.props.modules, tabBinding);
-    } else {
-      this.modules = props.modules;
+      this.modules = merge({}, this.modules, tabBinding);
     }
   }
 

--- a/lib/global.css
+++ b/lib/global.css
@@ -159,6 +159,10 @@ button {
   z-index: 9999;
 }
 
+:global(.editor-preview *) {
+  margin: 0;
+}
+
 :global(body[dir="rtl"] .floatEnd),
 :global(html[dir="rtl"] .floatEnd) {
   float: left !important;


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-605

## Purpose
Avoid creation of an empty lines before ordered list in Editor and remove margins between lines appeared after text was created with a help of Editor.

## Approach
- Add default prop `matchVisual` to Editor component config
- Add global style class `editor-preview` which reset margins of internal elements

## TODO
- Apply style class on Note view page for details section in stripes-smart-components https://github.com/folio-org/stripes-smart-components/pull/632
- Apply style class on ui-circulation Settings for staff slips description section

## Screenshots
Before
![2019-10-07 12 07 01](https://user-images.githubusercontent.com/43621626/66298942-3da26900-e8fb-11e9-862e-75945c929e8f.gif)
After
![2019-10-07 12 10 35](https://user-images.githubusercontent.com/43621626/66299105-8a863f80-e8fb-11e9-8aa2-a57475445307.gif)

