### PR TITLE
STCOM-686: Allow for changing the heading level of the <MetaSection> component

### DIFF
--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -22,6 +22,7 @@ const propTypes = {
   displayWhenClosed: PropTypes.element, // eslint-disable-line react/no-unused-prop-types
   displayWhenOpen: PropTypes.element, // eslint-disable-line react/no-unused-prop-types
   header: PropTypes.oneOfType([PropTypes.node, PropTypes.string, PropTypes.func]),
+  headerProps: PropTypes.object,
   id: PropTypes.string,
   label: PropTypes.oneOfType([ // eslint-disable-line react/no-unused-prop-types
     PropTypes.element,
@@ -37,6 +38,7 @@ const propTypes = {
 class Accordion extends React.Component {
   static defaultProps = {
     header: DefaultAccordionHeader,
+    headerProps: {},
     separator: true,
   }
 
@@ -227,12 +229,13 @@ class Accordion extends React.Component {
 
   render() {
     const {
-      open: openProp,
-      onToggle: onToggleProp,
+      children,
       header,
-      toggleKeyMap,
+      headerProps,
+      onToggle: onToggleProp,
+      open: openProp,
       toggleKeyHandlers,
-      children
+      toggleKeyMap,
     } = this.props;
 
     const {
@@ -241,13 +244,14 @@ class Accordion extends React.Component {
 
     const onToggle = typeof openProp === 'undefined' ? this.uncontrolledToggle : onToggleProp;
 
-    const headerProps = Object.assign({}, this.props, {
+    const accordionHeaderProps = Object.assign({}, this.props, {
       contentId: this.contentId,
       toggleRef: (ref) => { this.toggle = ref; },
       open,
-      onToggle
+      onToggle,
+      ...headerProps
     });
-    const headerElement = React.createElement(header, headerProps);
+    const headerElement = React.createElement(header, accordionHeaderProps);
 
     return (
       <section id={this.trackingId} className={this.getRootClasses()} data-test-accordion-section>

--- a/lib/Accordion/headers/DefaultAccordionHeader.js
+++ b/lib/Accordion/headers/DefaultAccordionHeader.js
@@ -9,11 +9,16 @@ const propTypes = {
   contentId: PropTypes.string,
   displayWhenClosed: PropTypes.element,
   displayWhenOpen: PropTypes.element,
+  headerElement: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.func]),
   id: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
   onToggle: PropTypes.func,
   open: PropTypes.bool,
   toggleRef: PropTypes.func,
+};
+
+const defaultProps = {
+  headerElement: 'h3'
 };
 
 const DefaultAccordionHeader = (props) => {
@@ -43,7 +48,7 @@ const DefaultAccordionHeader = (props) => {
   return (
     <div className={css.headerWrapper}>
       <div className={`${css.header} ${css.default}`}>
-        <Headline size="medium" tag="h3" block>
+        <Headline size="medium" tag={props.headerElement} block>
           <button
             type="button"
             onClick={handleHeaderClick}
@@ -76,5 +81,6 @@ const DefaultAccordionHeader = (props) => {
 };
 
 DefaultAccordionHeader.propTypes = propTypes;
+DefaultAccordionHeader.defaultProps = defaultProps;
 
 export default DefaultAccordionHeader;

--- a/lib/Accordion/headers/DefaultAccordionHeader.js
+++ b/lib/Accordion/headers/DefaultAccordionHeader.js
@@ -9,7 +9,7 @@ const propTypes = {
   contentId: PropTypes.string,
   displayWhenClosed: PropTypes.element,
   displayWhenOpen: PropTypes.element,
-  headerElement: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.func]),
+  headerElement: PropTypes.string,
   id: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
   onToggle: PropTypes.func,

--- a/lib/Accordion/headers/DefaultAccordionHeader.js
+++ b/lib/Accordion/headers/DefaultAccordionHeader.js
@@ -9,7 +9,7 @@ const propTypes = {
   contentId: PropTypes.string,
   displayWhenClosed: PropTypes.element,
   displayWhenOpen: PropTypes.element,
-  headerElement: PropTypes.string,
+  headingLevel: PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
   id: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
   onToggle: PropTypes.func,
@@ -18,7 +18,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  headerElement: 'h3'
+  headingLevel: 3
 };
 
 const DefaultAccordionHeader = (props) => {
@@ -48,7 +48,7 @@ const DefaultAccordionHeader = (props) => {
   return (
     <div className={css.headerWrapper}>
       <div className={`${css.header} ${css.default}`}>
-        <Headline size="medium" tag={props.headerElement} block>
+        <Headline size="medium" tag={`h${props.headingLevel}`} block>
           <button
             type="button"
             onClick={handleHeaderClick}

--- a/lib/Accordion/headers/FilterAccordionHeader.js
+++ b/lib/Accordion/headers/FilterAccordionHeader.js
@@ -14,7 +14,7 @@ class FilterAccordionHeader extends React.Component {
     displayClearButton: PropTypes.bool,
     displayWhenClosed: PropTypes.element,
     displayWhenOpen: PropTypes.element,
-    headerElement: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.func]),
+    headerElement: PropTypes.string,
     id: PropTypes.string,
     label: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
     name: PropTypes.string,

--- a/lib/Accordion/headers/FilterAccordionHeader.js
+++ b/lib/Accordion/headers/FilterAccordionHeader.js
@@ -14,6 +14,7 @@ class FilterAccordionHeader extends React.Component {
     displayClearButton: PropTypes.bool,
     displayWhenClosed: PropTypes.element,
     displayWhenOpen: PropTypes.element,
+    headerElement: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.func]),
     id: PropTypes.string,
     label: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
     name: PropTypes.string,
@@ -25,6 +26,7 @@ class FilterAccordionHeader extends React.Component {
 
   static defaultProps = {
     displayClearButton: true,
+    headerElement: 'h3'
   };
 
   handleHeaderClick = (e) => {
@@ -55,12 +57,13 @@ class FilterAccordionHeader extends React.Component {
       displayWhenClosed,
       displayClearButton,
       onClearFilter,
-      contentId
+      contentId,
+      headerElement,
     } = this.props;
     const clearButtonVisible = displayClearButton && typeof onClearFilter === 'function';
     return (
       <div className={css.headerWrapper}>
-        <Headline size="small" tag="h3" block={!clearButtonVisible}>
+        <Headline size="small" tag={headerElement} block={!clearButtonVisible}>
           <button
             type="button"
             tabIndex="0"

--- a/lib/Accordion/headers/FilterAccordionHeader.js
+++ b/lib/Accordion/headers/FilterAccordionHeader.js
@@ -14,7 +14,7 @@ class FilterAccordionHeader extends React.Component {
     displayClearButton: PropTypes.bool,
     displayWhenClosed: PropTypes.element,
     displayWhenOpen: PropTypes.element,
-    headerElement: PropTypes.string,
+    headingLevel: PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
     id: PropTypes.string,
     label: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
     name: PropTypes.string,
@@ -26,7 +26,7 @@ class FilterAccordionHeader extends React.Component {
 
   static defaultProps = {
     displayClearButton: true,
-    headerElement: 'h3'
+    headingLevel: 3
   };
 
   handleHeaderClick = (e) => {
@@ -58,12 +58,12 @@ class FilterAccordionHeader extends React.Component {
       displayClearButton,
       onClearFilter,
       contentId,
-      headerElement,
+      headingLevel,
     } = this.props;
     const clearButtonVisible = displayClearButton && typeof onClearFilter === 'function';
     return (
       <div className={css.headerWrapper}>
-        <Headline size="small" tag={headerElement} block={!clearButtonVisible}>
+        <Headline size="small" tag={`h${headingLevel}`} block={!clearButtonVisible}>
           <button
             type="button"
             tabIndex="0"

--- a/lib/Accordion/readme.md
+++ b/lib/Accordion/readme.md
@@ -146,16 +146,17 @@ The default header suits many cases, but if it is not adequate, a custom header 
 
 Name | type | description | default | required
 --- | --- | --- | --- | ---
-label | string, element | visible header label | | true
-open | bool | open or closed | true |
+label | string, element | Visible header label | | true
+open | bool | Open or closed | true |
 closedByDefault | bool | Use to collapse the Accordion by default. Ensure that you use it only when the Accordion is not being controlled by an `open` prop | false |
-id | string | unique ID to track accordion state | |
-displayWhenOpen | element | content to display in header when Accordion is in the open state | |
-displayWhenClosed | element | content to display in header when Accordion is in the closed state | |
-onToggle | func | callback for toggling the accordion open/closed | |
-header | node, func | used to render a custom accordion header | |
-contentRef | func | reference function for accessing the accordion content's DOM element. | |
-children | node, array of nodes | content of the accordion | |
+id | string | Unique ID to track accordion state | |
+displayWhenOpen | element | Content to display in header when Accordion is in the open state | |
+displayWhenClosed | element | Content to display in header when Accordion is in the closed state | |
+onToggle | func | Callback for toggling the accordion open/closed | |
+header | node, func | Used to render a custom accordion header | |
+headerProps | object | Passes additional props for the header component of the accordion | |
+contentRef | func | Reference function for accessing the accordion content's DOM element. | |
+children | node, array of nodes | Content of the accordion | |
 autoFocus | bool | If this prop is `true`, Accordion toggle/label will automatically focus on mount | |
 
 ## Expand or Collapse All

--- a/lib/Accordion/readme.md
+++ b/lib/Accordion/readme.md
@@ -139,8 +139,12 @@ onToggleSection({label, id}) {
 </AccordionSet>
 ```
 
-## Custom Headers
-The default header suits many cases, but if it is not adequate, a custom header can be provided via `<Accordion>`'s `header` prop. A custom header component should take `ContentId` prop in order to appropriately apply aria-attributes to the custom header. Any props passed to `<Accordion>` will also be passed to its `header` component.
+## Header
+The `<Accordion>` comes with a default header component out of the box. The default header suits many cases, but if it is not adequate, a custom header can be provided via `<Accordion>`'s `header` prop.
+
+A custom header component should take `ContentId` prop in order to appropriately apply aria-attributes to the custom header. Any props passed to `<Accordion>` will also be passed to its `header` component.
+
+You can pass down additional props for the header component by using the `headerProps`-prop. This can be useful for e.g. changing the header element of the default accordion header via. the `headerElement`-prop (defaults to `h3`).
 
 ## Accordion Props
 

--- a/lib/Accordion/readme.md
+++ b/lib/Accordion/readme.md
@@ -144,7 +144,7 @@ The `<Accordion>` comes with a default header component out of the box. The defa
 
 A custom header component should take `ContentId` prop in order to appropriately apply aria-attributes to the custom header. Any props passed to `<Accordion>` will also be passed to its `header` component.
 
-You can pass down additional props for the header component by using the `headerProps`-prop. This can be useful for e.g. changing the header element of the default accordion header via. the `headerElement`-prop (defaults to `h3`).
+You can pass down additional props for the header component by using the `headerProps`-prop. This can be useful for e.g. changing the header level of the default accordion header via. the `headingLevel`-prop (defaults to `3`).
 
 ## Accordion Props
 

--- a/lib/Accordion/stories/BasicUsage.js
+++ b/lib/Accordion/stories/BasicUsage.js
@@ -11,7 +11,7 @@ import Button from '../../Button';
 
 const BasicUsage = () => (
   <AccordionSet>
-    <Accordion label="Information" displayWhenOpen={<Button icon="plus-sign">Add</Button>}>
+    <Accordion label="Information" displayWhenOpen={<Button icon="plus-sign">Add</Button>} headerProps={{ headerElement: 'h2' }}>
       This is an example of an AccordionSet. The 2nd of these accordions is closed by default using the &quot;closedByDefault&quot; prop.
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas vitae fringilla felis, sed commodo tellus. Sed bibendum mi id lorem sagittis sodales. Quisque ac lectus gravida, viverra ante et, iaculis sapien. Praesent eget ligula tortor. Praesent vitae ipsum placerat, blandit quam quis, tempus tortor. Aliquam erat volutpat. Fusce hendrerit lectus sed ex dictum, in pretium eros vestibulum. Nulla semper vehicula leo at varius. Quisque bibendum mauris sit amet tellus lobortis ultricies. Mauris eleifend sapien vel est posuere tincidunt. Proin ut nunc ut enim rhoncus elementum vitae in mauris. Nullam ultrices dictum nulla in commodo. Suspendisse potenti. Donec et velit ac quam consequat cursus. Pellentesque quis elit magna. Fusce velit libero, mattis ac placerat eget, aliquam a ante.
       <br />

--- a/lib/Accordion/stories/BasicUsage.js
+++ b/lib/Accordion/stories/BasicUsage.js
@@ -11,7 +11,7 @@ import Button from '../../Button';
 
 const BasicUsage = () => (
   <AccordionSet>
-    <Accordion label="Information" displayWhenOpen={<Button icon="plus-sign">Add</Button>} headerProps={{ headerElement: 'h2' }}>
+    <Accordion label="Information" displayWhenOpen={<Button icon="plus-sign">Add</Button>} headerProps={{ headingLevel: 2 }}>
       This is an example of an AccordionSet. The 2nd of these accordions is closed by default using the &quot;closedByDefault&quot; prop.
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas vitae fringilla felis, sed commodo tellus. Sed bibendum mi id lorem sagittis sodales. Quisque ac lectus gravida, viverra ante et, iaculis sapien. Praesent eget ligula tortor. Praesent vitae ipsum placerat, blandit quam quis, tempus tortor. Aliquam erat volutpat. Fusce hendrerit lectus sed ex dictum, in pretium eros vestibulum. Nulla semper vehicula leo at varius. Quisque bibendum mauris sit amet tellus lobortis ultricies. Mauris eleifend sapien vel est posuere tincidunt. Proin ut nunc ut enim rhoncus elementum vitae in mauris. Nullam ultrices dictum nulla in commodo. Suspendisse potenti. Donec et velit ac quam consequat cursus. Pellentesque quis elit magna. Fusce velit libero, mattis ac placerat eget, aliquam a ante.
       <br />

--- a/lib/MetaSection/MetaAccordionHeader.js
+++ b/lib/MetaSection/MetaAccordionHeader.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 import Icon from '../Icon';
 import Headline from '../Headline';
 import css from './MetaSection.css';
@@ -44,7 +45,9 @@ const MetaAccordionHeader = (props) => {
 
   return (
     <div className={css.headerWrapper} ref={(ref) => { containerElem = ref; }}>
-      <Headline className="sr-only" size="small" margin="none" tag={props.headerElement}>Update information</Headline>
+      <Headline className="sr-only" size="small" margin="none" tag={props.headerElement}>
+        <FormattedMessage id="stripes-components.metaSection.screenReaderLabel" />
+      </Headline>
       <button
         className={css.metaHeaderButton}
         type="button"

--- a/lib/MetaSection/MetaAccordionHeader.js
+++ b/lib/MetaSection/MetaAccordionHeader.js
@@ -9,7 +9,7 @@ const propTypes = {
   contentId: PropTypes.string,
   displayWhenClosed: PropTypes.element,
   displayWhenOpen: PropTypes.element,
-  headerElement: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.func]),
+  headerElement: PropTypes.string,
   id: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
   onToggle: PropTypes.func,

--- a/lib/MetaSection/MetaAccordionHeader.js
+++ b/lib/MetaSection/MetaAccordionHeader.js
@@ -8,10 +8,15 @@ const propTypes = {
   contentId: PropTypes.string,
   displayWhenClosed: PropTypes.element,
   displayWhenOpen: PropTypes.element,
+  headerElement: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.func]),
   id: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
   onToggle: PropTypes.func,
   open: PropTypes.bool,
+};
+
+const defaultProps = {
+  headerElement: 'h4'
 };
 
 const MetaAccordionHeader = (props) => {
@@ -39,7 +44,7 @@ const MetaAccordionHeader = (props) => {
 
   return (
     <div className={css.headerWrapper} ref={(ref) => { containerElem = ref; }}>
-      <Headline className="sr-only" size="small" margin="none" tag="h4">Update information</Headline>
+      <Headline className="sr-only" size="small" margin="none" tag={props.headerElement}>Update information</Headline>
       <button
         className={css.metaHeaderButton}
         type="button"
@@ -64,5 +69,6 @@ const MetaAccordionHeader = (props) => {
 };
 
 MetaAccordionHeader.propTypes = propTypes;
+MetaAccordionHeader.defaultProps = defaultProps;
 
 export default MetaAccordionHeader;

--- a/lib/MetaSection/MetaAccordionHeader.js
+++ b/lib/MetaSection/MetaAccordionHeader.js
@@ -9,7 +9,7 @@ const propTypes = {
   contentId: PropTypes.string,
   displayWhenClosed: PropTypes.element,
   displayWhenOpen: PropTypes.element,
-  headerElement: PropTypes.string,
+  headingLevel: PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
   id: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
   onToggle: PropTypes.func,
@@ -17,7 +17,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  headerElement: 'h4'
+  headingLevel: 4
 };
 
 const MetaAccordionHeader = (props) => {
@@ -45,7 +45,7 @@ const MetaAccordionHeader = (props) => {
 
   return (
     <div className={css.headerWrapper} ref={(ref) => { containerElem = ref; }}>
-      <Headline className="sr-only" size="small" margin="none" tag={props.headerElement}>
+      <Headline className="sr-only" size="small" margin="none" tag={`h${props.headingLevel}`}>
         <FormattedMessage id="stripes-components.metaSection.screenReaderLabel" />
       </Headline>
       <button

--- a/lib/MetaSection/MetaSection.js
+++ b/lib/MetaSection/MetaSection.js
@@ -22,6 +22,7 @@ const propTypes = {
     PropTypes.node, // Passing a node will _not_ render a link to the user record
   ]),
   createdDate: PropTypes.string,
+  headerElement: PropTypes.string,
   id: PropTypes.string,
   lastUpdatedBy: PropTypes.oneOfType([
     PropTypes.shape({
@@ -40,6 +41,7 @@ const propTypes = {
 
 const defaultProps = {
   showUserLink: false,
+  headerElement: 'h4'
 };
 
 class MetaSection extends React.Component {
@@ -67,10 +69,11 @@ class MetaSection extends React.Component {
 
   render() {
     const {
-      lastUpdatedDate,
-      lastUpdatedBy,
+      createdBy,
       createdDate,
-      createdBy
+      headerElement,
+      lastUpdatedBy,
+      lastUpdatedDate,
     } = this.props;
 
     const lastUpdatedLabel = lastUpdatedDate ?
@@ -115,6 +118,9 @@ class MetaSection extends React.Component {
       <div className={css.metaSectionRoot} data-test-meta-section>
         <Accordion
           header={MetaAccordionHeader}
+          headerProps={{
+            headerElement
+          }}
           closedByDefault
           id={this.props.id}
           contentId={this.props.contentId}

--- a/lib/MetaSection/MetaSection.js
+++ b/lib/MetaSection/MetaSection.js
@@ -22,7 +22,7 @@ const propTypes = {
     PropTypes.node, // Passing a node will _not_ render a link to the user record
   ]),
   createdDate: PropTypes.string,
-  headerElement: PropTypes.string,
+  headingLevel: PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
   id: PropTypes.string,
   lastUpdatedBy: PropTypes.oneOfType([
     PropTypes.shape({
@@ -41,7 +41,7 @@ const propTypes = {
 
 const defaultProps = {
   showUserLink: false,
-  headerElement: 'h4'
+  headingLevel: 4
 };
 
 class MetaSection extends React.Component {
@@ -71,7 +71,7 @@ class MetaSection extends React.Component {
     const {
       createdBy,
       createdDate,
-      headerElement,
+      headingLevel,
       lastUpdatedBy,
       lastUpdatedDate,
     } = this.props;
@@ -119,7 +119,7 @@ class MetaSection extends React.Component {
         <Accordion
           header={MetaAccordionHeader}
           headerProps={{
-            headerElement
+            headingLevel
           }}
           closedByDefault
           id={this.props.id}

--- a/lib/MetaSection/readme.md
+++ b/lib/MetaSection/readme.md
@@ -2,22 +2,24 @@
 Component for displaying record metadata such as the last date/time a record was modified.
 
 ## Usage
-```
+```js
 <MetaSection
-  id="userInfoRecordMeta"
   contentId="userInfoRecordMetaContent"
-  lastUpdatedDate={user.updatedDate}
   createdDate={user.createdDate}
+  headerElement="h4" // Optional
+  id="userInfoRecordMeta"
+  lastUpdatedDate={user.updatedDate}
 />
 ```
 
 ## Props
 Name | type | description | default | required
 --- | --- | --- | --- | ---
-lastUpdatedDate | string | Latest date/time a record was modified. |  |
+contentId | string | HTML id attribute assigned to accordion's content |  |
+createdBy | string/object | Name/record of the user who created the record. |  |
+createdDate | string | Date/time a record was created. |  |
+headerElement | string | Sets the HTML element for the header | h4 |
+id | string | HTML id attribute assigned to accordion's root. |  |
 lastUpdatedBy | string/object | Name/record of the last user who modified the record. |  |
-createdDate: | string | Date/time a record was created. |  |
-createdBy: | string/object | Name/record of the user who created the record. |  |
-id: | string | HTML id attribute assigned to accordion's root. |  |
-contentId: | string | HTML id attribute assigned to accordion's content |  |
+lastUpdatedDate | string | Latest date/time a record was modified. |  |
 showUserLink | boolean | Should the user name link to the user record? Pass in permission | false |

--- a/lib/MetaSection/readme.md
+++ b/lib/MetaSection/readme.md
@@ -6,7 +6,7 @@ Component for displaying record metadata such as the last date/time a record was
 <MetaSection
   contentId="userInfoRecordMetaContent"
   createdDate={user.createdDate}
-  headerElement="h4" // Optional
+  headingLevel={4} // Optional
   id="userInfoRecordMeta"
   lastUpdatedDate={user.updatedDate}
 />
@@ -18,7 +18,7 @@ Name | type | description | default | required
 contentId | string | HTML id attribute assigned to accordion's content |  |
 createdBy | string/object | Name/record of the user who created the record. |  |
 createdDate | string | Date/time a record was created. |  |
-headerElement | string | Sets the HTML element for the header | h4 |
+headingLevel | number | Sets the heading level of the heading inside the accordion header. | 4 |
 id | string | HTML id attribute assigned to accordion's root. |  |
 lastUpdatedBy | string/object | Name/record of the last user who modified the record. |  |
 lastUpdatedDate | string | Latest date/time a record was modified. |  |

--- a/lib/MetaSection/stories/BasicUsage.js
+++ b/lib/MetaSection/stories/BasicUsage.js
@@ -1,0 +1,36 @@
+/**
+ * MetaSection -> Basic Usage
+ */
+
+import React from 'react';
+import { StaticRouter } from 'react-router-dom';
+import MetaSection from '../MetaSection';
+
+const BasicUsage = () => (
+  <StaticRouter context={{}}>
+    <MetaSection
+      id="meta-section-example"
+      headerElement="h3"
+      contentId="meta-section-example-content"
+      createdDate="12/12/2019"
+      lastUpdatedDate="12/12/2019"
+      showUserLink
+      createdBy={{
+        id: '1234',
+        personal: {
+          firstName: 'Cutter',
+          lastName: 'John',
+        }
+      }}
+      lastUpdatedBy={{
+        personal: {
+          firstName: 'Oliver',
+          lastName: 'Jones',
+          middleName: 'Wendell',
+        }
+      }}
+    />
+  </StaticRouter>
+);
+
+export default BasicUsage;

--- a/lib/MetaSection/stories/BasicUsage.js
+++ b/lib/MetaSection/stories/BasicUsage.js
@@ -10,7 +10,7 @@ const BasicUsage = () => (
   <StaticRouter context={{}}>
     <MetaSection
       id="meta-section-example"
-      headerElement="h3"
+      headingLevel={3}
       contentId="meta-section-example-content"
       createdDate="12/12/2019"
       lastUpdatedDate="12/12/2019"

--- a/lib/MetaSection/stories/MetaSection.stories.js
+++ b/lib/MetaSection/stories/MetaSection.stories.js
@@ -1,0 +1,8 @@
+import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
+import readme from '../readme.md';
+import BasicUsage from './BasicUsage';
+
+storiesOf('MetaSection', module)
+  .addDecorator(withReadme(readme))
+  .add('Basic Usage', BasicUsage);

--- a/translations/stripes-components/en.json
+++ b/translations/stripes-components/en.json
@@ -55,6 +55,7 @@
   "metaSection.recordCreatedNoData": "Record created: Unknown",
   "metaSection.recordLastUpdated": "Record last updated: {date} {time}",
   "metaSection.recordLastUpdatedNoData": "Record last updated: Unknown",
+  "metaSection.screenReaderLabel": "Update information",
   "tableEmpty": "The list contains no items",
   "button.edit": "Edit",
   "button.duplicate": "Duplicate",


### PR DESCRIPTION
## Ticket
https://issues.folio.org/browse/STCOM-686

## Changes
- Added `headerProps`-prop for `<Accordion>` to enable passing additional props down to the header component. Updated documentation.
- Updated `<MetaAccordionHeader>`, `<DefaultAccordionHeader>` and `<FilterAccordionHeader>` to include a `headingLevel`-prop that allows for changing the header level of the internal `<Headline>`
- Added `headingLevel` for `<MetaSection>` to allow for changing the heading level of the meta section accordion heading.
- Added storybook example for `<MetaSection>`
- Replaced a hardcoded string with a localized string in `<MetaAccordionHeader>`