### PR TITLE
STCOM-670: expose filter delimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix issue with `initialStatus` prop on Accordions not working.
 * Fix bug with impossibility to use mouse to set Associated Service Point for Fee/Fine Owner. Refs UIU-1539.
 * Introduce a new filter config property called `operator`. Refs STCOM-662.
+* Expose `FILTER_GROUP_SEPARATOR` and `FILTER_SEPARATOR` for splitting/joing filters. Refs STCOM-670.
 * a11y improvements for form components and update primary color. Refs STCOM-658.
 
 ## [6.1.0](https://github.com/folio-org/stripes-components/tree/v6.1.0) (2020-03-16)

--- a/index.js
+++ b/index.js
@@ -93,7 +93,14 @@ export { default as SearchField } from './lib/SearchField';
 
 /* specific use */
 export { default as FilterPane } from './lib/FilterPane';
-export { default as FilterGroups, filterState, filters2cql, onChangeFilter } from './lib/FilterGroups';
+export {
+  default as FilterGroups,
+  filterState,
+  filters2cql,
+  onChangeFilter,
+  FILTER_SEPARATOR,
+  FILTER_GROUP_SEPARATOR,
+} from './lib/FilterGroups';
 export { default as FilterControlGroup } from './lib/FilterControlGroup';
 export { default as FilterPaneSearch } from './lib/FilterPaneSearch';
 export { default as ExportCsv } from './lib/ExportCsv';

--- a/lib/FilterGroups/FilterGroups.js
+++ b/lib/FilterGroups/FilterGroups.js
@@ -11,6 +11,13 @@ import {
 } from '../Accordion';
 import Checkbox from '../Checkbox';
 
+// a constant used to split multiple filters in
+// order to convert them to CQL
+export const FILTER_SEPARATOR = ',';
+
+// a constant used to split filter groups
+export const FILTER_GROUP_SEPARATOR = '.';
+
 // private
 const FilterCheckbox = (props) => {
   const { groupName, name, displayName, checked, onChangeFilter: ocf, disabled } = props;
@@ -78,7 +85,7 @@ export function initialFilterState(config, filters) {
   const state = {};
 
   if (filters) {
-    const fullNames = filters.split(',');
+    const fullNames = filters.split(FILTER_SEPARATOR);
     const register = {};
     for (const fullName of fullNames) {
       register[fullName] = true;
@@ -101,7 +108,7 @@ export function filterState(filters) {
   const state = {};
 
   if (filters) {
-    const fullNames = filters.split(',');
+    const fullNames = filters.split(FILTER_SEPARATOR);
     for (const fullName of fullNames) {
       state[fullName] = true;
     }
@@ -133,7 +140,7 @@ export function filterState(filters) {
  */
 export function filters2cql(config, filters = '') {
   const groups = {};
-  const fullNames = filters.split(',');
+  const fullNames = filters.split(FILTER_SEPARATOR);
 
   // restructure the "filters" argument from a string,
   // e.g. "foo.valueOne,foo.valueTwo,bar.valueThree", to an object,
@@ -142,7 +149,7 @@ export function filters2cql(config, filters = '') {
     // Note: splitting an empty string returns an empty string,
     // so we need to check if fullName is actually a legit filtername
     if (fullName) {
-      const [groupName, fieldName] = fullName.split('.');
+      const [groupName, fieldName] = fullName.split(FILTER_GROUP_SEPARATOR);
       if (groups[groupName] === undefined) groups[groupName] = [];
       groups[groupName].push(fieldName);
     }
@@ -228,7 +235,7 @@ export function onChangeFilter(e) {
 export function handleFilterChange(e) {
   const state = filterState(this.queryParam('filters'));
   state[e.target.name] = e.target.checked;
-  this.transitionToParams({ filters: Object.keys(state).filter(key => state[key]).join(',') });
+  this.transitionToParams({ filters: Object.keys(state).filter(key => state[key]).join(FILTER_SEPARATOR) });
   return state;
 }
 
@@ -241,7 +248,7 @@ export function handleFilterClear(name) {
     }
   });
 
-  this.transitionToParams({ filters: Object.keys(state).filter(key => state[key]).join(',') });
+  this.transitionToParams({ filters: Object.keys(state).filter(key => state[key]).join(FILTER_SEPARATOR) });
   return state;
 }
 

--- a/lib/FilterGroups/index.js
+++ b/lib/FilterGroups/index.js
@@ -7,4 +7,6 @@ export {
   handleFilterChange,
   handleFilterClear,
   handleClearAllFilters,
+  FILTER_SEPARATOR,
+  FILTER_GROUP_SEPARATOR,
 } from './FilterGroups';

--- a/lib/FilterGroups/tests/helpers/filterGroupsUsageTest.js
+++ b/lib/FilterGroups/tests/helpers/filterGroupsUsageTest.js
@@ -6,6 +6,8 @@ import FilterGroups, {
   handleFilterChange,
   handleFilterClear,
   handleClearAllFilters,
+  FILTER_SEPARATOR,
+  FILTER_GROUP_SEPARATOR,
 } from '../../index';
 
 const config1 = [
@@ -75,8 +77,13 @@ export class FilterGroupsFirstComponent extends Component {
       { value: 'dvds', displayName: 'DVDs' },
       { value: 'microfilm', displayName: 'Microfilm' },
     ];
+
     this.state = {
-      filters: initialFilterState(this.config, 'item.books,item.dvds,item.microfilm'),
+      filters: initialFilterState(this.config, [
+        `item${FILTER_GROUP_SEPARATOR}books`,
+        `item${FILTER_GROUP_SEPARATOR}dvds`,
+        `item${FILTER_GROUP_SEPARATOR}microfilm`,
+      ].join(FILTER_SEPARATOR)),
     };
 
     this.onChangeFilter = onChangeFilter.bind(this);
@@ -125,7 +132,10 @@ export class FilterGroupsSecondComponent extends Component {
 
     this.config = config2;
     this.state = {
-      filters: initialFilterState(this.config, 'item.Books,item.Microfilm'),
+      filters: initialFilterState(this.config, [
+        `item${FILTER_GROUP_SEPARATOR}Books`,
+        `item${FILTER_GROUP_SEPARATOR}Microfilm`,
+      ].join(FILTER_SEPARATOR)),
     };
 
     this.filters2cql = filters2cql.bind(this);
@@ -162,7 +172,10 @@ export class FilterGroupsThirdComponent extends Component {
 
     this.config = config1;
     this.state = {
-      filters: initialFilterState(this.config, 'item.Books,item.Microfilm'),
+      filters: initialFilterState(this.config, [
+        `item${FILTER_GROUP_SEPARATOR}Books`,
+        `item${FILTER_GROUP_SEPARATOR}Microfilm`,
+      ].join(FILTER_SEPARATOR)),
     };
 
     this.handleClearAllFilters = handleClearAllFilters.bind(this);
@@ -193,7 +206,11 @@ export class FilterGroupsFourthComponent extends Component {
 
     this.config = config3;
     this.state = {
-      filters: initialFilterState(this.config, 'item.Books,item.Microfilm,location.Library of Trantor'),
+      filters: initialFilterState(this.config, [
+        `item${FILTER_GROUP_SEPARATOR}Books`,
+        `item${FILTER_GROUP_SEPARATOR}Microfilm`,
+        `location${FILTER_GROUP_SEPARATOR}Library of Trantor`,
+      ].join(FILTER_SEPARATOR)),
     };
 
     this.handleClearAllFilters = handleClearAllFilters.bind(this);
@@ -236,7 +253,12 @@ export class FilterGroupsFifthComponent extends Component {
 
     this.config = config3;
     this.state = {
-      filters: initialFilterState(this.config, 'item.Books,item.Microfilm,location.trantor,location.main'),
+      filters: initialFilterState(this.config, [
+        `item${FILTER_GROUP_SEPARATOR}Books`,
+        `item${FILTER_GROUP_SEPARATOR}Microfilm`,
+        `location${FILTER_GROUP_SEPARATOR}trantor`,
+        `location${FILTER_GROUP_SEPARATOR}main`,
+      ].join(FILTER_SEPARATOR)),
     };
 
     this.handleClearAllFilters = handleClearAllFilters.bind(this);
@@ -248,7 +270,12 @@ export class FilterGroupsFifthComponent extends Component {
 
   onChangeFilter = () => {
     this.setState(() => {
-      return this.filters2cql(this.config, 'item.Books,item.Microfilm,location.trantor,location.main');
+      return this.filters2cql(this.config, [
+        `item${FILTER_GROUP_SEPARATOR}Books`,
+        `item${FILTER_GROUP_SEPARATOR}Microfilm`,
+        `location${FILTER_GROUP_SEPARATOR}trantor`,
+        `location${FILTER_GROUP_SEPARATOR}main`,
+      ].join(FILTER_SEPARATOR));
     });
   }
 


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-670

In order to correctly handle the issue described in: https://issues.folio.org/browse/STSMACOM-329

We need to replace current filter delimiter (`,`) and expose it via stripes-components.

This PR does just that.