### PR TITLE
STCOM-649 prefix deprecated methods with UNSAFE_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 7.1.0 (IN PROGRESS)
 
 * `react-hot-loader` is not provided by the platform.
+* Use `UNSAFE_` prefix for deprecated React methods. We know, we know. Refs STCOM-649.
 
 ## [7.0.0](https://github.com/folio-org/stripes-components/tree/v7.0.0) (2020-05-19)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v6.1.0...v7.0.0)

--- a/lib/SRStatus/SRStatus.js
+++ b/lib/SRStatus/SRStatus.js
@@ -23,7 +23,8 @@ class SRStatus extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) { // eslint-disable-line react/no-deprecated
+  // eslint-disable-next-line camelcase, react/no-deprecated
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.message !== undefined &&
       nextProps.message !== '') {
       if (nextProps.message === this.props.message) {

--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -147,7 +147,8 @@ class SingleSelect extends React.Component {
     }
   }
 
-  componentWillReceiveProps(nextProps, nextState) { // eslint-disable-line react/no-deprecated
+  // eslint-disable-next-line camelcase, react/no-deprecated
+  UNSAFE_componentWillReceiveProps(nextProps, nextState) {
     if (!isEqual(this.props.dataOptions, nextProps.dataOptions)) {
       this.setState(curState => (
         // Reinit the selectedIndex in case the newly-received dataOptions

--- a/lib/Timepicker/TimeDropdown.js
+++ b/lib/Timepicker/TimeDropdown.js
@@ -76,7 +76,8 @@ class TimeDropdown extends React.Component {
     this.buildState = this.buildState.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) { // eslint-disable-line react/no-deprecated
+  // eslint-disable-next-line camelcase, react/no-deprecated
+  UNSAFE_componentWillReceiveProps(nextProps) {
     // if timeFormat updates, update the state's hours format (12/24hr time)
     if (nextProps.timeFormat !== this.props.timeFormat) {
       this.setState({

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -122,7 +122,8 @@ class Timepicker extends React.Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) { // eslint-disable-line react/no-deprecated
+  // eslint-disable-next-line camelcase, react/no-deprecated
+  UNSAFE_componentWillReceiveProps(nextProps) {
     let inputValue;
     let presentedValue = null;
     if (nextProps.input) { // if we're using redux-form....


### PR DESCRIPTION
We know about the need to refactor away from deprecated react methods.
STCOM-649 exists to capture that work, and we'll do it, but for right
now we just need a cleaner console.

Refs [STCOM-649](https://issues.folio.org/browse/STCOM-649)