### PR TITLE
STCOM-634 provide NoValue component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `aria-labelledby` functionality to `<MultiSelection>`. fixes STCOM-627.
 * Test coverage for `<FilterGroups>` at > 80%. Refs STCOM-610.
+* Provide `<NoValue>` to show a `-` and handle `aria-label` correctly. Fixes STCOM-634.
 
 ## [5.9.1](https://github.com/folio-org/stripes-components/tree/v5.9.1) (2019-12-09)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.9.0...v5.9.1)

--- a/index.js
+++ b/index.js
@@ -75,6 +75,7 @@ export { default as MetaSection } from './lib/MetaSection';
 export { default as NavList } from './lib/NavList';
 export { default as NavListItem } from './lib/NavListItem';
 export { default as NavListSection } from './lib/NavListSection';
+export { default as NoValue } from './lib/NoValue';
 export { default as Popover } from './lib/Popover';
 export { default as Selection, OptionSegment } from './lib/Selection';
 export { default as SRStatus } from './lib/SRStatus';

--- a/lib/NoValue/NoValue.js
+++ b/lib/NoValue/NoValue.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+
+/**
+ * this is used for reading the given dash character as "no value set" by a screenreader
+ */
+function NoValue() {
+  return (
+    <FormattedMessage id="stripes-components.noValue.noValueSet">
+      {ariaLabel => (
+        <span
+          /* eslint-disable-next-line jsx-a11y/aria-role */
+          role="text"
+          aria-label={ariaLabel}
+          data-test-no-value
+        >
+          {'-'}
+        </span>
+      )}
+    </FormattedMessage>
+  );
+}
+
+export default NoValue;

--- a/lib/NoValue/index.js
+++ b/lib/NoValue/index.js
@@ -1,0 +1,1 @@
+export { default } from './NoValue';

--- a/lib/NoValue/readme.md
+++ b/lib/NoValue/readme.md
@@ -1,0 +1,12 @@
+# NoValue
+
+Render a dash, `-`, to indicate "no value set", including the appropriate
+`aria-label` so screen readers will also read "no value set".
+
+## Basic Usage
+
+```
+import { NoValue } from '@folio/stripes/components';
+
+<NoValue />
+```

--- a/lib/NoValue/tests/NoValue-test.js
+++ b/lib/NoValue/tests/NoValue-test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { expect } from 'chai';
+
+import {
+  beforeEach,
+  describe,
+  it,
+} from '@bigtest/mocha';
+
+import NoValue from '../NoValue';
+
+import { mountWithContext } from '../../../tests/helpers';
+import NoValueInteractor from './interactor';
+
+describe('NoValue', () => {
+  const noValue = new NoValueInteractor();
+
+  beforeEach(async () => {
+    await mountWithContext(<NoValue />);
+  });
+
+  // Dummy test: make sure the component is present. I mean, duh.
+  it('should display label', () => {
+    expect(noValue.isPresent).to.be.true;
+  });
+
+  // Check that the attribute `role="text"` is present.
+  // This is potentially controversial. Let me explain. role="text"
+  // is not technically part of ARIA 1.1 and a span is usually considered
+  // to be text anyway, so ... WTF? It's messy. The only thing inside this
+  // span is a single dash character, which might not otherwise look like
+  // text.
+  it('should have a "role" attribute', () => {
+    expect(noValue.roleAttribute).to.equal('text');
+  });
+
+  // Check to make sure an aria-label attribute, which is what will be read
+  // by screenreaders in lieu of the text-value of the span.
+  it('should have an "aria-label" attribute', () => {
+    expect(noValue.ariaLabelAttribute).to.equal('No value set');
+  });
+});

--- a/lib/NoValue/tests/interactor.js
+++ b/lib/NoValue/tests/interactor.js
@@ -1,0 +1,11 @@
+import {
+  attribute,
+  interactor,
+} from '@bigtest/interactor';
+
+export default interactor(class NoValueInteractor {
+  static defaultScope = '[data-test-no-value]';
+
+  roleAttribute = attribute('role');
+  ariaLabelAttribute = attribute('aria-label');
+});

--- a/translations/stripes-components/en.json
+++ b/translations/stripes-components/en.json
@@ -78,6 +78,7 @@
   "passwordStrength.infoPopoverText": "Include digits/symbols or make your password longer and more random",
   "passwordStrength.label": "Password strength:",
   "MessageBanner.dismissButtonAriaLabel": "Hide message",
+  "noValue.noValueSet": "No value set",
   "countries.AF": "Afghanistan",
   "countries.AX": "Aland Islands",
   "countries.AL": "Albania",


### PR DESCRIPTION
Provide a "no value" component that shows a `-` on screen and correctly
handles the `aria-label` attribute so that "no value set" is read by
screen readers.

Refs [STCOM-634](https://issues.folio.org/browse/STCOM-634)