### PR TITLE
mountWithContext accepts translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 * Export the `<Popper>` component at top level.
 * Added `<MessageBanner>` component (STCOM-592)
+* Optionally include translations in `mountWithContext` test helper.
 
 ## [5.8.0](https://github.com/folio-org/stripes-components/tree/v5.8.0) (2019-09-25)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.7.1...v5.8.0)

--- a/tests/Harness.js
+++ b/tests/Harness.js
@@ -16,19 +16,26 @@ const reducer = combineReducers(reducers);
 const store = createStore(reducer);
 
 // mimics the StripesTranslationPlugin in @folio/stripes-core
-function prefixKeys(obj) {
+function prefixKeys(obj, prefix) {
   const res = {};
   for (const key of Object.keys(obj)) {
-    res[`stripes-components.${key}`] = obj[key];
+    res[`${prefix}.${key}`] = obj[key];
   }
   return res;
 }
 
 class Harness extends React.Component {
   render() {
+    const t = prefixKeys(translations, 'stripes-components');
+    if (this.props.translations) {
+      this.props.translations.forEach(tx => {
+        Object.assign(t, prefixKeys(tx.translations, tx.prefix));
+      });
+    }
+
     return (
       <Provider store={store}>
-        <IntlProvider locale="en" key="en" timeZone="UTC" messages={prefixKeys(translations)}>
+        <IntlProvider locale="en" key="en" timeZone="UTC" messages={t}>
           {this.props.children}
         </IntlProvider>
       </Provider>
@@ -38,6 +45,12 @@ class Harness extends React.Component {
 
 Harness.propTypes = {
   children: PropTypes.node,
+  translations: PropTypes.arrayOf(
+    PropTypes.shape({
+      prefix: PropTypes.string,
+      translations: PropTypes.object,
+    })
+  ),
 };
 
 export default Harness;

--- a/tests/Harness.js
+++ b/tests/Harness.js
@@ -15,7 +15,14 @@ const reducer = combineReducers(reducers);
 
 const store = createStore(reducer);
 
-// mimics the StripesTranslationPlugin in @folio/stripes-core
+/**
+ * mimics the StripesTranslationPlugin in @folio/stripes-core:
+ * given a list of key-value pairs like {"foo": "bar"} and a prefix,
+ * return {"prefix.foo": "bar", ...}.
+ *
+ * @param {*} obj map of key-value pairs
+ * @param {*} prefix module-path to prepend to each key
+ */
 function prefixKeys(obj, prefix) {
   const res = {};
   for (const key of Object.keys(obj)) {
@@ -24,18 +31,20 @@ function prefixKeys(obj, prefix) {
   return res;
 }
 
+/**
+ * mount a component with contexts provided by redux-store
+ * and react-intl.
+ */
 class Harness extends React.Component {
   render() {
-    const t = prefixKeys(translations, 'stripes-components');
-    if (this.props.translations) {
-      this.props.translations.forEach(tx => {
-        Object.assign(t, prefixKeys(tx.translations, tx.prefix));
-      });
-    }
+    const allTranslations = prefixKeys(translations, 'stripes-components');
+    this.props.translations.forEach(tx => {
+      Object.assign(allTranslations, prefixKeys(tx.translations, tx.prefix));
+    });
 
     return (
       <Provider store={store}>
-        <IntlProvider locale="en" key="en" timeZone="UTC" messages={t}>
+        <IntlProvider locale="en" key="en" timeZone="UTC" messages={allTranslations}>
           {this.props.children}
         </IntlProvider>
       </Provider>
@@ -44,13 +53,19 @@ class Harness extends React.Component {
 }
 
 Harness.propTypes = {
+  // the components to render into the context
   children: PropTypes.node,
+  // l10n map for the component's translation keys
   translations: PropTypes.arrayOf(
     PropTypes.shape({
       prefix: PropTypes.string,
       translations: PropTypes.object,
     })
   ),
+};
+
+Harness.propTypes = {
+  translations: [],
 };
 
 export default Harness;

--- a/tests/Harness.js
+++ b/tests/Harness.js
@@ -64,7 +64,7 @@ Harness.propTypes = {
   ),
 };
 
-Harness.propTypes = {
+Harness.defaultProps = {
   translations: [],
 };
 

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -29,9 +29,20 @@ export function mount(component) {
   });
 }
 
-export function mountWithContext(component) {
+/**
+ * Mount the given component under a context with redux-store's Provider
+ * and react-intl's IntlProvider.
+ *
+ * @param {*} component the component to mount
+ * @param {*} translations an array of {translations, prefix} objects
+ */
+export function mountWithContext(component, translations) {
   return new Promise(resolve => {
-    ReactDOM.render(<Harness>{component}</Harness>, getCleanTestingRoot(), resolve);
+    ReactDOM.render(
+      <Harness translations={translations}>{component}</Harness>,
+      getCleanTestingRoot(),
+      resolve,
+    );
   });
 }
 


### PR DESCRIPTION
# Summary
Provide `mountWithContext` with the ability to include additional
translations to those found locally.

# Approach
`mountWithContext` is exported as a test helper for use by other
repositories. As such, it should be able to include the translation
strings used by those repositories when running tests in order to avoid
errors like this during testing:
```
ERROR: '[React Intl] Missing message: "ui-circulation.settings.common.delete" for locale: "en-US"'
ERROR: '[React Intl] Cannot format message: "ui-circulation.settings.common.delete", using message id as fallback.'
```
By accepting an additional optional prop, `translations`, containing an
array of `{ translations, prefix }` objects, it can now load arbitrary
translations in addition to those it finds locally.