### PR TITLE
STCOM-382: Updated <Datepicker> to use <Popper> instead of react-tether

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Correctly specify `SelectList` proptypes.
 * Introduce a new filter config function called `parse`. Part of STCOM-654.
 * Introduce `ariaLabel` prop on `<NoValue>`. Refs UIEH-832.
+* Converted `<Datepicker>` to use `<Popper>` instead of react-tether. STCOM-382.
 
 ## [6.0.0](https://github.com/folio-org/stripes-components/tree/v6.0.0) (2020-03-03)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v5.9.2...v6.0.0)

--- a/lib/Datepicker/Calendar.css
+++ b/lib/Datepicker/Calendar.css
@@ -15,15 +15,6 @@
   z-index: 9999;
 }
 
-.srOnly {
-  position: absolute !important;
-  clip: rect(1px 1px 1px 1px); /* old IE */
-  clip: rect(1px, 1px, 1px, 1px);
-  height: 1px;
-  width: 1px;
-  overflow: hidden;
-}
-
 .calendarInner {
   & td {
     vertical-align: middle;

--- a/lib/Datepicker/Calendar.css
+++ b/lib/Datepicker/Calendar.css
@@ -1,5 +1,10 @@
 @import '../variables.css';
 
+.container {
+  position: relative;
+  width: 100%;
+}
+
 .calendar {
   position: relative;
   background: #fff;

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -554,7 +554,7 @@ class Datepicker extends React.Component {
         <div
           aria-live="assertive"
           aria-relevant="additions"
-          className={css.srOnly}
+          className="sr-only"
         >
           <div>{this.state.srMessage}</div>
         </div>

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { createRef } from 'react';
 import { FormattedMessage, intlShape } from 'react-intl';
+import { deprecated } from 'prop-types-extra';
 import PropTypes from 'prop-types';
 import TetherComponent from 'react-tether';
 import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
@@ -9,6 +10,7 @@ import debounce from 'lodash/debounce';
 import uniqueId from 'lodash/uniqueId';
 import noop from 'lodash/noop';
 
+import Popper, { AVAILABLE_PLACEMENTS } from '../Popper';
 import IconButton from '../IconButton';
 import TextField from '../TextField';
 import Calendar from './Calendar';
@@ -43,14 +45,20 @@ const propTypes = {
   label: PropTypes.node,
   locale: PropTypes.string,
   meta: PropTypes.object,
+  modifiers: PropTypes.object,
   onChange: PropTypes.func,
   onSetDate: PropTypes.func,
   parser: PropTypes.func,
+  placement: PropTypes.oneOf(AVAILABLE_PLACEMENTS),
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
   screenReaderMessage: PropTypes.string,
   showCalendar: PropTypes.bool,
-  tether: PropTypes.object,
+  tether: deprecated(PropTypes.object, `
+    For overlay placement you can use the 'placement'-prop'. 
+    For other modifications you use the 'modifiers'-prop. 
+    See the documentation for <Popper> for more information.
+  `),
   timeZone: PropTypes.string,
   useFocus: PropTypes.bool,
   value: PropTypes.string,
@@ -64,24 +72,10 @@ const defaultProps = {
   autoFocus: false,
   backendDateStandard: 'ISO8601',
   hideOnChoose: true,
+  modifiers: {},
   parser: defaultParser,
+  placement: 'bottom',
   screenReaderMessage: '',
-  tether: {
-    attachment: 'top center',
-    targetAttachment: 'bottom center',
-    optimizations: {
-      gpu: false,
-    },
-    constraints: [{
-      to: 'window',
-      attachment: 'together',
-    },
-    {
-      to: 'scrollParent',
-      pin: true,
-    },
-    ],
-  },
   useFocus: true,
 };
 
@@ -94,10 +88,9 @@ class Datepicker extends React.Component {
     super(props);
 
     this.picker = null;
-    this.container = null;
-    this.srSpace = null;
-    this.textfield = props.inputRef || React.createRef();
-    this.hiddenInput = React.createRef();
+    this.containerRef = createRef(null);
+    this.textfield = props.inputRef || createRef(null);
+    this.hiddenInput = createRef();
 
     this.dbhideCalendar = debounce(this.hideCalendar, 10);
 
@@ -197,7 +190,7 @@ class Datepicker extends React.Component {
     // used by <RootCloseWrapper> to determine whether or not it should hide the picker.
     // it should determine that the element that's focused is outside of the datepicker's containing div and
     // the calendar widget (this.picker).
-    if (!contains(this.container, e.target)) {
+    if (!contains(this.containerRef.current, e.target)) {
       if (!this.datePickerIsFocused()) {
         this.hideCalendar();
       }
@@ -388,7 +381,7 @@ class Datepicker extends React.Component {
   }
 
   datePickerIsFocused() {
-    if (contains(this.container, document.activeElement) &&
+    if (contains(this.containerRef.current, document.activeElement) &&
       document.activeElement !== document.body) {
       if (this.picker) {
         return (contains(this.picker.getDOMContainer(), document.activeElement));
@@ -554,22 +547,71 @@ class Datepicker extends React.Component {
   }
 
   render() {
-    return (
-      <TetherComponent {...defaultProps.tether} {...this.props.tether}>
-        <div style={{ position: 'relative', width: '100%' }} ref={(ref) => { this.container = ref; }}>
-          <div
-            aria-live="assertive"
-            aria-relevant="additions"
-            className={css.srOnly}
-            ref={(ref) => { this.srSpace = ref; }}
-          >
-            <div>{this.state.srMessage}</div>
-          </div>
-          {this.renderInput()}
-          <input type="hidden" hidden value={this.state.hiddenValue} ref={this.hiddenInput} />
+    const { placement, modifiers } = this.props;
+
+    const content = (
+      <div className={css.container} ref={this.containerRef}>
+        <div
+          aria-live="assertive"
+          aria-relevant="additions"
+          className={css.srOnly}
+        >
+          <div>{this.state.srMessage}</div>
         </div>
-        {this.state.showCalendar && this.renderCalendar()}
-      </TetherComponent>
+        {this.renderInput()}
+        <input type="hidden" hidden value={this.state.hiddenValue} ref={this.hiddenInput} />
+      </div>
+    );
+
+    /**
+     * Legacy support – will be removed in a future release
+     */
+    if (this.props.tether) {
+      const tetherProps = {
+        attachment: 'top center',
+        targetAttachment: 'bottom center',
+        optimizations: {
+          gpu: false,
+        },
+        constraints: [{
+          to: 'window',
+          attachment: 'together',
+        },
+        {
+          to: 'scrollParent',
+          pin: true,
+        },
+        ],
+      };
+
+      return (
+        <TetherComponent {...tetherProps} {...this.props.tether}>
+          {content}
+          {this.state.showCalendar && this.renderCalendar()}
+        </TetherComponent>
+      );
+    }
+
+    return (
+      <>
+        {content}
+        <Popper
+          placement={placement}
+          hideIfClosed
+          isOpen={this.state.showCalendar}
+          anchorRef={this.containerRef}
+          onToggle={this.toggleCalendar}
+          modifiers={{
+            offset: {
+              enabled: true,
+              offset: '0,10',
+            },
+            ...modifiers
+          }}
+        >
+          {this.renderCalendar()}
+        </Popper>
+      </>
     );
   }
 }

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -597,7 +597,6 @@ class Datepicker extends React.Component {
         {content}
         <Popper
           placement={placement}
-          hideIfClosed
           isOpen={this.state.showCalendar}
           anchorRef={this.containerRef}
           onToggle={this.toggleCalendar}

--- a/lib/Datepicker/readme.md
+++ b/lib/Datepicker/readme.md
@@ -12,18 +12,20 @@ import { Datepicker } from '@folio/stripes/components';
 ## Props
 Name | type | description | default | required
 --- | --- | --- | --- | ---
-`label` | string | visible field label | | false
-`backendDateStandard` | string | parses to/from ISO 8601 standard by default before committing value. | "ISO 8601" | false
-`id` | string | id for date field - used in the "id" attribute of the text input | | false
-`useFocus` | bool | if set to false, component relies solely on clicking the calendar icon to toggle appearance of calendar. | true | false
 `autoFocus` | bool | If this prop is `true`, component will automatically focus on mount | |
+`backendDateStandard` | string | parses to/from ISO 8601 standard by default before committing value. | "ISO 8601" | false
 `disabled` | bool | if true, field will be disabled for focus or entry. | false | false
-`readOnly` | bool | if true, field will be readonly. 'Calendar' and 'clear' buttons will be omitted. | false | false
-`value` | string | date to be displayed in the textfield. In forms, this is supplied by the initialValues prop supplied to the form | "" | false
+`id` | string | id for date field - used in the "id" attribute of the text input | | false
+`label` | string | visible field label | | false
+`locale` | string | Overrides the locale provided by context. | "en" | false
 `onChange` | func | Event handler to handle updates to the datefield text. | | false
+`placement` | string | Determines the position of the date picker overlay. See available options in the [Popper documentation](/?selectedKind=Popper). | bottom | false
+`modifiers` | object | Passes modifiers for the internal [Popper](/?selectedKind=Popper) -component which handles the positioning of the date picker overlay. | | false
+`readOnly` | bool | if true, field will be readonly. 'Calendar' and 'clear' buttons will be omitted. | false | false
 `screenReaderMessage` | string | Additional message to be read by screenreaders when textfield is focused in addition to the label and format - which are always read. | | false
 `timeZone` | string | Overrides the time zone provided by context. | "UTC" | false
-`locale` | string | Overrides the locale provided by context. | "en" | false
+`useFocus` | bool | if set to false, component relies solely on clicking the calendar icon to toggle appearance of calendar. | true | false
+`value` | string | date to be displayed in the textfield. In forms, this is supplied by the initialValues prop supplied to the form | "" | false
 
 <!-- dateFormat | string | system formatting for date. [Moment.js formats](https://momentjs.com/docs/#/displaying/format/) are supported | "MM/DD/YYYY" | false-->
 

--- a/lib/Datepicker/tests/Datepicker-ReduxForm-test.js
+++ b/lib/Datepicker/tests/Datepicker-ReduxForm-test.js
@@ -285,7 +285,7 @@ describe('Datepicker with Redux Form integration', () => {
       beforeEach(async () => datepicker.calendar.cursor.pressEscape());
 
       it('closes the calendar', () => {
-        expect(datepicker.calendar.isVisible).to.be.false;
+        expect(datepicker.calendar.isPresent).to.be.false;
       });
     });
   });

--- a/lib/Datepicker/tests/Datepicker-ReduxForm-test.js
+++ b/lib/Datepicker/tests/Datepicker-ReduxForm-test.js
@@ -285,7 +285,7 @@ describe('Datepicker with Redux Form integration', () => {
       beforeEach(async () => datepicker.calendar.cursor.pressEscape());
 
       it('closes the calendar', () => {
-        expect(datepicker.calendar.isPresent).to.be.false;
+        expect(datepicker.calendar.isVisible).to.be.false;
       });
     });
   });

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -90,7 +90,7 @@ describe('Datepicker', () => {
     });
 
     it('it did not open the calendar', () => {
-      expect(datepicker.calendar.isVisible).to.be.false;
+      expect(datepicker.calendar.isPresent).to.be.false;
     });
   });
 
@@ -222,7 +222,7 @@ describe('Datepicker', () => {
     describe('choosing a date from calendar', () => {
       beforeEach(async () => datepicker.clickInput().focusInput());
       it('did not open the calendar', () => {
-        expect(datepicker.calendar.isVisible).to.be.false;
+        expect(datepicker.calendar.isPresent).to.be.false;
       });
 
       it('did not call onChange', () => {
@@ -243,7 +243,7 @@ describe('Datepicker', () => {
     });
 
     it('is opened the calendar', () => {
-      expect(datepicker.calendar.isVisible).to.be.true;
+      expect(datepicker.calendar.isPresent).to.be.true;
     });
   });
 
@@ -255,7 +255,7 @@ describe('Datepicker', () => {
     });
 
     it('opened the calendar', () => {
-      expect(datepicker.calendar.isVisible).to.be.true;
+      expect(datepicker.calendar.isPresent).to.be.true;
     });
   });
 
@@ -270,27 +270,27 @@ describe('Datepicker', () => {
     });
 
     it('is closed', () => {
-      expect(datepicker.calendar.isVisible).to.be.false;
+      expect(datepicker.calendar.isPresent).to.be.false;
     });
 
     describe('focus', () => {
       beforeEach(async () => datepicker.focusInput());
 
       it('opens on focus', () => {
-        expect(datepicker.calendar.isVisible).to.be.true;
+        expect(datepicker.calendar.isPresent).to.be.true;
       });
 
       describe('clicking outside of calendar', () => {
         beforeEach(() => document.getElementById('anywhere-else').click());
         it('closes the calendar picker', () => {
-          expect(datepicker.calendar.isVisible).to.be.false;
+          expect(datepicker.calendar.isPresent).to.be.false;
         });
       });
 
       describe('pressing escape while calendar open', () => {
         beforeEach(async () => datepicker.pressTab());
         it('closes the calendar picker', () => {
-          expect(datepicker.calendar.isVisible).to.be.false;
+          expect(datepicker.calendar.isPresent).to.be.false;
         });
       });
 
@@ -300,7 +300,7 @@ describe('Datepicker', () => {
         });
 
         it('closes the calendar picker', () => {
-          expect(datepicker.calendar.isVisible).to.be.false;
+          expect(datepicker.calendar.isPresent).to.be.false;
         });
       });
     });

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -90,7 +90,7 @@ describe('Datepicker', () => {
     });
 
     it('it did not open the calendar', () => {
-      expect(datepicker.calendar.isPresent).to.be.false;
+      expect(datepicker.calendar.isVisible).to.be.false;
     });
   });
 
@@ -222,7 +222,7 @@ describe('Datepicker', () => {
     describe('choosing a date from calendar', () => {
       beforeEach(async () => datepicker.clickInput().focusInput());
       it('did not open the calendar', () => {
-        expect(datepicker.calendar.isPresent).to.be.false;
+        expect(datepicker.calendar.isVisible).to.be.false;
       });
 
       it('did not call onChange', () => {
@@ -243,7 +243,7 @@ describe('Datepicker', () => {
     });
 
     it('is opened the calendar', () => {
-      expect(datepicker.calendar.isPresent).to.be.true;
+      expect(datepicker.calendar.isVisible).to.be.true;
     });
   });
 
@@ -255,7 +255,7 @@ describe('Datepicker', () => {
     });
 
     it('opened the calendar', () => {
-      expect(datepicker.calendar.isPresent).to.be.true;
+      expect(datepicker.calendar.isVisible).to.be.true;
     });
   });
 
@@ -270,7 +270,7 @@ describe('Datepicker', () => {
     });
 
     it('is closed', () => {
-      expect(datepicker.calendar.isPresent).to.be.false;
+      expect(datepicker.calendar.isVisible).to.be.false;
     });
 
     describe('focus', () => {
@@ -283,14 +283,14 @@ describe('Datepicker', () => {
       describe('clicking outside of calendar', () => {
         beforeEach(() => document.getElementById('anywhere-else').click());
         it('closes the calendar picker', () => {
-          expect(datepicker.calendar.isPresent).to.be.false;
+          expect(datepicker.calendar.isVisible).to.be.false;
         });
       });
 
       describe('pressing escape while calendar open', () => {
         beforeEach(async () => datepicker.pressTab());
         it('closes the calendar picker', () => {
-          expect(datepicker.calendar.isPresent).to.be.false;
+          expect(datepicker.calendar.isVisible).to.be.false;
         });
       });
 
@@ -300,7 +300,7 @@ describe('Datepicker', () => {
         });
 
         it('closes the calendar picker', () => {
-          expect(datepicker.calendar.isPresent).to.be.false;
+          expect(datepicker.calendar.isVisible).to.be.false;
         });
       });
     });

--- a/lib/Popper/index.js
+++ b/lib/Popper/index.js
@@ -1,1 +1,1 @@
-export { default } from './Popper';
+export { default, AVAILABLE_PLACEMENTS } from './Popper';


### PR DESCRIPTION
## Changes
- Updated `<Datepicker>` to use `<Popper>` instead of react-tether
- Added deprecation warning for `tether`-prop
- Moved default tether props from Datepicker.defaultProps into the code so we only need to remove the block of code in the render method
- Added `modifier`- and `placement`-props and updated readme
- Fixed tests
- Moved inline styling into the stylesheet instead