### PR TITLE
STCOM-698: Fixed <Popover> positioning bug

### DIFF
--- a/lib/Popover/Popover.css
+++ b/lib/Popover/Popover.css
@@ -6,7 +6,7 @@
 }
 
 .popoverPop {
-  position: absolute;
+  position: fixed;
   display: inline-block;
   padding: var(--gutter-static);
   border: 1px solid var(--color-border-p2 rgba(0, 0, 0, 0.1));


### PR DESCRIPTION
## Ticket
https://issues.folio.org/browse/STCOM-698

## Notes
This bug was introduced after I updated the location and positioning of the overlay container in stripes-core. I played around with different options regarding the CSS for the overlay container but found that while it fixed the issue of the popover, it would mess up the positioning of dropdowns in the main navigation.

## Changes
Changed Popover position to fixed instead of absolute. This is tested and working. 

This is a quick fix for the bug at hand but we should consider refactoring the Popover component entirely to use the Popper component instead of custom positioning logic. This will most likely be a breaking change though.

## Before
![image](https://user-images.githubusercontent.com/640976/85542204-1fab9e80-b619-11ea-94c9-be0d20e0603d.png)

## After
![image](https://user-images.githubusercontent.com/640976/85542225-2508e900-b619-11ea-933d-616fa3244593.png)


