### PR TITLE
STCOM-727: Extend `Pane` interactor with `header`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Increment `react-router` to `^5.2`.
 * Add a utility list of language names & helper functions. Refs UIIN-829.
 * Added `<TextLink>`-component. Refs STCOM-699.
+* Extend `ConfirmationModal` interactor. STCOM-710.
 * Added `lightning` icon. Refs UX-377.
 * Fix layout of inputed MultiColumnList in Accordion. Refs STCOM-719.
 * Added focus-within styles for `<Pane>`. Refs STCOM-477.
@@ -14,6 +15,7 @@
 * Increase test coverage to 80% | FilterPaneSearch. Refs STCOM-689.
 * Datepicker refactor: numerous fixes in accessibility, internationalization, usability. Addresses STCOM-325, STCOM-606, STCOM-684, STCOM-640, STCOM-577, STCOM-315, STCOM-653, STCOM-639, STCOM-470, STCOM-641.
 * Support AutoSuggest field in react-final-form. Refs STCOM-725
+* Extend `Pane` interactor with `header` field. STCOM-727.
 
 ## 7.1.0 (IN PROGRESS)
 

--- a/lib/Pane/tests/Pane-test.js
+++ b/lib/Pane/tests/Pane-test.js
@@ -11,18 +11,34 @@ import Pane from '../Pane';
 import PaneInteractor from './interactor';
 
 describe('Pane', () => {
-  const pane = new PaneInteractor();
+  describe('General usage', () => {
+    const pane = new PaneInteractor();
+    const title = 'title';
+    const subTitle = 'subTitle';
 
-  beforeEach(async () => {
-    await mountWithContext(
-      <Paneset>
-        <Pane defaultWidth="fill" />
-      </Paneset>
-    );
-  });
+    beforeEach(async () => {
+      await mountWithContext(
+        <Paneset>
+          <Pane
+            defaultWidth="fill"
+            paneTitle={title}
+            paneSub={subTitle}
+          />
+        </Paneset>
+      );
+    });
 
-  it('renders the pane', () => {
-    expect(pane.isPresent).to.be.true;
+    it('renders the pane', () => {
+      expect(pane.isPresent).to.be.true;
+    });
+
+    it('should have correct header title', () => {
+      expect(pane.header.title).to.equal(title);
+    });
+
+    it('should have correct header sub title', () => {
+      expect(pane.header.sub).to.equal(subTitle);
+    });
   });
 
   describe('Dismissible pane', () => {

--- a/lib/Pane/tests/interactor.js
+++ b/lib/Pane/tests/interactor.js
@@ -4,14 +4,17 @@ import {
   scoped,
 } from '@bigtest/interactor';
 
+import PaneHeaderInteractor from '../../PaneHeader/tests/interactor';
 import { computedStyle } from '../../../tests/helpers';
 
 import css from '../Pane.css';
 
 export default interactor(class PaneInteractor {
   static defaultScope = `.${css.pane}`;
+
   computedWidth = computedStyle(this.$element, 'width')
   style = attribute('style');
   dismissButton = scoped('[data-test-pane-header-dismiss-button]');
   content = attribute(`${css.paneContent}`, 'style');
+  header = new PaneHeaderInteractor();
 });


### PR DESCRIPTION
## Purpose

Extend `Pane` interactor with `header` field in the scope of the [STCOM-727](https://issues.folio.org/browse/STCOM-727).