### PR TITLE
UIIN-929: Adjust footer width

### DIFF
--- a/lib/PaneFooter/DefaultPaneFooter.css
+++ b/lib/PaneFooter/DefaultPaneFooter.css
@@ -1,5 +1,6 @@
 .paneFooterContent {
-  width: 50em;
+  max-width: 50em;
+  width: 100%;
   display: flex;
   justify-content: flex-start;
   flex-wrap: wrap;


### PR DESCRIPTION
Is required by story [UIIN-929](https://issues.folio.org/browse/UIIN-929)

### Description
Added `max-width` and `width `properties to the `PaneFooter`, so when the width of a pane is less than `50em`, the footer is stretched across the width of the pane.