### PR TITLE
Upgrade babel-eslint-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@storybook/addons": "^4.0.12",
     "@storybook/react": "^4.0.12",
     "autoprefixer": "^7.1.6",
-    "babel-eslint": "^9.0.0",
+    "babel-eslint": "^10.1.0",
     "babel-loader": "^8.0.0",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-remove-jsx-attributes": "^0.0.2",


### PR DESCRIPTION
Seeing some fantanstically false positives for `no-unused-vars` in `for...in` loops.

As mentioned in this issue: https://github.com/babel/babel-eslint/issues/791 ,upgrading `babel-eslint` from "^9" to "^10" resolves.