### PR TITLE
STCOM-628: Fix aria-labelledby parameter in Select component

### DIFF
--- a/lib/Select/Select.js
+++ b/lib/Select/Select.js
@@ -68,6 +68,19 @@ class Select extends Component {
     );
   }
 
+  getAriaLabelledBy() {
+    let ariaLabelledBy;
+    const label = this.props.label && `${this.id}-label`;
+    const readOnly = this.props.readOnly && `${this.id}-read-only-message`;
+    const ariaLabelledByString = [label, readOnly].filter(item => !!item).join(' ');
+
+    if (ariaLabelledByString.length) {
+      ariaLabelledBy = ariaLabelledByString;
+    }
+
+    return ariaLabelledBy;
+  }
+
   render() {
     /* eslint-disable no-unused-vars */
     const {
@@ -120,8 +133,8 @@ class Select extends Component {
         className={this.getSelectClass()}
         name={name}
         {...omitProps(selectCustom, ['selectClass'])}
-        aria-labelledby={`${this.id}-label ${this.props.readOnly ? `${this.id}-read-only-message` : ''}`.trim()}
-        aria-invalid={!!(this.props.error)}
+        aria-labelledby={this.getAriaLabelledBy()}
+        aria-invalid={!!this.props.error}
         id={this.id}
         readOnly={this.props.readOnly}
       >


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-628

## Purpose
Currently, `aria-labelledby` always points to label HTML element. So when there is no label, it points to nonexistent node and it causes an issue for screen readers.

## Approach
Define `aria-labelledby` parameter only when label is provided.