### PR TITLE
STCOM-719: Fix layout of inputed MultiColumnList in Accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add a utility list of language names & helper functions. Refs UIIN-829.
 * Added `<Link>`-component. Refs STCOM-699.
 * Added `lightning` icon. Refs UX-377.
+* Fix layout of inputed MultiColumnList in Accordion. Refs STCOM-719.
 
 ## 7.1.0 (IN PROGRESS)
 

--- a/lib/Accordion/Accordion.css
+++ b/lib/Accordion/Accordion.css
@@ -72,7 +72,6 @@
 .content {
   max-height: 0; /* hidden */
   overflow: hidden;
-  margin: 0 0 1em 0;
   transition: max-height 0.25s ease;
   width: 100%;
 
@@ -81,6 +80,7 @@
     min-height: 0;
     max-height: none; /* max-height applied inline */
     overflow: visible;
+    margin: 0 0 1em 0;
   }
 }
 

--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -87,10 +87,11 @@ class Accordion extends React.Component {
   componentDidMount() {
     this.syncMaxHeight();
     // fix issue with accordion not animating open if closed on mount.
-    if ((!this.state.isOpen)) {
+    if (!this.state.isOpen) {
       this.content.style.maxHeight = '0';
       this.content.style.visibility = 'hidden';
-      this.content.style.position = 'fixed';
+      this.content.style.position = 'static';
+      this.content.style.maxWidth = 'inherit';
     }
 
     if (this.props.accordionSet) {


### PR DESCRIPTION
## Description
MultiColumnList has an unneeded horizontal scroll. It happens when MCL set into Accordion which closed by default. MCL row gets width of closed Accordion content which has property `position: fixed`. So in this PR some changes to fix it
 - Margin(`margin: 0 0 1em 0`) was moved to `& expanded` selector because it needed only when Accordion is open.
 - Position was changed from `fixed` to `static`  and `max-width: inherit` to set a correct width of parent element.

## Issue
[STSMACOM-360](https://issues.folio.org/browse/STSMACOM-360)

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/55701515/87015126-a9409c00-c1d5-11ea-933e-321ec91c3823.png)

### Result
![mDf8MSrrmi](https://user-images.githubusercontent.com/55701515/87014025-32ef6a00-c1d4-11ea-95be-b4ffa8a75fef.gif)
