### PR TITLE
avoid setState in unmounted components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * `react-hot-loader` is not provided by the platform.
 * Use `UNSAFE_` prefix for deprecated React methods. We know, we know. Refs STCOM-649.
+* `<PasswordStrength>` must not set state if unmounted.
 
 ## [7.0.0](https://github.com/folio-org/stripes-components/tree/v7.0.0) (2020-05-19)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v6.1.0...v7.0.0)

--- a/lib/PasswordStrength/PasswordStrength.js
+++ b/lib/PasswordStrength/PasswordStrength.js
@@ -68,7 +68,7 @@ class PasswordStrength extends Component {
   }
 
   componentWillUnmount() {
-    this._isMounted = true;
+    this._isMounted = false;
   }
 
   initPasswordStrength() {

--- a/lib/PasswordStrength/PasswordStrength.js
+++ b/lib/PasswordStrength/PasswordStrength.js
@@ -63,7 +63,12 @@ class PasswordStrength extends Component {
   }
 
   componentDidMount() {
+    this._isMounted = true;
     this.initPasswordStrength();
+  }
+
+  componentWillUnmount() {
+    this._isMounted = true;
   }
 
   initPasswordStrength() {
@@ -71,8 +76,9 @@ class PasswordStrength extends Component {
       this.strengthTester = new taiPasswordStrength.PasswordStrength();
       this.strengthTester.addCommonPasswords(taiPasswordStrength.commonPasswords);
       this.strengthTester.addTrigraphMap(taiPasswordStrength.trigraphs);
-
-      this.setState({ hasLoaded: true });
+      if (this._isMounted) {
+        this.setState({ hasLoaded: true });
+      }
     });
   }
 


### PR DESCRIPTION
A promise may return after a component has unmounted. In this case, it
should avoid calling `setState`.