### PR TITLE
STCOM-613 add placeholder and translate it

### DIFF
--- a/lib/SearchField/SearchField.js
+++ b/lib/SearchField/SearchField.js
@@ -91,7 +91,7 @@ const SearchField = (props) => {
   let inputPlaceholder = placeholder;
   if (!placeholder && hasSearchableIndexes && selectedIndex) {
     const selectedIndexConfig = searchableIndexes.find(index => index.value === selectedIndex) || {};
-    inputPlaceholder = selectedIndexConfig.placeholder;
+    inputPlaceholder = selectedIndexConfig.placeholder || '';
   }
 
   return (

--- a/lib/SearchField/SearchField.js
+++ b/lib/SearchField/SearchField.js
@@ -7,6 +7,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { injectIntl, intlShape } from 'react-intl';
+
 import TextField from '../TextField';
 import Select from '../Select';
 import TextFieldIcon from '../TextField/TextFieldIcon';
@@ -20,6 +22,7 @@ const propTypes = {
   id: PropTypes.string,
   inputClass: PropTypes.string,
   inputRef: PropTypes.object,
+  intl: intlShape,
   loading: PropTypes.bool,
   onChange: PropTypes.func,
   onChangeIndex: PropTypes.func,
@@ -49,6 +52,7 @@ const SearchField = (props) => {
     selectedIndex,
     searchableIndexesPlaceholder,
     inputClass,
+    intl: { formatMessage },
     ...rest
   } = props;
 
@@ -83,7 +87,15 @@ const SearchField = (props) => {
   const searchIcon = (<TextFieldIcon iconClassName={css.searchIcon} icon="search" />);
 
   // Placeholder
-  const inputPlaceholder = (hasSearchableIndexes && selectedIndex) ? `Search for ${selectedIndex}` : placeholder;
+  let inputPlaceholder = placeholder;
+  if (hasSearchableIndexes && selectedIndex) {
+    const selectedIndexConfig = searchableIndexes.find(index => index.value === selectedIndex) || {};
+    const placeholderTranslationId = selectedIndexConfig.placeholderId || 'stripes-components.searchField.placeholder';
+    inputPlaceholder = formatMessage(
+      { id: placeholderTranslationId },
+      { label: selectedIndexConfig.label },
+    );
+  }
 
   return (
     <div className={rootStyles}>
@@ -110,4 +122,4 @@ const SearchField = (props) => {
 
 SearchField.propTypes = propTypes;
 
-export default SearchField;
+export default injectIntl(SearchField);

--- a/lib/SearchField/SearchField.js
+++ b/lib/SearchField/SearchField.js
@@ -7,7 +7,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { injectIntl, intlShape } from 'react-intl';
 
 import TextField from '../TextField';
 import Select from '../Select';
@@ -22,15 +21,18 @@ const propTypes = {
   id: PropTypes.string,
   inputClass: PropTypes.string,
   inputRef: PropTypes.object,
-  intl: intlShape,
   loading: PropTypes.bool,
   onChange: PropTypes.func,
   onChangeIndex: PropTypes.func,
   onClear: PropTypes.func,
   placeholder: PropTypes.string,
-  searchableIndexes: PropTypes.arrayOf(
-    PropTypes.object,
-  ),
+  searchableIndexes: PropTypes.arrayOf(PropTypes.shape({
+    disabled: PropTypes.bool,
+    id: PropTypes.string,
+    label: PropTypes.string,
+    placeholder: PropTypes.string,
+    value: PropTypes.string,
+  })),
   searchableIndexesPlaceholder: PropTypes.string,
   selectedIndex: PropTypes.string,
   value: PropTypes.string,
@@ -52,7 +54,6 @@ const SearchField = (props) => {
     selectedIndex,
     searchableIndexesPlaceholder,
     inputClass,
-    intl: { formatMessage },
     ...rest
   } = props;
 
@@ -88,13 +89,9 @@ const SearchField = (props) => {
 
   // Placeholder
   let inputPlaceholder = placeholder;
-  if (hasSearchableIndexes && selectedIndex) {
+  if (!placeholder && hasSearchableIndexes && selectedIndex) {
     const selectedIndexConfig = searchableIndexes.find(index => index.value === selectedIndex) || {};
-    const placeholderTranslationId = selectedIndexConfig.placeholderId || 'stripes-components.searchField.placeholder';
-    inputPlaceholder = formatMessage(
-      { id: placeholderTranslationId },
-      { label: selectedIndexConfig.label },
-    );
+    inputPlaceholder = selectedIndexConfig.placeholder;
   }
 
   return (
@@ -122,4 +119,4 @@ const SearchField = (props) => {
 
 SearchField.propTypes = propTypes;
 
-export default injectIntl(SearchField);
+export default SearchField;

--- a/lib/SearchField/readme.md
+++ b/lib/SearchField/readme.md
@@ -23,7 +23,7 @@ The component supports adding an array of searchable indexes which adds a select
 
   const searchableIndexes = [
     { label: 'ID', value: 'id' },
-    { label: 'Title', value: 'title', placeholderId: 'ui-orders.field.title.placeholder' },
+    { label: 'Title', value: 'title', placeholder: 'Search by Title' },
     { label: 'Identifier', value: 'identifier', localOnly: true },
   ];
 

--- a/lib/SearchField/readme.md
+++ b/lib/SearchField/readme.md
@@ -23,7 +23,7 @@ The component supports adding an array of searchable indexes which adds a select
 
   const searchableIndexes = [
     { label: 'ID', value: 'id' },
-    { label: 'Title', value: 'title' },
+    { label: 'Title', value: 'title', placeholderId: 'ui-orders.field.title.placeholder' },
     { label: 'Identifier', value: 'identifier', localOnly: true },
   ];
 

--- a/lib/SearchField/stories/BasicUsage.js
+++ b/lib/SearchField/stories/BasicUsage.js
@@ -55,7 +55,7 @@ export default class SearchFieldUsage extends Component {
     const { hasSearchableIndexes } = this.state;
     const searchableIndexes = [
       { label: 'ID', value: 'id' },
-      { label: 'Title', value: 'title' },
+      { label: 'Title', value: 'title', placeholderId: 'stripes-components.city' },
       { label: 'Identifier', value: 'identifier', localOnly: true },
       { label: 'ISBN', value: 'identifier/type=isbn' },
       { label: 'ISSN', value: 'identifier/type=issn' },

--- a/lib/SearchField/stories/BasicUsage.js
+++ b/lib/SearchField/stories/BasicUsage.js
@@ -55,7 +55,7 @@ export default class SearchFieldUsage extends Component {
     const { hasSearchableIndexes } = this.state;
     const searchableIndexes = [
       { label: 'ID', value: 'id' },
-      { label: 'Title', value: 'title', placeholderId: 'stripes-components.city' },
+      { label: 'Title', value: 'title', placeholder: 'Please input title...' },
       { label: 'Identifier', value: 'identifier', localOnly: true },
       { label: 'ISBN', value: 'identifier/type=isbn' },
       { label: 'ISSN', value: 'identifier/type=issn' },

--- a/lib/SearchField/tests/SearchField-test.js
+++ b/lib/SearchField/tests/SearchField-test.js
@@ -8,6 +8,7 @@ import SearchFieldInteractor from './interactor';
 
 const LABEL_PUBLISHER = 'Publisher';
 const LABEL_SUBJECT = 'Subject';
+const PLACEHOLDER_SUBJECT = 'Subject...';
 
 describe('SearchField', () => {
   const searchField = new SearchFieldInteractor();
@@ -54,7 +55,7 @@ describe('SearchField', () => {
       { label: 'ISBN', value: 'identifier/type=isbn' },
       { label: 'ISSN', value: 'identifier/type=issn' },
       { label: 'Contributor', value: 'contributor' },
-      { label: LABEL_SUBJECT, value: 'subject', placeholderId: 'stripes-components.searchField.placeholder' },
+      { label: LABEL_SUBJECT, value: 'subject', placeholder: PLACEHOLDER_SUBJECT },
       { label: 'Classification', value: 'classification' },
       { label: LABEL_PUBLISHER, value: 'publisher' },
     ];
@@ -91,7 +92,7 @@ describe('SearchField', () => {
       });
 
       it('should update the placeholder', () => {
-        expect(searchField.placeholder).to.equal(`Search for ${LABEL_PUBLISHER}`);
+        expect(searchField.placeholder).to.be.empty;
       });
     });
 
@@ -101,7 +102,7 @@ describe('SearchField', () => {
       });
 
       it('should update the placeholder', () => {
-        expect(searchField.placeholder).to.equal(`Search for ${LABEL_SUBJECT}`);
+        expect(searchField.placeholder).to.equal(PLACEHOLDER_SUBJECT);
       });
     });
   });

--- a/lib/SearchField/tests/SearchField-test.js
+++ b/lib/SearchField/tests/SearchField-test.js
@@ -6,6 +6,9 @@ import { mountWithContext } from '../../../tests/helpers';
 import SearchField from '../SearchField';
 import SearchFieldInteractor from './interactor';
 
+const LABEL_PUBLISHER = 'Publisher';
+const LABEL_SUBJECT = 'Subject';
+
 describe('SearchField', () => {
   const searchField = new SearchFieldInteractor();
 
@@ -51,9 +54,9 @@ describe('SearchField', () => {
       { label: 'ISBN', value: 'identifier/type=isbn' },
       { label: 'ISSN', value: 'identifier/type=issn' },
       { label: 'Contributor', value: 'contributor' },
-      { label: 'Subject', value: 'subject' },
+      { label: LABEL_SUBJECT, value: 'subject', placeholderId: 'stripes-components.searchField.placeholder' },
       { label: 'Classification', value: 'classification' },
-      { label: 'Publisher', value: 'publisher' },
+      { label: LABEL_PUBLISHER, value: 'publisher' },
     ];
 
     class SearchFieldHarness extends React.Component {
@@ -84,11 +87,21 @@ describe('SearchField', () => {
 
     describe('changing the index', () => {
       beforeEach(async () => {
-        await searchField.selectIndex('Publisher');
+        await searchField.selectIndex(LABEL_PUBLISHER);
       });
 
       it('should update the placeholder', () => {
-        expect(searchField.placeholder).to.equal('Search for publisher');
+        expect(searchField.placeholder).to.equal(`Search for ${LABEL_PUBLISHER}`);
+      });
+    });
+
+    describe('changing the index with placeholder', () => {
+      beforeEach(async () => {
+        await searchField.selectIndex(LABEL_SUBJECT);
+      });
+
+      it('should update the placeholder', () => {
+        expect(searchField.placeholder).to.equal(`Search for ${LABEL_SUBJECT}`);
       });
     });
   });

--- a/translations/stripes-components/en.json
+++ b/translations/stripes-components/en.json
@@ -57,7 +57,6 @@
   "button.duplicate": "Duplicate",
   "button.new": "New",
   "exportToCsv": "Export to CSV",
-  "searchField.placeholder": "Search for {label}",
   "selection.emptyList": "List is empty",
   "selection.noMatches": "No matching options",
   "selection.filterOptionsLabel": "{label} options filter",

--- a/translations/stripes-components/en.json
+++ b/translations/stripes-components/en.json
@@ -57,6 +57,7 @@
   "button.duplicate": "Duplicate",
   "button.new": "New",
   "exportToCsv": "Export to CSV",
+  "searchField.placeholder": "Search for {label}",
   "selection.emptyList": "List is empty",
   "selection.noMatches": "No matching options",
   "selection.filterOptionsLabel": "{label} options filter",


### PR DESCRIPTION
Here are two reasons for this PR:
* to remove default non-translated placeholders for all apps if any search index selected, it's a old known issue;
* feature request in the ticket to make these placeholders custom.

1. if placeholder prop is provided to SearchField - it will be displayed always, no matter of selected index;
2. if placeholder prop isn't provided to SearchField - we look for this prop in selected index config object. If it exists - it will be displayed as is, so any app that needs to use it should apply the same pattern as for translation of labels for SearchAndSort.

Any comments/suggestions are welcome, thank you in advance