### PR TITLE
react-hot-loader is a direct dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for stripes-components
 
-## 6.2.0 (IN-PROGRESS)
+## 7.0.0 (IN-PROGRESS)
 
 * Fix issue with `initialStatus` prop on Accordions not working.
 * Fix bug with impossibility to use mouse to set Associated Service Point for Fee/Fine Owner. Refs UIU-1539.
@@ -14,6 +14,8 @@
 * Allowed `to`, `href` and `labelStrings` props to be passed as functions to `defaultRowFormatter`. Refs STDTC-8.
 * Pane resizing is suppressed when Panes are overlapped. Fixes STCOM-673, STCOM-674.
 * Pin `moment` at `~2.24.0`. Refs STRIPES-678.
+* Migrate to `react-intl` `v4.5`. Refs STRIPES-672.
+* `react-hot-loader` must be a direct dep.
 
 ## [6.1.0](https://github.com/folio-org/stripes-components/tree/v6.1.0) (2020-03-16)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v6.0.0...v6.1.0)

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "query-string": "^6.1.0",
     "react-flexbox-grid": "1.1.3",
     "react-highlight-words": "^0.16.0",
+    "react-hot-loader": "^4.0.0",
     "react-overlays": "^0.8.3",
     "react-quill": "^1.3.3",
     "react-svg-loader": "^3.0.3",
@@ -122,7 +123,6 @@
     "tai-password-strength": "^1.1.1"
   },
   "peerDependencies": {
-    "react-hot-loader": "^4.0.0",
     "react-intl": "^4.5.1",
     "react-router-dom": "^4.1.1"
   },


### PR DESCRIPTION
`react-hot-loader` is not provided by the platform, hence it should not
be a peer-dep. Resolves the following build warning:
```
warning " > @folio/stripes-components@7.0.0" has unmet peer dependency "react-hot-loader@^4.0.0".
```