### PR TITLE
bump package patch in concert with latest release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
The master branch version must be >= the latest released version in
order for clones in a workspace to be accepted as fulfilling the current
stripes dep on `~6.1.1`.