### PR TITLE
STCOM-720 Avoid a11y error on AutoSuggest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ## 7.1.0 (IN PROGRESS)
 
+* Avoid `ARIA attributes must conform to valid values` error on AutoSuggest field. Refs STCOM-720.
 * Export currency options as a hook. Addition to STCOM-614.
 * Provide `<CountrySelection>`. Fixes STCOM-291.
 * Localize currency names in `<CurrencySelect>`. Fixes STCOM-614.

--- a/lib/AutoSuggest/AutoSuggest.js
+++ b/lib/AutoSuggest/AutoSuggest.js
@@ -129,7 +129,8 @@ class AutoSuggest extends React.Component {
           isOpen,
           inputValue,
         }) => (
-          <div className={css.downshift} data-test-autosuggest>
+          // eslint-disable-next-line jsx-a11y/aria-proptypes
+          <div className={css.downshift} data-test-autosuggest aria-labelledby={undefined}>
             <TetherComponent {...mergedTetherProps}>
               <div
                 className={css.textFieldDiv}
@@ -137,13 +138,16 @@ class AutoSuggest extends React.Component {
                 aria-live="assertive"
                 aria-relevant="additions"
               >
-                <TextField {...getInputProps(
-                  {
-                    ...inputProps,
-                    onBlur,
-                    onFocus
-                  }
-                )}
+                <TextField
+                  {...getInputProps(
+                    {
+                      ...inputProps,
+                      onBlur,
+                      onFocus
+                    }
+                  )}
+                  // eslint-disable-next-line jsx-a11y/aria-proptypes
+                  aria-labelledby={undefined}
                 />
               </div>
               <ul


### PR DESCRIPTION
The root cause is that `Downshift` provides wrong `aria-labelledby` attributes. At the same time we pass `label` to the `AutoSuggest`, and it works well with used textfield.
https://issues.folio.org/browse/STCOM-720