### PR TITLE
do not check component types

### DIFF
--- a/lib/ModalFooter/ModalFooter.js
+++ b/lib/ModalFooter/ModalFooter.js
@@ -35,8 +35,8 @@ const ModalFooter = ({ children, primaryButton, secondaryButton }) => {
 
 ModalFooter.propTypes = {
   children: PropTypes.oneOfType([
-    PropTypes.arrayOf(Button),
-    PropTypes.objectOf(Button),
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.objectOf(PropTypes.node),
   ]),
   primaryButton: deprecated(PropTypes.shape({
     ...buttonPropTypes,


### PR DESCRIPTION
A PropTypes check for a particular component type may fail if that
component is, say, a functional component or one that returns a ref.
`PropTypes.node` allows us to detect that we're getting a renderable
thing without thinking too hard about it.

Why am I doing this? I want a clean console, and you should too.