### PR TITLE
Support ref in Modal via forwardRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-components
 ## 5.9.1 IN Progress
 
+* Support ref in Modal via forwardRef. Refs ERM-620
 * Hotfix for dropdowns: clicks to menu whitespace will not propagate to container.
 * include `header` in exceptions for focus-trapping.
 

--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Modal as OverlayModal } from 'react-overlays';
 import classNames from 'classnames';
@@ -75,7 +75,7 @@ const defaultProps = {
   wrappingElement: 'div',
 };
 
-const Modal = (props) => {
+const Modal = forwardRef((props, ref) => {
   const {
     children,
     closeOnBackgroundClick,
@@ -117,7 +117,7 @@ const Modal = (props) => {
     contentClass,
   );
 
-  const renderBackdrop = ({ onClick, ref, style }) => { /* eslint-disable-line react/prop-types */
+  const renderBackdrop = ({ onClick, ref, style }) => { /* eslint-disable-line react/prop-types, no-shadow */
     const handleClick = closeOnBackgroundClick ? onClick : undefined;
 
     /* eslint-disable-next-line */
@@ -126,7 +126,7 @@ const Modal = (props) => {
 
   return (
     <TransitionGroup>
-      { open &&
+      {open &&
         <Transition
           in={open}
           unmountOnExit
@@ -141,7 +141,7 @@ const Modal = (props) => {
                 container={getModalScope()}
                 onHide={onClose}
                 onShow={onOpen}
-                onBackdropClick={closeOnBackgroundClick ? onClose : () => {}}
+                onBackdropClick={closeOnBackgroundClick ? onClose : () => { }}
                 enforceFocus={enforceFocus}
                 restoreFocus={restoreFocus}
                 renderBackdrop={renderBackdrop}
@@ -150,9 +150,10 @@ const Modal = (props) => {
                   className={getModalClass()}
                   aria-label={props.ariaLabel}
                   id={props.id}
+                  ref={ref}
                   {...rest}
                 >
-                  { showHeader &&
+                  {showHeader &&
                     <div className={css.modalHeader}>
                       <Headline
                         tag="h1"
@@ -198,7 +199,7 @@ const Modal = (props) => {
       }
     </TransitionGroup>
   );
-};
+});
 
 Modal.propTypes = propTypes;
 Modal.defaultProps = defaultProps;

--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -117,7 +117,7 @@ const Modal = forwardRef((props, ref) => {
     contentClass,
   );
 
-  const renderBackdrop = ({ onClick, ref, style }) => { /* eslint-disable-line react/prop-types, no-shadow */
+  const renderBackdrop = ({ onClick, ref: backdropRef, style }) => { /* eslint-disable-line react/prop-types */
     const handleClick = closeOnBackgroundClick ? onClick : undefined;
 
     /* eslint-disable-next-line */

--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -121,7 +121,7 @@ const Modal = forwardRef((props, ref) => {
     const handleClick = closeOnBackgroundClick ? onClick : undefined;
 
     /* eslint-disable-next-line */
-    return (<div className={css.backdrop} onClick={handleClick} style={style} ref={ref} />);
+    return (<div className={css.backdrop} onClick={handleClick} style={style} ref={backdropRef} />);
   };
 
   return (


### PR DESCRIPTION
In relation to https://github.com/folio-org/ui-plugin-find-user/pull/112, we need to have a reference to the Modal so that the condition [here](https://github.com/folio-org/ui-plugin-find-user/pull/112/files#diff-96e3556dd15eba52e6c744f5d35fd2eeR56) would resolve to true if the **X** dismissible button when in focus (when clicked), is still inside the Modal.

Previously, we were just targeting the [modal content](https://github.com/folio-org/ui-plugin-find-user/pull/112/files#diff-96e3556dd15eba52e6c744f5d35fd2eeL56) and due to this the **X** iconButton in the modals header wasn't contained in the element targeted by the modalContent `ref`, and hence the focus on the modal trigger [here](https://github.com/folio-org/ui-plugin-find-user/pull/112/files#diff-96e3556dd15eba52e6c744f5d35fd2eeR57) when the modal was dismissed wasnt being called. This PR fixes this.