### PR TITLE
remove warnings

### DIFF
--- a/lib/MultiSelection/SelectOption.js
+++ b/lib/MultiSelection/SelectOption.js
@@ -33,7 +33,7 @@ const SelectOption = (props) => {
 };
 
 SelectOption.propTypes = {
-  children: PropTypes.object,
+  children: PropTypes.node,
   id: PropTypes.string,
   isActive: PropTypes.bool,
   isSelected: PropTypes.bool,

--- a/lib/MultiSelection/ValueChip.js
+++ b/lib/MultiSelection/ValueChip.js
@@ -28,7 +28,7 @@ const ValueChip = ({ children, id, removeButtonProps, controlLabelId, descriptio
 };
 
 ValueChip.propTypes = {
-  children: PropTypes.object,
+  children: PropTypes.node,
   controlLabelId: PropTypes.string,
   descriptionId: PropTypes.string,
   id: PropTypes.string,


### PR DESCRIPTION
to clean-up console, because it could be a string and unnecessary warning. I think `node` is more appropriate prop type