### PR TITLE
Icon: Support Tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Export the `<Popper>` component at top level.
 * Added `<MessageBanner>` component (STCOM-592)
 * Optionally include translations in `mountWithContext` test helper.
+* Support `ref` in `<Tooltip>` via `forwardRef`.
 
 ## [5.8.0](https://github.com/folio-org/stripes-components/tree/v5.8.0) (2019-09-25)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.7.1...v5.8.0)
@@ -40,7 +41,7 @@
 * Replace Autosizer component with third-party equivalent [react-virtualized-auto-sizer](https://github.com/bvaughn/react-virtualized-auto-sizer). Refs STCOM-543.
 * `<ExpandAllButton>` now accepts an optional `id` prop to set on the `<Button>`.
 * `<Icon>` may receive custom icons. Refs STCOM-542.
-* Correctly set `<Accordion>`'s `id`. Refs STCOM-551. 
+* Correctly set `<Accordion>`'s `id`. Refs STCOM-551.
 * `<MetaSection>` elegantly handles missing metadata. Refs STCOM-538.
 * `<Datepicker>` cleanup: better i18n, issues with untouched fields.
 * Add an optional `footer` prop for `Pane` component for fixed footer feature. Refs STCOM-429.

--- a/lib/Icon/Icon.js
+++ b/lib/Icon/Icon.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { pickBy } from 'lodash';
 import css from './Icon.css';
 import icons from './icons';
 
 const propTypes = {
   ariaLabel: PropTypes.string,
-  ariaLabelledBy: PropTypes.string,
   children: PropTypes.node,
   icon: PropTypes.oneOfType([
     PropTypes.oneOf(Object.keys(icons)),
@@ -32,26 +32,29 @@ const propTypes = {
     'warn',
     'success',
   ]),
+  tabIndex: PropTypes.string,
 };
 
 const defaultProps = {
   size: 'medium',
   iconPosition: 'start',
   icon: 'default',
+  tabIndex: '-1',
 };
 
 const Icon = React.forwardRef(({
-  icon,
-  children,
   ariaLabel,
-  ariaLabelledBy,
+  children,
+  icon,
   iconClassName,
+  iconPosition,
+  iconRootClass,
+  iconStyle,
   id,
   size,
   status,
-  iconRootClass,
-  iconPosition,
-  iconStyle,
+  tabIndex,
+  ...rest
 }, ref) => {
   const getRootClass = classNames(
     css.icon,
@@ -84,14 +87,16 @@ const Icon = React.forwardRef(({
     IconElement = icons[icon];
   }
 
+  const ariaAttributes = pickBy(rest, (_, key) => key.startsWith('aria-'));
+
   return (
     <span
       aria-label={ariaLabel}
-      aria-labelledby={ariaLabelledBy}
       className={getRootClass}
       id={id}
       ref={ref}
-      tabIndex="-1"
+      tabIndex={tabIndex}
+      {...ariaAttributes}
     >
       <IconElement
         data-test-icon-element
@@ -104,6 +109,7 @@ const Icon = React.forwardRef(({
   );
 });
 
+Icon.displayName = 'Icon';
 Icon.defaultProps = defaultProps;
 Icon.propTypes = propTypes;
 

--- a/lib/Icon/Icon.js
+++ b/lib/Icon/Icon.js
@@ -4,107 +4,107 @@ import classNames from 'classnames';
 import css from './Icon.css';
 import icons from './icons';
 
-/* eslint-disable react/prefer-stateless-function */
-/* We write this as a class because other components apply and use a ref to it */
+const propTypes = {
+  ariaLabel: PropTypes.string,
+  ariaLabelledBy: PropTypes.string,
+  children: PropTypes.node,
+  icon: PropTypes.oneOfType([
+    PropTypes.oneOf(Object.keys(icons)),
+    PropTypes.func,
+  ]),
+  iconClassName: PropTypes.string,
+  iconPosition: PropTypes.oneOf([
+    'start',
+    'end',
+  ]),
+  iconRootClass: PropTypes.string,
+  iconStyle: PropTypes.oneOf([
+    'action',
+  ]),
+  id: PropTypes.string,
+  size: PropTypes.oneOf([
+    'small',
+    'medium',
+    'large',
+  ]),
+  status: PropTypes.oneOf([
+    'error',
+    'warn',
+    'success',
+  ]),
+};
 
-class Icon extends React.Component {
-  static propTypes = {
-    ariaLabel: PropTypes.string,
-    children: PropTypes.node,
-    icon: PropTypes.oneOfType([
-      PropTypes.oneOf(Object.keys(icons)),
-      PropTypes.func,
-    ]),
-    iconClassName: PropTypes.string,
-    iconPosition: PropTypes.oneOf([
-      'start',
-      'end',
-    ]),
-    iconRootClass: PropTypes.string,
-    iconStyle: PropTypes.oneOf([
-      'action',
-    ]),
-    id: PropTypes.string,
-    size: PropTypes.oneOf([
-      'small',
-      'medium',
-      'large',
-    ]),
-    status: PropTypes.oneOf([
-      'error',
-      'warn',
-      'success',
-    ]),
+const defaultProps = {
+  size: 'medium',
+  iconPosition: 'start',
+  icon: 'default',
+};
+
+const Icon = React.forwardRef(({
+  icon,
+  children,
+  ariaLabel,
+  ariaLabelledBy,
+  iconClassName,
+  id,
+  size,
+  status,
+  iconRootClass,
+  iconPosition,
+  iconStyle,
+}, ref) => {
+  const getRootClass = classNames(
+    css.icon,
+    iconRootClass,
+    // If icon position is defined
+    { [css[`icon-position-${iconPosition}`]]: children && iconPosition },
+    // If a status is defined
+    { [css[`status-${status}`]]: status },
+    // Icons that contains "left" or "right should flip on dir="rtl"
+    { [css.flippable]: typeof icon === 'string' && icon.match(/(right|left)/) },
+    // Apply icon style
+    { [css[iconStyle]]: iconStyle },
+  );
+
+  const getSVGClass = classNames(
+    'stripes__icon',
+    iconClassName,
+    `icon-${icon}`,
+    css[size],
+  );
+
+  // Defaults to the default-icon
+  let IconElement = icons.default;
+
+  // Custom icon
+  if (typeof icon === 'function') {
+    IconElement = icon;
+  // Find icon in icons list
+  } else if (typeof icon === 'string' && typeof icons[icon] === 'function') {
+    IconElement = icons[icon];
   }
 
-  static defaultProps = {
-    size: 'medium',
-    iconPosition: 'start',
-    icon: 'default',
-  }
+  return (
+    <span
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      className={getRootClass}
+      id={id}
+      ref={ref}
+      tabIndex="-1"
+    >
+      <IconElement
+        data-test-icon-element
+        className={getSVGClass}
+        viewBox="0 0 32 32"
+        focusable="false"
+      />
+      { children ? <span className={css.label}>{children}</span> : null }
+    </span>
+  );
+});
 
-  render() {
-    const {
-      icon,
-      children,
-      ariaLabel,
-      iconClassName,
-      id,
-      size,
-      status,
-      iconRootClass,
-      iconPosition,
-      iconStyle,
-    } = this.props;
-
-    const getRootClass = classNames(
-      css.icon,
-      iconRootClass,
-      // If icon position is defined
-      { [css[`icon-position-${iconPosition}`]]: children && iconPosition },
-      // If a status is defined
-      { [css[`status-${status}`]]: status },
-      // Icons that contains "left" or "right should flip on dir="rtl"
-      { [css.flippable]: typeof icon === 'string' && icon.match(/(right|left)/) },
-      // Apply icon style
-      { [css[iconStyle]]: iconStyle },
-    );
-
-    const getSVGClass = classNames(
-      'stripes__icon',
-      iconClassName,
-      `icon-${icon}`,
-      css[size],
-    );
-
-    // Defaults to the default-icon
-    let IconElement = icons.default;
-
-    // Custom icon
-    if (typeof icon === 'function') {
-      IconElement = icon;
-    // Find icon in icons list
-    } else if (typeof icon === 'string' && typeof icons[icon] === 'function') {
-      IconElement = icons[icon];
-    }
-
-    return (
-      <span
-        className={getRootClass}
-        tabIndex="-1"
-        aria-label={ariaLabel}
-        id={id}
-      >
-        <IconElement
-          data-test-icon-element
-          className={getSVGClass}
-          viewBox="0 0 32 32"
-          focusable="false"
-        />
-        { children ? <span className={css.label}>{children}</span> : null }
-      </span>
-    );
-  }
-}
+Icon.defaultProps = defaultProps;
+Icon.propTypes = propTypes;
 
 export default Icon;


### PR DESCRIPTION
@EthanFreestone found an issue where you couldn't wrap an `<Icon>` in a `<Tooltip>`. 

At first, it crashes due to the lack of a forwarded ref. Once I converted Icon to use `forwardRef`, we still needed some way of setting `aria-labelledby`. I just added support for this via another prop.

**Questions**
- Is this worth it? There is a workaround which is to wrap the `Icon` in a `<span>` and set the ref/aria-labelledby on the span instead.
- Does anyone know of a way we could be breaking a parent's expectations for what `ref` should here? I couldn't find any in the code.
- Should we _not_ add a specific `ariaLabelledBy` prop and instead do some `pickBy(rest, (_, key) => key.startsWith('aria-'))` grouping of props and apply them wholesale instead?