### PR TITLE
<Tooltip> updates

### DIFF
--- a/lib/Tooltip/Tooltip.css
+++ b/lib/Tooltip/Tooltip.css
@@ -9,7 +9,7 @@
   justify-content: center;
   flex-direction: column;
   min-height: 36px;
-  background-color: #000;
+  background-color: rgba(0, 0, 0, 0.85);
   color: #fff;
   margin-top: var(--gutter-static-one-third);
   border-radius: 4px;
@@ -20,6 +20,7 @@
   animation-iteration-count: 1;
   animation-timing-function: ease-in;
   animation-duration: 0.1s;
+  font-size: var(--font-size-small);
 }
 
 .text {

--- a/lib/Tooltip/Tooltip.js
+++ b/lib/Tooltip/Tooltip.js
@@ -140,15 +140,21 @@ export default class Tooltip extends Component {
 
     // Get list of all aria values on the trigger as a string
     const triggerAriaValues = Array.from(get(this.triggerEl, 'attributes', []))
-      .filter(attr => attr.name.indexOf('aria') >= 0)
+      .filter(attr => attr.name.includes('aria'))
       .map(attr => attr.value)
       .join(' ');
 
     // Check if the correct ID's are present
-    const hasCorrectIds = ariaIds.filter(id => triggerAriaValues.indexOf(id) >= 0).length === ariaIds.length;
+    const hasCorrectIds = ariaIds.filter(id => triggerAriaValues.includes(id)).length === ariaIds.length;
 
     // // Make it clear for the developer that something is wrong
     if (!hasCorrectIds) {
+      console.warn(
+        'For accessibility reasons, your <Tooltip> trigger element:', this.triggerEl,
+        'should include one or both of the following attributes: aria-labelledby',
+        'and/or aria-describedby with the relevant ID(s):', ariaIds, '.',
+        'See the <Tooltip> readme for more information.'
+      );
       this.triggerEl.style.backgroundColor = 'red';
     }
   }

--- a/lib/Tooltip/readme.md
+++ b/lib/Tooltip/readme.md
@@ -29,34 +29,20 @@ Content of Tooltips should be kept very simple, thus, we only allow for simple s
 
 The `<Tooltip>` won't be 100% accessible out of the box – it's up to you as a developer to provide the relevant information in an accessible way. This can be achieved in several ways and it must be tailored to the specific implementation of a given UI.
 
-Using aria-attributes, you can provide the same information for all users. Here's some examples:
-
-### Using aria-label
-Passing the same string for both the `<Tooltip>` text prop and the `aria-label` of the trigger component will ensure that the contents of the tooltip is available for all users.
-
-```js
-const label = 'Delete';
-
-<Tooltip
-  title={label}
-  id="my-tooltip"
->
-  {({ ref, ariaIds }) => (
-    <IconButton
-      icon="trash"
-      ref={ref}
-      aria-label={label}
-    />
-  )}
-</Tooltip>
-```
+Using aria-attributes, you can provide the same information for all users.
 
 ### Using aria-labelledby and aria-describedby
 If you want to render a tooltip with both a text and a sub, you can use `aria-labelledby` and `aria-describedby` to make the information available for screen reader users.
 
-**Note:** `aria-labelledby` is announced by screen readers first, followed by `aria-describedby`. In some cases `aria-describedby` is made optional depending on the browser/screen reader combination. The `aria-label` trumps the `aria-labelledby` so if you want to announce both the text and the sub then you should either use `aria-labelledby` or a combination of `aria-labelledby` and `aria-describedby`.
+**Note** 
+
+`aria-labelledby` is announced by screen readers first, followed by `aria-describedby`. In some cases `aria-describedby` is made optional depending on the browser/screen reader combination. The `aria-label` trumps the `aria-labelledby` so if you want to announce both the text and the sub then you should either use `aria-labelledby` or a combination of `aria-labelledby` and `aria-describedby`.
 
 Be aware that both the `aria-label` and `aria-labelledby` will override the visible text for certain elements, such as links and buttons.
+
+**Validation**
+
+The `<Tooltip>`-component has built in a11y validation which will apply a <span style="padding: 2px;color:#FFF;background-color:red;">red</span> background color on your trigger element if you haven't applied the neccessary aria-attributes.
 
 ```js
 <Tooltip
@@ -70,8 +56,8 @@ Be aware that both the `aria-label` and `aria-labelledby` will override the visi
       ref={ref}
 
       // Option 1 - this will read out the text first and then the sub afterwards
-      aria-labelledby={ariaIds.text} // The primary information
-      aria-describedby={ariaIds.sub} // The secondary information
+      aria-labelledby={ariaIds.text} // The ID for the primary information (my-tooltip-text)
+      aria-describedby={ariaIds.sub} // The ID for the secondary information (my-tooltip-sub)
 
       // Option 2 - this will read out both text and sub immidiately when the trigger is focused
       aria-labelledby={`${ariaIds.text} ${ariaIds.sub}`}
@@ -93,15 +79,15 @@ The ref external ref replaces the default ref and will be passed down using the 
 
   // Pass ref to trigger
   <IconButton
-    aria-label="Delete"
+    aria-labelledby="tooltip-example-text"
     icon="trash"
     ref={ref}
   />
 
   // Pass ref to the "triggerRef"-prop
   // Important: Place the <Tooltip> after your trigger component
-  // Note: The "label" matches the aria-label on the trigger element, making it accessible for screen reader users
   <Tooltip
+    id="tooltip-example"
     text="Delete"
     triggerRef={ref}
   />


### PR DESCRIPTION
## Changes
- Updated background color and font-size on Filip's request
- Added a console.warn for developers if the <Tooltip> trigger element is missing one or more aria-attributes
- Updated readme to inform about the a11y validation. Removed example for aria-label because we want developers to use the ID so we can ensure that the values in the tooltip are equal to the information that will be announced by the screen reader

## Updated styles
![image](https://user-images.githubusercontent.com/640976/68209067-e1526800-ffd2-11e9-9231-d57f9c4831ca.png)

## Regarding the a11y validation
I talked to a developer that was a bit confused about the red background color on the trigger element which is why I have updated the readme to inform about this and also added the console.warn to give some useful information.

I am aware that this console.warn will log on every render but I'm assuming that the a11y validation issue is something that you as a developer would fix quite fast so that the warning won't clutter your console for too long.

![image](https://user-images.githubusercontent.com/640976/68209123-ff1fcd00-ffd2-11e9-9354-da2a28623076.png)

![image](https://user-images.githubusercontent.com/640976/68209037-d566a600-ffd2-11e9-9e9c-6a00d083e82a.png)

