### PR TITLE
MultiSelect: Add `data-open` attr for ease of testing

### DIFF
--- a/lib/MultiSelection/MultiSelectResponsiveRenderer.js
+++ b/lib/MultiSelection/MultiSelectResponsiveRenderer.js
@@ -11,7 +11,7 @@ const MultiSelectResponsiveRenderer = (props) => {
     return (
       ReactDOM.createPortal(
         (
-          <div className={css.mobileBackdrop} hidden={!props.isOpen}>
+          <div className={css.mobileBackdrop} hidden={!props.isOpen} open={props.isOpen}>
             <div className={css.mobileContainer}>
               <MultiSelectOptionsList {...props} />
             </div>

--- a/lib/MultiSelection/MultiSelectResponsiveRenderer.js
+++ b/lib/MultiSelection/MultiSelectResponsiveRenderer.js
@@ -11,7 +11,7 @@ const MultiSelectResponsiveRenderer = (props) => {
     return (
       ReactDOM.createPortal(
         (
-          <div className={css.mobileBackdrop} hidden={!props.isOpen} open={props.isOpen}>
+          <div className={css.mobileBackdrop} data-open={props.isOpen} hidden={!props.isOpen}>
             <div className={css.mobileContainer}>
               <MultiSelectOptionsList {...props} />
             </div>

--- a/lib/MultiSelection/OptionsListWrapper.js
+++ b/lib/MultiSelection/OptionsListWrapper.js
@@ -13,7 +13,7 @@ const OptionsListWrapper = React.forwardRef(({
   ...props
 }, ref) => {
   if (useLegacy) {
-    return <div {...menuPropGetter({ ref })} {...props} hidden={!isOpen} open={isOpen}>{children}</div>;
+    return <div {...menuPropGetter({ ref })} {...props} data-open={props.isOpen} hidden={!isOpen}>{children}</div>;
   }
 
   const {

--- a/lib/MultiSelection/OptionsListWrapper.js
+++ b/lib/MultiSelection/OptionsListWrapper.js
@@ -13,7 +13,7 @@ const OptionsListWrapper = React.forwardRef(({
   ...props
 }, ref) => {
   if (useLegacy) {
-    return <div {...menuPropGetter({ ref })} {...props} hidden={!isOpen}>{children}</div>;
+    return <div {...menuPropGetter({ ref })} {...props} hidden={!isOpen} open={isOpen}>{children}</div>;
   }
 
   const {


### PR DESCRIPTION
Sure, this looks dumb. 

But @MikeTaylor stumbled onto [this bit of information just now](https://github.com/folio-org/stripes-testing/blob/master/doc/nightmare.md#be-careful-with-multiselection) and I gotta admit, I don't love that [we have to write `:not([hidden])` here](https://github.com/folio-org/ui-inventory/pull/828/files#diff-85c813b2a76a618951639af498e3f0c9R65).

I don't want to break existing functionality obviously, so I'm just adding this attribute to be able to write selectors in a more lexically cogent manner.