### PR TITLE
instanceOf(Element) added to triggerRef for Tooltip

### DIFF
--- a/lib/Tooltip/Tooltip.js
+++ b/lib/Tooltip/Tooltip.js
@@ -31,7 +31,8 @@ export default class Tooltip extends Component {
     ]).isRequired,
     triggerRef: PropTypes.oneOfType([
       PropTypes.func,
-      PropTypes.shape({ current: PropTypes.elementType })
+      PropTypes.shape({ current: PropTypes.elementType }),
+      PropTypes.shape({ current: PropTypes.instanceOf(Element) })
     ]),
   }
 


### PR DESCRIPTION
Added proptype:
`PropTypes.shape({ current: PropTypes.instanceOf(Element) })` to triggerRef in Tooltip to stop warnings showing in ERM plugin components.
--Suggested by @aditya-matukumalli 