### PR TITLE
Call setStatus *and* onToggle if setStatus is present

### DIFF
--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -44,15 +44,6 @@ class Accordion extends React.Component {
   constructor(props) {
     super(props);
 
-    this.uncontrolledToggle = this.uncontrolledToggle.bind(this);
-    this.initializeAccordion = this.initializeAccordion.bind(this);
-    this.setContentRef = this.setContentRef.bind(this);
-    this.tearDownHandlers = this.tearDownHandlers.bind(this);
-    this.syncMaxHeight = this.syncMaxHeight.bind(this);
-    this.handleTransitionEnd = this.handleTransitionEnd.bind(this);
-    this.collapseRaf = this.collapseRaf.bind(this);
-    this.getRef = this.getRef.bind(this);
-
     // ref to content div.
     this.content = null;
     // ref to toggle.
@@ -75,20 +66,27 @@ class Accordion extends React.Component {
     this.transitioningOpen = false;
     this.transitioningClosed = false;
 
+    this.state = {
+      isOpen: props.open || !props.closedByDefault
+    };
+
     // id for content div needed for proper area support - either supplied or auto-generated.
-    this.contentId = this.initializeContentId();
+    this.contentId = props.contentId || uniqueId('accordion');
 
-    // local state may or may not be set up if open prop is passed.
-    this.state = this.initializeAccordion();
+    this.trackingId = props.id || uniqueId('acc');
+  }
 
-    this.trackingId = this.props.id || uniqueId('acc');
+  static getDerivedStateFromProps(props) {
+    if (typeof props.open !== 'undefined') {
+      return { isOpen: props.open };
+    }
+    return null;
   }
 
   componentDidMount() {
     this.syncMaxHeight();
     // fix issue with accordion not animating open if closed on mount.
-    if ((Object.prototype.hasOwnProperty.call(this.props, 'open') && this.props.open === false) ||
-        (Object.prototype.hasOwnProperty.call(this.state, 'isOpen') && !this.state.isOpen)) {
+    if ((!this.state.isOpen)) {
       this.content.style.maxHeight = '0';
       this.content.style.visibility = 'hidden';
       this.content.style.position = 'fixed';
@@ -102,12 +100,8 @@ class Accordion extends React.Component {
   componentDidUpdate(prevProps, prevState) {
     // prop/state changes to open status set off the animation callbacks.
     // if using state...
-    if (isBoolean(this.state.isOpen)) {
-      if (this.state.isOpen !== prevState.isOpen) {
-        this.setAnimationCallbacks(this.state.isOpen);
-      }
-    } else if (this.props.open !== prevProps.open) {
-      this.setAnimationCallbacks(this.props.open);
+    if (this.state.isOpen !== prevState.isOpen) {
+      this.setAnimationCallbacks(this.state.isOpen);
     }
   }
 
@@ -117,7 +111,7 @@ class Accordion extends React.Component {
 
   getRef = () => this.toggle;
 
-  setAnimationCallbacks(isOpen) {
+  setAnimationCallbacks = (isOpen) => {
     if (isOpen) {
       this.transitioningOpen = true;
       this.syncedHeight = false;
@@ -129,7 +123,7 @@ class Accordion extends React.Component {
     }
   }
 
-  syncMaxHeight() {
+  syncMaxHeight = () => {
     this.syncHeightCallback = window.requestAnimationFrame(() => {
       this.contentHeight = this.content ? this.content.scrollHeight : 0;
       this.syncedHeight = true;
@@ -137,7 +131,7 @@ class Accordion extends React.Component {
     });
   }
 
-  collapseRaf() {
+  collapseRaf = () => {
     if (this.collapseCallback) { // if there's a collapse in progress, let it finish...
       this.transitioningClosed = false;
       return;
@@ -159,7 +153,7 @@ class Accordion extends React.Component {
     });
   }
 
-  expandRaf() {
+  expandRaf = () => {
     if (this.expandCallback) {
       this.transitioningOpen = false;
       return;
@@ -175,29 +169,13 @@ class Accordion extends React.Component {
     });
   }
 
-  initializeAccordion() {
-    // if no 'open' boolean is provided, set up our own state...
-    if (this.props.open === undefined) {
-      if (this.props.closedByDefault) {
-        return {};
-      }
-      return { isOpen: true };
-    }
-    return {};
-  }
-
-  // generate unique id if no id is provided.
-  initializeContentId() {
-    return (this.props.contentId === undefined) ? uniqueId('accordion') : this.props.contentId;
-  }
-
-  tearDownHandlers() {
+  tearDownHandlers = () => {
     window.cancelAnimationFrame(this.syncHeightCallback);
     window.cancelAnimationFrame(this.expandCallback);
     window.cancelAnimationFrame(this.collapseCallback);
   }
 
-  uncontrolledToggle() {
+  uncontrolledToggle = () => {
     this.setState((curState) => {
       const newState = { ...curState };
       newState.isOpen = !curState.isOpen;
@@ -205,14 +183,14 @@ class Accordion extends React.Component {
     });
   }
 
-  setContentRef(ref) {
+  setContentRef = (ref) => {
     this.content = ref;
     if (this.props.contentRef) {
       this.props.contentRef(ref);
     }
   }
 
-  handleTransitionEnd() {
+  handleTransitionEnd = () => {
     if (this.transitioningOpen) {
       this.transitioningOpen = false;
       this.content.style.maxHeight = 'none';
@@ -225,14 +203,14 @@ class Accordion extends React.Component {
     }
   }
 
-  getContentClass(open) {
+  getContentClass = (open) => {
     return classNames(
       css.content,
       { [`${css.expanded}`]: open },
     );
   }
 
-  getRootClasses() {
+  getRootClasses = () => {
     return classNames(
       css.accordion,
       { [css.hasSeparator]: this.props.separator },
@@ -240,20 +218,25 @@ class Accordion extends React.Component {
     );
   }
 
-  render() {
-    let open;
-    if (this.props.open !== undefined) {
-      open = this.props.open;
-    } else {
-      open = this.state.isOpen;
-    }
+  renderChildren = (children, open) => {
+    return typeof children === 'function' ? children(open) : children;
+  }
 
-    let onToggle;
-    if (this.props.onToggle && this.props.open !== undefined) {
-      onToggle = this.props.onToggle;
-    } else {
-      onToggle = this.uncontrolledToggle;
-    }
+  render() {
+    const {
+      open: openProp,
+      onToggle: onToggleProp,
+      header,
+      toggleKeyMap,
+      toggleKeyHandlers,
+      children
+    } = this.props;
+
+    const {
+      isOpen : open
+    } = this.state;
+
+    const onToggle = typeof openProp === 'undefined' ? this.uncontrolledToggle : onToggleProp;
 
     const headerProps = Object.assign({}, this.props, {
       contentId: this.contentId,
@@ -261,14 +244,14 @@ class Accordion extends React.Component {
       open,
       onToggle
     });
-    const headerElement = React.createElement(this.props.header, headerProps);
+    const headerElement = React.createElement(header, headerProps);
 
     return (
       <section id={this.trackingId} className={this.getRootClasses()} data-test-accordion-section>
         <HotKeys
           id={`${this.trackingId}-hotkeys`}
-          keyMap={this.props.toggleKeyMap}
-          handlers={this.props.toggleKeyHandlers}
+          keyMap={toggleKeyMap}
+          handlers={toggleKeyHandlers}
           noWrapper
         >
           {headerElement}
@@ -286,7 +269,7 @@ class Accordion extends React.Component {
           }}
           data-test-accordion-wrapper
         >
-          {this.props.children}
+          {this.renderChildren(children, open)}
         </div>
       </section>
     );

--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {
-  isBoolean,
   uniqueId,
 } from 'lodash';
 

--- a/lib/Accordion/ExpandAllButton.js
+++ b/lib/Accordion/ExpandAllButton.js
@@ -42,9 +42,8 @@ const ExpandAllButton = ({
 
   function handleClick() {
     const newState = expandAll(accordionStatus, func);
-    return setStatus ?
-      setStatus(newState) :
-      onToggle(newState);
+    if (setStatus) setStatus(newState);
+    if (onToggle) onToggle(newState);
   }
 
   return (

--- a/lib/Accordion/readme.md
+++ b/lib/Accordion/readme.md
@@ -72,6 +72,17 @@ const initial = {
     ...
 ```
 
+## Open render-prop
+Accordions can pass a their open status to their children via a functional child: 
+
+```
+<Accordion label="Lazy content">
+  { open => (
+    <List contentData={open ? data : []} />
+  )}
+</Accordion>
+```
+
 ## Controlled
 Accordions can, of course, be controlled by state or local resource. Simply include an object with a list of keys for each accordion's `id` set to a boolean value that will be passed through to the corresponding accordion's `open` prop. This object should be passed to the `<AccordionSet>`'s `accordionStatus` prop. An `onToggle` handler will also need to be provided for proper state interaction. Passed to the `<AccordionSet>`'s `onToggle` prop, it will receive both the label and id of the target accordion, either of which could be used for additional interactions as needed.
 

--- a/lib/Accordion/stories/Accordion.stories.js
+++ b/lib/Accordion/stories/Accordion.stories.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
 import withReadme from 'storybook-readme/with-readme';
 import Readme from '../readme.md';
 import BasicUsage from './BasicUsage';
 import Accordion from '../Accordion';
 import AccordionSet from '../AccordionSet';
 import Status from './Status';
+import ExpandAllWithin from './ExpandAllWithinSet';
 
 const as = {
   acc1: false,
@@ -19,11 +19,6 @@ storiesOf('Accordion', module)
   .addDecorator(withReadme(Readme))
   .add('with defaults', () => <BasicUsage />)
   .add('Accordion Status', () => <Status />)
-  .add('open', () => (
-    <Accordion open>
-      Content
-    </Accordion>
-  ))
   .add('Keyboard Navigation', () => (
     <AccordionSet accordionStatus={as}>
       <Accordion label="Up Arrow" id="acc1">
@@ -40,38 +35,23 @@ storiesOf('Accordion', module)
       </Accordion>
     </AccordionSet>
   ))
-  .add('id and contentId', () => (
-    <Accordion contentId="pTag">
-      <p id="pTag">
+  .add('displayWhen- props', () => (
+    <>
+      <h2>&quot;displayWhenOpen&quot; prop</h2>
+      <Accordion label="Here is a label" displayWhenOpen={<p>Add item</p>}>
         Content
-      </p>
-    </Accordion>
-  ))
-  .add('displayWhenOpen', () => (
-    <Accordion label="Here is a label" displayWhenOpen={<p>Add item</p>}>
-      Content
-    </Accordion>
-  ))
-  .add('displayWhenClosed', () => (
-    <Accordion open={false} displayWhenClosed={<p>Some items</p>}>
-      Content
-    </Accordion>
+      </Accordion>
+      <h2>&quot;displayWhenClosed&quot; prop</h2>
+      <Accordion open={false} displayWhenClosed={<p>Some items</p>}>
+        Content
+      </Accordion>
+    </>
   ))
   .add('separator', () => (
     <Accordion separator={false}>
       Separator set to false.
     </Accordion>
   ))
-  .add('toggleKeyHandlers', () => {
-    const handlers = {
-      delete() { action('delete'); }
-    };
-    return (
-      <Accordion toggleKeyHandlers={handlers}>
-        content
-      </Accordion>
-    );
-  })
   .add('header', () => {
     const header = () => (<p>content</p>);
     return (
@@ -79,4 +59,5 @@ storiesOf('Accordion', module)
         Content
       </Accordion>
     );
-  });
+  })
+  .add('ExpandAll within set', () => (<ExpandAllWithin />));

--- a/lib/Accordion/stories/ExpandAllWithinSet.js
+++ b/lib/Accordion/stories/ExpandAllWithinSet.js
@@ -1,0 +1,69 @@
+/**
+ * Accordion: Expand all within AccordionSet
+ */
+
+/* eslint-disable max-len */
+
+import React from 'react';
+import faker from 'faker';
+import { AccordionSet, Accordion, ExpandAllButton } from '..';
+import Button from '../../Button';
+
+const ExpandAllWithin = () => {
+  const [status, updateStatus] = React.useState({
+    info: true,
+    exinfo: true,
+    proxy: true,
+    loans: true,
+  });
+
+  const onToggleAll = () => {
+    updateStatus(curStatus => {
+      const newStatus = {};
+      Object.keys(curStatus).forEach((s) => {
+        newStatus[s] = !curStatus[s];
+      });
+      return newStatus;
+    });
+  };
+
+  const onToggle = ({ id }) => {
+    updateStatus(current => ({
+      ...current,
+      [id]: !current[id]
+    }));
+  };
+
+  return (
+    <AccordionSet accordionStatus={status} onToggle={onToggle}>
+      <ExpandAllButton onToggle={onToggleAll} />
+      <Accordion label="Information" id="info" displayWhenOpen={<Button icon="plus-sign">Add</Button>}>
+        This is an example of an AccordionSet. The 2nd of these accordions is closed by default using the &quot;closedByDefault&quot; prop.
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas vitae fringilla felis, sed commodo tellus. Sed bibendum mi id lorem sagittis sodales. Quisque ac lectus gravida, viverra ante et, iaculis sapien. Praesent eget ligula tortor. Praesent vitae ipsum placerat, blandit quam quis, tempus tortor. Aliquam erat volutpat. Fusce hendrerit lectus sed ex dictum, in pretium eros vestibulum. Nulla semper vehicula leo at varius. Quisque bibendum mauris sit amet tellus lobortis ultricies. Mauris eleifend sapien vel est posuere tincidunt. Proin ut nunc ut enim rhoncus elementum vitae in mauris. Nullam ultrices dictum nulla in commodo. Suspendisse potenti. Donec et velit ac quam consequat cursus. Pellentesque quis elit magna. Fusce velit libero, mattis ac placerat eget, aliquam a ante.
+        <br />
+        <br />
+        {faker.lorem.paragraph()}
+      </Accordion>
+      <Accordion label="Extended Information" id="exinfo" closedByDefault>
+        {faker.lorem.paragraph()}
+        <br />
+        <br />
+        {faker.lorem.paragraph()}
+      </Accordion>
+      <Accordion label="Proxy" id="proxy">
+        {faker.lorem.paragraph()}
+        <br />
+        <br />
+        {faker.lorem.paragraph()}
+      </Accordion>
+      <Accordion label="Loans" id="loans">
+        {faker.lorem.paragraph()}
+        <br />
+        <br />
+        {faker.lorem.paragraph()}
+      </Accordion>
+    </AccordionSet>
+  );
+};
+
+export default ExpandAllWithin;

--- a/lib/Accordion/stories/ExpandAllWithinSet.js
+++ b/lib/Accordion/stories/ExpandAllWithinSet.js
@@ -14,7 +14,6 @@ const ExpandAllWithin = () => {
     info: true,
     exinfo: true,
     proxy: true,
-    loans: true,
   });
 
   const onToggleAll = () => {
@@ -35,34 +34,54 @@ const ExpandAllWithin = () => {
   };
 
   return (
-    <AccordionSet accordionStatus={status} onToggle={onToggle}>
-      <ExpandAllButton onToggle={onToggleAll} />
-      <Accordion label="Information" id="info" displayWhenOpen={<Button icon="plus-sign">Add</Button>}>
-        This is an example of an AccordionSet. The 2nd of these accordions is closed by default using the &quot;closedByDefault&quot; prop.
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas vitae fringilla felis, sed commodo tellus. Sed bibendum mi id lorem sagittis sodales. Quisque ac lectus gravida, viverra ante et, iaculis sapien. Praesent eget ligula tortor. Praesent vitae ipsum placerat, blandit quam quis, tempus tortor. Aliquam erat volutpat. Fusce hendrerit lectus sed ex dictum, in pretium eros vestibulum. Nulla semper vehicula leo at varius. Quisque bibendum mauris sit amet tellus lobortis ultricies. Mauris eleifend sapien vel est posuere tincidunt. Proin ut nunc ut enim rhoncus elementum vitae in mauris. Nullam ultrices dictum nulla in commodo. Suspendisse potenti. Donec et velit ac quam consequat cursus. Pellentesque quis elit magna. Fusce velit libero, mattis ac placerat eget, aliquam a ante.
-        <br />
-        <br />
-        {faker.lorem.paragraph()}
-      </Accordion>
-      <Accordion label="Extended Information" id="exinfo" closedByDefault>
-        {faker.lorem.paragraph()}
-        <br />
-        <br />
-        {faker.lorem.paragraph()}
-      </Accordion>
-      <Accordion label="Proxy" id="proxy">
-        {faker.lorem.paragraph()}
-        <br />
-        <br />
-        {faker.lorem.paragraph()}
-      </Accordion>
-      <Accordion label="Loans" id="loans">
-        {faker.lorem.paragraph()}
-        <br />
-        <br />
-        {faker.lorem.paragraph()}
-      </Accordion>
-    </AccordionSet>
+    <>
+      <h2>Controlled (The old way)</h2>
+      <AccordionSet accordionStatus={status} onToggle={onToggle}>
+        <ExpandAllButton accordionStatus={status} onToggle={onToggleAll} />
+        <Accordion label="Information" id="info" displayWhenOpen={<Button icon="plus-sign">Add</Button>}>
+          This is an example of an AccordionSet. The 2nd of these accordions is closed by default using the &quot;closedByDefault&quot; prop.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas vitae fringilla felis, sed commodo tellus. Sed bibendum mi id lorem sagittis sodales. Quisque ac lectus gravida, viverra ante et, iaculis sapien. Praesent eget ligula tortor. Praesent vitae ipsum placerat, blandit quam quis, tempus tortor. Aliquam erat volutpat. Fusce hendrerit lectus sed ex dictum, in pretium eros vestibulum. Nulla semper vehicula leo at varius. Quisque bibendum mauris sit amet tellus lobortis ultricies. Mauris eleifend sapien vel est posuere tincidunt. Proin ut nunc ut enim rhoncus elementum vitae in mauris. Nullam ultrices dictum nulla in commodo. Suspendisse potenti. Donec et velit ac quam consequat cursus. Pellentesque quis elit magna. Fusce velit libero, mattis ac placerat eget, aliquam a ante.
+          <br />
+          <br />
+          {faker.lorem.paragraph()}
+        </Accordion>
+        <Accordion label="Extended Information" id="exinfo" closedByDefault>
+          {faker.lorem.paragraph()}
+          <br />
+          <br />
+          {faker.lorem.paragraph()}
+        </Accordion>
+        <Accordion label="Proxy" id="proxy">
+          {faker.lorem.paragraph()}
+          <br />
+          <br />
+          {faker.lorem.paragraph()}
+        </Accordion>
+      </AccordionSet>
+      <h2>Uncontrolled (The new way)</h2>
+      <AccordionSet>
+        <ExpandAllButton />
+        <Accordion label="Information" displayWhenOpen={<Button icon="plus-sign">Add</Button>}>
+          This is an example of an AccordionSet. The 2nd of these accordions is closed by default using the &quot;closedByDefault&quot; prop.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas vitae fringilla felis, sed commodo tellus. Sed bibendum mi id lorem sagittis sodales. Quisque ac lectus gravida, viverra ante et, iaculis sapien. Praesent eget ligula tortor. Praesent vitae ipsum placerat, blandit quam quis, tempus tortor. Aliquam erat volutpat. Fusce hendrerit lectus sed ex dictum, in pretium eros vestibulum. Nulla semper vehicula leo at varius. Quisque bibendum mauris sit amet tellus lobortis ultricies. Mauris eleifend sapien vel est posuere tincidunt. Proin ut nunc ut enim rhoncus elementum vitae in mauris. Nullam ultrices dictum nulla in commodo. Suspendisse potenti. Donec et velit ac quam consequat cursus. Pellentesque quis elit magna. Fusce velit libero, mattis ac placerat eget, aliquam a ante.
+          <br />
+          <br />
+          {faker.lorem.paragraph()}
+        </Accordion>
+        <Accordion label="Extended Information" closedByDefault>
+          {faker.lorem.paragraph()}
+          <br />
+          <br />
+          {faker.lorem.paragraph()}
+        </Accordion>
+        <Accordion label="Proxy">
+          {faker.lorem.paragraph()}
+          <br />
+          <br />
+          {faker.lorem.paragraph()}
+        </Accordion>
+      </AccordionSet>
+    </>
   );
 };
 


### PR DESCRIPTION
## Problem
Some modules are developed with the following pattern:
```
<AccordionSet>
  <ExpandAllButton>
  ...Accordions
</AccordionSet>
```
Which a late change in `<ExpandAllButton>` broke...
This PR resolves that issue...

## Approach
Call both a setStatus (if it exists) and then onToggle. setStatus trumps in the state update if it's the same state they're updating.

Additionally, child functions for Accordion are also now supported, passing the `open` status as a render prop. 🎉 