### PR TITLE
MCL: Don't include data-loader rows in rowCount

### DIFF
--- a/lib/MultiColumnList/tests/interactor.js
+++ b/lib/MultiColumnList/tests/interactor.js
@@ -45,7 +45,7 @@ export default interactor(class MultiColumnListInteractor {
   containerVisible = isVisible(`.${css.mclContainer}`);
   containerWidth = property(`.${css.mclContainer}`, 'offsetWidth');
   containerHeight = property(`.${css.mclContainer}`, 'offsetHeight');
-  rowCount = count(`.${css.mclRow}`);
+  rowCount = count(`.${css.mclRow}:not([data-loader])`);
   columnCount = count(`.${css.mclHeader}`);
   rows = collection(`.${css.mclRow}:not([data-loader])`, RowInteractor);
   rowMeasurers = collection(`.${css.mclRowFormatterContainer}`, RowMeasurerInteractor);


### PR DESCRIPTION
Like the definition of `rows` below it, the interactors shouldn't consider the presence of data-loader rows when computing rowCount.