### PR TITLE
STCOM-622 MCL 'Load More' button

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -53,9 +53,6 @@ module.exports = {
         use: [
           {
             loader: 'style-loader',
-            options: {
-              sourceMap: true,
-            },
           },
           {
             loader: 'css-loader',

--- a/lib/Loading/DotSpinner.css
+++ b/lib/Loading/DotSpinner.css
@@ -1,0 +1,36 @@
+.spinner {
+  width: inherit;
+  height: inherit;
+  display: flex;
+  align-items: center;
+
+  & .bounce1 {
+    animation-delay: -0.32s;
+  }
+
+  & .bounce2 {
+    animation-delay: -0.16s;
+  }
+
+  & > div {
+    width: 33%;
+    height: 33%;
+    margin: 0 8%;
+    background-color: rgba(0, 0, 0, 0.62);
+    border-radius: 100%;
+    display: inline-block;
+    animation: sk-bouncedelay 1.4s infinite ease-in-out both;
+  }
+}
+
+@keyframes sk-bouncedelay {
+  0%,
+  80%,
+  100% {
+    transform: scale(0);
+  }
+
+  40% {
+    transform: scale(1);
+  }
+}

--- a/lib/Loading/Loading.js
+++ b/lib/Loading/Loading.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import css from './DotSpinner.css';
+
+const Loading = ({ size, useCurrentColor }) => {
+  const multiplyerMap = {
+    small: 0.5,
+    medium: 1,
+    large: 2,
+    xlarge: 3
+  };
+
+  const getStyle = () => {
+    if (size) {
+      const wAmount = multiplyerMap[size] * 30;
+      const hAmount = multiplyerMap[size] * 15;
+      return { width: `${wAmount}px`, height: `${hAmount}px` };
+    }
+    return null;
+  };
+
+  const dotStyle = {
+    backgroundColor: useCurrentColor ? 'currentColor' : null
+  };
+
+  return (
+    <div className={css.spinner} style={getStyle()}>
+      <div className={css.bounce1} style={dotStyle} />
+      <div className={css.bounce2} style={dotStyle} />
+      <div className={css.bounce3} style={dotStyle} />
+    </div>
+  );
+};
+
+Loading.propTypes = {
+  size: PropTypes.oneOf(['small', 'medium', 'large', 'xlarge']),
+  useCurrentColor: PropTypes.bool,
+};
+Loading.defaultProps = {
+  size: 'medium'
+};
+
+export default Loading;

--- a/lib/Loading/LoadingPane.js
+++ b/lib/Loading/LoadingPane.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import Pane from '../Pane';
+import Layout from '../Layout';
+import Loading from './Loading';
+
+export default (props) => {
+  const spinnerStyle = { maxWidth: '15rem', height: '8rem' };
+  return (
+    <Pane {...props}>
+      <Layout className="centered full" style={spinnerStyle}>
+        &nbsp;
+        <Loading size="xlarge" />
+      </Layout>
+    </Pane>
+  );
+};

--- a/lib/Loading/LoadingView.js
+++ b/lib/Loading/LoadingView.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Paneset from '../Paneset';
+import LoadingPane from './LoadingPane';
+
+const LoadingView = ({ panesetProps, ...props }) => (
+  <Paneset {...panesetProps}>
+    <LoadingPane {...props} />
+  </Paneset>
+);
+
+LoadingView.propTypes = {
+  panesetProps: PropTypes.object,
+};
+
+export default LoadingView;

--- a/lib/Loading/index.js
+++ b/lib/Loading/index.js
@@ -1,0 +1,3 @@
+export { default as LoadingView } from './LoadingView';
+export { default as LoadingPane } from './LoadingPane';
+export { default as Loading } from './Loading';

--- a/lib/Loading/readme.md
+++ b/lib/Loading/readme.md
@@ -1,0 +1,7 @@
+# Loading (spinners)
+
+Components for loading animations for various scenarios within your application.
+
+- `<Loading>` a basic, standalone loading spinner
+- `<LoadingPane>` a Pane with a loading spinner. For use within existing `<Paneset>`s. Accepts the props of `<Pane>`.
+- `<LoadingView>` for fullscreen views. Accepts the props of `<Pane>` and includes a wrapping `<Paneset>`.

--- a/lib/Loading/stories/Loading.stories.js
+++ b/lib/Loading/stories/Loading.stories.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
+import Readme from '../readme.md';
+import Loading from '../Loading';
+import LoadingView from '../LoadingView';
+import LoadingPane from './LoadingPane.story';
+
+storiesOf('Loading', module)
+  .addDecorator(withReadme(Readme))
+  .add('Loading Spinner', () => <Loading />)
+  .add('Loading Pane', () => <LoadingPane />)
+  .add('Loading View', () => <LoadingView paneTitle="Loading view animation" />);

--- a/lib/Loading/stories/LoadingPane.story.js
+++ b/lib/Loading/stories/LoadingPane.story.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import Paneset from '../../Paneset';
+import LoadingPane from '../LoadingPane';
+
+export default () => (
+  <Paneset>
+    <LoadingPane paneTitle="Loading pane" />
+  </Paneset>
+);

--- a/lib/MultiColumnList/CenteredContainer.js
+++ b/lib/MultiColumnList/CenteredContainer.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { isFinite } from 'lodash';
+import Layout from '../Layout';
+import css from './MCLRenderer.css';
+
+const CenteredContainer = ({ innerRef, visible, width, children }) => {
+  // subtracting the margins to prevent horizontal scroll
+  const endOfListWidth = isFinite(width) ? `${Math.max(width - 20, 200)}px` : '100%';
+
+  return (
+    <div
+      ref={innerRef}
+      className={css.mclCenteredContainer}
+      style={
+        { width: endOfListWidth,
+          visibility: `${visible ? 'visible' : 'hidden'}`,
+          height: `${visible ? null : 0}`,
+          padding: `${visible ? null : 0}` }
+        }
+    >
+      <Layout className="textCentered">
+        {children}
+      </Layout>
+    </div>
+  );
+};
+
+CenteredContainer.propTypes = {
+  children: PropTypes.node,
+  innerRef: PropTypes.object,
+  visible: PropTypes.bool,
+  width: PropTypes.number,
+};
+
+export default CenteredContainer;

--- a/lib/MultiColumnList/EndOfList.js
+++ b/lib/MultiColumnList/EndOfList.js
@@ -1,46 +1,15 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { isFinite } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import Layout from '../Layout';
 import Icon from '../Icon';
 import css from './MCLRenderer.css';
 
-export default class EndOfList extends React.Component {
-  static propTypes = {
-    innerRef: PropTypes.object,
-    visible: PropTypes.bool,
-    width: PropTypes.number,
-  }
-
-  render() {
-    const {
-      width,
-      innerRef,
-      visible,
-    } = this.props;
-
-    // subtracting the margins to prevent horizontal scroll
-    const endOfListWidth = isFinite(width) ? `${Math.max(width, 200)}px` : '100%';
-
-    return (
-      <div
-        key="end-of-list"
-        ref={innerRef}
-        className={css.mclEndOfList}
-        style={
-          { width: endOfListWidth,
-            visibility: `${visible ? 'visible' : 'hidden'}`,
-            height: `${visible ? null : 0}`,
-            padding: `${visible ? null : 0}` }
-          }
-      >
-        <Layout className="textCentered">
-          <Icon icon="end-mark">
-            <FormattedMessage id="stripes-components.endOfList" />
-          </Icon>
-        </Layout>
-      </div>
-    );
-  }
-}
+export default () => {
+  return (
+    <Layout className={css.mclEndOfList}>
+      <Icon icon="end-mark">
+        <FormattedMessage id="stripes-components.endOfList" />
+      </Icon>
+    </Layout>
+  );
+};

--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -215,11 +215,19 @@
   padding: 1rem;
 }
 
+.mclEndOfListContainer {
+  position: absolute;
+  overflow: hidden;
+}
+
+.mclCenteredContainer {
+  position: relative;
+  left: 0;
+}
+
 .mclEndOfList {
   color: var(--color-text-p2);
   padding: var(--gutter-static-two-thirds) 0;
-  position: relative;
-  left: 0;
 }
 
 /* loader rows */

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -28,6 +28,7 @@ import memoizeOne from 'memoize-one';
 import Icon from '../Icon';
 import EmptyMessage from '../EmptyMessage';
 import { HotKeys } from '../HotKeys';
+import SRStatus from '../SRStatus';
 import css from './MCLRenderer.css';
 import defaultRowFormatter from './defaultRowFormatter';
 import CellMeasurer from './CellMeasurer';
@@ -36,11 +37,13 @@ import LoaderRow from './LoaderRow';
 import EndOfList from './EndOfList';
 import DimensionCache from './DimensionCache';
 
+import { getNextFocusable } from '../../util/getFocusableElements';
 import * as baseHandlers from './defaultHandlers';
 import { calculateColumnWidth3q } from './calculateWidth';
 import convertToPixels from './convertToPixels';
 import RowPositioner from './RowPositioner';
-
+import CenteredContainer from './CenteredContainer';
+import PagingButton from './PagingButton';
 /* some item fields will have arrays... those don't always come back in the same
 *  order, despite the item being the same. This function checks for equality with that in mind.
 */
@@ -122,6 +125,7 @@ class MCLRenderer extends React.Component {
     columnWidths: PropTypes.object,
     containerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     contentData: PropTypes.arrayOf(PropTypes.object),
+    dataEndReached: PropTypes.bool,
     formatter: PropTypes.object,
     headerMetadata: PropTypes.object,
     headerRowClass: PropTypes.string,
@@ -144,6 +148,8 @@ class MCLRenderer extends React.Component {
     onNeedMoreData: PropTypes.func,
     onRowClick: PropTypes.func,
     onScroll: PropTypes.func,
+    pageAmount: PropTypes.number,
+    pagingType: PropTypes.oneOf(['scroll', 'click']),
     rowFormatter: PropTypes.func,
     rowMetadata: PropTypes.arrayOf(PropTypes.string),
     rowProps: PropTypes.object,
@@ -167,6 +173,7 @@ class MCLRenderer extends React.Component {
     columnOverflow: {},
     columnWidths: {},
     contentData: [],
+    dataEndReached: false,
     formatter: {},
     hotKeys: { keyMap: {}, handlers: {} },
     interactive: true,
@@ -175,6 +182,8 @@ class MCLRenderer extends React.Component {
     },
     isEmptyMessage: <FormattedMessage id="stripes-components.tableEmpty" />,
     onScroll: noop,
+    pageAmount: 30,
+    pagingType: 'scroll',
     rowFormatter: defaultRowFormatter,
     rowProps: {},
     rowUpdater: noop,
@@ -195,6 +204,9 @@ class MCLRenderer extends React.Component {
     this.headerContainer = React.createRef();
     this.scrollContainer = React.createRef();
     this.endOfList = React.createRef();
+    this.pageButton = React.createRef();
+    this.status = React.createRef();
+
     this.headerHeight = 0;
     this.focusedRowIndex = null;
     this.maximumRowHeight = 30;
@@ -358,7 +370,7 @@ class MCLRenderer extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { columnWidths, width, visibleColumns, contentData } = this.props;
+    const { columnWidths, width, visibleColumns, contentData, pagingType } = this.props;
 
     let newState = {};
 
@@ -386,6 +398,16 @@ class MCLRenderer extends React.Component {
       }
       newState.averageRowHeight = 0;
       newState.firstIndex = 0;
+    } else if (pagingType === 'click') {
+      if (this.focusTargetIndex) {
+        const target = document.querySelector(`[data-row-index="row-${this.focusTargetIndex}"]`);
+        if (target) {
+          const inner = getNextFocusable(target, true, true);
+          const elem = inner || target;
+          elem.focus();
+          this.focusTargetIndex = null;
+        }
+      }
     }
 
     if (!isEqual(visibleColumns, prevProps.visibleColumns)) {
@@ -550,8 +572,13 @@ class MCLRenderer extends React.Component {
         this.headerContainer.current.scrollLeft = this.scrollContainer.current.scrollLeft;
 
         const eOL = this.endOfList.current;
+        const pageButton = this.pageButton.current;
+        const newLeft = `${this.scrollContainer.current.scrollLeft}px`;
         if (eOL) {
-          eOL.style.left = `${this.scrollContainer.current.scrollLeft}px`;
+          eOL.style.left = newLeft;
+        }
+        if (pageButton) {
+          pageButton.style.left = newLeft;
         }
       }
     });
@@ -656,6 +683,16 @@ class MCLRenderer extends React.Component {
     return false;
   }
 
+  setFocusIndex = (index) => {
+    this.focusTargetIndex = index;
+  }
+
+  sendMessage = (message) => {
+    if (this.status.current) {
+      this.status.current.sendMessage(message);
+    }
+  }
+
   checkForMaxHeight = (cacheResult) => {
     if (cacheResult.result > this.maximumRowHeight) {
       this.maximumRowHeight = cacheResult.result;
@@ -664,16 +701,18 @@ class MCLRenderer extends React.Component {
 
   getRowData = (rowIndex) => this.props.contentData[rowIndex];
 
-  renderDataRow = ({ rowIndex, position }) => {
+  renderDataRow = (rowIndex) => {
     const {
       id,
       rowProps: pRowProps,
       contentData,
       width,
+      rowUpdater,
       columnMapping,
       interactive,
       rowFormatter,
       virtualize,
+      selectedRow,
       onRowClick,
     } = this.props;
 
@@ -724,59 +763,245 @@ class MCLRenderer extends React.Component {
       ...cellObject, // cells, labelStrings
     };
 
-    let positionedRowStyle;
-    if (position !== null) {
-      positionedRowStyle = { top: `${position}px` };
-    } else {
-      positionedRowStyle = { top: '100%' };
-    }
-    if (!virtualize) positionedRowStyle = { position: 'static' };
     return (
-      <RowMeasurer
+      /* RowPositioner is a PureComponent - this brings maximum efficiency at the cost of making it aware
+        of any side effects that could cause a difference in the rendered output - components/functions
+        within formatters that depend on data outside of the contentData itself.
+      */
+      <RowPositioner
+        key={`row-positioner-${rowIndex}-${this.keyId}`}
+        gridId={this.props.id}
+        rowWidth={this.state.rowWidth}
+        positionCache={this.positionCache}
+        shouldPosition={!this.state.staticBody}
+        onPosition={this.onRowPositioned}
         heightCache={this.rowHeightCache}
-        gridId={id}
+        dataItem={contentData[rowIndex]}
+        columnCount={columns.length}
+        columnWidths={Object.keys(columnWidths).length}
         rowIndex={rowIndex}
-        measure={!staticBody && (columns.length <= Object.keys(columnWidths).length)}
-        onMeasure={this.checkForMaxHeight}
-        key={`row-measurer-${rowIndex}-${this.keyId}`}
+        selected={this.maybeSelected(selectedRow, rowIndex)}
+        shouldUpdate={rowUpdater(contentData[rowIndex], rowIndex)}
       >
-        <div
-          data-row-index={`row-${rowIndex}`}
-          className={css.mclRowFormatterContainer}
-          onFocus={this.handleRowFocus}
-          onBlur={this.handleRowBlur}
-          style={positionedRowStyle}
-        >
-          {rowFormatter(injectedRowProps)}
-        </div>
-      </RowMeasurer>
+        {({ localRowIndex, position }) => {
+          let positionedRowStyle;
+          if (position !== null) {
+            positionedRowStyle = { top: `${position}px` };
+          } else {
+            positionedRowStyle = { top: '100%' };
+          }
+          if (!virtualize) positionedRowStyle = { position: 'static' };
+          return (
+            <RowMeasurer
+              heightCache={this.rowHeightCache}
+              gridId={id}
+              rowIndex={localRowIndex}
+              measure={!staticBody && (columns.length <= Object.keys(columnWidths).length)}
+              onMeasure={this.checkForMaxHeight}
+              key={`row-measurer-${localRowIndex}-${this.keyId}`}
+            >
+              <div
+                data-row-index={`row-${localRowIndex}`}
+                className={css.mclRowFormatterContainer}
+                onFocus={this.handleRowFocus}
+                onBlur={this.handleRowBlur}
+                style={positionedRowStyle}
+              >
+                {rowFormatter(injectedRowProps)}
+              </div>
+            </RowMeasurer>
+          );
+        }}
+      </RowPositioner>
+    );
+  }
+
+  renderLoaderRow = (rowIndex, dataRowsRendered, heightIncrement) => {
+    const {
+      contentData,
+      totalCount,
+      pageAmount,
+    } = this.props;
+
+    const {
+      columns,
+      columnWidths,
+      firstIndex,
+      rowWidth,
+      staticBody,
+    } = this.state;
+
+    const loaderClassname = `${css.mclRow} ${rowIndex % 2 !== 0 ? '' : css.mclIsOdd}`;
+    // if an onNeedMoreData callback is present, render at least one loader...
+    // the single loader is visibly hidden.
+    if (totalCount === 0) {
+      // no totalCount means it's up to the position in the data to decide to load more...
+      if (contentData.length - (firstIndex + dataRowsRendered) < pageAmount) {
+        return (
+          <LoaderRow
+            key={`loader-row-${rowIndex}-${this.keyId}`}
+            askAmount={pageAmount}
+            height={0}
+            rowIndex={rowIndex}
+            loadMore={this.handleLoadMore}
+            className={loaderClassname}
+            columns={columns}
+            columnWidths={columnWidths}
+          />
+        );
+      }
+    }
+    // totalCount allows the grid to render placeholders for not-yet-loaded rows...
+    return (
+      <RowPositioner
+        key={`row-loader-positioner-${rowIndex}-${this.keyId}`}
+        gridId={this.props.id}
+        shouldPosition={!staticBody}
+        onPosition={this.onRowPositioned}
+        heightCache={this.rowHeightCache}
+        positionCache={this.positionCache}
+        columnCount={columns.length}
+        columnWidths={Object.keys(columnWidths).length}
+        averageHeight={heightIncrement}
+        rowIndex={rowIndex}
+      >
+        { /*  rowIndex passed through to children as localRowIndex since
+              the outer scope rowIndex changes */
+          ({ localRowIndex, position }) => (
+            <LoaderRow
+              key={`loader-row-${localRowIndex}-${this.keyId}`}
+              askAmount={Math.min(pageAmount, totalCount - contentData.length)}
+              height={heightIncrement}
+              minWidth={rowWidth}
+              rowIndex={localRowIndex}
+              loadMore={this.handleLoadMore}
+              className={loaderClassname}
+              columns={columns}
+              styleTop={position}
+              columnWidths={columnWidths}
+            />
+          )
+        }
+      </RowPositioner>
+    );
+  };
+
+  renderEndOfList = (endIndex, renderPosition) => {
+    const {
+      dataEndReached,
+      id,
+      virtualize,
+      totalCount,
+      width,
+    } = this.props;
+
+    const {
+      prevWidth,
+      staticBody
+    } = this.state;
+
+    return (
+      <RowPositioner
+        key={`end-of-list-positioner-${renderPosition}-${this.keyId}`}
+        gridId={id}
+        heightCache={this.rowHeightCache}
+        positionCache={this.positionCache}
+        onPosition={this.updateBodyHeight}
+        shouldPosition={!staticBody}
+        rowIndex={endIndex}
+      >
+        { ({ position }) => {
+          return (
+            <div data-end-of-list={endIndex} className={css.mclEndOfListContainer} style={{ top: `${position}px` }}>
+              <CenteredContainer
+                width={width || prevWidth || undefined}
+                innerRef={this.endOfList}
+                visible={virtualize && (dataEndReached || (totalCount > 0 && totalCount <= renderPosition))}
+              >
+                <EndOfList />
+              </CenteredContainer>
+            </div>
+          );
+        }}
+      </RowPositioner>
+    );
+  }
+
+  renderPagingButton = (rowIndex) => {
+    const {
+      dataEndReached,
+      id,
+      width,
+      pageAmount
+    } = this.props;
+
+    const {
+      prevWidth,
+      loading,
+      staticBody,
+    } = this.state;
+
+    if (dataEndReached) { return null; }
+
+    return (
+      <RowPositioner
+        key={`load-button-positioner-${rowIndex}-${this.keyId}`}
+        gridId={id}
+        heightCache={this.rowHeightCache}
+        positionCache={this.positionCache}
+        shouldPosition={!staticBody}
+        rowIndex={rowIndex}
+      >
+        {({ localRowIndex, position }) => (
+          <div
+            key={`${localRowIndex}-load-button`}
+            style={{ position: 'absolute', top: `${position}px`, marginTop: '1rem' }}
+          >
+            <CenteredContainer
+              width={width || prevWidth || undefined}
+              innerRef={this.pageButton}
+              visible
+            >
+              <FormattedMessage id="stripes-components.mcl.itemsRequestedMessage">
+                { message => (
+                  <PagingButton
+                    rowIndex={rowIndex}
+                    onClick={() => {
+                      this.setFocusIndex(rowIndex);
+                      this.handleLoadMore(pageAmount, rowIndex);
+                    }}
+                    sendMessage={this.sendMessage}
+                    loadingMessage={message}
+                    loading={loading}
+                    gridId={id || this.keyId}
+                  />
+                )}
+              </FormattedMessage>
+            </CenteredContainer>
+          </div>
+        )}
+      </RowPositioner>
     );
   }
 
   renderRows = () => {
     const {
       minimumRowHeight,
-      width,
       maxHeight,
       contentData,
+      pagingType,
       totalCount,
       virtualize,
       onNeedMoreData,
-      rowUpdater,
-      selectedRow
     } = this.props;
 
     const {
       firstIndex,
-      columnWidths,
       scrollTop,
-      columns,
       averageRowHeight,
-      rowWidth,
       maxScrollDelta,
       scrollDirection,
       prevHeight,
-      prevWidth,
     } = this.state;
 
     this.framePositions = {};
@@ -822,85 +1047,17 @@ class MCLRenderer extends React.Component {
       currentTop += minimumRowHeight, rowIndex += 1, renderPosition += 1
     ) {
       if (contentData[rowIndex] && rowIndex < contentData.length) {
-        rows.push(
-          /* RowPositioner is a PureComponent - this brings maximum efficiency at the cost of making it aware
-            of any side effects that could cause a difference in the rendered output - components/functions
-            within formatters that depend on data outside of the contentData itself.
-          */
-          <RowPositioner
-            key={`row-positioner-${rowIndex}-${this.keyId}`}
-            gridId={this.props.id}
-            rowWidth={this.state.rowWidth}
-            positionCache={this.positionCache}
-            shouldPosition={!this.state.staticBody}
-            onPosition={this.onRowPositioned}
-            heightCache={this.rowHeightCache}
-            dataItem={contentData[rowIndex]}
-            columnCount={columns.length}
-            columnWidths={Object.keys(columnWidths).length}
-            rowIndex={rowIndex}
-            selected={this.maybeSelected(selectedRow, rowIndex)}
-            shouldUpdate={rowUpdater(contentData[rowIndex], rowIndex)}
-          >
-            {this.renderDataRow}
-          </RowPositioner>
-        );
+        rows.push(this.renderDataRow(rowIndex));
         dataRowsRendered += 1;
       } else if (loaderSettings.load && (totalCount === 0 || rowIndex < totalCount)) {
-        const loaderClassname = `${css.mclRow} ${rowIndex % 2 !== 0 ? '' : css.mclIsOdd}`;
-        // if an onNeedMoreData callback is present, render at least one loader...
-        // the single loader is visibly hidden.
         if (totalCount === 0) {
           currentTop = bodyExtent;
-          // no totalCount means it's up to the position in the data to decide to load more...
-          if (contentData.length - (firstIndex + dataRowsRendered) < 30) {
-            rows.push(
-              <LoaderRow
-                key={`loader-row-${rowIndex}-${this.keyId}`}
-                askAmount={30}
-                height={0}
-                rowIndex={rowIndex}
-                loadMore={this.handleLoadMore}
-                className={loaderClassname}
-                columns={columns}
-                columnWidths={columnWidths}
-              />
-            );
-          }
-        } else {
-          // totalCount allows the grid to render placeholders for not-yet-loaded rows...
-          rows.push(
-            <RowPositioner
-              key={`row-loader-positioner-${rowIndex}-${this.keyId}`}
-              gridId={this.props.id}
-              shouldPosition={!this.state.staticBody}
-              onPosition={this.onRowPositioned}
-              heightCache={this.rowHeightCache}
-              positionCache={this.positionCache}
-              columnCount={columns.length}
-              columnWidths={Object.keys(columnWidths).length}
-              averageHeight={heightIncrement}
-              rowIndex={rowIndex}
-            >
-              { /*  rowIndex passed through to children as localRowIndex since
-                    the outer scope rowIndex changes */
-                ({ localRowIndex, position }) => (
-                  <LoaderRow
-                    key={`loader-row-${localRowIndex}-${this.keyId}`}
-                    askAmount={Math.min(30, totalCount - contentData.length)}
-                    height={heightIncrement}
-                    minWidth={rowWidth}
-                    rowIndex={localRowIndex}
-                    loadMore={this.handleLoadMore}
-                    className={loaderClassname}
-                    columns={columns}
-                    styleTop={position}
-                    columnWidths={columnWidths}
-                  />
-                )
-              }
-            </RowPositioner>
-          );
+        }
+        if (pagingType === 'scroll') {
+          rows.push(this.renderLoaderRow(rowIndex, dataRowsRendered, heightIncrement));
+        } else if (pagingType === 'click') {
+          currentTop = bodyExtent;
+          rows.push(this.renderPagingButton(rowIndex));
         }
       }
     }
@@ -908,41 +1065,7 @@ class MCLRenderer extends React.Component {
     const endIndex = onNeedMoreData ? renderPosition : dataRowsRendered;
     // keep a count of the amount of rows rendered in the view.
     this.rowCount = endIndex - firstIndex;
-    rows.push(
-      <RowPositioner
-        key={`end-of-list-positioner-${renderPosition}-${this.keyId}`}
-        gridId={this.props.id}
-        heightCache={this.rowHeightCache}
-        positionCache={this.positionCache}
-        onPosition={this.updateBodyHeight}
-        shouldPosition={!this.state.staticBody}
-        rowIndex={endIndex}
-      >
-        { ({ position }) => {
-          const endOfListContainerStyle = {
-            position: 'absolute',
-            overflow: 'hidden'
-          };
-          if (position !== null) {
-            endOfListContainerStyle.top = `${position}px`;
-          }
-
-          let eOLWidth = (width || prevWidth);
-          if (eOLWidth > 0) { eOLWidth -= 20; }
-          // Render EndOfList with width - 20 to avoid unnecessary horizontal scroll
-          // when a vertical scrollbar is present.
-          return (
-            <div data-end-of-list={endIndex} style={endOfListContainerStyle}>
-              <EndOfList
-                width={eOLWidth || undefined}
-                innerRef={this.endOfList}
-                visible={virtualize && (totalCount > 0 && totalCount <= renderPosition)}
-              />
-            </div>
-          );
-        }}
-      </RowPositioner>
-    );
+    rows.push(this.renderEndOfList(endIndex, renderPosition));
 
     return rows;
   }
@@ -1219,7 +1342,7 @@ class MCLRenderer extends React.Component {
   }
 
   getRowContainerStyle = () => {
-    const { totalCount, wrapCells, height, minimumRowHeight, virtualize } = this.props;
+    const { totalCount, wrapCells, height, minimumRowHeight, virtualize, pagingType } = this.props;
     const { receivedRows, rowWidth, averageRowHeight } = this.state;
 
     let position = 'static';
@@ -1239,7 +1362,7 @@ class MCLRenderer extends React.Component {
       // if we have a totalCount, we can set size based on that... if not, the receivedRows count.
       const scrollBarHeight = 20;
       newHeight = Math.max(
-        ((totalCount || receivedRows) * minimumRowHeight),
+        ((pagingType === 'click' ? receivedRows : totalCount || receivedRows) * minimumRowHeight),
         (height - this.headerHeight - scrollBarHeight)
       );
       return { height: `${newHeight}px`, width, position };
@@ -1344,6 +1467,7 @@ class MCLRenderer extends React.Component {
 
     return (
       <HotKeys handlers={this.handlers} noWrapper>
+        <SRStatus ref={this.status} />
         <div
           style={this.getOuterElementStyle()}
           tabIndex="0" // eslint-disable-line jsx-a11y/no-noninteractive-tabindex

--- a/lib/MultiColumnList/PagingButton.js
+++ b/lib/MultiColumnList/PagingButton.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { Loading } from '../Loading';
+
+import Button from '../Button';
+
+const PagingButton = ({ loading, onClick, loadingMessage, sendMessage, gridId }) => {
+  const handleClick = () => {
+    sendMessage(loadingMessage);
+    onClick();
+  };
+
+  return (
+    <React.Fragment>
+      <Button
+        disabled={loading}
+        onClick={handleClick}
+        style={{ width: '75%' }}
+        data-test-paging-button
+        id={`${gridId}-clickable-paging-button`}
+      >
+        {!loading && <FormattedMessage id="stripes-components.mcl.loadMore" />}
+        {loading && <Loading size="medium" useCurrentColor />}
+      </Button>
+    </React.Fragment>
+  );
+};
+
+PagingButton.propTypes = {
+  gridId: PropTypes.string,
+  loading: PropTypes.bool,
+  loadingMessage: PropTypes.string,
+  onClick: PropTypes.func,
+  sendMessage: PropTypes.func
+};
+
+export default PagingButton;

--- a/lib/MultiColumnList/readme.md
+++ b/lib/MultiColumnList/readme.md
@@ -76,7 +76,7 @@ Name | type | description | default | required
 `selectedClass` | string | override class for the default style applied to selected rows. | built-in |
 `sortedClass` | string | override class for the default style applied to headers of sorted columns. | built-in |
 `isEmptyMessage` | string, object, node, arrayOf(node) | Message to display when the supplied contentData array is empty. | <FormattedMessage id="stripes-components.tableEmpty" /> |
-`onNeedMoreData` | func | Callback for fetching more data | |
+`onNeedMoreData` | func(`askAmount`, `index`) | Callback for fetching more data. If this prop is provided and a `totalCount` prop is provided, but un-reached by the count of loaded data items, `askAmount` will ask for the remainder of items or the `pageAmount` prop, whichever is less. This can be used to fulfill `limit` query parameters. `rowIndex` can be used to fulfill an `offset` query parameter. | |
 `virtualize` | bool | Employs virtualization for performant rendering of large sets of data. | |
 `loading` | bool | If true, will display an animated loading icon. | |
 `onScroll` | func | Callback for scrolling of list body. | `noop` |
@@ -85,6 +85,9 @@ Name | type | description | default | required
 `interactive` | bool | Applies a "pointer" cursor when the mouse hovers over a row | `true` |
 `headerRowClass` | string | Applies a css class to the header row of the list. | |
 `rowUpdater` | func(`rowData`, `rowIndex`) | This function should return a shallow data structure (flattened object) or primitive (string, number) that will indicate that exterior data for a row has changed. It will receive two parameters of the `rowData` and the `rowIndex` that can be used to base return values. This result is fed directly to the data rows via props, keeping them pure. You should rarely have to use this prop, as most changes will be relayed directly in the `contentData` array itself. | `noop` |
+`pagingType` | string | Controls the interaction type when loading more data in the MCL. `"scroll"` is used for infinite scroll/loading scenarios, `"click"` renders a paging button below the results if the loaded count is less than the `totalCount` prop. | `"scroll"` | 
+`dataEndReached` | bool | Used in conjuction with `pagingType="click"`, `dataEndReached` can be used if a suitable `totalCount` prop cannot be obtained. Setting this to `true` will render the "end-of-list" marker rather than the load button. | `false` | 
+`pageAmount` | number | The base amount of data to pass as the `askAmount` parameter for the `onNeedMoreData` prop | `30` | 
 
 ## Usability: Clickable Rows vs clickable cells
 Using both types of interaction is not good for users or developers, so it's best to simply use one or the other. For clickable cell content, place clickable elements within `formatter`s. Clickable rows are easily created by using the `onRowClick` prop.

--- a/lib/MultiColumnList/stories/MultiColumnList.stories.js
+++ b/lib/MultiColumnList/stories/MultiColumnList.stories.js
@@ -13,6 +13,7 @@ import CheckboxSelect from './CheckboxSelect';
 import ColumnChooser from './ColumnChooser';
 import EndOfListMarker from './EndOfListMarker';
 import Formatter from './Formatter';
+import PagingType from './PagingType';
 
 storiesOf('MultiColumnList', module)
   .addDecorator(withReadme(readme))
@@ -26,4 +27,5 @@ storiesOf('MultiColumnList', module)
   .add('Static height', () => <Static />)
   .add('Add Items', () => <AddItem />)
   .add('CheckboxSelect', () => <CheckboxSelect />)
-  .add('Column chooser', () => <ColumnChooser />);
+  .add('Column chooser', () => <ColumnChooser />)
+  .add('Paging type', () => <PagingType />);

--- a/lib/MultiColumnList/stories/PagingType.js
+++ b/lib/MultiColumnList/stories/PagingType.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import MultiColumnList from '../MultiColumnList';
+import { asyncGenerate } from './service';
+
+export default class LoadAction extends React.Component {
+  constructor() {
+    super();
+    this.endReached = false;
+    this.state = {
+      dataA: [],
+      dataB: [],
+      widths: {
+        index: '100px',
+        title: '150px',
+        date: '200px',
+        email: '50%',
+      },
+    };
+    this.requestMoreA(2, 0);
+    this.requestMoreB(2, 0);
+  }
+
+  requestMoreA = async (amount, index) => {
+    const newData = await asyncGenerate(amount, index, 1000);
+    this.setState(curState => ({
+      dataA: [...curState.dataA, ...newData]
+    }));
+  }
+
+  requestMoreB = async (amount, index) => {
+    const newData = await asyncGenerate(amount, index, 1000);
+    this.setState(curState => ({
+      dataB: [...curState.dataB, ...newData]
+    }));
+  }
+
+  render() {
+    const { dataB, dataA, widths } = this.state;
+    this.endReached = dataB.length > 500;
+    return (
+      <React.Fragment>
+        <div style={{ display: 'flex' }}>
+          <div style={{ width: '480px', height:'400px' }}>
+            <h2>Using totalCount prop</h2>
+            <MultiColumnList
+              contentData={dataA}
+              columnWidths={widths}
+              onNeedMoreData={this.requestMoreA}
+              visibleColumns={['index', 'title', 'date', 'email']}
+              interactive={false}
+              maxHeight={500}
+              pageAmount={100}
+              totalCount={400}
+              pagingType="click"
+              virtualize
+            />
+          </div>
+          <div style={{ width: '480px', height:'400px' }}>
+            <h2>Using dataEndReached prop</h2>
+            <MultiColumnList
+              contentData={dataB}
+              columnWidths={widths}
+              dataEndReached={this.endReached}
+              onNeedMoreData={this.requestMoreB}
+              visibleColumns={['index', 'title', 'date', 'email']}
+              interactive={false}
+              maxHeight={500}
+              pageAmount={100}
+              pagingType="click"
+              virtualize
+            />
+          </div>
+        </div>
+      </React.Fragment>
+    );
+  }
+}

--- a/lib/MultiColumnList/tests/MultiColumnList-test.js
+++ b/lib/MultiColumnList/tests/MultiColumnList-test.js
@@ -574,6 +574,30 @@ describe('MultiColumnList', () => {
     });
   });
 
+  describe('using the pagingType prop', () => {
+    let pagingNeedMore;
+    beforeEach(async () => {
+      pagingNeedMore = sinon.fake();
+      await mountWithContext(
+        <MultiColumnList contentData={data3} onNeedMoreData={pagingNeedMore} pagingType="click" />
+      );
+    });
+
+    it('renders the paging button', () => {
+      expect(mcl.pagingButton.isPresent).to.be.true;
+    });
+
+    describe('clicking the paging button', () => {
+      beforeEach(async () => {
+        await mcl.pagingButton.click();
+      });
+
+      it('calls the onNeedMoreData handler', () => {
+        expect(pagingNeedMore.calledOnce).to.be.true;
+      });
+    });
+  });
+
   describe('detecting data changes', () => {
     let currentData;
     let nextData;

--- a/lib/MultiColumnList/tests/interactor.js
+++ b/lib/MultiColumnList/tests/interactor.js
@@ -56,6 +56,7 @@ export default interactor(class MultiColumnListInteractor {
   displaysEmptyMessage = isPresent(`.${css.mclEmptyMessage}`);
   displaysLoadingIcon = isPresent(`.${css.mclContentLoading}`);
   cell = scoped(`.${css.mclCell}`, CellInteractor);
+  pagingButton = scoped('[data-test-paging-button]');
 
   columnsMeasured() {
     return this.when(() => (this.cell.style && this.cell.style.width !== ''));

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@bigtest/mocha": "^0.5.0",
     "@folio/eslint-config-stripes": "^4.2.0",
     "@folio/stripes-cli": "^1.6.0",
+    "@folio/stripes-core": "~3.11.2",
     "@storybook/addon-actions": "^4.0.12",
     "@storybook/addon-knobs": "^4.0.12",
     "@storybook/addon-options": "^4.0.12",
@@ -112,7 +113,10 @@
     "tai-password-strength": "^1.1.1"
   },
   "peerDependencies": {
-    "@folio/stripes-core": "^3.0.0",
+    "@folio/stripes-core": "~3.11.2",
     "react-hot-loader": "^4.0.0"
+  },
+  "resolutions": {
+    "@folio/stripes-core": "3.11.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -117,6 +117,6 @@
     "react-hot-loader": "^4.0.0"
   },
   "resolutions": {
-    "@folio/stripes-core": "3.11.2"
+    "@folio/stripes-core": "~3.11.2"
   }
 }

--- a/translations/stripes-components/en.json
+++ b/translations/stripes-components/en.json
@@ -46,6 +46,8 @@
   "addSelection": "Add selection",
   "collapseSection": "Collapse section",
   "expandSection": "Expand section",
+  "mcl.loadMore": "Load more",
+  "mcl.itemsRequestedMessage": "Requesting more results, will focus next row when they arrive",
   "metaSection.source": "Source: {source}",
   "metaSection.sourceNoData": "Source: Automated process",
   "metaSection.recordCreated": "Record created: {date} {time}",


### PR DESCRIPTION
Provide an opt-in path for `<MultiColumnList>` to present a "Load more" button for requesting pages one-at-a-time as an alternative to infinite scroll.

It's a cherry-pick of the commits in #1117 onto a patch branch in order to make that feature, and that feature alone, available as a patch to the [2019-q4 stripes release](https://github.com/folio-org/stripes/releases/tag/v2.12.1). 