### PR TITLE
STCOM-611 receive correct prop-type for scope

### DIFF
--- a/lib/Commander/HasCommand.js
+++ b/lib/Commander/HasCommand.js
@@ -16,7 +16,7 @@ class HasCommand extends React.Component {
     ]).isRequired,
     commands: PropTypes.arrayOf(PropTypes.object),
     isWithinScope: PropTypes.func,
-    scope: PropTypes.node,
+    scope: PropTypes.object,
   }
 
   constructor(props) {


### PR DESCRIPTION
`PropTypes.object` is correct for receiving `document.body`.
Interestingly, `PropTypes.node` does not include `object`.

Refs [STCOM-611](https://issues.folio.org/browse/STCOM-611)