### PR TITLE
UIU-1051 bottom-margin spacing for NavListSection

### DIFF
--- a/lib/NavListSection/NavListSection.css
+++ b/lib/NavListSection/NavListSection.css
@@ -1,0 +1,3 @@
+.listSection {
+  margin-bottom: 1.5rem;
+}

--- a/lib/NavListSection/NavListSection.js
+++ b/lib/NavListSection/NavListSection.js
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import Headline from '../Headline';
 import listItemCss from '../NavListItem/NavListItem.css';
+import navListSectionCss from './NavListSection.css';
 
 const propTypes = {
   activeLink: PropTypes.string,
@@ -31,8 +32,10 @@ function NavListSection(props) {
       const elemProps = Object.assign({}, child.props, newProps);
       return React.cloneElement(child, elemProps, child.props.children);
     }) : props.children;
+
+  const cssClassName = props.className || navListSectionCss.listSection;
   return (
-    <div className={props.className}>
+    <div className={cssClassName}>
       {props.label && (
         <Headline
           margin="none"


### PR DESCRIPTION
Provide `margin-bottom` spacing directly on `NavListSection` if no other
classname is provided. The style was cribbed from
stripes-smart-components' `<Settings>` component, which should be
deprecated in favor of using local routing.

Refs [UIU-1051](https://issues.folio.org/browse/UIU-1051)