### PR TITLE
STCOM-592: Added <MessageBanner> component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## 5.9.0 (IN-PROGRESS)
 
 * Export the `<Popper>` component at top level.
+* Added `<MessageBanner>` component (STCOM-592)
 
 ## [5.8.0](https://github.com/folio-org/stripes-components/tree/v5.8.0) (2019-09-25)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.7.1...v5.8.0)

--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ export {
 /* misc */
 export { default as Icon } from './lib/Icon';
 export { default as IconButton } from './lib/IconButton';
+export { default as MessageBanner } from './lib/MessageBanner';
 export { default as Modal } from './lib/Modal';
 export { default as ModalFooter } from './lib/ModalFooter';
 export { default as AppIcon } from './lib/AppIcon';

--- a/lib/MessageBanner/MessageBanner.js
+++ b/lib/MessageBanner/MessageBanner.js
@@ -1,0 +1,115 @@
+/**
+ * MessageBanner
+ */
+
+import React, { forwardRef, useState } from 'react';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import { CSSTransition } from 'react-transition-group';
+import IconButton from '../IconButton';
+import Icon from '../Icon';
+import css from './MessageBanner.module.css';
+
+export const TYPES = {
+  DEFAULT: 'default',
+  SUCCESS: 'success',
+  ERROR: 'error',
+  WARNING: 'warning',
+};
+
+const MessageBanner = forwardRef(
+  (
+    {
+      type,
+      children,
+      className,
+      dismissable,
+      element: Element,
+      icon,
+      onExit,
+      onExited,
+      ...rest
+    },
+    ref
+  ) => {
+    const [visible, setVisible] = useState(true);
+    const onDismiss = () => setVisible(false);
+
+    const renderIcon = () => {
+      let iconName = null;
+
+      if (type === TYPES.SUCCESS) {
+        iconName = 'check-circle';
+      }
+
+      if (type === TYPES.WARNING || type === TYPES.ERROR) {
+        iconName = 'exclamation-circle';
+      }
+
+      // Allow custom icon
+      if (typeof icon === 'string') {
+        iconName = icon;
+      }
+
+      if (!iconName) {
+        return null;
+      }
+
+      return (
+        <Icon icon={iconName} className={css.icon} size="small" />
+      );
+    };
+
+    return (
+      <CSSTransition
+        in={visible}
+        timeout={200}
+        unmountOnExit
+        onExit={onExit}
+        onExited={onExited}
+        classNames={{
+          enter: css.enter,
+          enterActive: css.enterActive,
+          exit: css.exit,
+          exitActive: css.exitActive,
+        }}
+      >
+        <Element
+          className={classnames(css.root, css[`type-${type}`], className)}
+          ref={ref}
+          role="alert"
+          {...rest}
+        >
+          {renderIcon()}
+          <div className={css.content}>{children}</div>
+          {dismissable && (
+            <div className={css.dismissButtonWrap}>
+              <IconButton
+                className={css.dismissButton}
+                size="small"
+                onClick={onDismiss}
+                icon="times"
+              />
+            </div>
+          )}
+        </Element>
+      </CSSTransition>
+    );
+  }
+);
+
+MessageBanner.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  element: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.func]),
+  type: PropTypes.oneOf(Object.keys(TYPES).map(key => TYPES[key])),
+};
+
+MessageBanner.defaultProps = {
+  type: TYPES.DEFAULT,
+  element: 'div',
+};
+
+MessageBanner.displayName = 'MessageBanner';
+
+export default MessageBanner;

--- a/lib/MessageBanner/MessageBanner.js
+++ b/lib/MessageBanner/MessageBanner.js
@@ -17,6 +17,12 @@ export const TYPES = {
   WARNING: 'warning',
 };
 
+export const DEFAULT_ICONS = {
+  SUCCESS: 'check-circle',
+  ERROR: 'exclamation-circle',
+  WARNING: 'exclamation-circle',
+};
+
 const MessageBanner = forwardRef(
   (
     {
@@ -43,15 +49,7 @@ const MessageBanner = forwardRef(
     }, [show]);
 
     const renderIcon = () => {
-      let iconName = null;
-
-      if (type === TYPES.SUCCESS) {
-        iconName = 'check-circle';
-      }
-
-      if (type === TYPES.WARNING || type === TYPES.ERROR) {
-        iconName = 'exclamation-circle';
-      }
+      let iconName = typeof type === 'string' ? DEFAULT_ICONS[type.toUpperCase()] : null;
 
       // Allow custom icon
       if (typeof icon === 'string' || icon === null) {

--- a/lib/MessageBanner/MessageBanner.js
+++ b/lib/MessageBanner/MessageBanner.js
@@ -49,7 +49,7 @@ const MessageBanner = forwardRef(
     }, [show]);
 
     const renderIcon = () => {
-      let iconName = DEFAULT_ICONS[type.toUpperCase()];
+      let iconName = typeof type === 'string' && DEFAULT_ICONS[type.toUpperCase()];
 
       // Allow custom icon and disabling icon by setting it to null
       if (typeof icon === 'string' || icon === null) {

--- a/lib/MessageBanner/MessageBanner.js
+++ b/lib/MessageBanner/MessageBanner.js
@@ -2,7 +2,7 @@
  * MessageBanner
  */
 
-import React, { forwardRef, useState } from 'react';
+import React, { forwardRef, useState, useEffect } from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { CSSTransition } from 'react-transition-group';
@@ -20,20 +20,27 @@ export const TYPES = {
 const MessageBanner = forwardRef(
   (
     {
-      type,
       children,
       className,
       dismissable,
       element: Element,
       icon,
+      onEnter,
+      onEntered,
       onExit,
       onExited,
+      show,
+      type,
       ...rest
     },
     ref
   ) => {
-    const [visible, setVisible] = useState(true);
+    const [visible, setVisible] = useState(show);
     const onDismiss = () => setVisible(false);
+
+    useEffect(() => {
+      setVisible(show);
+    }, [show]);
 
     const renderIcon = () => {
       let iconName = null;
@@ -47,7 +54,7 @@ const MessageBanner = forwardRef(
       }
 
       // Allow custom icon
-      if (typeof icon === 'string') {
+      if (typeof icon === 'string' || icon === null) {
         iconName = icon;
       }
 
@@ -56,7 +63,11 @@ const MessageBanner = forwardRef(
       }
 
       return (
-        <Icon icon={iconName} iconRootClass={css.icon} size="medium" />
+        <Icon
+          icon={iconName}
+          iconRootClass={css.icon}
+          size="medium"
+        />
       );
     };
 
@@ -67,6 +78,8 @@ const MessageBanner = forwardRef(
         unmountOnExit
         onExit={onExit}
         onExited={onExited}
+        onEnter={onEnter}
+        onEntered={onEntered}
         classNames={{
           enter: css.enter,
           enterActive: css.enterActive,
@@ -101,12 +114,18 @@ const MessageBanner = forwardRef(
 MessageBanner.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
+  dismissable: PropTypes.bool,
   element: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.func]),
+  icon: PropTypes.string,
+  onExit: PropTypes.func,
+  onExited: PropTypes.func,
+  show: PropTypes.bool,
   type: PropTypes.oneOf(Object.keys(TYPES).map(key => TYPES[key])),
 };
 
 MessageBanner.defaultProps = {
   type: TYPES.DEFAULT,
+  show: true,
   element: 'div',
 };
 

--- a/lib/MessageBanner/MessageBanner.js
+++ b/lib/MessageBanner/MessageBanner.js
@@ -56,7 +56,7 @@ const MessageBanner = forwardRef(
       }
 
       return (
-        <Icon icon={iconName} className={css.icon} size="small" />
+        <Icon icon={iconName} iconRootClass={css.icon} size="medium" />
       );
     };
 
@@ -86,7 +86,7 @@ const MessageBanner = forwardRef(
             <div className={css.dismissButtonWrap}>
               <IconButton
                 className={css.dismissButton}
-                size="small"
+                size="medium"
                 onClick={onDismiss}
                 icon="times"
               />

--- a/lib/MessageBanner/MessageBanner.js
+++ b/lib/MessageBanner/MessageBanner.js
@@ -49,9 +49,9 @@ const MessageBanner = forwardRef(
     }, [show]);
 
     const renderIcon = () => {
-      let iconName = typeof type === 'string' ? DEFAULT_ICONS[type.toUpperCase()] : null;
+      let iconName = DEFAULT_ICONS[type.toUpperCase()];
 
-      // Allow custom icon
+      // Allow custom icon and disabling icon by setting it to null
       if (typeof icon === 'string' || icon === null) {
         iconName = icon;
       }
@@ -62,6 +62,7 @@ const MessageBanner = forwardRef(
 
       return (
         <Icon
+          data-test-message-dismiss-button
           icon={iconName}
           iconRootClass={css.icon}
           size="medium"
@@ -86,7 +87,14 @@ const MessageBanner = forwardRef(
         }}
       >
         <Element
-          className={classnames(css.root, css[`type-${type}`], className)}
+          data-test-message-banner
+          className={
+            classnames(
+              css.root,
+              css[`type-${type}`],
+              className
+            )
+          }
           ref={ref}
           role="alert"
           {...rest}
@@ -96,6 +104,7 @@ const MessageBanner = forwardRef(
           {dismissable && (
             <div className={css.dismissButtonWrap}>
               <IconButton
+                data-test-message-dismiss-button
                 className={css.dismissButton}
                 size="medium"
                 onClick={onDismiss}
@@ -115,6 +124,8 @@ MessageBanner.propTypes = {
   dismissable: PropTypes.bool,
   element: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.func]),
   icon: PropTypes.string,
+  onEnter: PropTypes.func,
+  onEntered: PropTypes.func,
   onExit: PropTypes.func,
   onExited: PropTypes.func,
   show: PropTypes.bool,

--- a/lib/MessageBanner/MessageBanner.module.css
+++ b/lib/MessageBanner/MessageBanner.module.css
@@ -6,10 +6,10 @@
 
 :root {
   --message-banner-font-size: var(--font-size-medium);
-  --message-banner-vertical-padding: var(--gutter-static-one-third);
-  --message-banner-horizontal-padding: var(--gutter-static-two-thirds);
+  --message-banner-padding-small: var(--gutter-static-one-third);
+  --message-banner-padding-large: var(--gutter-static-two-thirds);
   --message-banner-border-radius: var(--radius);
-  --message-banner-min-height: var(--control-min-size-desktop);
+  --message-banner-min-height: 32px;
   --message-banner-line-height: 1.25;
 
   --message-banner-default-fill: #000;
@@ -30,13 +30,12 @@
 }
 
 .root {
-  padding: var(--message-banner-vertical-padding) var(--message-banner-horizontal-padding);
   min-height: var(--message-banner-min-height);
   font-size: var(--message-banner-font-size);
   display: flex;
   align-items: center;
   width: 100%;
-  line-height: var(--message-banner-line-height);;
+  line-height: var(--message-banner-line-height);
   text-align: left;
   border-radius: var(--message-banner-border-radius);
   border: 1px solid;
@@ -48,13 +47,21 @@
  */
 .content {
   flex: 1;
+  align-self: center;
+  padding: var(--message-banner-padding-small) var(--message-banner-padding-large);
 }
 
 /**
  * Icon
  */
 .icon {
-  margin: 0 var(--gutter-static-two-thirds);
+  margin: 0 0 0 var(--message-banner-padding-large);
+  min-height: var(--message-banner-min-height);
+  align-self: flex-start;
+}
+
+[dir="rtl"] .icon {
+  margin: 0 var(--message-banner-padding-large) 0;
 }
 
 
@@ -62,10 +69,15 @@
  * Dismiss button
  */
 .dismissButtonWrap {
+  margin: 0 var(--message-banner-padding-small) 0 0;
   min-height: var(--message-banner-min-height);
   display: flex;
   align-items: center;
   align-self: flex-start;
+}
+
+[dir="rtl"] .dismissButtonWrap {
+  margin: 0 0 0 var(--message-banner-padding-small);
 }
 
 /**

--- a/lib/MessageBanner/MessageBanner.module.css
+++ b/lib/MessageBanner/MessageBanner.module.css
@@ -8,6 +8,7 @@
   --message-banner-font-size: var(--font-size-medium);
   --message-banner-padding-small: var(--gutter-static-one-third);
   --message-banner-padding-large: var(--gutter-static-two-thirds);
+  --message-banner-stacked-margin-top: var(--gutter-static);
   --message-banner-border-radius: var(--radius);
   --message-banner-min-height: 32px;
   --message-banner-line-height: 1.25;
@@ -41,6 +42,12 @@
   border: 1px solid;
 }
 
+/**
+ * MessageBanner
+ */
+.root + .root {
+  margin-top: var(--message-banner-stacked-margin-top);
+}
 
 /**
  * Content

--- a/lib/MessageBanner/MessageBanner.module.css
+++ b/lib/MessageBanner/MessageBanner.module.css
@@ -1,0 +1,120 @@
+/**
+ * MessageBanner
+ */
+
+@import '../variables.css';
+
+:root {
+  --message-banner-font-size: var(--font-size-medium);
+  --message-banner-vertical-padding: var(--gutter-static-one-third);
+  --message-banner-horizontal-padding: var(--gutter-static-two-thirds);
+  --message-banner-border-radius: var(--radius);
+  --message-banner-min-height: var(--control-min-size-desktop);
+  --message-banner-line-height: 1.25;
+
+  --message-banner-default-fill: #000;
+  --message-banner-default-color: #FFF;
+  --message-banner-default-border-color: #000;
+
+  --message-banner-error-fill: var(--error-fill);
+  --message-banner-error-color: var(--error);
+  --message-banner-error-border-color: var(--error);
+
+  --message-banner-success-fill: var(--success-fill);
+  --message-banner-success-color: var(--success);
+  --message-banner-success-border-color: var(--success);
+
+  --message-banner-warning-fill: var(--warn-fill);
+  --message-banner-warning-color: var(--warn);
+  --message-banner-warning-border-color: var(--warn);
+}
+
+.root {
+  padding: var(--message-banner-vertical-padding) var(--message-banner-horizontal-padding);
+  min-height: var(--message-banner-min-height);
+  font-size: var(--message-banner-font-size);
+  display: flex;
+  align-items: center;
+  width: 100%;
+  line-height: var(--message-banner-line-height);;
+  text-align: left;
+  border-radius: var(--message-banner-border-radius);
+  border: 1px solid;
+}
+
+
+/**
+ * Content
+ */
+.content {
+  flex: 1;
+}
+
+/**
+ * Icon
+ */
+.icon {
+  margin: 0 var(--gutter-static-two-thirds);
+}
+
+
+/**
+ * Dismiss button
+ */
+.dismissButtonWrap {
+  min-height: var(--message-banner-min-height);
+  display: flex;
+  align-items: center;
+  align-self: flex-start;
+}
+
+/**
+ * Types
+ */
+.type-default {
+  background-color: var(--message-banner-default-fill);
+  color: var(--message-banner-default-color);
+  border-color: var(--message-banner-default-border-color);
+}
+
+.type-error {
+  background-color: var(--message-banner-error-fill);
+  color: var(--message-banner-error-color);
+  border-color: var(--message-banner-error-border-color);
+}
+
+.type-success {
+  background-color: var(--message-banner-success-fill);
+  color: var(--message-banner-success-color);
+  border-color: var(--message-banner-success-border-color);
+}
+
+.type-warning {
+  background-color: var(--message-banner-warning-fill);
+  color: var(--message-banner-warning-color);
+  border-color: var(--message-banner-warning-border-color);
+}
+
+/**
+ * Transition
+ */
+
+.enter {
+  opacity: 0;
+}
+
+.enterActive {
+  transform: translateY(0);
+  opacity: 1;
+  transition: opacity 200ms, transform 200ms;
+}
+
+.exit {
+  opacity: 1;
+}
+
+.exitActive {
+  transform: translateY(-10px);
+  opacity: 0;
+  transition: opacity 200ms, transform 200ms;
+}

--- a/lib/MessageBanner/MessageBanner.module.css
+++ b/lib/MessageBanner/MessageBanner.module.css
@@ -94,6 +94,10 @@
   background-color: var(--message-banner-default-fill);
   color: var(--message-banner-default-color);
   border-color: var(--message-banner-default-border-color);
+
+  & .dismissButton {
+    color: #FFF;
+  }
 }
 
 .type-error {
@@ -120,6 +124,7 @@
 
 .enter {
   opacity: 0;
+  transform: translateY(-10px);
 }
 
 .enterActive {

--- a/lib/MessageBanner/examples/BasicUsage.js
+++ b/lib/MessageBanner/examples/BasicUsage.js
@@ -1,0 +1,27 @@
+/**
+ * Button -> Basic Usage
+ */
+
+import React from 'react';
+import MessageBanner from '../MessageBanner';
+
+const BasicUsage = () => (
+  <div style={{ maxWidth: 800 }}>
+    <MessageBanner>Default</MessageBanner>
+    <br />
+    <MessageBanner type="success">
+      Success
+    </MessageBanner>
+    <br />
+    <MessageBanner type="error">
+      Error
+    </MessageBanner>
+    <br />
+    <MessageBanner type="warning">Warning</MessageBanner>
+    <br />
+    <MessageBanner type="warning">With a lot of content Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla imperdiet, turpis a egestas consequat, elit elit fringilla ligula, et luctus magna nunc et mauris. Praesent in felis mollis, congue tellus sed, faucibus arcu. Mauris iaculis quam eu elementum interdum. Donec nulla augue, scelerisque in scelerisque a, ultrices non arcu. Etiam vehicula convallis erat, ultricies pellentesque est commodo vitae. Sed sed est ut odio laoreet lobortis tincidunt vel velit. </MessageBanner>
+    <br />
+  </div>
+);
+
+export default BasicUsage;

--- a/lib/MessageBanner/examples/BasicUsage.js
+++ b/lib/MessageBanner/examples/BasicUsage.js
@@ -6,7 +6,7 @@ import React from 'react';
 import MessageBanner from '../MessageBanner';
 
 const BasicUsage = () => (
-  <div style={{ maxWidth: 800 }}>
+  <div style={{ maxWidth: 850 }}>
     <MessageBanner>Default</MessageBanner>
     <br />
     <MessageBanner type="success">

--- a/lib/MessageBanner/examples/BasicUsage.js
+++ b/lib/MessageBanner/examples/BasicUsage.js
@@ -1,5 +1,5 @@
 /**
- * Button -> Basic Usage
+ * MessageBanner -> Basic Usage
  */
 
 import React from 'react';
@@ -11,7 +11,13 @@ const BasicUsage = () => (
     <MessageBanner type="success">Success</MessageBanner>
     <MessageBanner type="error">Error</MessageBanner>
     <MessageBanner type="warning">Warning</MessageBanner>
-    <MessageBanner type="warning">With a lot of content Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla imperdiet, turpis a egestas consequat, elit elit fringilla ligula, et luctus magna nunc et mauris. Praesent in felis mollis, congue tellus sed, faucibus arcu. Mauris iaculis quam eu elementum interdum. Donec nulla augue, scelerisque in scelerisque a, ultrices non arcu. Etiam vehicula convallis erat, ultricies pellentesque est commodo vitae. Sed sed est ut odio laoreet lobortis tincidunt vel velit. </MessageBanner>
+    <MessageBanner type="warning">
+      With a lot of content Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla imperdiet, turpis
+      a egestas consequat, elit elit fringilla ligula, et luctus magna nunc et mauris. Praesent in felis
+      mollis, congue tellus sed, faucibus arcu. Mauris iaculis quam eu elementum interdum. Donec nulla augue,
+      scelerisque in scelerisque a, ultrices non arcu. Etiam vehicula convallis erat, ultricies pellentesque
+      est commodo vitae. Sed sed est ut odio laoreet lobortis tincidunt vel velit.
+    </MessageBanner>
   </div>
 );
 

--- a/lib/MessageBanner/examples/BasicUsage.js
+++ b/lib/MessageBanner/examples/BasicUsage.js
@@ -8,19 +8,10 @@ import MessageBanner from '../MessageBanner';
 const BasicUsage = () => (
   <div style={{ maxWidth: 850 }}>
     <MessageBanner>Default</MessageBanner>
-    <br />
-    <MessageBanner type="success">
-      Success
-    </MessageBanner>
-    <br />
-    <MessageBanner type="error">
-      Error
-    </MessageBanner>
-    <br />
+    <MessageBanner type="success">Success</MessageBanner>
+    <MessageBanner type="error">Error</MessageBanner>
     <MessageBanner type="warning">Warning</MessageBanner>
-    <br />
     <MessageBanner type="warning">With a lot of content Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla imperdiet, turpis a egestas consequat, elit elit fringilla ligula, et luctus magna nunc et mauris. Praesent in felis mollis, congue tellus sed, faucibus arcu. Mauris iaculis quam eu elementum interdum. Donec nulla augue, scelerisque in scelerisque a, ultrices non arcu. Etiam vehicula convallis erat, ultricies pellentesque est commodo vitae. Sed sed est ut odio laoreet lobortis tincidunt vel velit. </MessageBanner>
-    <br />
   </div>
 );
 

--- a/lib/MessageBanner/examples/Dismissable.js
+++ b/lib/MessageBanner/examples/Dismissable.js
@@ -8,21 +8,12 @@ import MessageBanner from '../MessageBanner';
 const BasicUsage = () => (
   <div style={{ maxWidth: 850 }}>
     <MessageBanner dismissable>Default</MessageBanner>
-    <br />
-    <MessageBanner dismissable type="success">
-      Success
-    </MessageBanner>
-    <br />
+    <MessageBanner dismissable type="success">Success</MessageBanner>
     <MessageBanner dismissable type="error">
       <strong>Patron</strong> has <strong>blocks</strong> in place.
     </MessageBanner>
-    <br />
-    <MessageBanner dismissable type="warning">
-      Warning
-    </MessageBanner>
-    <br />
+    <MessageBanner dismissable type="warning">Warning</MessageBanner>
     <MessageBanner dismissable type="warning">With a lot of content Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla imperdiet, turpis a egestas consequat, elit elit fringilla ligula, et luctus magna nunc et mauris. Praesent in felis mollis, congue tellus sed, faucibus arcu. Mauris iaculis quam eu elementum interdum. Donec nulla augue, scelerisque in scelerisque a, ultrices non arcu. Etiam vehicula convallis erat, ultricies pellentesque est commodo vitae. Sed sed est ut odio laoreet lobortis tincidunt vel velit. </MessageBanner>
-    <br />
   </div>
 );
 

--- a/lib/MessageBanner/examples/Dismissable.js
+++ b/lib/MessageBanner/examples/Dismissable.js
@@ -6,7 +6,7 @@ import React from 'react';
 import MessageBanner from '../MessageBanner';
 
 const BasicUsage = () => (
-  <div>
+  <div style={{ maxWidth: 850 }}>
     <MessageBanner dismissable>Default</MessageBanner>
     <br />
     <MessageBanner dismissable type="success">

--- a/lib/MessageBanner/examples/Dismissable.js
+++ b/lib/MessageBanner/examples/Dismissable.js
@@ -1,5 +1,5 @@
 /**
- * Button -> Dismissable
+ * MessageBanner -> Dismissable
  */
 
 import React from 'react';
@@ -13,7 +13,13 @@ const BasicUsage = () => (
       <strong>Patron</strong> has <strong>blocks</strong> in place.
     </MessageBanner>
     <MessageBanner dismissable type="warning">Warning</MessageBanner>
-    <MessageBanner dismissable type="warning">With a lot of content Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla imperdiet, turpis a egestas consequat, elit elit fringilla ligula, et luctus magna nunc et mauris. Praesent in felis mollis, congue tellus sed, faucibus arcu. Mauris iaculis quam eu elementum interdum. Donec nulla augue, scelerisque in scelerisque a, ultrices non arcu. Etiam vehicula convallis erat, ultricies pellentesque est commodo vitae. Sed sed est ut odio laoreet lobortis tincidunt vel velit. </MessageBanner>
+    <MessageBanner dismissable type="warning">
+      With a lot of content Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla imperdiet, turpis
+      a egestas consequat, elit elit fringilla ligula, et luctus magna nunc et mauris. Praesent in felis
+      mollis, congue tellus sed, faucibus arcu. Mauris iaculis quam eu elementum interdum. Donec nulla augue,
+      scelerisque in scelerisque a, ultrices non arcu. Etiam vehicula convallis erat, ultricies pellentesque
+      est commodo vitae. Sed sed est ut odio laoreet lobortis tincidunt vel velit.
+    </MessageBanner>
   </div>
 );
 

--- a/lib/MessageBanner/examples/Dismissable.js
+++ b/lib/MessageBanner/examples/Dismissable.js
@@ -1,0 +1,29 @@
+/**
+ * Button -> Dismissable
+ */
+
+import React from 'react';
+import MessageBanner from '../MessageBanner';
+
+const BasicUsage = () => (
+  <div>
+    <MessageBanner dismissable>Default</MessageBanner>
+    <br />
+    <MessageBanner dismissable type="success">
+      Success
+    </MessageBanner>
+    <br />
+    <MessageBanner dismissable type="error">
+      <strong>Patron</strong> has <strong>blocks</strong> in place.
+    </MessageBanner>
+    <br />
+    <MessageBanner dismissable type="warning">
+      Warning
+    </MessageBanner>
+    <br />
+    <MessageBanner dismissable type="warning">With a lot of content Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla imperdiet, turpis a egestas consequat, elit elit fringilla ligula, et luctus magna nunc et mauris. Praesent in felis mollis, congue tellus sed, faucibus arcu. Mauris iaculis quam eu elementum interdum. Donec nulla augue, scelerisque in scelerisque a, ultrices non arcu. Etiam vehicula convallis erat, ultricies pellentesque est commodo vitae. Sed sed est ut odio laoreet lobortis tincidunt vel velit. </MessageBanner>
+    <br />
+  </div>
+);
+
+export default BasicUsage;

--- a/lib/MessageBanner/examples/MessageBanner.stories.js
+++ b/lib/MessageBanner/examples/MessageBanner.stories.js
@@ -1,13 +1,13 @@
+import React from 'react';
 import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
 import BasicUsage from './BasicUsage';
 import Dismissable from './Dismissable';
+import ShowHide from './ShowHide';
 import readme from '../readme.md';
 
 storiesOf('MessageBanner', module)
-  .addParameters({
-    readme: {
-      sidebar: readme,
-    },
-  })
+  .addDecorator(withReadme(readme))
   .add('Basic Usage', BasicUsage)
+  .add('Show/hide', () => <ShowHide />)
   .add('Dismissable', Dismissable);

--- a/lib/MessageBanner/examples/MessageBanner.stories.js
+++ b/lib/MessageBanner/examples/MessageBanner.stories.js
@@ -1,0 +1,13 @@
+import { storiesOf } from '@storybook/react';
+import BasicUsage from './BasicUsage';
+import Dismissable from './Dismissable';
+import readme from '../readme.md';
+
+storiesOf('MessageBanner', module)
+  .addParameters({
+    readme: {
+      sidebar: readme,
+    },
+  })
+  .add('Basic Usage', BasicUsage)
+  .add('Dismissable', Dismissable);

--- a/lib/MessageBanner/examples/ShowHide.js
+++ b/lib/MessageBanner/examples/ShowHide.js
@@ -1,0 +1,30 @@
+/* eslint-disable no-console */
+/**
+ * MessageBanner -> Show/hide
+ */
+
+import React, { useState } from 'react';
+import Button from '../../Button';
+import MessageBanner from '../MessageBanner';
+
+const BasicUsage = () => {
+  const [show, setShow] = useState(false);
+
+  return (
+    <div style={{ maxWidth: 850 }}>
+      <Button onClick={() => setShow(!show)}>Toggle</Button>
+      <MessageBanner
+        onEnter={() => console.log('Enter')}
+        onEntered={() => console.log('Entered')}
+        onExit={() => console.log('Exit')}
+        onExited={() => console.log('Exited')}
+        show={show}
+        type="success"
+      >
+        Success
+      </MessageBanner>
+    </div>
+  );
+};
+
+export default BasicUsage;

--- a/lib/MessageBanner/index.js
+++ b/lib/MessageBanner/index.js
@@ -1,0 +1,1 @@
+export { default } from './MessageBanner';

--- a/lib/MessageBanner/readme.md
+++ b/lib/MessageBanner/readme.md
@@ -1,18 +1,13 @@
 # MessageBanner
-Renders a message to the user
+Display a message to the user. The message banner has short and clear content with key information in bold.
 
 ```js
-import { MessageBanner } from 'Components';
+import { MessageBanner } from '@folio/stripes/components';
 
 <MessageBanner>Default</MessageBanner>
-<MessageBanner icon="check-circle" appearance="success">
-  Success
-</MessageBanner>
-<MessageBanner icon="exclamation-circle" appearance="error">
-  Error
-</MessageBanner>
+<MessageBanner appearance="success">Success</MessageBanner>
+<MessageBanner appearance="error">Error</MessageBanner>
 <MessageBanner appearance="warning">Warning</MessageBanner>
-<MessageBanner appearance="info">Info</MessageBanner>
 
 // Dismissable MessageBanner
 <MessageBanner 
@@ -21,20 +16,44 @@ import { MessageBanner } from 'Components';
   onExit={() => console.log('Will exit now')}
   onExited={() => console.log('Has exited')}
 >
-    I'm dismissable
+  I'm dismissable
+</MessageBanner>
+```
+
+## Controlled
+Passing the `show`-prop makes it possible to control the visibility externally. This also enables enter/exit transitioning.
+
+```js
+const [show, setShow] = useState(false);
+
+<Button onClick={() => setShow(!show)}>Toggle</Button>
+<MessageBanner
+  show={show}
+
+  // Optional
+  onEnter={() => console.log('Enter')}
+  onEntered={() => console.log('Entered')}
+  onExit={() => console.log('Exit')}
+  onExited={() => console.log('Exited')}
+>
+  Hello World
 </MessageBanner>
 ```
 
 ## Props
-| Name       | Type            | Description                             | Options              | Default |
-| ---------- | --------------- | --------------------------------------- | -------------------- | ------- |
-| appearance | string          | Sets the style for the MessageBanner           | default, error, info, success, warning    | default |
-| children   | node            | Renders the contents of the MessageBanner      |                      |
-| dismissable   | bool            | Adds a close icon and makes the MessageBanner dismissable      | true/false                     | false
-| icon   | string            | Renders an icon next to the message. Supports all icons available for the `<Icon>`-component.      |                      |
-| onExit   | string            | Callback when the MessageBanner exits (must be dismissable) |                      |
-| onExited   | string            | Callback when the MessageBanner has exited (must be dismissable) |                      |
-| className  | string          | Adds a custom class name for the MessageBanner |                      |
-| element    | string, element, func | Changes the root element of the MessageBanner  |                      | button  |
+Name | Type | Description | Options | Default
+-- | -- | -- | -- | --
+appearance | string | Sets the style of the `<MessageBanner>` | default, error, success, warning | default
+children | node | Renders the contents of the `<MessageBanner>` | |
+dismissable | boolean | Adds a close icon and makes the `<MessageBanner>` dismissable | true/false | false
+icon | string | Renders an icon next to the message. Supports all icons available for the [`<Icon>`](/?selectedKind=Icon)-component. When the `appearance`-prop is set to either "success", "error" and "warning" the `<MessageBanner>` will have icons by default but these too can be overwritten by using the `icon`-prop. If you want to remove the icon entirely you can simply set `icon` to `null` | |
+onEnter | func | Callback when the `<MessageBanner>` enters | |
+onEntered | func | Callback when the `<MessageBanner>` has entered | |
+onExit | func | Callback when the `<MessageBanner>` exits | |
+onExited | func | Callback when the `<MessageBanner>` has exited | |
+className | string | Adds a custom class name for the `<MessageBanner>` | |
+element | string, element, func | Changes the root element of the `<MessageBanner>` | | div |
+show | boolean | Control the visiblity externally. Using the show-prop will enable the `<MessageBanner>` to transition in and out. | true/false | |
+
 
 The rest of the props passed to `<MessageBanner>` will be spread onto the root element of the component. This component also accepts a `ref`.

--- a/lib/MessageBanner/readme.md
+++ b/lib/MessageBanner/readme.md
@@ -1,6 +1,7 @@
 # MessageBanner
 Display a message to the user. The message banner has short and clear content with key information in bold.
 
+## Basic Usage
 ```js
 import { MessageBanner } from '@folio/stripes/components';
 
@@ -8,20 +9,19 @@ import { MessageBanner } from '@folio/stripes/components';
 <MessageBanner appearance="success">Success</MessageBanner>
 <MessageBanner appearance="error">Error</MessageBanner>
 <MessageBanner appearance="warning">Warning</MessageBanner>
+```
 
-// Dismissable MessageBanner
-<MessageBanner 
-  appearance="info" 
-  dismissable
-  onExit={() => console.log('Will exit now')}
-  onExited={() => console.log('Has exited')}
->
+## Dismissible
+Setting the `dismissble`-prop enables the option for the user to hide the `<MessageBanner>`. It is also possible to control the visibility externally by using the `show`-prop. See an example below this section.
+
+```js
+<MessageBanner dismissable>
   I'm dismissable
 </MessageBanner>
 ```
 
 ## Controlled
-Passing the `show`-prop makes it possible to control the visibility externally. This also enables enter/exit transitioning.
+Passing the `show`-prop makes it possible to control the visibility externally. This also enables enter/exit transitions.
 
 ```js
 const [show, setShow] = useState(false);
@@ -56,4 +56,4 @@ element | string, element, func | Changes the root element of the `<MessageBanne
 show | boolean | Control the visiblity externally. Using the show-prop will enable the `<MessageBanner>` to transition in and out. | true/false | |
 
 
-The rest of the props passed to `<MessageBanner>` will be spread onto the root element of the component. This component also accepts a `ref`.
+The remaining props passed to `<MessageBanner>` will be spread onto the root element of the component. This component also accepts a `ref`.

--- a/lib/MessageBanner/readme.md
+++ b/lib/MessageBanner/readme.md
@@ -6,9 +6,9 @@ Display a message to the user. The message banner has short and clear content wi
 import { MessageBanner } from '@folio/stripes/components';
 
 <MessageBanner>Default</MessageBanner>
-<MessageBanner appearance="success">Success</MessageBanner>
-<MessageBanner appearance="error">Error</MessageBanner>
-<MessageBanner appearance="warning">Warning</MessageBanner>
+<MessageBanner type="success">Success</MessageBanner>
+<MessageBanner type="error">Error</MessageBanner>
+<MessageBanner type="warning">Warning</MessageBanner>
 ```
 
 ## Dismissible
@@ -43,10 +43,10 @@ const [show, setShow] = useState(false);
 ## Props
 Name | Type | Description | Options | Default
 -- | -- | -- | -- | --
-appearance | string | Sets the style of the `<MessageBanner>` | default, error, success, warning | default
+type | string | Sets the style of the `<MessageBanner>` | default, error, success, warning | default
 children | node | Renders the contents of the `<MessageBanner>` | |
 dismissable | boolean | Adds a close icon and makes the `<MessageBanner>` dismissable | true/false | false
-icon | string | Renders an icon next to the message. Supports all icons available for the [`<Icon>`](/?selectedKind=Icon)-component. When the `appearance`-prop is set to either "success", "error" and "warning" the `<MessageBanner>` will have icons by default but these too can be overwritten by using the `icon`-prop. If you want to remove the icon entirely you can simply set `icon` to `null` | |
+icon | string | Renders an icon next to the message. Supports all icons available for the [`<Icon>`](/?selectedKind=Icon)-component. When the `type`-prop is set to either "success", "error" and "warning" the `<MessageBanner>` will have icons by default but these too can be overwritten by using the `icon`-prop. If you want to remove the icon entirely you can simply set `icon` to `null` | |
 onEnter | func | Callback when the `<MessageBanner>` enters | |
 onEntered | func | Callback when the `<MessageBanner>` has entered | |
 onExit | func | Callback when the `<MessageBanner>` exits | |

--- a/lib/MessageBanner/readme.md
+++ b/lib/MessageBanner/readme.md
@@ -1,0 +1,40 @@
+# MessageBanner
+Renders a message to the user
+
+```js
+import { MessageBanner } from 'Components';
+
+<MessageBanner>Default</MessageBanner>
+<MessageBanner icon="check-circle" appearance="success">
+  Success
+</MessageBanner>
+<MessageBanner icon="exclamation-circle" appearance="error">
+  Error
+</MessageBanner>
+<MessageBanner appearance="warning">Warning</MessageBanner>
+<MessageBanner appearance="info">Info</MessageBanner>
+
+// Dismissable MessageBanner
+<MessageBanner 
+  appearance="info" 
+  dismissable
+  onExit={() => console.log('Will exit now')}
+  onExited={() => console.log('Has exited')}
+>
+    I'm dismissable
+</MessageBanner>
+```
+
+## Props
+| Name       | Type            | Description                             | Options              | Default |
+| ---------- | --------------- | --------------------------------------- | -------------------- | ------- |
+| appearance | string          | Sets the style for the MessageBanner           | default, error, info, success, warning    | default |
+| children   | node            | Renders the contents of the MessageBanner      |                      |
+| dismissable   | bool            | Adds a close icon and makes the MessageBanner dismissable      | true/false                     | false
+| icon   | string            | Renders an icon next to the message. Supports all icons available for the `<Icon>`-component.      |                      |
+| onExit   | string            | Callback when the MessageBanner exits (must be dismissable) |                      |
+| onExited   | string            | Callback when the MessageBanner has exited (must be dismissable) |                      |
+| className  | string          | Adds a custom class name for the MessageBanner |                      |
+| element    | string, element, func | Changes the root element of the MessageBanner  |                      | button  |
+
+The rest of the props passed to `<MessageBanner>` will be spread onto the root element of the component. This component also accepts a `ref`.

--- a/lib/MessageBanner/tests/MessageBanner-test.js
+++ b/lib/MessageBanner/tests/MessageBanner-test.js
@@ -5,9 +5,8 @@
 import React from 'react';
 import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
-import camelCase from 'lodash/camelCase';
 import { mount } from '../../../tests/helpers';
-import MessageBanner, { TYPES } from '../MessageBanner';
+import MessageBanner from '../MessageBanner';
 import MessageBannerInteractor from './interactor';
 
 describe('MessageBanner', () => {

--- a/lib/MessageBanner/tests/MessageBanner-test.js
+++ b/lib/MessageBanner/tests/MessageBanner-test.js
@@ -1,0 +1,96 @@
+/**
+ * MessageBanner tests
+ */
+
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+import camelCase from 'lodash/camelCase';
+import { mount } from '../../../tests/helpers';
+import MessageBanner, { TYPES } from '../MessageBanner';
+import MessageBannerInteractor from './interactor';
+
+describe('MessageBanner', () => {
+  const messageBanner = new MessageBannerInteractor();
+
+  beforeEach(async () => {
+    await mount(
+      <MessageBanner
+        element="span"
+        className="my-class"
+        icon={null}
+        dismissable
+      >
+        Test
+      </MessageBanner>
+    );
+    await messageBanner.dismissButton.click();
+  });
+
+  it('Should not have an icon if the icon-prop = null', () => {
+    expect(messageBanner.icon.isPresent).to.be.false;
+  });
+
+  it('Should disappear when the dismiss button is clicked', () => {
+    expect(messageBanner.isPresent).to.be.false;
+  });
+
+  it('Should have a dismiss button if the dismissble-prop is true', () => {
+    expect(messageBanner.dismissButton.isPresent).to.be.true;
+  });
+
+  it('Should have a custom class name if passed to the className prop', () => {
+    expect(messageBanner.className).to.include('my-class');
+  });
+
+  it('Should have a root element of <span> if passed via. the element prop', () => {
+    expect(messageBanner.element).to.equal('SPAN');
+  });
+
+  it('Should render the content passed via. children', () => {
+    expect(messageBanner.text).to.include('Test');
+  });
+
+  it('Should have a the default style if no type is defined', () => {
+    expect(messageBanner.isDefault).to.be.true;
+  });
+
+  describe('If the type prop is set to success', () => {
+    beforeEach(async () => {
+      await mount(
+        <MessageBanner type="success">
+          Test
+        </MessageBanner>
+      );
+    });
+    it('Should have success style', () => {
+      expect(messageBanner.isSuccess).to.be.true;
+    });
+  });
+
+  describe('If the type prop is set to warning', () => {
+    beforeEach(async () => {
+      await mount(
+        <MessageBanner type="warning">
+          Test
+        </MessageBanner>
+      );
+    });
+    it('Should have warning style', () => {
+      expect(messageBanner.isWarning).to.be.true;
+    });
+  });
+
+  describe('If the type prop is set to error', () => {
+    beforeEach(async () => {
+      await mount(
+        <MessageBanner type="error">
+          Test
+        </MessageBanner>
+      );
+    });
+    it('Should have error style', () => {
+      expect(messageBanner.isError).to.be.true;
+    });
+  });
+});

--- a/lib/MessageBanner/tests/MessageBanner.test.js
+++ b/lib/MessageBanner/tests/MessageBanner.test.js
@@ -1,1 +1,0 @@
-// Silence is golden

--- a/lib/MessageBanner/tests/MessageBanner.test.js
+++ b/lib/MessageBanner/tests/MessageBanner.test.js
@@ -1,0 +1,1 @@
+// Silence is golden

--- a/lib/MessageBanner/tests/interactor.js
+++ b/lib/MessageBanner/tests/interactor.js
@@ -4,12 +4,10 @@
 
 import {
   interactor,
-  isPresent,
   text,
   hasClass,
   attribute,
   property,
-  scoped
 } from '@bigtest/interactor';
 import IconButtonInteractor from '../../IconButton/tests/interactor';
 import IconInteractor from '../../Icon/tests/interactor';

--- a/lib/MessageBanner/tests/interactor.js
+++ b/lib/MessageBanner/tests/interactor.js
@@ -1,0 +1,32 @@
+/**
+ * MessageBanner interactor
+ */
+
+import {
+  interactor,
+  isPresent,
+  text,
+  hasClass,
+  attribute,
+  property,
+  scoped
+} from '@bigtest/interactor';
+import IconButtonInteractor from '../../IconButton/tests/interactor';
+import IconInteractor from '../../Icon/tests/interactor';
+
+import css from '../MessageBanner.module.css';
+
+export default interactor(class MessageBannerInteractor {
+  static defaultScope = '[data-test-message-banner]';
+  className = attribute('class');
+  text = text(`.${css.content}`);
+  element = property('tagName');
+
+  isDefault = hasClass(css['type-default']);
+  isWarning = hasClass(css['type-warning']);
+  isError = hasClass(css['type-error']);
+  isSuccess = hasClass(css['type-success']);
+
+  dismissButton = new IconButtonInteractor('[data-test-message-dismiss-button]');
+  icon = new IconInteractor('[data-test-message-icon]')
+});

--- a/lib/variables.css
+++ b/lib/variables.css
@@ -21,9 +21,12 @@
   --primary: #2b75bb;
   --secondary: #999;
   --error: #900;
+  --error-fill: rgba(149, 29, 18, 0.20);
   --danger: #900;
   --warn: #943e00;
+  --warn-fill: rgba(215, 137, 88, 0.20);
   --success: #070;
+  --success-fill: rgba(51, 117, 30, 0.20);
   --control-margin-bottom: 1rem;
   --control-min-size-touch: 44px;
   --control-min-size-desktop: 24px;


### PR DESCRIPTION
In this PR I have added a new component: `<MessageBanner>`. 

## Ticket
https://issues.folio.org/browse/STCOM-592

## Details
- Comes with different types of styling: default, success, warning & error
- Has an optional dismiss button
- Can be controlled externally by using the `show`-prop (which enables enter/leave transitions)
- Works with RTL
- 100% test coverage

More information about the component itself can be found in the readme.

## UX Docs
https://ux.folio.org/docs/guidelines/components/message-banner/

## Screenshot
![image](https://user-images.githubusercontent.com/640976/67607952-904aa480-f786-11e9-8769-5264576dc42a.png)

## GIF
![Oct-26-2019 00-22-18](https://user-images.githubusercontent.com/640976/67607995-b40dea80-f786-11e9-841d-844bebfa2e6b.gif)
