### PR TITLE
UIEH-832 Added ariaLabel prop to <NoValue>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Provide `allocate`, `cart`, `drag-drop`, `receive`, and `transfer`icons.
 * Correctly specify `SelectList` proptypes.
 * Introduce a new filter config function called `parse`. Part of STCOM-654.
+* Introduce `ariaLabel` prop on `<NoValue>`. Refs UIEH-832.
 
 ## [6.0.0](https://github.com/folio-org/stripes-components/tree/v6.0.0) (2020-03-03)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.9.2...v6.0.0)

--- a/lib/NoValue/NoValue.js
+++ b/lib/NoValue/NoValue.js
@@ -1,17 +1,22 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+
+const propTypes = {
+  ariaLabel: PropTypes.string,
+};
 
 /**
  * this is used for reading the given dash character as "no value set" by a screenreader
  */
-function NoValue() {
+function NoValue({ ariaLabel = null }) {
   return (
     <FormattedMessage id="stripes-components.noValue.noValueSet">
-      {ariaLabel => (
+      {message => (
         <span
           /* eslint-disable-next-line jsx-a11y/aria-role */
           role="text"
-          aria-label={ariaLabel}
+          aria-label={ariaLabel || message}
           data-test-no-value
         >
           {'-'}
@@ -20,5 +25,7 @@ function NoValue() {
     </FormattedMessage>
   );
 }
+
+NoValue.propTypes = propTypes;
 
 export default NoValue;

--- a/lib/NoValue/tests/NoValue-test.js
+++ b/lib/NoValue/tests/NoValue-test.js
@@ -34,9 +34,30 @@ describe('NoValue', () => {
     expect(noValue.roleAttribute).to.equal('text');
   });
 
-  // Check to make sure an aria-label attribute, which is what will be read
-  // by screenreaders in lieu of the text-value of the span.
-  it('should have an "aria-label" attribute', () => {
-    expect(noValue.ariaLabelAttribute).to.equal('No value set');
+
+  describe('when aria-label is not passed from parent', () => {
+    beforeEach(async () => {
+      await mountWithContext(<NoValue />);
+    });
+
+    // Check to make sure an aria-label attribute, which is what will be read
+    // by screenreaders in lieu of the text-value of the span.
+    it('should have a default "aria-label" attribute', () => {
+      expect(noValue.ariaLabelAttribute).to.equal('No value set');
+    });
+  });
+
+  describe('when aria-label was passed from parent', () => {
+    const ariaLabel = 'No custom value set';
+
+    beforeEach(async () => {
+      await mountWithContext(<NoValue ariaLabel={ariaLabel} />);
+    });
+
+    // Check to make sure that aria-label attribute has value passed down
+    // from parent component
+    it('should have a custom "aria-label" attribute', () => {
+      expect(noValue.ariaLabelAttribute).to.equal(ariaLabel);
+    });
   });
 });


### PR DESCRIPTION
## Purpose
- Give `<NoValue>` component users ability to pass custom text to `aria-label` attribute.