### PR TITLE
Linking to GitHub readme instead of Storybook stories

### DIFF
--- a/lib/Button/readme.md
+++ b/lib/Button/readme.md
@@ -16,7 +16,7 @@ import { Button } from '@folio/stripes/components';
 ## Props
 Name | Type | Description
 --- | --- | ---
-buttonStyle | string | Change the style/color of the button (see the [styles section](/?selectedKind=Button&selectedStory=Styles)) |
+buttonStyle | string | Change the style/color of the button |
 type | string | Change the button type |
 buttonClass | string | Add a custom class |
 align | string | Change the alignment of the button (with flexbox) Options: start, center, end |

--- a/lib/Datepicker/readme.md
+++ b/lib/Datepicker/readme.md
@@ -19,8 +19,8 @@ Name | type | description | default | required
 `label` | string | visible field label | | false
 `locale` | string | Overrides the locale provided by context. | "en" | false
 `onChange` | func | Event handler to handle updates to the datefield text. | | false
-`placement` | string | Determines the position of the date picker overlay. See available options in the [Popper documentation](/?selectedKind=Popper). | bottom | false
-`modifiers` | object | Passes modifiers for the internal [Popper](/?selectedKind=Popper) -component which handles the positioning of the date picker overlay. | | false
+`placement` | string | Determines the position of the date picker overlay. See available options in the <a href="https://github.com/folio-org/stripes-components/tree/master/lib/Popper" target="_blank">Popper documentation</a>. | bottom | false
+`modifiers` | object | Passes modifiers for the internal <a href="https://github.com/folio-org/stripes-components/tree/master/lib/Popper" target="_blank">Popper</a>-component which handles the positioning of the date picker overlay. | | false
 `readOnly` | bool | if true, field will be readonly. 'Calendar' and 'clear' buttons will be omitted. | false | false
 `screenReaderMessage` | string | Additional message to be read by screenreaders when textfield is focused in addition to the label and format - which are always read. | | false
 `timeZone` | string | Overrides the time zone provided by context. | "UTC" | false

--- a/lib/MessageBanner/readme.md
+++ b/lib/MessageBanner/readme.md
@@ -65,7 +65,7 @@ children | node | Renders the contents of the `<MessageBanner>` | |
 dismissable | boolean | Adds a close icon and makes the `<MessageBanner>` dismissable | true/false | false
 dismissButtonAriaLabel | string | Adds an aria-label attribute for the dismiss `<IconButton>`. | | "Hide message"
 dismissButtonProps | object | Add custom props for the dismiss button. This can be useful for e.g. adding a custom class name for the internal `<IconButton>`. | | {}
-icon | string | Renders an icon next to the message. Supports all icons available for the [`<Icon>`](/?selectedKind=Icon)-component. When the `type`-prop is set to either "success", "error" and "warning" the `<MessageBanner>` will have icons by default but these too can be overwritten by using the `icon`-prop. If you want to remove the icon entirely you can simply set `icon` to `null` | |
+icon | string | Renders an icon next to the message. Supports all icons available for the <a href="https://github.com/folio-org/stripes-components/tree/master/lib/Icon" target="_blank">`<Icon>`</a>-component. When the `type`-prop is set to either "success", "error" and "warning" the `<MessageBanner>` will have icons by default but these too can be overwritten by using the `icon`-prop. If you want to remove the icon entirely you can simply set `icon` to `null` | |
 onEnter | func | Callback when the `<MessageBanner>` enters | |
 onEntered | func | Callback when the `<MessageBanner>` has entered | |
 onExit | func | Callback when the `<MessageBanner>` exits | |


### PR DESCRIPTION
@MikeTaylor made me aware of broken links in the Datepicker-readme.

These links were linking to other Storybook stories but this obviously won't work properly when viewing the component documentation directly on Github.

I changed the links to link directly to the Github readmes instead.