### PR TITLE
UIEH-899: Settings > eholdings > KB credentials page | UI updates

### DIFF
--- a/translations/stripes-components/en.json
+++ b/translations/stripes-components/en.json
@@ -32,6 +32,7 @@
   "addressSection": "Address Section",
   "cancel": "Cancel",
   "submit": "Submit",
+  "save": "Save",
   "saveAndClose": "Save & close",
   "saveChangesToThisItem": "Save changes to this item",
   "cancelEditingThisItem": "Cancel editing this item",


### PR DESCRIPTION
## Purpose
Change submit KB form button text from 'Save & close' to 'Save'

Related PR in `ui-eholdings`: https://github.com/folio-org/ui-eholdings/pull/1063

## Issue
[UIEH-899](https://issues.folio.org/browse/UIEH-899)
