### PR TITLE
STCOM-649 Refactor away from componentWillReceiveProps

### DIFF
--- a/lib/SRStatus/SRStatus.js
+++ b/lib/SRStatus/SRStatus.js
@@ -6,6 +6,7 @@ class SRStatus extends React.Component {
   static propTypes = {
     ariaLive: PropTypes.oneOf(['polite', 'assertive', 'off']),
     message: PropTypes.string,
+    rest: PropTypes.object,
   }
 
   static defaultProps = {
@@ -24,8 +25,7 @@ class SRStatus extends React.Component {
     };
   }
 
-  shouldComponentUpdate(nextProps)
-  {
+  shouldComponentUpdate(nextProps) {
     if (nextProps.message !== undefined &&
       nextProps.message !== '') {
       return true;
@@ -35,7 +35,7 @@ class SRStatus extends React.Component {
     }
     return false;
   }
-  
+
   componentDidUpdate(prevProps) {
     if (prevProps.message === this.props.message) {
       if (this.willUpdateRepeats) {

--- a/lib/SRStatus/SRStatus.js
+++ b/lib/SRStatus/SRStatus.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import isEqual from 'lodash/isEqual';
 
 class SRStatus extends React.Component {
   static propTypes = {
@@ -23,16 +24,25 @@ class SRStatus extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) { // eslint-disable-line react/no-deprecated
+  shouldComponentUpdate(nextProps)
+  {
     if (nextProps.message !== undefined &&
       nextProps.message !== '') {
-      if (nextProps.message === this.props.message) {
-        if (this.willUpdateRepeats) {
-          this.sendMessage(nextProps.message);
-        }
-      } else {
-        this.sendMessage(nextProps.message);
+      return true;
+    }
+    if (nextProps.ariaLive !== this.props.ariaLive || !isEqual(nextProps.rest, this.props.rest)) {
+      return true;
+    }
+    return false;
+  }
+  
+  componentDidUpdate(prevProps) {
+    if (prevProps.message === this.props.message) {
+      if (this.willUpdateRepeats) {
+        this.sendMessage(this.props.message);
       }
+    } else {
+      this.sendMessage(this.props.message);
     }
   }
 

--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -1,3 +1,5 @@
+/* eslint-disable react/no-did-update-set-state */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';

--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -148,28 +148,6 @@ class SingleSelect extends React.Component {
   }
 
   componentWillReceiveProps(nextProps, nextState) { // eslint-disable-line react/no-deprecated
-    if (!isEqual(this.props.dataOptions, nextProps.dataOptions)) {
-      this.setState(curState => (
-        // Reinit the selectedIndex in case the newly-received dataOptions
-        // have the selected value in a different position.
-        Object.assign({}, curState, {
-          renderedList: nextProps.dataOptions,
-          selectedIndex: nextProps.dataOptions.findIndex(o => o.value === nextProps.value),
-        })
-      ));
-    }
-
-    if (nextProps.value !== this.props.value) {
-      const newValue = this.initValue(nextProps.value, nextProps.dataOptions);
-      this.setState(curState => (
-        Object.assign({}, curState, {
-          selectedIndex: newValue.index,
-          selectedValue: newValue.value,
-          selectedLabel: newValue.label,
-        })
-      ));
-    }
-
     // if the select list is being shown and an item is selected, sync the cursor...
     if (this.state.selectedIndex !== -1) {
       if (!this.state.showList && nextState.showList) {
@@ -181,6 +159,30 @@ class SingleSelect extends React.Component {
           return newState;
         });
       }
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (!isEqual(prevProps.dataOptions, this.props.dataOptions)) {
+      this.setState(curState => (
+        // Reinit the selectedIndex in case the newly-received dataOptions
+        // have the selected value in a different position.
+        Object.assign({}, curState, {
+          renderedList: this.props.dataOptions,
+          selectedIndex: this.props.dataOptions.findIndex(o => o.value === this.props.value),
+        })
+      ));
+    }
+
+    if (this.props.value !== prevProps.value) {
+      const newValue = this.initValue(this.props.value, this.props.dataOptions);
+      this.setState(curState => (
+        Object.assign({}, curState, {
+          selectedIndex: newValue.index,
+          selectedValue: newValue.value,
+          selectedLabel: newValue.label,
+        })
+      ));
     }
   }
 

--- a/lib/Timepicker/TimeDropdown.js
+++ b/lib/Timepicker/TimeDropdown.js
@@ -1,3 +1,5 @@
+/* eslint-disable react/no-did-update-set-state */
+
 /*
 * Display picker UI for Timepicker.
 */

--- a/lib/Timepicker/TimeDropdown.js
+++ b/lib/Timepicker/TimeDropdown.js
@@ -79,24 +79,24 @@ class TimeDropdown extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) { // eslint-disable-line react/no-deprecated
-    // if timeFormat updates, update the state's hours format (12/24hr time)
-    if (nextProps.timeFormat !== this.props.timeFormat) {
-      this.setState({
-        hoursFormat: this.deriveHoursFormat(nextProps.timeFormat),
-      });
-      this.buildState(nextProps);
-    }
-
-    if (nextProps.selectedTime !== this.props.selectedTime) {
-      this.buildState(nextProps);
-    }
-
     if (!nextProps.visible && nextProps.visible !== this.props.visible) {
       this._focusTimeout = setTimeout(() => { this.props.mainControl.current.focus(); }, 20);
     }
   }
 
   componentDidUpdate(prevProps) {
+    // if timeFormat updates, update the state's hours format (12/24hr time)
+    if (prevProps.timeFormat !== this.props.timeFormat) {
+      this.setState({
+        hoursFormat: this.deriveHoursFormat(this.props.timeFormat),
+      });
+      this.buildState(this.props);
+    }
+
+    if (prevProps.selectedTime !== this.props.selectedTime) {
+      this.buildState(this.props);
+    }
+
     if (!prevProps.visible && this.props.visible) {
       this._focusTimeout = setTimeout(() => { this.hourField.focus(); }, 20);
     }

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -135,40 +135,6 @@ class Timepicker extends React.Component {
   }
 
   componentWillReceiveProps(nextProps, nextContext) { // eslint-disable-line react/no-deprecated
-    let inputValue;
-    let presentedValue = null;
-    if (nextProps.input) { // if we're using redux-form....
-      // if value has changed....
-      if (nextProps.input.value !== '' && nextProps.input.value !== this.props.input.value) {
-        if (nextProps.input.value === nextProps.passThroughValue) {
-          presentedValue = nextProps.passThroughValue;
-          inputValue = moment.tz(this.timeZone).format(this._timeFormat);
-          this.setState({
-            presentedValue,
-            timeString: inputValue,
-          });
-        }
-        // if value is blank....
-      } else if (nextProps.input.value === '' && nextProps.input.value !== this.props.input.value) {
-        inputValue = '';
-        this.setState({
-          presentedValue,
-          timeString: inputValue,
-        });
-      }
-    } else if (this.props.value !== '' && this.props.value !== nextProps.value) {
-      if (nextProps.value === this.props.passThroughValue) {
-        inputValue = moment.tz(this.timeZone).format(this._timeFormat);
-        presentedValue = this.props.passThroughValue;
-      } else {
-        inputValue = moment.tz(this.timeZone).format(this._timeFormat);
-      }
-      this.setState({
-        presentedValue,
-        timeString: inputValue,
-      });
-    }
-
     // adjust displayed time format for a change in locale
     if (nextContext.intl.locale !== this.context.intl.locale) {
       moment.locale(nextContext.intl.locale);
@@ -183,6 +149,42 @@ class Timepicker extends React.Component {
           timeFormat: this._timeFormat,
           timeString: newTimeString,
         };
+      });
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    let inputValue;
+    let presentedValue = null;
+    if (this.props.input) { // if we're using redux-form....
+      // if value has changed....
+      if (this.props.input.value !== '' && this.props.input.value !== prevProps.input.value) {
+        if (this.props.input.value === this.props.passThroughValue) {
+          presentedValue = this.props.passThroughValue;
+          inputValue = moment.tz(this.timeZone).format(this._timeFormat);
+          this.setState({
+            presentedValue,
+            timeString: inputValue,
+          });
+        }
+        // if value is blank....
+      } else if (this.props.input.value === '' && this.props.input.value !== prevProps.input.value) {
+        inputValue = '';
+        this.setState({
+          presentedValue,
+          timeString: inputValue,
+        });
+      }
+    } else if (prevProps.value !== '' && prevProps.value !== this.props.value) {
+      if (this.props.value === prevProps.passThroughValue) {
+        inputValue = moment.tz(this.timeZone).format(this._timeFormat);
+        presentedValue = this.props.passThroughValue;
+      } else {
+        inputValue = moment.tz(this.timeZone).format(this._timeFormat);
+      }
+      this.setState({
+        presentedValue,
+        timeString: inputValue,
       });
     }
   }

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -1,3 +1,5 @@
+/* eslint-disable react/no-did-update-set-state */
+
 import React from 'react';
 import { FormattedMessage, intlShape } from 'react-intl';
 import PropTypes from 'prop-types';


### PR DESCRIPTION
- This is a first pass to move as much code out of the deprecated React lifecycle `componentWillReceiveProps` as possible.
- When moving code into `componentDidUpdate` the general strategy is for `nextProps` to go to `this.props` and `this.props` to go to `prevProps` since we have moved to the other side of the `render` lifecycle.
- Remaining code was attempted to move, but all attempts thus far have resulted in failing tests. More investigation is needed into how we handle these other cases, or if there are some actions that aren't needed anymore, which will also require modifying some of the test assertions.
- Also note, that state is being set in some cases for `componentDidUpdate`. While not ideal, I'm open to suggestions here if there is a better path forward.