### PR TITLE
STCOM-633 Horizontal scrollbar when columnWidths add up to 100%...

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -103,10 +103,14 @@ export function initColumnsFromData(item, headerMeta, rowMeta) {
 
 function getPixelColumnWidths(columnWidths, width) {
   const columnsFromProps = {};
+  // account for margin of rows (5px in CSS... 5 * 2 = 10).
+  // this will prevent percentage width that sum to 100% values from exceeding
+  // actual width and causing horizontal scroll. - STCOM-633
+  const calculatedWidth = width - 10;
   forOwn(columnWidths, (value, key) => {
     columnsFromProps[key] = convertToPixels(
       value,
-      width,
+      calculatedWidth,
     );
   });
   return columnsFromProps;
@@ -734,7 +738,7 @@ class MCLRenderer extends React.Component {
     *  or the rowWidth (sum of the columnWidths)
     *  whichever is greater.
     */
-    const defaultStyle = { minWidth: `${Math.max((widthVar - rowMargin), rowWidthVar)}px` };
+    const defaultStyle = { minWidth: `${Math.max((widthVar - (rowMargin * 2)), rowWidthVar)}px` };
 
     const onClick = onRowClick ? (e) => { this.handleRowClick(e, this.getRowData(rowIndex)); } : undefined;
     const defaultRowProps = {
@@ -1072,11 +1076,11 @@ class MCLRenderer extends React.Component {
 
   renderCells = (rowIndex) => {
     const { formatter, contentData, columnOverflow, id, columnWidths: columnWidthsProp } = this.props;
-    const { columnWidths } = this.state;
+    const { columnWidths, columns } = this.state;
 
     const cells = [];
     const labelStrings = [];
-    this.state.columns.forEach((col) => {
+    columns.forEach((col) => {
       let value;
       let stringValue;
 


### PR DESCRIPTION
# Problem
See title... the width calculation was based on a full width value rather than the value minus the margins, hence the horizontal scroll.

## Approach
 Adjusted the width being calculated in the column width calculation.

## Screenshots
### Before:
![image](https://user-images.githubusercontent.com/20704067/72173235-b1da2600-339c-11ea-99d7-5f4260a979b1.png)

### After:
![image](https://user-images.githubusercontent.com/20704067/72173098-6de72100-339c-11ea-8a56-2dee62b1ba06.png)
