### PR TITLE
STCOM-654: Introduce a new filter config function called parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-components
 
+## [6.0.1] IN PROGRESS
+
+* Introduce a new filter config function called `parse`. Part of STCOM-654.
+
 ## [6.0.0](https://github.com/folio-org/stripes-components/tree/v6.0.0) (2020-03-03)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.9.2...v6.0.0)
 

--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -186,7 +186,10 @@ export function filters2cql(config, filters = '') {
           return (obj.length > 0) ? obj[0].cql : v;
         });
 
-        if (group.isRange) {
+        // parse to CQL manually via parse
+        if (typeof group.parse === 'function') {
+          conds.push(group.parse(mappedValues));
+        } else if (group.isRange) {
           const { isIncludingStart = true, isIncludingEnd = true, rangeSeparator = ':' } = group;
           const [start, end] = mappedValues[0].split(rangeSeparator);
           const startCondition = `${cqlIndex}>${isIncludingStart ? '=' : ''}"${start}"`;

--- a/lib/FilterGroups/readme.md
+++ b/lib/FilterGroups/readme.md
@@ -87,6 +87,7 @@ filter groups. Each group is represented by an object with four keys:
 * `isIncludingStart` -- The flag is used only with `isRange: true` to include boundary value from the start. By default `true`.
 * `isIncludingEnd` -- The flag is used only with `isRange: true` to include boundary value from the end. By default `true`.
 * `rangeSeparator` -- The string is used only with `isRange: true` to break range value to `start` and `end` values. By default `:`.
+* `parse` -- an optional function which can be used to convert filter values into a CQL manually
 
 Each of the `values` is typically represented by a simple string, which
 is used both to display on the page and as the value to use in


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-654

This PR introduces a new filter config function called `parse` which can be used to parse given filter value to CQL "by hand". This is required by:

https://issues.folio.org/browse/MODINVSTOR-453
https://issues.folio.org/browse/UIIN-968

An example usage from ui-inventory:

````js
{
  name: 'discoverySuppress',
  cql: 'discoverySuppress',
  values: [],
  parse: (values) => {
    if (values.length === 2) {
      return 'discoverySuppress="*"';
    } else if (values.length === 1 && values[0] === 'false') {
      return 'discoverySuppress="*" not discoverySuppress="true"';
    } else {
      return 'discoverySuppress="true"';
    }
  },
},
````

