### PR TITLE
STCOM-679: Hide tooltip on escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Increase test coverage to 80% | Dropdown menu. Refs STCOM-667.
 * Increase test coverage to 80% | Selection. Refs STCOM-668.
 * Added `unregisterAccordion` method to `<AccordionSet>` and unregistering of `<Accordion>` when unmounted. Refs STSMACOM-267.
+* Tooltips now hides when hitting escape. Refs STCOM-679.
 
 ## [6.1.0](https://github.com/folio-org/stripes-components/tree/v6.1.0) (2020-03-16)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v6.0.0...v6.1.0)

--- a/lib/IconButton/tests/interactor.js
+++ b/lib/IconButton/tests/interactor.js
@@ -4,6 +4,7 @@ import {
   focusable,
   interactor,
   is,
+  triggerable,
 } from '@bigtest/interactor';
 
 import css from '../IconButton.css';
@@ -21,4 +22,5 @@ export default interactor(class IconButtonInteractor {
   clickIconButton = clickable();
   focus = focusable();
   isFocused = is(':focus');
+  pressEscape = triggerable('keydown', { keyCode: 27, key: 'Escape' });
 });

--- a/lib/MultiSelection/MultiSelect.css
+++ b/lib/MultiSelection/MultiSelect.css
@@ -23,7 +23,7 @@
 
 .multiSelectControlGroup {
   display: flex;
-  flex: 1;
+  flex: 2 0 90%;
   flex-wrap: wrap;
 }
 

--- a/lib/MultiSelection/MultiSelect.css
+++ b/lib/MultiSelection/MultiSelect.css
@@ -23,7 +23,7 @@
 
 .multiSelectControlGroup {
   display: flex;
-  flex: 2 0 90%;
+  flex: 1;
   flex-wrap: wrap;
 }
 

--- a/lib/Tooltip/Tooltip.js
+++ b/lib/Tooltip/Tooltip.js
@@ -70,6 +70,16 @@ export default class Tooltip extends Component {
     }
   }
 
+  componentDidUpdate(_, { open: prevOpen }) {
+    const { open } = this.state;
+
+    if (open && !prevOpen) {
+      this.triggerEl.addEventListener('keydown', this.handleKeyDown, true);
+    } else if (!open && prevOpen) {
+      this.triggerEl.removeEventListener('keydown', this.handleKeyDown, true);
+    }
+  }
+
   componentWillUnmount() {
     clearTimeout(this.timeout);
     if (this.triggerEl) {
@@ -80,9 +90,14 @@ export default class Tooltip extends Component {
       HIDE_EVENT_LISTENERS.forEach(listener => {
         this.triggerEl.removeEventListener(listener, this.hide, true);
       });
+
+      this.triggerEl.removeEventListener('keydown', this.handleKeyDown, true);
     }
   }
 
+  /**
+   * Show, hide and toggle tooltip
+   */
   toggle = (bool) => {
     const { open } = this.state;
     if (bool !== open) {
@@ -100,6 +115,17 @@ export default class Tooltip extends Component {
   hide = () => {
     clearTimeout(this.timeout);
     this.toggle(false);
+  }
+
+  /**
+   * Close tooltip on escape
+   */
+  handleKeyDown = ({ key }) => {
+    const { open } = this.state;
+
+    if (open && key === 'Escape') {
+      this.hide();
+    }
   }
 
   /**

--- a/lib/Tooltip/tests/Tooltip-test.js
+++ b/lib/Tooltip/tests/Tooltip-test.js
@@ -61,11 +61,27 @@ describe('Tooltip', () => {
 
   describe('Focusing the trigger element', () => {
     beforeEach(async () => {
-      await iconButton.focus();
+      await iconButton
+        .focus()
+        .when(() => tooltip.isTooltipVisible);
     });
 
     it('displays the attached tooltip', () => {
       expect(tooltip.isTooltipVisible).to.be.true;
+    });
+  });
+
+  describe('Pressing the escape key', () => {
+    beforeEach(async () => {
+      await iconButton
+        .focus()
+        .when(() => tooltip.isTooltipVisible)
+        .pressEscape()
+        .when(() => !tooltip.isTooltipVisible);
+    });
+
+    it('should hide the tooltip', () => {
+      expect(tooltip.isTooltipVisible).to.be.false;
     });
   });
 

--- a/lib/Tooltip/tests/interactor.js
+++ b/lib/Tooltip/tests/interactor.js
@@ -7,7 +7,7 @@ import {
   isPresent,
 } from '@bigtest/interactor';
 
-export default interactor(class AvatarInteractor {
+export default interactor(class TooltipInteractor {
   isTooltipVisible = isPresent('[data-test-tooltip]');
   hasText = isPresent('[data-test-tooltip-text]');
   hasSub = isPresent('[data-test-tooltip-sub]');


### PR DESCRIPTION
## Ticket
https://issues.folio.org/browse/STCOM-679

## Changes
- Added event listener when a tooltip is visible to enable hiding it
- Updated tests