### PR TITLE
STCOM-726: Create/Edit User Record: Multi-select custom field does not have a label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Increase test coverage to 80% | Editor. Refs STCOM-660.
 * Increase test coverage to 80% | FilterPaneSearch. Refs STCOM-689.
 * Datepicker refactor: numerous fixes in accessibility, internationalization, usability. Addresses STCOM-325, STCOM-606, STCOM-684, STCOM-640, STCOM-577, STCOM-315, STCOM-653, STCOM-639, STCOM-470, STCOM-641.
+* Fix missing label for MultiSelection hidden value input element. Refs STCOM-726.
 
 ## 7.1.0 (IN PROGRESS)
 

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -390,7 +390,7 @@ class MultiSelection extends React.Component {
             };
 
             const inputProps = {
-              ariaLabelledBy,
+              ariaLabelledBy: `${uiId}-label`,
               id: `multiselect-input-${uiId}`,
               required,
               getInputProps,


### PR DESCRIPTION
## Purpose
- Set correct label for MultiSelection's hidden value input so it no longer violates accessibility guidelines

## Issue
(STCOM-726)[https://issues.folio.org/browse/STCOM-726]