### PR TITLE
Callout: Return callout id from sendCallout

### DIFF
--- a/lib/Callout/Callout.js
+++ b/lib/Callout/Callout.js
@@ -34,18 +34,21 @@ class Callout extends React.Component {
   }
 
   sendCallout({ type = 'success', message, timeout = 6000 }) {
+    const newCallout = Object.assign(
+      { id: uniqueId('callout-'), onDismiss: this.removeCallout },
+      { type, message, timeout }
+    );
+
     this.setState((curState) => {
       const newState = cloneDeep(curState);
-      const newCallout = Object.assign(
-        { id: uniqueId('callout-'), onDismiss: this.removeCallout },
-        { type, message, timeout }
-      );
       newState.callouts.push(newCallout);
       if (timeout !== 0) {
         this.timeouts.push(window.setTimeout(() => { this.removeCallout(newCallout.id); }, timeout));
       }
       return newState;
     });
+
+    return newCallout.id;
   }
 
   removeCallout(id) {


### PR DESCRIPTION
Sometimes it's nice to be able to control exactly when the callout disappears because it becomes no longer relevant. This tweak allows a component to use not just sendCallout but also removeCallout.

This PR lets us do things like:
```
const calloutId = sendCallout({
  message: 'Preparing file for download...this may take a few minutes...',
  timeout: 0
});

fetchEndpointThatTakesAWhileToGenerateAFileToDownload()
  .then(downloadResponseBlob)
  .then(removeCallout(calloutId));
```