### PR TITLE
STDTC-8: Allowed `to`, `href` and `labelStrings` props to be passed as function to `defaultRowFormatter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * a11y improvements for form components and update primary color. Refs STCOM-658.
 * Fixed text overflow bug on `<Select>`. Refs UX-341.
 * Added `centerContent `-prop for `<Pane>`. Refs STCOM-618.
+* Allowed `to`, `href` and `labelStrings` props to be passed as functions to `defaultRowFormatter`. Refs STDTC-8.
 
 ## [6.1.0](https://github.com/folio-org/stripes-components/tree/v6.1.0) (2020-03-16)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v6.0.0...v6.1.0)

--- a/lib/MultiColumnList/defaultRowFormatter.js
+++ b/lib/MultiColumnList/defaultRowFormatter.js
@@ -1,29 +1,53 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
+import { isFunction } from 'lodash';
 
 const propTypes = {
   cells: PropTypes.arrayOf(PropTypes.element),
-  labelStrings: PropTypes.arrayOf(PropTypes.string),
+  labelStrings: PropTypes.oneOf([PropTypes.arrayOf(PropTypes.string), PropTypes.func]),
   rowClass: PropTypes.string,
+  rowData: PropTypes.object,
   rowIndex: PropTypes.number,
   rowProps: PropTypes.object,
   rowWidth: PropTypes.number,
 };
 
-function defaultRowFormatter({ rowIndex, rowClass, cells, rowProps, labelStrings }) {
+function defaultRowFormatter(row) {
+  const {
+    rowIndex,
+    rowClass,
+    rowData,
+    cells,
+    rowProps: initialRowProps,
+    labelStrings: initialLabelStrings,
+  } = row;
+
   // Default row element
+  const rowProps = { ...initialRowProps };
   let Element = 'div';
 
   // Render a <Link> if a "to"-prop is provided (react-router API)
   if (rowProps.to) {
     Element = Link;
+
+    if (isFunction(rowProps.to)) {
+      rowProps.to = rowProps.to(rowData.id);
+    }
   }
 
   // Render an anchor tag if an "href"-prop is provided
   if (rowProps.href) {
     Element = 'a';
+
+    if (isFunction(rowProps.href)) {
+      rowProps.href = rowProps.href(rowData.id);
+    }
   }
+
+  const labelStrings = isFunction(rowProps.labelStrings)
+    ? rowProps.labelStrings(row)
+    : initialLabelStrings;
 
   // Render a button if an "onClick"-prop is provided
   if (rowProps.onClick) {

--- a/lib/MultiColumnList/tests/MultiColumnList-test.js
+++ b/lib/MultiColumnList/tests/MultiColumnList-test.js
@@ -1,8 +1,8 @@
 import React from 'react';
+import { StaticRouter } from 'react-router';
 import { describe, beforeEach, before, it } from '@bigtest/mocha';
 import { Interactor } from '@bigtest/interactor';
 import sinon from 'sinon';
-
 import { expect } from 'chai';
 
 import { mountWithContext } from '../../../tests/helpers';
@@ -489,6 +489,70 @@ describe('MultiColumnList', () => {
       it('renders the formatter', () => {
         expect(mcl.contains('[data-test-date-joined]')).to.be.true;
       });
+    });
+  });
+
+  describe('passing rowProps with "to" as string', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <StaticRouter context={{}}>
+          <MultiColumnList
+            contentData={data3}
+            rowProps={{ to: 'to' }}
+          />
+        </StaticRouter>
+      );
+    });
+
+    it('renders default formatter (rows as anchors)', () => {
+      expect(mcl.rows(0).isAnchor).to.be.true;
+    });
+  });
+
+  describe('passing rowProps with "to" as function', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <StaticRouter context={{}}>
+          <MultiColumnList
+            contentData={data3}
+            rowProps={{ to: id => id }}
+          />
+        </StaticRouter>
+      );
+    });
+
+    it('renders default formatter (rows as anchors)', () => {
+      expect(mcl.rows(0).isAnchor).to.be.true;
+    });
+  });
+
+  describe('passing rowProps with "href" as string', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <MultiColumnList
+          contentData={data3}
+          rowProps={{ href: 'href' }}
+        />
+      );
+    });
+
+    it('renders default formatter (rows as anchors)', () => {
+      expect(mcl.rows(0).isAnchor).to.be.true;
+    });
+  });
+
+  describe('passing rowProps with "href" as function', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <MultiColumnList
+          contentData={data3}
+          rowProps={{ href: id => id }}
+        />
+      );
+    });
+
+    it('renders default formatter (rows as anchors)', () => {
+      expect(mcl.rows(0).isAnchor).to.be.true;
     });
   });
 

--- a/lib/MultiColumnList/tests/generate.js
+++ b/lib/MultiColumnList/tests/generate.js
@@ -5,6 +5,7 @@ export default function generate(num) {
   let cur = num;
   while (cur) {
     const obj = {
+      id: faker.random.uuid(),
       name: faker.name.findName(),
       email: faker.internet.email(),
       phone: faker.phone.phoneNumber(),


### PR DESCRIPTION
## Purpose

The idea is to extend [defaultRowFormatter](https://github.com/folio-org/stripes-components/blob/master/lib/MultiColumnList/defaultRowFormatter.js) to make `to`, `href` also as functions to accept `rowData.id` as a parameter. Usually, upon clicking on row item there is a need to navigate to a specific item route and for this, the `id` is needed. Because of existing limitation, other apps usually need to define their own row formatted. ([example](https://github.com/folio-org/ui-users/blob/master/src/views/UserSearch/UserSearch.js#L217)). Additionally, @doytch suggested having a similar possibility for `labelStrings`.