### PR TITLE
UX-350: Right aligned the contents of <MessageBanner> when direction is RTL.

### DIFF
--- a/lib/MessageBanner/MessageBanner.module.css
+++ b/lib/MessageBanner/MessageBanner.module.css
@@ -51,6 +51,10 @@
   padding: var(--message-banner-padding-small) var(--message-banner-padding-large);
 }
 
+[dir="rtl"] .content {
+  text-align: right;
+}
+
 /**
  * Icon
  */


### PR DESCRIPTION
**Ticket:** https://issues.folio.org/browse/UX-350

## Before
![image](https://user-images.githubusercontent.com/640976/72896293-b3eaa000-3d1f-11ea-940e-31a2d2172eeb.png)

## After
![image](https://user-images.githubusercontent.com/640976/72896281-a9300b00-3d1f-11ea-89ab-cd4d17f379e2.png)
