### PR TITLE
Rename Link -> TextLink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Increment `react-router` to `^5.2`.
 * Add a utility list of language names & helper functions. Refs UIIN-829.
-* Added `<Link>`-component. Refs STCOM-699.
+* Added `<TextLink>`-component. Refs STCOM-699.
 * Added `lightning` icon. Refs UX-377.
 * Fix layout of inputed MultiColumnList in Accordion. Refs STCOM-719.
 * Extend `getCellClass` callback with `rowData` and `column` name parameters. Introduced `getHeaderCellClass` callback prop to extend styling on the header cells. Refs STCOM-718

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Component | doc | categories
 [`<SRStatus>`](lib/SRStatus) | [doc](lib/SRStatus/readme.md) | accessibility, user-feedback
 [`<TextArea>`](lib/TextArea) | | control
 [`<TextField>`](lib/TextField) | [doc](lib/TextField/readme.md) | control
+[`<TextLink>`](lib/TextLink) | [doc](lib/TextLink/readme.md) | control
 [`<Timepicker>`](lib/Timepicker) | [doc](lib/Timepicker/readme.md) | control
 
 There are also various [utility _functions_](util) (as opposed to React components), which are [documented separately](util/README.md).

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ export { default as DateRangeWrapper } from './lib/DateRangeWrapper';
 export { default as EmptyMessage } from './lib/EmptyMessage';
 export { default as FormattedUTCDate } from './lib/FormattedUTCDate';
 export { default as Label } from './lib/Label';
-export { default as Link } from './lib/Link';
+export { default as TextLink } from './lib/TextLink';
 export { Loading, LoadingPane, LoadingView } from './lib/Loading';
 export { default as RadioButton } from './lib/RadioButton';
 export { default as RadioButtonGroup } from './lib/RadioButtonGroup';

--- a/lib/Link/index.js
+++ b/lib/Link/index.js
@@ -1,1 +1,0 @@
-export { default } from './Link';

--- a/lib/TextLink/TextLink.css
+++ b/lib/TextLink/TextLink.css
@@ -1,5 +1,5 @@
 /**
- * Link
+ * TextLink
  */
 
 @import '../variables.css';
@@ -66,7 +66,7 @@
     display: inline-block;
 
     /* Prevents double underline */
-    &:not(:active) {
+    &:not(:active):not(:hover) {
       text-decoration: none;
     }
 

--- a/lib/TextLink/TextLink.js
+++ b/lib/TextLink/TextLink.js
@@ -1,15 +1,15 @@
 /**
- * Link
+ * TextLink
  */
 
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import classnames from 'classnames';
-import css from './Link.css';
+import css from './TextLink.css';
 
-const Link = forwardRef(({ className, href, to, children, ...rest }, ref) => {
-  const Element = to ? RouterLink : 'a';
+const TextLink = forwardRef(({ className, href, to, children, ...rest }, ref) => {
+  const Element = to ? Link : 'a';
 
   const props = {
     className: classnames(css.root, className),
@@ -19,19 +19,19 @@ const Link = forwardRef(({ className, href, to, children, ...rest }, ref) => {
   };
 
   return (
-    <Element data-test-link {...props} ref={ref}>
+    <Element data-test-text-link {...props} ref={ref}>
       {children}
     </Element>
   );
 });
 
-Link.propTypes = {
+TextLink.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   href: PropTypes.string,
   to: PropTypes.string,
 };
 
-Link.displayName = 'Link';
+TextLink.displayName = 'TextLink';
 
-export default Link;
+export default TextLink;

--- a/lib/TextLink/index.js
+++ b/lib/TextLink/index.js
@@ -1,0 +1,1 @@
+export { default } from './TextLink';

--- a/lib/TextLink/readme.md
+++ b/lib/TextLink/readme.md
@@ -1,17 +1,17 @@
-# Link
-A replacement for the native `<a>` and the react-router-dom `<Link>`-component with a11y friendly interaction styles.
+# TextLink
+A replacement for the native `<a>` and the react-router-dom `<TextLink>`-component with a11y friendly interaction styles.
 
 ## Usage
 ```js
-import { Link } from '@folio/stripes/components';
+import { TextLink } from '@folio/stripes/components';
 
-<Link to="/users">
+<TextLink to="/users">
   I'm an internal link
-</Link>
+</TextLink>
 
-<Link target="_blank" rel="noopener noreferrer" href="https://folio.org">
+<TextLink target="_blank" rel="noopener noreferrer" href="https://folio.org">
   I'm an external link
-</Link>
+</TextLink>
 ```
 
 ## Props

--- a/lib/TextLink/stories/BasicUsage.js
+++ b/lib/TextLink/stories/BasicUsage.js
@@ -1,28 +1,29 @@
 /**
- * Link: Basic Usage
+ * TextLink: Basic Usage
  */
 
 import React from 'react';
 import { HashRouter } from 'react-router-dom';
 import Icon from '../../Icon';
 import Tooltip from '../../Tooltip';
-import Link from '../Link';
+import TextLink from '../TextLink';
 
 const BasicUsage = () => (
   <HashRouter>
-    Lorem ipsum dolor sit amet, <Link to="#/some-page">consectetur adipiscing elit</Link>. Mauris nec elementum quam.
+    Lorem ipsum dolor sit amet,{' '}
+    <TextLink to="/some-page">consectetur adipiscing elit</TextLink>. Mauris nec elementum quam.
     <br /><br />
-    <Link target="_blank" rel="noopener noreferrer" href="https://folio.org">
+    <TextLink target="_blank" rel="noopener noreferrer" href="https://folio.org">
       <Icon icon="external-link" iconPosition="end">
           This is an external link
       </Icon>
-    </Link>
+    </TextLink>
     <br /><br />
     <div style={{ width: 300 }}>
-      <Link href="#some-hash">
+      <TextLink href="#some-hash">
         This is a multiline link. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris nec elementum quam.
         Aliquam porta sapien dolor, vel gravida risus condimentum et. Nam eget elit purus.
-      </Link>
+      </TextLink>
     </div>
     <br /><br />
     <Tooltip
@@ -30,13 +31,13 @@ const BasicUsage = () => (
       id="link-tooltip"
     >
       {({ ref, ariaIds }) => (
-        <Link
+        <TextLink
           to="/some-page"
           ref={ref}
           aria-labelledby={ariaIds.text}
         >
           With tooltip
-        </Link>
+        </TextLink>
       )}
     </Tooltip>
   </HashRouter>

--- a/lib/TextLink/stories/TextLink.stories.js
+++ b/lib/TextLink/stories/TextLink.stories.js
@@ -4,6 +4,6 @@ import withReadme from 'storybook-readme/with-readme';
 import readme from '../readme.md';
 import BasicUsage from './BasicUsage';
 
-storiesOf('Link', module)
+storiesOf('TextLink', module)
   .addDecorator(withReadme(readme))
   .add('Basic Usage', () => <BasicUsage />);

--- a/lib/TextLink/tests/TextLink-test.js
+++ b/lib/TextLink/tests/TextLink-test.js
@@ -1,5 +1,5 @@
 /**
- * Link -> tests
+ * TextLink -> tests
  */
 
 import React from 'react';
@@ -8,36 +8,36 @@ import { HashRouter } from 'react-router-dom';
 import { expect } from 'chai';
 import { mount } from '../../../tests/helpers';
 
-import LinkInteractor from './interactor';
-import Link from '../Link';
+import TextLinkInteractor from './interactor';
+import TextLink from '../TextLink';
 
-describe('Link', () => {
-  const link = new LinkInteractor();
+describe('TextLink', () => {
+  const textLink = new TextLinkInteractor();
 
   beforeEach(async () => {
     await mount(
-      <Link
+      <TextLink
         id="some-id"
         href="/hello-world"
       >
-        Link
-      </Link>
+        TextLink
+      </TextLink>
     );
   });
 
   it('Should have an ID', () => {
-    expect(link.id).to.equal('some-id');
+    expect(textLink.id).to.equal('some-id');
   });
 
   describe('If rendered with a "href"-prop', () => {
     beforeEach(async () => {
       await mount(
-        <Link href="/hello-world">Link</Link>
+        <TextLink href="/hello-world">TextLink</TextLink>
       );
     });
 
     it('Should render a native anchor tag', () => {
-      expect(link.tagName).to.equal('a');
+      expect(textLink.tagName).to.equal('a');
     });
   });
 
@@ -45,13 +45,13 @@ describe('Link', () => {
     beforeEach(async () => {
       await mount(
         <HashRouter>
-          <Link to="/hello-world">Link</Link>
+          <TextLink to="/hello-world">TextLink</TextLink>
         </HashRouter>
       );
     });
 
     it('Should render a native anchor tag', () => {
-      expect(link.tagName).to.equal('a');
+      expect(textLink.tagName).to.equal('a');
     });
   });
 });

--- a/lib/TextLink/tests/interactor.js
+++ b/lib/TextLink/tests/interactor.js
@@ -15,7 +15,7 @@ function tagName(selector) {
 }
 
 export default interactor(class LinkInteractor {
-  static defaultScope = '[data-test-link]';
+  static defaultScope = '[data-test-text-link]';
 
   id = attribute('id');
   tagName = tagName();


### PR DESCRIPTION
Because of potential name conflicts with the react-router-dom `<Link>`-component, we decided to rename our own link component to `<TextLink>`.