### PR TITLE
UIU-1674: fix multiselect carat not aligned when there is not enough space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-components
 
+## 7.1.0 (IN PROGRESS)
+
+* Fix MultiSelect carat not aligned when there is not enough space.
+
 ## [7.0.1](https://github.com/folio-org/stripes-components/tree/v7.0.1) (2020-06-08)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v7.0.0...v7.0.1)
 

--- a/lib/MultiSelection/MultiSelect.css
+++ b/lib/MultiSelection/MultiSelect.css
@@ -38,6 +38,7 @@
 }
 
 .multiSelectFilterField {
+  width: 100%;
   margin: 2px;
   background-color: transparent;
   padding: 0 4px;

--- a/lib/MultiSelection/MultiSelect.css
+++ b/lib/MultiSelection/MultiSelect.css
@@ -39,6 +39,7 @@
 
 .multiSelectFilterField {
   width: 100%;
+  flex: 1;
   margin: 2px;
   background-color: transparent;
   padding: 0 4px;


### PR DESCRIPTION
Ticket:  https://issues.folio.org/browse/UIU-1674

## Before
![image](https://user-images.githubusercontent.com/43514877/84790258-d399a200-aff9-11ea-81da-02d5b29f73a2.png)
![image](https://user-images.githubusercontent.com/43514877/84790306-e14f2780-aff9-11ea-8799-824455876c3b.png)
![image](https://user-images.githubusercontent.com/43514877/84790406-fdeb5f80-aff9-11ea-8557-2ac99c6eb453.png)

## After
![image](https://user-images.githubusercontent.com/43514877/84790136-b238b600-aff9-11ea-9a9e-e0e191b3ce53.png)
![image](https://user-images.githubusercontent.com/43514877/84790077-9fbe7c80-aff9-11ea-8798-1419620b0672.png)
![image](https://user-images.githubusercontent.com/43514877/84790467-0e033f00-affa-11ea-9144-2daab57e8c59.png)




