### PR TITLE
disable SearchField if loading is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ## 7.1.0 (IN PROGRESS)
 
+* Disable `SearchField` interactions if `loading` is true
 * Avoid `ARIA attributes must conform to valid values` error on AutoSuggest field. Refs STCOM-720.
 * Export currency options as a hook. Addition to STCOM-614.
 * Provide `<CountrySelection>`. Fixes STCOM-291.

--- a/lib/SearchField/SearchField.js
+++ b/lib/SearchField/SearchField.js
@@ -72,6 +72,7 @@ const SearchField = (props) => {
       <Select
         aria-label={indexLabel}
         dataOptions={searchableIndexes}
+        disabled={loading}
         id={`${id}-qindex`}
         marginBottom0
         onChange={onChangeIndex}
@@ -106,6 +107,7 @@ const SearchField = (props) => {
         {...rest}
         aria-label={rest['aria-label'] || ariaLabel}
         clearFieldId={clearSearchId}
+        disabled={loading}
         focusedClass={css.isFocused}
         id={id}
         hasClearIcon={typeof onClear === 'function' && loading !== true}
@@ -123,5 +125,8 @@ const SearchField = (props) => {
 };
 
 SearchField.propTypes = propTypes;
+SearchField.defaultProps = {
+  loading: false,
+};
 
 export default SearchField;

--- a/lib/SearchField/tests/SearchField-test.js
+++ b/lib/SearchField/tests/SearchField-test.js
@@ -45,6 +45,23 @@ describe('SearchField', () => {
         expect(fieldValue).to.equal('testing text');
       });
     });
+
+    describe('rendering a SearchField in loading state', () => {
+      beforeEach(async () => {
+        await mountWithContext(
+          <SearchField
+            id="searchFieldTest"
+            loading
+            searchableIndexes={[{ label: 'ID', value: 'id' }]}
+          />
+        );
+      });
+
+      it('input and select are disabled', () => {
+        expect(searchField.isDisabled).to.be.true;
+        expect(searchField.isDisabledIndex).to.be.true;
+      });
+    });
   });
 
   describe('using with indexes', () => {
@@ -84,6 +101,11 @@ describe('SearchField', () => {
       await mountWithContext(
         <SearchFieldHarness />
       );
+    });
+
+    it('input and select are not disabled', () => {
+      expect(searchField.isDisabled).to.be.false;
+      expect(searchField.isDisabledIndex).to.be.false;
     });
 
     describe('changing the index', () => {

--- a/lib/SearchField/tests/interactor.js
+++ b/lib/SearchField/tests/interactor.js
@@ -2,6 +2,7 @@ import {
   attribute,
   fillable,
   interactor,
+  property,
   selectable
 } from '@bigtest/interactor';
 
@@ -10,4 +11,6 @@ export default interactor(class SearchFieldInteractor {
   fillInput = fillable('input');
   selectIndex = selectable('select');
   placeholder = attribute('input', 'placeholder');
+  isDisabled = property('input', 'disabled');
+  isDisabledIndex = property('select', 'disabled');
 });


### PR DESCRIPTION
@JohnC-80 recently I discovered that user can hit search with some filter entered, but search might take time. So user clears the filter, clicks search again, some results are returned, but first one response comes after and rewrites results with the previous search. So maybe it's a good idea to disable fields until previous request is fulfilled, what do you think?