### PR TITLE
STCOM-662: Introduce a new filter config property called operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 6.1.1 (IN-PROGRESS)
 
 * Fix issue with `initialStatus` prop on Accordions not working.
+* Introduce a new filter config property called `operator`. Refs STCOM-662.
 
 ## [6.1.0](https://github.com/folio-org/stripes-components/tree/v6.1.0) (2020-03-16)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v6.0.0...v6.1.0)

--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -199,7 +199,8 @@ export function filters2cql(config, filters = '') {
         } else {
           let joinedValues = mappedValues.map(v => `"${v}"`).join(' or ');
           if (values.length > 1) joinedValues = `(${joinedValues})`;
-          conds.push(`${cqlIndex}=${joinedValues}`);
+          const { operator = '=' } = group;
+          conds.push(`${cqlIndex}${operator}${joinedValues}`);
         }
       }
     } else {

--- a/lib/FilterGroups/readme.md
+++ b/lib/FilterGroups/readme.md
@@ -87,7 +87,8 @@ filter groups. Each group is represented by an object with four keys:
 * `isIncludingStart` -- The flag is used only with `isRange: true` to include boundary value from the start. By default `true`.
 * `isIncludingEnd` -- The flag is used only with `isRange: true` to include boundary value from the end. By default `true`.
 * `rangeSeparator` -- The string is used only with `isRange: true` to break range value to `start` and `end` values. By default `:`.
-* `parse` -- an optional function which can be used to convert filter values into a CQL manually
+* `parse` -- An optional function which can be used to convert filter values into a CQL manually.
+* `operator` -- An optional string which can be used to change matching operator. By default `=`.
 
 Each of the `values` is typically represented by a simple string, which
 is used both to display on the page and as the value to use in


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-662

The PR adds optional operator property that defaults to `=` (to preserve existing filters) but allows the filter to specify an alternative, i.e. `==`