### PR TITLE
UX-371: Update disabled/read-only styles for RadioButton and Checkbox

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -3,7 +3,6 @@
     margin: 0;
     padding: 1rem;
     position: relative;
-    overflow: scroll !important;
   }
 
   #OverlayContainer {

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -3,6 +3,7 @@
     margin: 0;
     padding: 1rem;
     position: relative;
+    overflow: scroll !important;
   }
 
   #OverlayContainer {

--- a/lib/Checkbox/Checkbox.css
+++ b/lib/Checkbox/Checkbox.css
@@ -11,7 +11,6 @@
   color: var(--color-text);
   line-height: var(--line-height);
   margin-bottom: 0;
-  cursor: pointer;
 
   &.fullWidth {
     width: 100%;
@@ -168,7 +167,9 @@
  */
 .disabled,
 .readOnly {
-  cursor: default;
+  & .inner {
+    cursor: default;
+  }
 
   & .checkboxIcon,
   & input:checked + .checkboxIcon {

--- a/lib/Checkbox/Checkbox.css
+++ b/lib/Checkbox/Checkbox.css
@@ -2,6 +2,7 @@
 
 :root {
   --checkbox-size: 12px;
+  --checkbox-disabled-color: #cecece;
 }
 
 .checkbox {
@@ -164,11 +165,18 @@
 }
 
 /**
- * Disabled
+ * Disabled or read-only
  */
-.disabled {
-  & .checkboxIcon {
-    opacity: 0.5;
+.disabled,
+.readOnly {
+  & .checkboxIcon,
+  & input:checked + .checkboxIcon {
+    background-color: var(--checkbox-disabled-color);
+    border-color: var(--checkbox-disabled-color);
+
+    & svg path {
+      stroke: #000;
+    }
   }
 
   &:hover .inner {

--- a/lib/Checkbox/Checkbox.css
+++ b/lib/Checkbox/Checkbox.css
@@ -2,7 +2,6 @@
 
 :root {
   --checkbox-size: 12px;
-  --checkbox-disabled-color: #cecece;
 }
 
 .checkbox {
@@ -12,6 +11,7 @@
   color: var(--color-text);
   line-height: var(--line-height);
   margin-bottom: 0;
+  cursor: pointer;
 
   &.fullWidth {
     width: 100%;
@@ -48,7 +48,6 @@
   min-height: var(--control-min-size-desktop);
   display: flex;
   align-items: baseline;
-  cursor: pointer;
   flex-grow: 2;
   position: relative;
   border-radius: var(--radius);
@@ -74,9 +73,9 @@
  */
 .input {
   position: absolute;
-  z-index: 10;
+  z-index: -1;
   opacity: 0;
-  cursor: pointer;
+  pointer-events: none;
 }
 
 .noLabel .input {
@@ -169,18 +168,12 @@
  */
 .disabled,
 .readOnly {
+  cursor: default;
+
   & .checkboxIcon,
   & input:checked + .checkboxIcon {
-    background-color: var(--checkbox-disabled-color);
-    border-color: var(--checkbox-disabled-color);
-
-    & svg path {
-      stroke: #000;
-    }
-  }
-
-  &:hover .inner {
-    cursor: default;
+    background-color: var(--checkable-disabled-fill);
+    border-color: var(--checkable-disabled-fill);
   }
 }
 

--- a/lib/Checkbox/Checkbox.css
+++ b/lib/Checkbox/Checkbox.css
@@ -1,4 +1,5 @@
 @import '../variables.css';
+/* stylelint-disable no-descending-specificity */
 
 :root {
   --checkbox-size: 12px;
@@ -82,6 +83,65 @@
 }
 
 /**
+ * Checkbox feedback
+ */
+.checkboxFeedback {
+  font-size: var(--font-size-medium);
+}
+
+.hasWarning {
+  & .checkboxFeedback {
+    color: var(--warn);
+  }
+
+  & .checkboxIcon {
+    border-color: var(--warn);
+  }
+}
+
+.hasError {
+  & .checkboxFeedback {
+    color: var(--error);
+  }
+
+  & .checkboxIcon {
+    border-color: var(--error);
+  }
+}
+
+/**
+ * Disabled or read-only
+ */
+.disabled,
+.readOnly {
+  & .inner {
+    cursor: default;
+  }
+
+  & .checkboxIcon,
+  & input:checked + .checkboxIcon {
+    background-color: var(--checkable-disabled-fill);
+    border-color: var(--checkable-disabled-fill);
+  }
+}
+
+/**
+ * Checked state
+ */
+
+.input:checked + .checkboxIcon {
+  background-color: #000;
+
+  & svg {
+    opacity: 1;
+  }
+
+  & svg path {
+    stroke: #fff;
+  }
+}
+
+/**
  * Vertical label alignment
  */
 .vertical .label {
@@ -121,33 +181,6 @@
 }
 
 /**
- * Checkbox feedback
- */
-.checkboxFeedback {
-  font-size: var(--font-size-medium);
-}
-
-.hasWarning {
-  & .checkboxFeedback {
-    color: var(--warn);
-  }
-
-  & .checkboxIcon {
-    border-color: var(--warn);
-  }
-}
-
-.hasError {
-  & .checkboxFeedback {
-    color: var(--error);
-  }
-
-  & .checkboxIcon {
-    border-color: var(--error);
-  }
-}
-
-/**
  * Interaction styles (hover, focus, active)
  */
 .checkboxInteractionStylesControl {
@@ -160,36 +193,4 @@
 
 .labelFocused {
   composes: isFocused from "../sharedStyles/interactionStyles.css";
-}
-
-/**
- * Disabled or read-only
- */
-.disabled,
-.readOnly {
-  & .inner {
-    cursor: default;
-  }
-
-  & .checkboxIcon,
-  & input:checked + .checkboxIcon {
-    background-color: var(--checkable-disabled-fill);
-    border-color: var(--checkable-disabled-fill);
-  }
-}
-
-/**
- * Checked state
- */
-
-.input:checked + .checkboxIcon {
-  background-color: #000;
-
-  & svg {
-    opacity: 1;
-  }
-
-  & svg path {
-    stroke: #fff;
-  }
 }

--- a/lib/Checkbox/Checkbox.js
+++ b/lib/Checkbox/Checkbox.js
@@ -5,7 +5,6 @@ import uniqueId from 'lodash/uniqueId';
 import { FormattedMessage } from 'react-intl';
 
 import formField from '../FormField';
-import Icon from '../Icon';
 import Label from '../Label';
 import Asterisk from '../Label/components/Asterisk';
 import separateComponentProps from '../../util/separateComponentProps';
@@ -80,17 +79,18 @@ class Checkbox extends React.Component {
   }
 
   getRootClasses = () => {
-    const { className, fullWidth, vertical, label, disabled, inline, error, warning } = this.props;
+    const { className, fullWidth, vertical, label, disabled, inline, error, readOnly, warning } = this.props;
 
     return classNames(
-      [`${css.checkbox}`],
-      { [`${css.fullWidth}`]: fullWidth },
-      { [`${css.inline}`]: inline || vertical || !label },
-      { [`${css.vertical}`]: vertical },
-      { [`${css.disabled}`]: disabled },
-      { [`${css.noLabel}`]: !label },
-      { [`${css.hasError}`]: !!error },
-      { [`${css.hasWarning}`]: !!warning },
+      [css.checkbox],
+      { [css.fullWidth]: fullWidth },
+      { [css.inline]: inline || vertical || !label },
+      { [css.vertical]: vertical },
+      { [css.disabled]: disabled },
+      { [css.readOnly]: readOnly },
+      { [css.noLabel]: !label },
+      { [css.hasError]: !!error },
+      { [css.hasWarning]: !!warning },
       className,
     );
   }
@@ -155,11 +155,9 @@ class Checkbox extends React.Component {
         {label}
         {required && <Asterisk />}
         {readOnly && (
-          <Icon size="small" icon="lock">
-            <span className="sr-only">
-              <FormattedMessage id="stripes-components.readonly" />
-            </span>
-          </Icon>
+          <span className="sr-only">
+            <FormattedMessage id="stripes-components.readonly" />
+          </span>
         )}
       </span>
     );

--- a/lib/Checkbox/readme.md
+++ b/lib/Checkbox/readme.md
@@ -45,7 +45,7 @@ name | string | Sets the name of the input | `undefined`
 onBlur | func | Event handler for the input's `onBlur` event | `undefined`
 onChange | func | Event handler for the input's `onChange` event | `undefined`
 onFocus | func | Event handler for the input's `onFocus` event | `undefined`
-readOnly | bool | Renders the field as "read only" | `false`
+readOnly | bool | Renders the field as "read only" (focusable but non-interactive) | `false`
 required | bool | Sets the field as required | `false`
 value | string | Sets the selected value for the input | `undefined`
 vertical | bool | Renders the label vertically (above the checkbox) | `false`

--- a/lib/Checkbox/stories/BasicUsage.js
+++ b/lib/Checkbox/stories/BasicUsage.js
@@ -14,6 +14,11 @@ const CheckboxExample = () => (
     />
     <br />
     <Checkbox
+      checked
+      label="Checked state"
+    />
+    <br />
+    <Checkbox
       label="Inline Checkbox with label (disabled)"
       inline
       disabled
@@ -21,7 +26,7 @@ const CheckboxExample = () => (
     <br />
     <br />
     <Checkbox
-      label="Inline Checkbox with label (read only)"
+      label="Read only, inline and checked"
       checked
       inline
       readOnly
@@ -37,7 +42,7 @@ const CheckboxExample = () => (
     <br />
     <hr />
     <br />
-    <Headline size="large">No label</Headline>
+    <Headline size="large" margin="none">No label</Headline>
     <Checkbox
       aria-label="My label"
       inline

--- a/lib/RadioButton/RadioButton.css
+++ b/lib/RadioButton/RadioButton.css
@@ -6,8 +6,7 @@
 
 .radioButton {
   display: flex;
-  align-items: center;
-  cursor: pointer;
+  flex-direction: column;
 
   &.marginBottom0 {
     margin-bottom: 0;
@@ -80,7 +79,9 @@
  * Disabled or read only
  */
 .disabled {
-  cursor: default;
+  & .radioLabel {
+    cursor: default;
+  }
 
   & .labelPseudo,
   & .input:checked + .labelPseudo {
@@ -144,7 +145,7 @@
  * Feedback
  */
 .radioFeedback {
-  font-size: var(--font-size-small);
+  font-size: var(--font-size-medium);
 }
 
 .hasWarning {
@@ -152,7 +153,7 @@
     color: var(--warn);
   }
 
-  & .input {
+  & .labelPseudo {
     border-color: var(--warn);
   }
 }
@@ -162,7 +163,7 @@
     color: var(--error);
   }
 
-  & .input {
+  & .labelPseudo {
     border-color: var(--error);
   }
 }

--- a/lib/RadioButton/RadioButton.css
+++ b/lib/RadioButton/RadioButton.css
@@ -7,6 +7,7 @@
 .radioButton {
   display: flex;
   align-items: center;
+  cursor: pointer;
 
   &.marginBottom0 {
     margin-bottom: 0;
@@ -29,7 +30,6 @@
   line-height: var(--line-height);
   display: flex;
   align-items: baseline;
-  cursor: pointer;
   flex-grow: 2;
   border-radius: var(--radius);
   font-size: var(--font-size-medium);
@@ -76,15 +76,20 @@
   transition: all 0.2s ease;
 }
 
-.labelDisabled {
-  color: var(--color-text-p2);
+/**
+ * Disabled or read only
+ */
+.disabled {
+  cursor: default;
 
-  &:hover {
-    cursor: not-allowed;
-  }
+  & .labelPseudo,
+  & .input:checked + .labelPseudo {
+    background-color: var(--checkable-disabled-fill);
+    border-color: var(--checkable-disabled-fill);
 
-  & .labelPseudo {
-    opacity: 0.5;
+    &:after {
+      opacity: 0.5;
+    }
   }
 }
 

--- a/lib/RadioButton/RadioButton.css
+++ b/lib/RadioButton/RadioButton.css
@@ -1,4 +1,5 @@
 @import '../variables.css';
+/* stylelint-disable no-descending-specificity */
 
 :root {
   --radio-button-size: 12px;
@@ -88,7 +89,7 @@
     background-color: var(--checkable-disabled-fill);
     border-color: var(--checkable-disabled-fill);
 
-    &:after {
+    &::after {
       opacity: 0.5;
     }
   }

--- a/lib/RadioButton/RadioButton.js
+++ b/lib/RadioButton/RadioButton.js
@@ -4,7 +4,6 @@ import classNames from 'classnames';
 import uniqueId from 'lodash/uniqueId';
 import { FormattedMessage } from 'react-intl';
 
-import Icon from '../Icon';
 import Label from '../Label';
 import Asterisk from '../Label/components/Asterisk';
 import formField from '../FormField';

--- a/lib/RadioButton/RadioButton.js
+++ b/lib/RadioButton/RadioButton.js
@@ -60,7 +60,6 @@ class RadioButton extends React.Component {
       css.radioLabel,
       { [`${css[this.props.labelStyle]}`]: !this.props.labelClass && this.props.labelStyle },
       { [css.labelInteractionStyles]: !this.props.disabled },
-      { [css.labelDisabled]: this.props.disabled },
       { [css.labelFocused]: this.state.inputInFocus },
       this.props.labelClass,
     );
@@ -73,6 +72,7 @@ class RadioButton extends React.Component {
       { [`${css.hover}`]: this.props.hover },
       { [`${css.hovered}`]: (this.props.hover && this.state.inputInFocus) },
       { [`${css.fullWidth}`]: this.props.fullWidth },
+      { [`${css.disabled}`]: this.props.disabled || this.props.readOnly },
       { [`${css.marginBottom0}`]: this.props.marginBottom0 },
       { [`${css.inline}`]: this.props.inline },
       this.props.className,
@@ -188,11 +188,9 @@ class RadioButton extends React.Component {
                 {label}
                 {required && <Asterisk />}
                 {readOnly && (
-                  <Icon size="small" icon="lock">
-                    <span className="sr-only">
-                      <FormattedMessage id="stripes-components.readonly" />
-                    </span>
-                  </Icon>
+                  <span className="sr-only">
+                    <FormattedMessage id="stripes-components.readonly" />
+                  </span>
                 )}
               </span>
             )

--- a/lib/RadioButton/stories/BasicUsage.js
+++ b/lib/RadioButton/stories/BasicUsage.js
@@ -41,6 +41,12 @@ export default class BasicUsage extends React.Component {
           name: 'option',
           error: '(with error)',
         },
+        {
+          label: 'Option 6',
+          value: 'option_6',
+          name: 'option',
+          warning: '(with warning)',
+        },
       ],
     };
   }
@@ -61,6 +67,7 @@ export default class BasicUsage extends React.Component {
             disabled={option.disabled}
             readOnly={option.readOnly}
             required={option.required}
+            warning={option.warning}
           />
         )) }
         <br />

--- a/lib/variables.css
+++ b/lib/variables.css
@@ -20,6 +20,7 @@
   --shadow: 0 4px 32px rgba(0, 0, 0, 0.175);
   --bg: #fff;
   --bg-hover: color(var(--bg) contrast(100%) blend(var(--bg) 90%));
+  --checkable-disabled-fill: #808080;
   --primary: #1960a4;
   --secondary: #999;
   --error: #900;


### PR DESCRIPTION
## Ticket
https://issues.folio.org/browse/UX-371

## Changes
- Updated disabled/read-only styles for RadioButton and Checkbox
- Updated RadioButton error/warning styles to match Checkbox error/warning styles
- Removed the lock icon from read-only RadioButton and Checkbox

## Note
I had to disable the `no-descending-specificity`-rule for the CSS for both RadioButton and Checkbox. I tried making it work but it's pretty much impossible to fix the warnings unless you move CSS around in an illogical way that would do more harm than good.

## Before
![image](https://user-images.githubusercontent.com/640976/85161673-6c315b80-b260-11ea-92a8-f7b8d3540d49.png)

![image](https://user-images.githubusercontent.com/640976/85161691-75bac380-b260-11ea-8828-6e206bce1a89.png)

## After
![image](https://user-images.githubusercontent.com/640976/85161808-9e42bd80-b260-11ea-8fbc-50b171842543.png)

![image](https://user-images.githubusercontent.com/640976/85161752-8b2fed80-b260-11ea-9f38-0ae6c2cc5d3f.png)


