### PR TITLE
STSMACOM-362: Settings | Users | Custom fields | Ability to re-order options

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,7 @@ export {
   CommandList,
   HasCommand
 } from './lib/Commander';
+export { default as SortableList } from './lib/SortableList';
 
 /* structures */
 export { default as ConfirmationModal } from './lib/ConfirmationModal';

--- a/lib/SortableList/DraggableRow.css
+++ b/lib/SortableList/DraggableRow.css
@@ -1,0 +1,8 @@
+.DraggableRow {
+  &::after {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    content: '';
+  }
+}

--- a/lib/SortableList/DraggableRow.js
+++ b/lib/SortableList/DraggableRow.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+
+import css from './DraggableRow.css';
+
+const getItemStyle = (draggableStyle) => {
+  return {
+    userSelect: 'none',
+    ...draggableStyle,
+  };
+};
+
+const propTypes = {
+  cells: PropTypes.arrayOf(PropTypes.element),
+  provided: PropTypes.object,
+  rowClass: PropTypes.string,
+  rowIndex: PropTypes.number,
+  snapshot: PropTypes.object,
+};
+
+const DraggableRow = ({
+  snapshot,
+  provided,
+  rowIndex,
+  rowClass,
+  cells,
+}) => {
+  const usePortal = snapshot.isDragging;
+  const classNames = [rowClass];
+
+  if (usePortal) {
+    classNames.push(css.DraggableRow);
+  }
+
+  const Row = (
+    <div
+      id={`row-${rowIndex}`}
+      data-test-draggable-row
+      ref={provided.innerRef}
+      {...provided.draggableProps}
+      {...provided.dragHandleProps}
+      key={`row-${rowIndex}`}
+      className={classNames}
+      role="row"
+      tabIndex="0"
+      style={getItemStyle(
+        provided.draggableProps.style,
+      )}
+    >
+      {cells}
+    </div>
+  );
+
+  if (!usePortal) {
+    return Row;
+  }
+
+  const container = document.getElementById('ModuleContainer');
+  return ReactDOM.createPortal(Row, container);
+}
+
+DraggableRow.propTypes = propTypes;
+
+export default DraggableRow;

--- a/lib/SortableList/DraggableRow.js
+++ b/lib/SortableList/DraggableRow.js
@@ -58,7 +58,7 @@ const DraggableRow = ({
 
   const container = document.getElementById('ModuleContainer');
   return ReactDOM.createPortal(Row, container);
-}
+};
 
 DraggableRow.propTypes = propTypes;
 

--- a/lib/SortableList/SortableList.js
+++ b/lib/SortableList/SortableList.js
@@ -1,19 +1,19 @@
-import { uniqueId } from 'lodash';
 import React from 'react';
+import { uniqueId, noop } from 'lodash';
 import PropTypes from 'prop-types';
-import { MultiColumnList } from '@folio/stripes-components';
 import {
   DragDropContext,
   Droppable,
 } from 'react-beautiful-dnd';
-import { noop } from 'lodash';
+
+import MultiColumnList from '../MultiColumnList';
 
 import draggableRowFormatter from './draggableRowFormatter';
 
 const propTypes = {
+  className: PropTypes.string,
   droppableId: PropTypes.string,
   id: PropTypes.string,
-  className: PropTypes.string,
   isRowDraggable: PropTypes.func,
   onDragEnd: PropTypes.func,
   onDragStart: PropTypes.func,
@@ -23,16 +23,16 @@ const propTypes = {
 };
 
 const SortableList = ({
-    droppableId,
-    onDragEnd,
-    onDragStart,
-    onDragUpdate,
-    rowFormatter,
-    isRowDraggable,
-    rowProps,
-    id,
-    className,
-    ...rest
+  droppableId,
+  onDragEnd,
+  onDragStart,
+  onDragUpdate,
+  rowFormatter,
+  isRowDraggable,
+  rowProps,
+  id,
+  className,
+  ...rest
 }) => {
   return (
     <DragDropContext
@@ -64,7 +64,7 @@ const SortableList = ({
       </Droppable>
     </DragDropContext>
   );
-}
+};
 
 SortableList.defaultProps = {
   droppableId: uniqueId('droppable'),

--- a/lib/SortableList/SortableList.js
+++ b/lib/SortableList/SortableList.js
@@ -1,0 +1,83 @@
+import { uniqueId } from 'lodash';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { MultiColumnList } from '@folio/stripes-components';
+import {
+  DragDropContext,
+  Droppable,
+} from 'react-beautiful-dnd';
+import { noop } from 'lodash';
+
+import draggableRowFormatter from './draggableRowFormatter';
+
+const propTypes = {
+  droppableId: PropTypes.string,
+  id: PropTypes.string,
+  className: PropTypes.string,
+  isRowDraggable: PropTypes.func,
+  onDragEnd: PropTypes.func,
+  onDragStart: PropTypes.func,
+  onDragUpdate: PropTypes.func,
+  rowFormatter: PropTypes.func,
+  rowProps: PropTypes.object,
+};
+
+const SortableList = ({
+    droppableId,
+    onDragEnd,
+    onDragStart,
+    onDragUpdate,
+    rowFormatter,
+    isRowDraggable,
+    rowProps,
+    id,
+    className,
+    ...rest
+}) => {
+  return (
+    <DragDropContext
+      onDragEnd={onDragEnd}
+      onDragStart={onDragStart}
+      onDragUpdate={onDragUpdate}
+    >
+      <Droppable droppableId={droppableId}>
+        {(provided, snapshot) => (
+          <div
+            id={id}
+            className={className}
+            {...provided.droppableProps}
+            ref={provided.innerRef}
+          >
+            <MultiColumnList
+              {...rest}
+              rowFormatter={rowFormatter}
+              rowProps={{
+                ...rowProps,
+                rowsCount: rest.contentData.length,
+                isRowDraggable,
+                isDraggingOver: snapshot.isDraggingOver,
+                placeholder: provided.placeholder,
+              }}
+            />
+          </div>
+        )}
+      </Droppable>
+    </DragDropContext>
+  );
+}
+
+SortableList.defaultProps = {
+  droppableId: uniqueId('droppable'),
+  rowFormatter: draggableRowFormatter,
+  isRowDraggable: () => true,
+  onDragEnd: noop,
+  onDragStart: noop,
+  onDragUpdate: noop,
+  id: uniqueId('sortable-list-'),
+  className: '',
+  rowProps: {},
+};
+
+SortableList.propTypes = propTypes;
+
+export default SortableList;

--- a/lib/SortableList/draggableRowFormatter.js
+++ b/lib/SortableList/draggableRowFormatter.js
@@ -54,7 +54,7 @@ const draggableRowFormatter = ({
       )}
     </Draggable>
   );
-}
+};
 
 draggableRowFormatter.propTypes = propTypes;
 

--- a/lib/SortableList/draggableRowFormatter.js
+++ b/lib/SortableList/draggableRowFormatter.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Draggable
+} from 'react-beautiful-dnd';
+
+import DraggableRow from './DraggableRow';
+
+const propTypes = {
+  rowData: PropTypes.object,
+  rowIndex: PropTypes.number,
+  rowProps: PropTypes.shape({
+    isDraggingOver: PropTypes.bool,
+    isRowDraggable: PropTypes.bool,
+    isSingleSelect: PropTypes.bool,
+    placeholder: PropTypes.node.isRequired,
+    rowsCount: PropTypes.number.isRequired,
+  }),
+};
+
+const draggableRowFormatter = ({
+  rowIndex,
+  rowData,
+  rowProps: {
+    isRowDraggable,
+    rowsCount,
+    isDraggingOver,
+    placeholder,
+  },
+  ...rest
+}) => {
+  // only render placeholder after the last row in MCL
+  const shouldRenderPlaceholder = isDraggingOver && (rowsCount === rowIndex + 1);
+
+  return (
+    <Draggable
+      key={`row-${rowData.id}`}
+      draggableId={rowData.id}
+      index={rowIndex}
+      isDragDisabled={!isRowDraggable(rowData, rowIndex)}
+    >
+      {(provided, snapshot) => (
+        <>
+          <DraggableRow
+            provided={provided}
+            snapshot={snapshot}
+            rowIndex={rowIndex}
+            {...rest}
+          />
+          {
+            shouldRenderPlaceholder ? placeholder : null
+          }
+        </>
+      )}
+    </Draggable>
+  );
+}
+
+draggableRowFormatter.propTypes = propTypes;
+
+export default draggableRowFormatter;

--- a/lib/SortableList/index.js
+++ b/lib/SortableList/index.js
@@ -1,0 +1,1 @@
+export { default } from './SortableList';

--- a/lib/SortableList/readme.md
+++ b/lib/SortableList/readme.md
@@ -1,0 +1,37 @@
+# SortableList
+Multi column list component with ability to sort rows via drag-and-drop.
+
+## Usage
+```
+import { SortableList } from '@folio/stripes/components';
+
+// later in your JSX
+<SortableList
+    onDragEnd={handleDragEnd}
+    contentData={[
+        {
+            id: 'id_0',
+        },
+        {
+            id: 'id_1',
+        },
+    ]}
+/>
+
+```
+
+`SortableList` component acts as a wrapper for `MultiColumnList` component and defines a custom row formatter with drag-and-drop functionality. Drag-and-drop is implemented using `react-beautiful-dnd` library.
+
+## Props
+
+Name | type | description | default | required
+--- | --- | --- | --- | ---
+`droppableId` | string | Droppable area id for `react-beautiful-dnd`.| `uniqueId('droppable')` |
+`id` | string | id for `MultiColumnList` wrapper element. | `uniqueId('sortable-list-')` |
+`className` | string | className for `MultiColumnList` wrapper element. | '' |
+`isRowDraggable` | func | Callback fired for each row. Returning `false` would disable dragging of a specific row. | `() => true` |
+`onDragEnd` | func | Callback that signals end of drag-and-drop. | `noop` |
+`onDragStart` | func | Callback that signals start of drag-and-drop. | `noop` |
+`onDragUpdate` | func | Callback that signals updates from drag-and-drop. | `noop` |
+`rowFormatter` | func | `rowFormatter` prop from `MultiColumnList` component. Can be passed to define a custom rowFormatter | `draggableRowFormatter` |
+`rowProps` | object | `rowProps` prop from `MultiColumnList` component. Can be passed to extend props that are passed to `rowFormatter` | {} |

--- a/lib/SortableList/stories/BasicUsage.js
+++ b/lib/SortableList/stories/BasicUsage.js
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import SortableList from '../SortableList';
+
+export default class BasicUsage extends React.Component {
+  constructor() {
+    super();
+
+    this.state = {
+      contentData: [
+        {
+          id: 'id_0',
+          index: 0,
+          label: 'Option 1',
+        },
+        {
+          id: 'id_1',
+          index: 1,
+          label: 'Option 2',
+        }, {
+          id: 'id_2',
+          index: 2,
+          label: 'Option 3',
+        },
+      ]
+    };
+
+    this.handleDragEnd = this.handleDragEnd.bind(this);
+  }
+
+  handleDragEnd(result) {
+    const { destination, source } = result;
+
+    if (!destination) {
+      return;
+    }
+
+    const { index: destIndex } = destination;
+    const { index: startIndex } = source;
+
+    const options = [...this.state.contentData];
+    const temporary = options[startIndex];
+    options[startIndex] = options[destIndex];
+    options[destIndex] = temporary;
+
+    this.setState({
+      contentData: options,
+    });
+  }
+
+  render() {
+    const { contentData } = this.state;
+
+    return (
+      <>
+        <div id="ModuleContainer"></div>
+        <SortableList
+          onDragEnd={this.handleDragEnd}
+          contentData={contentData}
+          visibleColumns={['id', 'label']}
+        />
+      </>
+    );
+  }
+}

--- a/lib/SortableList/stories/BasicUsage.js
+++ b/lib/SortableList/stories/BasicUsage.js
@@ -38,13 +38,15 @@ export default class BasicUsage extends React.Component {
     const { index: destIndex } = destination;
     const { index: startIndex } = source;
 
-    const options = [...this.state.contentData];
-    const temporary = options[startIndex];
-    options[startIndex] = options[destIndex];
-    options[destIndex] = temporary;
+    this.setState(({ contentData }) => {
+      const options = [...contentData];
+      const temporary = options[startIndex];
+      options[startIndex] = options[destIndex];
+      options[destIndex] = temporary;
 
-    this.setState({
-      contentData: options,
+      return {
+        contentData: options,
+      };
     });
   }
 
@@ -53,7 +55,7 @@ export default class BasicUsage extends React.Component {
 
     return (
       <>
-        <div id="ModuleContainer"></div>
+        <div id="ModuleContainer" />
         <SortableList
           onDragEnd={this.handleDragEnd}
           contentData={contentData}

--- a/lib/SortableList/stories/SortableList.stories.js
+++ b/lib/SortableList/stories/SortableList.stories.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
+
+import BasicUsage from './BasicUsage';
+import readme from '../readme.md';
+
+storiesOf('SortableList', module)
+  .addDecorator(withReadme(readme))
+  .add('Basic Usage', () => (<BasicUsage />));

--- a/lib/SortableList/tests/SortableList-test.js
+++ b/lib/SortableList/tests/SortableList-test.js
@@ -13,11 +13,11 @@ describe('SortableList', () => {
   const onDragEndFake = sinon.fake();
   const onDragStartFake = sinon.fake();
   const onDragUpdateFake = sinon.fake();
-  
+
   beforeEach(async () => {
     await mountWithContext(
       <>
-        <div id="ModuleContainer"></div>
+        <div id="ModuleContainer" />
         <SortableList
           onDragEnd={onDragEndFake}
           onDragStart={onDragStartFake}

--- a/lib/SortableList/tests/SortableList-test.js
+++ b/lib/SortableList/tests/SortableList-test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { mountWithContext } from '../../../tests/helpers';
+
+import SortableList from '../SortableList';
+import SortableListInteractor from './interactor';
+
+describe('SortableList', () => {
+  const sortableList = new SortableListInteractor();
+  const onDragEndFake = sinon.fake();
+  const onDragStartFake = sinon.fake();
+  const onDragUpdateFake = sinon.fake();
+  
+  beforeEach(async () => {
+    await mountWithContext(
+      <>
+        <div id="ModuleContainer"></div>
+        <SortableList
+          onDragEnd={onDragEndFake}
+          onDragStart={onDragStartFake}
+          onDragUpdate={onDragUpdateFake}
+          contentData={[
+            {
+              id: '0',
+              index: 0,
+            },
+            {
+              id: '1',
+              index: 1,
+            }
+          ]}
+        />
+      </>
+    );
+
+    onDragEndFake.resetHistory();
+    onDragStartFake.resetHistory();
+    onDragUpdateFake.resetHistory();
+  });
+
+  it('should render correct number of rows', () => {
+    expect(sortableList.rows().length).to.equal(2);
+  });
+
+  describe('when lifting a row', () => {
+    beforeEach(async () => {
+      await sortableList.liftRow();
+    });
+
+    it('should call onDragStart', () => {
+      expect(onDragStartFake.calledOnce).to.be.true;
+    });
+
+    describe('when moving a row', () => {
+      beforeEach(async () => {
+        await sortableList.moveRowUp();
+      });
+
+      it('should call onDragUpdate', () => {
+        expect(onDragUpdateFake.called).to.be.true;
+      });
+
+      describe('when dropping a row', () => {
+        beforeEach(async () => {
+          await sortableList.dropRow();
+        });
+
+        it('should call onDragEnd', () => {
+          expect(onDragEndFake.calledOnce).to.be.true;
+        });
+      });
+    });
+  });
+});

--- a/lib/SortableList/tests/interactor.js
+++ b/lib/SortableList/tests/interactor.js
@@ -1,0 +1,89 @@
+import {
+  collection,
+  focusable,
+  triggerable,
+  interactor,
+  isPresent,
+  scoped,
+  text,
+} from '@bigtest/interactor';
+
+@interactor class DraggableRow {
+  focus = focusable();
+  cols = collection('[role="gridcell"]');
+
+  pressSpace = triggerable('keydown', {
+    bubbles: true,
+    cancelable: true,
+    keyCode: 32,
+    which: 32,
+  });
+
+  pressArrowUp = triggerable('keydown', {
+    bubbles: true,
+    cancelable: true,
+    keyCode: 38,
+    key: 'ArrowUp',
+  });
+
+  pressArrowDown = triggerable('keydown', {
+    bubbles: true,
+    cancelable: true,
+    keyCode: 40,
+    key: 'ArrowDown',
+  });
+}
+
+@interactor class SortableListInteractor {
+  log = text('[role="log"]');
+  logPresent = isPresent('[role="log"]');
+  rows = collection('[data-test-draggable-row]', DraggableRow);
+
+  row = scoped('#row-1', DraggableRow);
+
+  liftRow() {
+    return this
+      .row.focus()
+      .row.pressSpace()
+      .whenRowLifted();
+  }
+
+  moveRowUp() {
+    return this
+      .row
+      .pressArrowUp()
+      .whenRowMoved();
+  }
+
+  moveRowDown() {
+    return this
+      .row
+      .pressArrowDown()
+      .whenRowMoved();
+  }
+
+  dropRow() {
+    return this
+      .row
+      .pressSpace()
+      .whenRowDropped();
+  }
+
+  whenRowLifted() {
+    return this.when(() => !!this.log.match(/You have lifted an item/i));
+  }
+
+  whenRowMoved() {
+    return this.when(() => !!this.log.match(/You have moved the item/i));
+  }
+
+  whenRowDropped() {
+    return this.when(() => !!this.log.match(/You have dropped the item/i));
+  }
+
+  whenLogIsPresent() {
+    return this.when(() => this.logPresent);
+  }
+}
+
+export default SortableListInteractor;

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "prop-types": "^15.5.10",
     "prop-types-extra": "^1.1.0",
     "query-string": "^6.1.0",
+    "react-beautiful-dnd": "^11.0.5",
     "react-flexbox-grid": "1.1.3",
     "react-highlight-words": "^0.16.0",
     "react-hot-loader": "^4.0.0",


### PR DESCRIPTION
## Purpose
Custom Fields settings uses `<MultiColumnList>` component to render it's options and we need to support changing order of these options via drag-and-drop.
Similar functionality was previously implemented in `ui-requests` to order request queues.
So as we are beginning to have similar implementations of drag-and-drop across several applications I believe we should consider moving MCL related drag-and-drop code to shared `stripes-components` repository.

## Approach

`<SortableList>` is a wrapper for `<MultiColumnList>` component. It uses `react-beautiful-dnd` library to extend it with drag-and-drop functionality. `<SortableList>` defines drag-and-drop context around `<MultiColumnList>` and passes a custom `rowFormatter` to MCL, which itself acts as a wrapper around each row to make them draggable within a single MCL.

#### TODOS and Open Questions

- Failed tests. These are caused by `react-beautiful-dnd` printing warnings that contain an emoji (👷). Warnings are printed because `<SortableList>` is unmounted before `react-beautiful-dnd` has had a chance to announce it's screen reader messages. I wonder if anybody knows how we can filter/disable warnings in tests console output. @mkuklis I believe you've worked on implementing drag-and-drop in `ui-requests`? Have you had these issues?