### PR TITLE
fix PropType for ModalFooter to support one button

### DIFF
--- a/lib/ModalFooter/ModalFooter.js
+++ b/lib/ModalFooter/ModalFooter.js
@@ -35,6 +35,7 @@ const ModalFooter = ({ children, primaryButton, secondaryButton }) => {
 
 ModalFooter.propTypes = {
   children: PropTypes.oneOfType([
+    PropTypes.node,
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.objectOf(PropTypes.node),
   ]),


### PR DESCRIPTION
If we pass only one button to ModalFooter it raises a console PropType warning