### PR TITLE
MCL: Remove labelstrings from DOM element

### DIFF
--- a/lib/MultiColumnList/defaultRowFormatter.js
+++ b/lib/MultiColumnList/defaultRowFormatter.js
@@ -49,7 +49,7 @@ function defaultRowFormatter(row) {
     ? rowProps.labelStrings(row)
     : initialLabelStrings;
 
-  delete rowProps.labelStrings;
+  delete rowProps.labelStrings; // We don't want to spread this onto the DOM element.
 
   // Render a button if an "onClick"-prop is provided
   if (rowProps.onClick) {

--- a/lib/MultiColumnList/defaultRowFormatter.js
+++ b/lib/MultiColumnList/defaultRowFormatter.js
@@ -49,6 +49,8 @@ function defaultRowFormatter(row) {
     ? rowProps.labelStrings(row)
     : initialLabelStrings;
 
+  delete rowProps.labelStrings;
+
   // Render a button if an "onClick"-prop is provided
   if (rowProps.onClick) {
     Element = 'button';


### PR DESCRIPTION
Need to remove this from the object we'll spread onto element we're creating to prevent React from complaining with `console.error`s.

We could do some fancy `filter()` and list of keys that get excluded...but given that it's just the single solitary key for now I wanted to keep it simple and obvious.