### PR TITLE
STCOM-623 validate args before accessing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added `<MessageBanner>` component (STCOM-592)
 * Optionally include translations in `mountWithContext` test helper.
 * Support `ref` in `<Tooltip>` via `forwardRef`.
+* Validate shape of arguments before accessing them in `<FilterGroups>`. Refs STCOM-623.
 
 ## [5.8.0](https://github.com/folio-org/stripes-components/tree/v5.8.0) (2019-09-25)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.7.1...v5.8.0)

--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -172,28 +172,30 @@ export function filters2cql(config, filters = '') {
     // with the same name. that *shouldn't* happen, but just in case it
     // does, only use the first one.
     const group = config.filter(g => g.name === groupName)[0];
-    const cqlIndex = group.cql;
+    if (group && group.cql) {
+      const cqlIndex = group.cql;
 
-    // values contains the selected filters
-    const values = groups[groupName];
-    if (!(values.length === (group.values.length) && !group.restrictWhenAllSelected)) {
-      const mappedValues = values.map((v) => {
-        // If the field is a {name,cql} object, use the CQL.
-        const obj = group.values.filter(f => typeof f === 'object' && f.name === v);
-        return (obj.length > 0) ? obj[0].cql : v;
-      });
+      // values contains the selected filters
+      const values = groups[groupName];
+      if (!(values.length === (group.values.length) && !group.restrictWhenAllSelected)) {
+        const mappedValues = values.map((v) => {
+          // If the field is a {name,cql} object, use the CQL.
+          const obj = group.values.filter(f => typeof f === 'object' && f.name === v);
+          return (obj.length > 0) ? obj[0].cql : v;
+        });
 
-      if (group.isRange) {
-        const { isIncludingStart = true, isIncludingEnd = true, rangeSeparator = ':' } = group;
-        const [start, end] = mappedValues[0].split(rangeSeparator);
-        const startCondition = `${cqlIndex}>${isIncludingStart ? '=' : ''}"${start}"`;
-        const endCondition = `${cqlIndex}<${isIncludingEnd ? '=' : ''}"${end}"`;
+        if (group.isRange) {
+          const { isIncludingStart = true, isIncludingEnd = true, rangeSeparator = ':' } = group;
+          const [start, end] = mappedValues[0].split(rangeSeparator);
+          const startCondition = `${cqlIndex}>${isIncludingStart ? '=' : ''}"${start}"`;
+          const endCondition = `${cqlIndex}<${isIncludingEnd ? '=' : ''}"${end}"`;
 
-        conds.push(`(${startCondition} and ${endCondition})`);
-      } else {
-        let joinedValues = mappedValues.map(v => `"${v}"`).join(' or ');
-        if (values.length > 1) joinedValues = `(${joinedValues})`;
-        conds.push(`${cqlIndex}=${joinedValues}`);
+          conds.push(`(${startCondition} and ${endCondition})`);
+        } else {
+          let joinedValues = mappedValues.map(v => `"${v}"`).join(' or ');
+          if (values.length > 1) joinedValues = `(${joinedValues})`;
+          conds.push(`${cqlIndex}=${joinedValues}`);
+        }
       }
     }
   }

--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -197,6 +197,8 @@ export function filters2cql(config, filters = '') {
           conds.push(`${cqlIndex}=${joinedValues}`);
         }
       }
+    } else {
+      console.warn(`Expected to find match for ${groupName} in filter-config`, config);
     }
   }
 


### PR DESCRIPTION
Validate the shape of `groups.cql` before attempting to access it in
order to avoid an NPE when it is not defined.

Fixes [STCOM-623](https://issues.folio.org/browse/STCOM-623)