### PR TITLE
Dropdown hotfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change history for stripes-components
+## 5.9.1 IN Progress
+
+* Hotfix for dropdowns: clicks to menu whitespace will not propagate to container.
+* include `header` in exceptions for focus-trapping.
 
 ## [5.9.0](https://github.com/folio-org/stripes-components/tree/v5.9.0) (2019-12-04)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.8.0...v5.9.0)

--- a/lib/Dropdown/Popdown.js
+++ b/lib/Dropdown/Popdown.js
@@ -251,7 +251,8 @@ const Popdown = ({
           'tabIndex': '-1',
           'onBlur': menuBlur,
           'onFocus': menuFocus,
-          'data-test-dropdown-menu-overlay': true
+          'data-test-dropdown-menu-overlay': true,
+          'onClick': (e) => { e.stopPropagation(); }
         }}
         portal={usePortal ? portalEl : null}
       >

--- a/lib/Dropdown/Popdown.js
+++ b/lib/Dropdown/Popdown.js
@@ -252,8 +252,9 @@ const Popdown = ({
           'onBlur': menuBlur,
           'onFocus': menuFocus,
           'data-test-dropdown-menu-overlay': true,
-          'onClick': (e) => { e.stopPropagation(); } // prevent propagation of click to trigger parents e.g. table rows.
-        }}
+          'onClick': (e) => { e.stopPropagation(); }  // prevent propagation of click events
+        }}                                            // to trigger parents e.g. table rows.
+                                                      // The events even propagate through react-portals.
         portal={usePortal ? portalEl : null}
       >
         <React.Fragment>

--- a/lib/Dropdown/Popdown.js
+++ b/lib/Dropdown/Popdown.js
@@ -252,7 +252,7 @@ const Popdown = ({
           'onBlur': menuBlur,
           'onFocus': menuFocus,
           'data-test-dropdown-menu-overlay': true,
-          'onClick': (e) => { e.stopPropagation(); }
+          'onClick': (e) => { e.stopPropagation(); } // prevent propagation of click to trigger parents e.g. table rows.
         }}
         portal={usePortal ? portalEl : null}
       >

--- a/util/trapFocus.js
+++ b/util/trapFocus.js
@@ -3,7 +3,7 @@ import contains from 'dom-helpers/query/contains';
 const getDefaultExceptions = () => [
   document.getElementById('OverlayContainer'),
   ...document.querySelectorAll('.tether-element'),
-  document.querySelector('header'),
+  document.querySelector('header'), // fix for main navigation dropdowns when <Layer> is open.
 ];
 
 export default function trapFocus(container, exceptions) {

--- a/util/trapFocus.js
+++ b/util/trapFocus.js
@@ -3,13 +3,16 @@ import contains from 'dom-helpers/query/contains';
 const getDefaultExceptions = () => [
   document.getElementById('OverlayContainer'),
   ...document.querySelectorAll('.tether-element'),
-  ...document.querySelector('header'),
+  document.querySelector('header'),
 ];
 
 export default function trapFocus(container, exceptions) {
   if (container && container.className !== document.activeElement.className) {
     if (!contains(container, document.activeElement)) {
-      if ([...getDefaultExceptions(), ...exceptions].filter((e) => contains(e, document.activeElement)).length === 0) {
+      if ([...getDefaultExceptions(), ...exceptions].filter((e) => {
+        if (!e) return false;
+        return contains(e, document.activeElement);
+      }).length === 0) {
         container.focus();
       }
     }

--- a/util/trapFocus.js
+++ b/util/trapFocus.js
@@ -3,8 +3,8 @@ import contains from 'dom-helpers/query/contains';
 const getDefaultExceptions = () => [
   document.getElementById('OverlayContainer'),
   ...document.querySelectorAll('.tether-element'),
-  document.querySelector('header'), // fix for main navigation dropdowns when <Layer> is open.
-];
+  document.querySelector('header'), // fix for main navigation dropdowns
+];                                  // which depend on having focus when <Layer> is open.
 
 export default function trapFocus(container, exceptions) {
   if (container && container.className !== document.activeElement.className) {

--- a/util/trapFocus.js
+++ b/util/trapFocus.js
@@ -3,6 +3,7 @@ import contains from 'dom-helpers/query/contains';
 const getDefaultExceptions = () => [
   document.getElementById('OverlayContainer'),
   ...document.querySelectorAll('.tether-element'),
+  ...document.querySelector('header'),
 ];
 
 export default function trapFocus(container, exceptions) {


### PR DESCRIPTION
Two fixes:
* resolve behavior: for dropdowns within table rows clicking empty space in menu would propagate the click to the parent row. Resolved with a stopPropagation call passed to the overlay within `<Popdown>`.
* included `header` selector in `trapfocus` exclusions. This will allow the Applist and ProfileDropdown in stripes-core to continue to function if a `<Layer>` is open.