### PR TITLE
STCOM-612 add missing prop-type

### DIFF
--- a/lib/MenuItem/MenuItem.js
+++ b/lib/MenuItem/MenuItem.js
@@ -9,7 +9,7 @@ const propTypes = {
     PropTypes.node,
   ]),
   itemMeta: PropTypes.any, // eslint-disable-line react/forbid-prop-types
-  onSelectItem: PropTypes.func,
+  onSelectItem: PropTypes.func.isRequired,
 };
 
 const MenuItem = (props) => {


### PR DESCRIPTION
`MenuItem.onSelectItem` is required but was not labeled as such.

Refs [STCOM-612](https://issues.folio.org/browse/STCOM-612)