### PR TITLE
document final-form's need for type="radio"

### DIFF
--- a/lib/RadioButton/readme.md
+++ b/lib/RadioButton/readme.md
@@ -62,5 +62,6 @@ import { RadioButton } from '@folio/stripes/components';
     value="ripe"
   />
 ```
+(When invoking a `<RadioButton>` as part of a react-final-form `<Field>`, it is necessary to explicitly pass `type="radio"` as well as `component={RadioButton}`, otherwise the form library does not understand how to interpret the value.)
 
 [`<RadioButtonGroup>`](../RadioButtonGroup) makes working with Redux Form easier.


### PR DESCRIPTION
Follow-up to #1282 which documented this need for checkboxes.

@JohnC-80, do you know if we need to do something special/similar when `<Field>` receives `component={RadioButtonGroup}`? 