### PR TITLE
STRIPES-678 pin moment to ~2.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for stripes-components
 
-## 6.1.1 (IN-PROGRESS)
+## 6.2.0 (IN-PROGRESS)
 
 * Fix issue with `initialStatus` prop on Accordions not working.
 * Fix bug with impossibility to use mouse to set Associated Service Point for Fee/Fine Owner. Refs UIU-1539.
@@ -13,6 +13,7 @@
 * Added `centerContent `-prop for `<Pane>`. Refs STCOM-618.
 * Allowed `to`, `href` and `labelStrings` props to be passed as functions to `defaultRowFormatter`. Refs STDTC-8.
 * Pane resizing is suppressed when Panes are overlapped. Fixes STCOM-673, STCOM-674.
+* Pin `moment` at `~2.24.0`. Refs STRIPES-678.
 
 ## [6.1.0](https://github.com/folio-org/stripes-components/tree/v6.1.0) (2020-03-16)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v6.0.0...v6.1.0)

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "json2csv": "^4.2.1",
     "lodash": "^4.17.4",
     "memoize-one": "^5.0.0",
-    "moment": "^2.17.1",
+    "moment": "~2.24.0",
     "moment-range": "^3.0.3",
     "moment-timezone": "^0.5.14",
     "normalize.css": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -125,5 +125,8 @@
     "react-hot-loader": "^4.0.0",
     "react-intl": "^2.5.0",
     "react-router-dom": "^4.1.1"
+  },
+  "resolutions": {
+    "moment": "~2.24.0"
   }
 }


### PR DESCRIPTION
Pin `moment` at `~2.24.0` in light of multiple issues with `2.25.0`
([5489](https://github.com/moment/moment/issues/5489), [5472](https://github.com/moment/moment/issues/5472)).

Refs [STRIPES-678](https://issues.folio.org/browse/STRIPES-678)