### PR TITLE
Add optional chain check on the dataOptions prop, refs STCOM-712

### DIFF
--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -207,8 +207,8 @@ class SingleSelect extends React.Component {
         }
       } else { // value not found, we just set the cursor to the first object...
         cursorObject.index = 0;
-        cursorObject.value = this.props.dataOptions[0].value;
-        cursorObject.label = this.props.dataOptions[0].label;
+        cursorObject.value = this.props.dataOptions[0]?.value;
+        cursorObject.label = this.props.dataOptions[0]?.label;
       }
       return cursorObject;
     }
@@ -273,8 +273,8 @@ class SingleSelect extends React.Component {
     if (e.target.value === '') {
       this.setState(prevState => ({
         cursoredIndex: prevState.selectedIndex || 0,
-        cursoredLabel: prevState.selectedLabel || dataOptions[0].label,
-        cursoredValue: prevState.selectedValue || dataOptions[0].value,
+        cursoredLabel: prevState.selectedLabel || dataOptions[0]?.label,
+        cursoredValue: prevState.selectedValue || dataOptions[0]?.value,
         searchTerm: '',
         renderedList: this.props.dataOptions,
         filtering: false,


### PR DESCRIPTION
`cursoredLabel` and `cursoredValue` [here](https://github.com/folio-org/stripes-components/blob/master/lib/Selection/SingleSelect.js#L276-L277) need additional checks in the scenario when the `dataOptions` prop is an empty array. If not `dataOptions[0]` would be undefined and `dataOptions[0].label` crashes the UI currently.

Added similar checks for the `cursorObject` [here](https://github.com/folio-org/stripes-components/blob/master/lib/Selection/SingleSelect.js#L210-L211) as well 

refs STCOM-712