### PR TITLE
Fix issue in tests with conflicting lists inside repeatable field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Allowed `to`, `href` and `labelStrings` props to be passed as functions to `defaultRowFormatter`. Refs STDTC-8.
 * Pane resizing is suppressed when Panes are overlapped. Fixes STCOM-673, STCOM-674.
 * Pin `moment` at `~2.24.0`. Refs STRIPES-678.
+* Fix issue in tests with conflicting lists inside repeatable field. Refs UIDATIMP-442
 
 ## [6.1.0](https://github.com/folio-org/stripes-components/tree/v6.1.0) (2020-03-16)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v6.0.0...v6.1.0)

--- a/lib/RepeatableField/tests/interactor.js
+++ b/lib/RepeatableField/tests/interactor.js
@@ -29,7 +29,7 @@ export default interactor(class RepeatableFieldInteractor {
 
   isHeadLabelsPresent = isPresent('[data-test-repeatable-field-list-item-labels]');
 
-  items = collection('li', RepeatableFieldItemInteractor);
+  items = collection('[data-test-repeatable-field-list-item]', RepeatableFieldItemInteractor);
 
   isAddDisabled = property('[data-test-repeatable-field-add-item-button]', 'disabled');
 });


### PR DESCRIPTION
## Description
When `<ul> <li>` structure are placed inside repeatable field (see screenshot), test couldn't find the right remove item button and fails.
## Approach
Change selector from `'li'` to `'[data-test-repeatable-field-list-item]'` for getting list of repeatable field to avoid issues, when another `<ul> <li>` structure are placed inside repeatable field.
## Screenshot
![image](https://user-images.githubusercontent.com/40805351/81285220-dd79ce00-9067-11ea-8500-7a4c042c49b2.png)
## Issue
[UIDATIMP-442](https://issues.folio.org/browse/UIDATIMP-442)