### PR TITLE
AccordionSet: registerAccordion should account initialStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-components
 
+## 6.1.1 (IN-PROGRESS)
+
+* Fix issue with `initialStatus` prop on Accordions not working.
+
 ## [6.1.0](https://github.com/folio-org/stripes-components/tree/v6.1.0) (2020-03-16)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v6.0.0...v6.1.0)
 

--- a/lib/Accordion/AccordionSet.js
+++ b/lib/Accordion/AccordionSet.js
@@ -27,7 +27,7 @@ class AccordionSet extends React.Component {
   constructor(props) {
     super(props);
 
-    this.registerAccordion = this.registerAccordion.bind(this);
+    // this.registerAccordion = this.registerAccordion.bind(this);
     this.focusNextAccordion = this.focusNextAccordion.bind(this);
     this.focusPreviousAccordion = this.focusPreviousAccordion.bind(this);
     this.focusFirstAccordion = this.focusFirstAccordion.bind(this);
@@ -94,16 +94,19 @@ class AccordionSet extends React.Component {
     this.accordionList[this.accordionList.length - 1].getRef().focus();
   }
 
-  registerAccordion(getRef, id, closedByDefault = false) {
+  registerAccordion = (getRef, id, closedByDefault = false) => {
+    const { initialStatus } = this.props;
+
+    const status = initialStatus || {};
     if (indexOf(this.accordionList, id) === -1 && id !== null) {
       this.accordionList.push({ id, getRef });
       const statusUpdater = this.props.setStatus || this.setState.bind(this);
-      statusUpdater((curState) => (
-        {
+      statusUpdater((curState) => {
+        return {
           ...curState,
-          [id]: !closedByDefault
-        }
-      ));
+          [id]: typeof status[id] !== 'undefined' ? status[id] : !closedByDefault
+        };
+      });
     }
   }
 

--- a/lib/Accordion/AccordionSet.js
+++ b/lib/Accordion/AccordionSet.js
@@ -100,12 +100,12 @@ class AccordionSet extends React.Component {
     if (indexOf(this.accordionList, id) === -1 && id !== null) {
       this.accordionList.push({ id, getRef });
       const statusUpdater = this.props.setStatus || this.setState.bind(this);
-      statusUpdater((curState) => {
-        return {
+      statusUpdater((curState) => (
+        {
           ...curState,
           [id]: typeof status[id] !== 'undefined' ? status[id] : !closedByDefault
-        };
-      });
+        }
+      ));
     }
   }
 

--- a/lib/Accordion/AccordionSet.js
+++ b/lib/Accordion/AccordionSet.js
@@ -27,7 +27,6 @@ class AccordionSet extends React.Component {
   constructor(props) {
     super(props);
 
-    // this.registerAccordion = this.registerAccordion.bind(this);
     this.focusNextAccordion = this.focusNextAccordion.bind(this);
     this.focusPreviousAccordion = this.focusPreviousAccordion.bind(this);
     this.focusFirstAccordion = this.focusFirstAccordion.bind(this);


### PR DESCRIPTION
Bug: initialStatus prop of AccordionSet doesn't work.

Reason: it's not accounted for when the accordion registers with the AccordionSet.

This PR fixes that.