### PR TITLE
To avoid warnings in console that defautWidth is required

### DIFF
--- a/lib/Loading/LoadingPane.js
+++ b/lib/Loading/LoadingPane.js
@@ -6,7 +6,7 @@ import Loading from './Loading';
 export default (props) => {
   const spinnerStyle = { maxWidth: '15rem', height: '8rem' };
   return (
-    <Pane {...props}>
+    <Pane defaultWidth="fill" {...props}>
       <Layout className="centered full" style={spinnerStyle}>
         &nbsp;
         <Loading size="xlarge" />


### PR DESCRIPTION
Usually we have to pass `"fill"` in every place we use `LoadingPane`, so maybe it makes sense to put it as default option