### PR TITLE
STCOM-604 Datepicker calendar button not working the first time

### DIFF
--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -180,12 +180,14 @@ class Datepicker extends React.Component {
   textfield = React.createRef();
 
   handleFieldFocus = () => {
+    console.log('field focus');
     if (this.props.useFocus && !this.props.disabled) {
       this.showCalendar();
     }
   }
 
   handleFieldClick = () => {
+    console.log('field click');
     if (this.props.useFocus) {
       if (!this.state.showCalendar) {
         this.showCalendar();
@@ -217,10 +219,9 @@ class Datepicker extends React.Component {
   }
 
   toggleCalendar = () => {
-    const current = this.state.showCalendar;
-    this.setState({
-      showCalendar: !current,
-    });
+    this.setState(current => ({
+      showCalendar: !current.showCalendar,
+    }));
   }
 
   handleKeyDown = (e) => {
@@ -471,8 +472,9 @@ class Datepicker extends React.Component {
           {ariaLabel => (
             <IconButton
               data-test-calendar-button
-              onClick={this.toggleCalendar}
               onKeyDown={this.handleKeyDown}
+              onClick={this.toggleCalendar}
+              onFocus={(e) => { e.stopPropagation(); }}
               aria-label={ariaLabel}
               id={`datepicker-toggle-calendar-button-${this.testId}`}
               tabIndex="-1"

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -180,14 +180,12 @@ class Datepicker extends React.Component {
   textfield = React.createRef();
 
   handleFieldFocus = () => {
-    console.log('field focus');
     if (this.props.useFocus && !this.props.disabled) {
       this.showCalendar();
     }
   }
 
   handleFieldClick = () => {
-    console.log('field click');
     if (this.props.useFocus) {
       if (!this.state.showCalendar) {
         this.showCalendar();


### PR DESCRIPTION
## Problem
Clicking the calendar in the datepicker wouldn't open the calendar the first time it was clicked. The user would have to click it again.

## Approach
The bug was caused by a conflicting state change - the focus event from the calender button would bubble to the input which would trigger a state change to open the calender... the click event would happen next, which triggered a toggle event - with the open state present, it closed the calender.

I gave the button an onFocus handler that stopped the propagation of the focus.
