### PR TITLE
UIU-1539: Add possibility to click to set Associated Service Point for Fee/Fine Owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 6.1.1 (IN-PROGRESS)
 
 * Fix issue with `initialStatus` prop on Accordions not working.
+* Fix bug with impossibility to use mouse to set Associated Service Point for Fee/Fine Owner. Refs UIU-1539.
 
 ## [6.1.0](https://github.com/folio-org/stripes-components/tree/v6.1.0) (2020-03-16)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v6.0.0...v6.1.0)

--- a/lib/MultiSelection/MultiSelect.css
+++ b/lib/MultiSelection/MultiSelect.css
@@ -165,6 +165,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  white-space: nowrap;
   list-style: none;
 
   &.valueChipSelected {

--- a/lib/MultiSelection/MultiSelect.css
+++ b/lib/MultiSelection/MultiSelect.css
@@ -69,6 +69,7 @@
   padding: 4px;
   background-color: #fff;
   border: 1px solid rgba(0, 0, 0, 0.2);
+  pointer-events: all;
 
   &.untethered {
     margin-top: -7px;
@@ -164,7 +165,6 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  white-space: nowrap;
   list-style: none;
 
   &.valueChipSelected {

--- a/lib/MultiSelection/OptionsListWrapper.js
+++ b/lib/MultiSelection/OptionsListWrapper.js
@@ -23,7 +23,7 @@ const OptionsListWrapper = React.forwardRef(({
 
   let portal;
   if (renderToOverlay) {
-    portal = document.getElementById('OverlayContainer');
+    portal = document.getElementById('ModuleContainer');
   }
 
   return (

--- a/lib/MultiSelection/OptionsListWrapper.js
+++ b/lib/MultiSelection/OptionsListWrapper.js
@@ -23,7 +23,7 @@ const OptionsListWrapper = React.forwardRef(({
 
   let portal;
   if (renderToOverlay) {
-    portal = document.getElementById('ModuleContainer');
+    portal = document.getElementById('OverlayContainer');
   }
 
   return (


### PR DESCRIPTION
# Description
**Settings --> Users --> Fee/Fine Owners**: Unable to use mouse to set Associated Service Point for Fee/Fine Owner.
# Approach
Looks like `OverlayContainer` is not a parent for Settings --> Users --> Fee/Fine Owners, so I changed to a parent component `ModuleContainer`.
# Issue
https://issues.folio.org/browse/UIU-1539
# Screenshot
![image](https://user-images.githubusercontent.com/55694637/77698320-13338d80-6fb9-11ea-9e99-820bd5dd3995.png)
