### PR TITLE
Updated MultiSelection css for small size of input field

### DIFF
--- a/lib/MultiSelection/MultiSelect.css
+++ b/lib/MultiSelection/MultiSelect.css
@@ -23,7 +23,7 @@
 
 .multiSelectControlGroup {
   display: flex;
-  flex: 2 0 90%;
+  flex: 1;
   flex-wrap: wrap;
 }
 


### PR DESCRIPTION
## Purpose
 For `MultiSelection` which size is less than 180px, selectionToggleButton starts to get out from input field block. It's hepend when we try to resize the pane which has `MultiSelection`
![image](https://user-images.githubusercontent.com/55701515/81787587-f2dc7580-9509-11ea-8a7d-80715fcece5f.png)

 or when we add this component on edit page with a small grid layout (example [CustomField - MultiSelect on User record edit page](https://github.com/folio-org/stripes-smart-components/pull/808))
![image](https://user-images.githubusercontent.com/55701515/81787792-3d5df200-950a-11ea-9793-02f536ef5bf4.png)

The most accurate way to solve the problem so as not to change the structure of the HTML is to add the css property `max-width`

## Screenshots
![image](https://user-images.githubusercontent.com/55701515/81788230-e3a9f780-950a-11ea-9c7f-afc3c9a5858e.png)
![image](https://user-images.githubusercontent.com/55701515/81788334-0a682e00-950b-11ea-84d2-f51981f90cc2.png)
