### PR TITLE
STCOM-710: Extend `ConfirmationModal` interactor

### DIFF
--- a/lib/ConfirmationModal/tests/interactor.js
+++ b/lib/ConfirmationModal/tests/interactor.js
@@ -2,15 +2,24 @@
  * ConfirmationModal interactor
  */
 
-import { interactor, scoped, computed } from '@bigtest/interactor';
+import {
+  interactor,
+  scoped,
+  computed,
+  Interactor,
+} from '@bigtest/interactor';
 import ButtonInteractor from '../../Button/tests/interactor';
+
+import css from '../../Modal/Modal.css';
 
 const tagName = selector => computed(function () {
   return this.$(selector).tagName.toLowerCase();
 });
 
-export default interactor(class ModalFooterInteractor {
+export default interactor(class ConfirmationModalInteractor {
+  heading = new Interactor(`.${css.modalLabel}`);
+  body = new Interactor('[data-test-confirmation-modal-message]');
+  bodyTagName = tagName('[data-test-confirmation-modal-message]');
   confirmButton = scoped('[data-test-confirmation-modal-confirm-button]', ButtonInteractor);
   cancelButton = scoped('[data-test-confirmation-modal-cancel-button]', ButtonInteractor);
-  bodyTagName = tagName('[data-test-confirmation-modal-message]');
 });


### PR DESCRIPTION
## Purpose

For the sake of testing the header and body content of the confirmation modal, new fields in the `ConfirmationModal` interactor were added.

Without this change, apps can go with the code below though (ui-data-export uses this approach for now)
```
  expect(confirmationModal.$('[data-test-headline]')
  expect(confirmationModal.$('[data-test-confirmation-modal-message]')
```
but this is kind of boilerplate to repeat in apps, so it would be great to have it in the interactor here.