### PR TITLE
Check if current is present

### DIFF
--- a/lib/Paneset/PaneResizeContainer.js
+++ b/lib/Paneset/PaneResizeContainer.js
@@ -31,7 +31,7 @@ const PaneResizeContainer = ({ isRoot, children, onElementResize, parentElement 
             const blockingNode = Array.from(m.addedNodes).find((n) => {
               const newBox = n?.getBoundingClientRect();
               return (
-                newBox &&
+                newBox && containerRect.current &&
                 newBox.left <= containerRect.current.left &&
                 newBox.width >= containerRect.current.width
               );


### PR DESCRIPTION
I noticed that randomly I would get an error similar to this:

````js
    in PaneResizeContainer (created by Paneset)
    in Paneset (created by Context.Consumer)
    in WithPaneset(Paneset) (created by ForwardRef)
    in ForwardRef (created by UserDetailFullscreen)
    in UserDetailFullscreen (created by UserRecordContainer)
    in UserRecordContainer (created by WithProxyComponent)
    in WithProxyComponent (created by WithTagsComponent)
    in WithTagsComponent (created by WithServicePointsComponent)
    in WithServicePointsComponent (created by Wrapper)
    in Wrapper (created by Context.Consumer)
    in WithConnect(Wrapper) (created by Connect(WithConnect(Wrapper)))
    in Connect(WithConnect(Wrapper)) (created by ConnectedComponent)
    in ConnectedComponent (created by Context.Consumer)
    in WithStripes(ConnectedComponent) (created by UserDetailFullscreenContainer)
    in UserDetailFullscreenContainer (created by Route)
    in Route (created by Route)
    in Route (created by UsersRouting)
    in Switch (created by UsersRouting)
    in UsersRouting (created by Route)
    in Titled (created by Context.Consumer)
    in GetContext (created by TitleManager)
    in TitleManager (created by Context.Consumer)
    in WithStripes(TitleManager) (created by Route)
    in ErrorBoundary (created by Route)
    in div (created by Route)
    in AddContext (created by Route)
    in Route (created by Context.Consumer)
    in Switch (created by RootWithIntl)
    in main (created by ModuleContainer)
    in ModuleContainer (created by RootWithIntl)
    in AppCtxMenuProvider (created by RootWithIntl)
    in div (created by MainContainer)
    in MainContainer (created by LastVisited)
    in LastVisited (created by Context.Consumer)
    in WithModules(LastVisited) (created by Route)
    in Route (created by withRouter(WithModules(LastVisited)))
    in withRouter(WithModules(LastVisited)) (created by RootWithIntl)
    in Router (created by RootWithIntl)
    in Provider (created by RootWithIntl)
    in FocusTrap (created by HotKeys)
    in HotKeys (created by Context.Consumer)
    in HotKeys-HotKeys (created by RootWithIntl)
    in Titled (created by Context.Consumer)
    in GetContext (created by TitleManager)
    in TitleManager (created by Context.Consumer)
    in WithStripes(TitleManager) (created by RootWithIntl)
    in ModuleTranslator (created by InjectIntl(ModuleTranslator))
    in InjectIntl(ModuleTranslator) (created by RootWithIntl)
    in RootWithIntl (created by Root)
    in IntlProvider (created by Root)
    in ApolloProvider (created by Root)
    in ErrorBoundary (created by Root)
    in Root (created by Context.Consumer)
    in WithModules(Root) (created by Connect(WithModules(Root)))
    in Connect(WithModules(Root)) (created by StripesCore)
    in StripesCore
    in Unknown
````

The same error can be observed in BigTest:

https://jenkins-aws.indexdata.com/job/folio-org/job/ui-users/job/PR-1282/9/console

although it's not obvious it's coming from `PaneResizeContainer`.

I wonder if this is some sort of timing issue when the ref is sometimes missing?

