### PR TITLE
Add instanceOf(Element) to HasCommand prop types

### DIFF
--- a/lib/Commander/HasCommand.js
+++ b/lib/Commander/HasCommand.js
@@ -16,7 +16,7 @@ class HasCommand extends React.Component {
     ]).isRequired,
     commands: PropTypes.arrayOf(PropTypes.object),
     isWithinScope: PropTypes.func,
-    scope: PropTypes.node,
+    scope: PropTypes.oneOfType([PropTypes.node, PropTypes.instanceOf(Element)])
   }
 
   constructor(props) {


### PR DESCRIPTION
# Purpose
`<HasCommand>` currently reports console errors that it was passed an invalid `scope` prop - this is typically a DOM element, but `PropTypes.node` is inadequate for this since certain elements like `document.body` are not React nodes.

## Approach
Expand the range of the propType to include DOM elements via `PropTypes.instanceOf(element)`