### PR TITLE
Ensure TextField and TextArea always have their <label> hooked up to the <input>

### DIFF
--- a/lib/NoValue/NoValue.js
+++ b/lib/NoValue/NoValue.js
@@ -14,8 +14,6 @@ function NoValue({ ariaLabel = null }) {
     <FormattedMessage id="stripes-components.noValue.noValueSet">
       {message => (
         <span
-          /* eslint-disable-next-line jsx-a11y/aria-role */
-          role="text"
           aria-label={ariaLabel || message}
           data-test-no-value
         >

--- a/lib/NoValue/tests/NoValue-test.js
+++ b/lib/NoValue/tests/NoValue-test.js
@@ -24,17 +24,6 @@ describe('NoValue', () => {
     expect(noValue.isPresent).to.be.true;
   });
 
-  // Check that the attribute `role="text"` is present.
-  // This is potentially controversial. Let me explain. role="text"
-  // is not technically part of ARIA 1.1 and a span is usually considered
-  // to be text anyway, so ... WTF? It's messy. The only thing inside this
-  // span is a single dash character, which might not otherwise look like
-  // text.
-  it('should have a "role" attribute', () => {
-    expect(noValue.roleAttribute).to.equal('text');
-  });
-
-
   describe('when aria-label is not passed from parent', () => {
     beforeEach(async () => {
       await mountWithContext(<NoValue />);

--- a/lib/NoValue/tests/interactor.js
+++ b/lib/NoValue/tests/interactor.js
@@ -6,6 +6,5 @@ import {
 export default interactor(class NoValueInteractor {
   static defaultScope = '[data-test-no-value]';
 
-  roleAttribute = attribute('role');
   ariaLabelAttribute = attribute('aria-label');
 });

--- a/lib/TextArea/TextArea.js
+++ b/lib/TextArea/TextArea.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import className from 'classnames';
+import uniqueId from 'lodash/uniqueId';
 
 import formField from '../FormField';
 import css from './TextArea.css';
@@ -55,6 +56,13 @@ class TextArea extends Component {
     validStylesEnabled: false,
   };
 
+  constructor(props) {
+    super(props);
+
+    // if no id has been supplied, generate a unique one
+    this.inputId = props.id ?? uniqueId('textarea-input-');
+  }
+
   getRootStyle() {
     return className(
       formStyles.inputGroup,
@@ -103,9 +111,10 @@ class TextArea extends Component {
         aria-invalid={!!(this.props.error)}
         autoFocus={autoFocus}
         className={this.getInputStyle()}
+        id={this.inputId}
         name={name}
         ref={inputRef}
-        {...omitProps(inputCustom, ['validationEnabled'])}
+        {...omitProps(inputCustom, ['id', 'validationEnabled'])}
       />
     );
 
@@ -117,7 +126,7 @@ class TextArea extends Component {
 
     const labelElement = label ?
       <Label
-        htmlFor={this.props.id}
+        htmlFor={this.inputId}
         required={required}
         readOnly={readOnly}
       >

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -351,6 +351,7 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
         aria-invalid={inputCustom['aria-invalid'] || !!(this.props.error)}
         autoComplete={this.props.autoComplete}
         autoFocus={this.props.autoFocus}
+        id={this.testId}
         name={name}
         onChange={this.handleChange}
         ref={this.input}
@@ -479,7 +480,7 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
       <div className={wrapperStyles}>
         {label && (
           <Label
-            htmlFor={this.props.id}
+            htmlFor={this.testId}
             required={required}
             readOnly={readOnly}
           >


### PR DESCRIPTION
Per [ERM-898](https://issues.folio.org/browse/ERM-898) and [ERM-899](https://issues.folio.org/browse/ERM-899), textfields and textareas fail axe a11y checks when an `id` is not provided. 

Use the/create a unique id and use that for the label's `for` and input's `id` attributes.

Per [ERM-900](https://issues.folio.org/browse/ERM-900), axe complains that `NoValue` sets an invalid `role` attribute. The `role` is unnecessary here so I've removed it.