### PR TITLE
Fix ref on downshift element

### DIFF
--- a/lib/MultiSelection/OptionsListWrapper.js
+++ b/lib/MultiSelection/OptionsListWrapper.js
@@ -13,7 +13,7 @@ const OptionsListWrapper = React.forwardRef(({
   ...props
 }, ref) => {
   if (useLegacy) {
-    return <div {...menuPropGetter()} {...props} ref={ref} hidden={!isOpen}>{children}</div>;
+    return <div {...menuPropGetter({ ref })} {...props} hidden={!isOpen}>{children}</div>;
   }
 
   const {


### PR DESCRIPTION
Hey @JohnC-80 and @rasmuswoelk I was seeing over 150 errors in ui-inventory similar to this:

````js
backend.js:6 downshift: The ref prop "ref" from getMenuProps was not applied correctly on your menu element. 
    in Downshift (created by MultiDownshift)
    in MultiDownshift (created by MultiSelection)
    in MultiSelection (created by FormField(MultiSelection))
    in FormField(MultiSelection) (created by MultiSelectionFilter)
    in MultiSelectionFilter (created by InstanceFilters)
    in InstanceFilters (created by SearchAndSort)
    in SearchAndSort (created by Context.Consumer)
    in Context.Consumer (created by WithStripes(SearchAndSort))
    in WithStripes(SearchAndSort) (created by Context.Consumer)
    in Context.Consumer (created by WithModule(WithStripes(SearchAndSort)))
    in WithModule(WithStripes(SearchAndSort)) (created by Route)
    in Route (created by withRouter(WithModule(WithStripes(SearchAndSort))))
    in withRouter(WithModule(WithStripes(SearchAndSort))) (created by InstancesView)
    in InstancesView (created by Location)
    in Location (created by Route)
    in Route (created by withRouter(Location))
    in withRouter(Location) (created by InjectIntl(withRouter(Location)))
    in InjectIntl(withRouter(Location)) (created by InstancesView)
    in InstancesView (created by InstancesRoute)
    in InstancesRoute (created by WithDataComponent)
    in WithDataComponent (created by Wrapper)
    in Wrapper (created by Context.Consumer)
    in Context.Consumer (created by WithConnect(Wrapper))
    in WithConnect(Wrapper) (created by Connect(WithConnect(Wrapper)))
    in Connect(WithConnect(Wrapper)) (created by ConnectedComponent)
    in ConnectedComponent (created by Context.Consumer)
    in Context.Consumer (created by WithStripes(ConnectedComponent))
    in WithStripes(ConnectedComponent) (created by Route)
    in Route (created by InventoryRouting)
    in InventoryRouting (created by HotExportedInventoryRouting)
    in HotExportedInventoryRouting (created by Route)
    in Route (created by Context.Consumer)
    in Context.Consumer (created by RootWithIntl)
    in RootWithIntl (created by Root)
    in Root (created by Context.Consumer)
    in Context.Consumer (created by WithModules(Root))
    in WithModules(Root) (created by Connect(WithModules(Root)))
    in Connect(WithModules(Root)) (created by HotExportedConnect(WithModules(Root)))
    in HotExportedConnect(WithModules(Root)) (created by StripesCore)
    in StripesCore
````

I'm not sure if this is the correct way to fix it but after moving the ref out of the `div` the error went away.