### PR TITLE
Add ability to pass container height as a string. Refs UIREQ-112

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -125,7 +125,7 @@ class MCLRenderer extends React.Component {
     formatter: PropTypes.object,
     headerMetadata: PropTypes.object,
     headerRowClass: PropTypes.string,
-    height: PropTypes.number,
+    height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     hotKeys: PropTypes.object,
     id: PropTypes.string,
     instanceRef: PropTypes.func,


### PR DESCRIPTION
@JohnC-80 while working on [UIREQ-112](https://issues.folio.org/browse/UIREQ-112) (reorder via drag/drop) I ran into a situation where I need to set the height of the `MCLRenderer` container to match the droppable wrapper's height. 

This PR allows us to pass a string as a height so we can pass other types of values:

https://developer.mozilla.org/en-US/docs/Web/CSS/height

It looks like the `height` inside the `MCLRenderer` already uses `string` in couple places:

https://github.com/folio-org/stripes-components/blob/master/lib/MultiColumnList/MCLRenderer.js#L1196

https://github.com/folio-org/stripes-components/blob/master/lib/MultiColumnList/MCLRenderer.js#L1204

so this just cleans it up a bit to avoid a warning from React.