### PR TITLE
STCOM-725 Support AutoSuggest field in react-final-form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Increase test coverage to 80% | Editor. Refs STCOM-660.
 * Increase test coverage to 80% | FilterPaneSearch. Refs STCOM-689.
 * Datepicker refactor: numerous fixes in accessibility, internationalization, usability. Addresses STCOM-325, STCOM-606, STCOM-684, STCOM-640, STCOM-577, STCOM-315, STCOM-653, STCOM-639, STCOM-470, STCOM-641.
+* Support AutoSuggest field in react-final-form. Refs STCOM-725
 
 ## 7.1.0 (IN PROGRESS)
 

--- a/lib/AutoSuggest/AutoSuggest.js
+++ b/lib/AutoSuggest/AutoSuggest.js
@@ -52,6 +52,7 @@ const propTypes = {
   validationEnabled: PropTypes.bool,
   value: PropTypes.string,
   valueKey: PropTypes.string,
+  withFinalForm: PropTypes.bool,
 };
 
 class AutoSuggest extends React.Component {
@@ -91,6 +92,7 @@ class AutoSuggest extends React.Component {
       validationEnabled,
       value,
       valueKey,
+      withFinalForm,
     } = this.props;
 
     const mergedTetherProps = { ...AutoSuggest.defaultProps.tether, ...tether };
@@ -115,7 +117,8 @@ class AutoSuggest extends React.Component {
         style={{ display: 'inline-block', position: 'relative' }}
         itemToString={renderValue}
         onChange={selectedItem => onChange(selectedItem[valueKey])}
-        onStateChange={({ inputValue }) => onChange(inputValue)}
+        onStateChange={withFinalForm ? undefined : ({ inputValue }) => onChange(inputValue)}
+        onInputValueChange={withFinalForm ? (inputValue) => onChange(inputValue) : undefined}
         selectedItem={value}
         inputValue={value}
         onSelect={onSelect}

--- a/lib/AutoSuggest/readme.md
+++ b/lib/AutoSuggest/readme.md
@@ -18,3 +18,4 @@ onChange | Callback called when the value changes | |
 renderOption | Callback that renders the item in the dropdown | `item => item.value` |
 renderValue | Callback that render the item in the input field | `item => item.value` |
 valueKey | The key in the item object to use as the value. | `"value"`
+withFinalForm | toggle form time: true - final-form, false - redux-from (default) | |


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-725

onStateChange is used for redux-from and onInputChange for final-form