### PR TITLE
Increased <SRStatus> timeout

### DIFF
--- a/lib/SRStatus/SRStatus.js
+++ b/lib/SRStatus/SRStatus.js
@@ -56,12 +56,12 @@ class SRStatus extends React.Component {
     if (this.updateTimer) {
       clearTimeout(this.updateTimer);
     }
-    this.updateTimer = setTimeout(() => { this.allowRepeatMessage(); }, 250);
+    this.updateTimer = setTimeout(() => { this.allowRepeatMessage(); }, 500);
   }
 
   allowRepeatMessage() {
     this.willUpdateRepeats = true;
-    this.setState({ updates: [] }, () => { this.forceUpdate(); });
+    // this.setState({ updates: [] }, () => { this.forceUpdate(); });
   }
 
   render() {

--- a/lib/SRStatus/SRStatus.js
+++ b/lib/SRStatus/SRStatus.js
@@ -51,7 +51,7 @@ class SRStatus extends React.Component {
     if (this.updateTimer) {
       clearTimeout(this.updateTimer);
     }
-    this.updateTimer = setTimeout(() => { this.allowRepeatMessage(); }, 100);
+    this.updateTimer = setTimeout(() => { this.allowRepeatMessage(); }, 200);
   }
 
   allowRepeatMessage() {

--- a/lib/SRStatus/SRStatus.js
+++ b/lib/SRStatus/SRStatus.js
@@ -51,7 +51,7 @@ class SRStatus extends React.Component {
     if (this.updateTimer) {
       clearTimeout(this.updateTimer);
     }
-    this.updateTimer = setTimeout(() => { this.allowRepeatMessage(); }, 200);
+    this.updateTimer = setTimeout(() => { this.allowRepeatMessage(); }, 250);
   }
 
   allowRepeatMessage() {

--- a/lib/SRStatus/SRStatus.js
+++ b/lib/SRStatus/SRStatus.js
@@ -3,7 +3,12 @@ import PropTypes from 'prop-types';
 
 class SRStatus extends React.Component {
   static propTypes = {
+    ariaLive: PropTypes.oneOf(['polite', 'assertive', 'off']),
     message: PropTypes.string,
+  }
+
+  static defaultProps = {
+    ariaLive: 'assertive',
   }
 
   constructor(props) {
@@ -60,6 +65,7 @@ class SRStatus extends React.Component {
   }
 
   render() {
+    const { ariaLive } = this.props;
     const srStyle = {
       position: 'absolute !important',
       clip: 'rect(1px, 1px, 1px, 1px)',
@@ -69,7 +75,7 @@ class SRStatus extends React.Component {
     };
 
     return (
-      <div aria-live="assertive" aria-relevant="additions" style={srStyle}>
+      <div aria-live={ariaLive} aria-relevant="additions" style={srStyle}>
         {this.state.updates}
       </div>
     );

--- a/lib/SRStatus/SRStatus.js
+++ b/lib/SRStatus/SRStatus.js
@@ -66,16 +66,9 @@ class SRStatus extends React.Component {
 
   render() {
     const { ariaLive } = this.props;
-    const srStyle = {
-      position: 'absolute !important',
-      clip: 'rect(1px, 1px, 1px, 1px)',
-      height: '1px',
-      width: '1px',
-      overflow: 'hidden',
-    };
 
     return (
-      <div aria-live={ariaLive} aria-relevant="additions" style={srStyle}>
+      <div aria-live={ariaLive} aria-relevant="additions" className="sr-only">
         {this.state.updates}
       </div>
     );

--- a/lib/SRStatus/readme.md
+++ b/lib/SRStatus/readme.md
@@ -9,20 +9,26 @@ SRStatus works via a method call against a ref to an instance of it.
 ```
 import { SRStatus } from '@folio/stripes/components';
 
-// in constructor
-this.srsRef = null;
+// set up a ref
+this.srsRef = React.createRef(null)
 
 // component methods/callbacks
-
 someCallback() {
   // call the sendMessage method on the component.
-  this.srsRef.sendMessage('hello user!');
+  this.srsRef.current.sendMessage('hello user!');
 }
 
 // in render()
-<SRStatus ref={(ref)=>{this.srsRef = ref;}} />
+<SRStatus ref={this.srsRef} />
 
 // of course, be sure to use the callback somewhere in your JSX.
 <Button type="button" onClick={this.someCallback}> Hear Message </Button>
 
 ```
+
+# Props
+Name | Type | Description | Options | Default
+-- | -- | -- | -- | --
+ariaLive | string | Sets the aria-live attribute for the live region. This is used to set the priority with which screen reader should treat updates to live regions. | assertive, polite, off | assertive
+message | string | Pass a message that will be read out by the screen reader. This is an alternative to using the `sendMessage`-method. | |
+ref | func | Passing a ref for `<SRStatus>` allows for accessing the `sendMessage`-method as shown in the example above. | |


### PR DESCRIPTION
While working on a ticket for ui-users I noticed an issue where messages didn't get read by the mac screen reader utility.

I increased the timeout to 500ms for `<SRStatus>` which fixed it.

**Update:** After talking to @JohnC-80 we decided that it would make sense to make the `aria-live`-attribute controllable by a prop so I updated the component to support this and updated the readme as well.