### PR TITLE
STCOM-727: Use `scoped` for `header` field in `Pane` interactor

### DIFF
--- a/lib/Pane/tests/interactor.js
+++ b/lib/Pane/tests/interactor.js
@@ -16,5 +16,5 @@ export default interactor(class PaneInteractor {
   style = attribute('style');
   dismissButton = scoped('[data-test-pane-header-dismiss-button]');
   content = attribute(`${css.paneContent}`, 'style');
-  header = new PaneHeaderInteractor();
+  header = scoped('[data-test-pane-header]', PaneHeaderInteractor);
 });


### PR DESCRIPTION
## Purpose

Use `scoped` for `header` field in `Pane` interactor for correctness in case of multiple instances in the scope of the [STCOM-727](https://issues.folio.org/browse/STCOM-727). Extends the work of #1353.