### PR TITLE
Minor actionMenu bug fix

### DIFF
--- a/lib/PaneHeader/PaneHeader.js
+++ b/lib/PaneHeader/PaneHeader.js
@@ -178,7 +178,7 @@ const PaneHeader = ({
     }
 
     // Prepend action menu dropdown toggle if we have an action menu to show
-    if (actionMenu && placement === 'last') {
+    if (hasActionMenu && placement === 'last') {
       content = React.cloneElement(
         content,
         {},


### PR DESCRIPTION
Fixed minor issue where we were checking for the presence of an `actionMenu`-prop (function) but not the return value which caused the action button to render even though it shouldn't and the action menu dropdown to be empty.