### PR TITLE
STCOM-648 Treat button ref consistently (return a DOM node for Link as well)

### DIFF
--- a/lib/Button/Button.js
+++ b/lib/Button/Button.js
@@ -87,7 +87,6 @@ const Button = React.forwardRef((props, ref) => {
     ...inputCustom,
     onClick,
     className: getStyle(),
-    ref: buttonRef || ref,
   };
 
   // Render a react router link
@@ -98,6 +97,7 @@ const Button = React.forwardRef((props, ref) => {
         to={to}
         role="button"
         {...sharedProps}
+        innerRef={buttonRef || ref}
       >
         {children}
       </Link>
@@ -113,6 +113,7 @@ const Button = React.forwardRef((props, ref) => {
         href={props.href}
         {...sharedProps}
         onClick={handleAnchorClick}
+        ref={buttonRef || ref}
       >
         {children}
       </a>
@@ -124,6 +125,7 @@ const Button = React.forwardRef((props, ref) => {
     <button
       type={type}
       {...sharedProps}
+      ref={buttonRef || ref}
     >
       <span className={css.inner}>
         {children}

--- a/lib/Button/tests/Button-test.js
+++ b/lib/Button/tests/Button-test.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { StaticRouter } from 'react-router'; /* eslint-disable-line import/no-extraneous-dependencies */
-import Link from 'react-router-dom/Link';
 import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 
@@ -156,8 +155,9 @@ describe('Button', () => {
       expect(clicked).to.be.true;
     });
 
-    it('buttonRef callback should return an instance of react-router-dom\'s <Link>', () => {
-      return expect(ref instanceof Link).to.be.true;
+    it('buttonRef callback should return the internal anchor of react-router-dom\'s <Link>', () => {
+      expect(ref instanceof Element).to.be.true;
+      expect(ref.tagName).to.equal('A');
     });
   });
 });


### PR DESCRIPTION
## Problem

Currently, when a `to` prop is used, `<Button>` renders a `<Link>`. `<Link>` in `react-router@v4` is a class component... so a `ref` prop returns an instance of the class. `<Link>` does have an `innerRef` prop that allows you to get to the `<a>` that it renders, which is the expected behavior, seeing as how using a ref on `<Button>` with and `href` prop or just as a `<button>` will get you a DOM node that you can use for focus management.

## Approach
Break `ref` out of `sharedProps` and apply it as `innerRef` to `<Link>` and a `ref` to `button` and `anchor` rendering. 
Update tests, checking for the `tagName` of the element to be sure.