### PR TITLE
STCOM-730: SearchField | Field cannot be disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Support AutoSuggest field in react-final-form. Refs STCOM-725
 * Extend `Pane` interactor with `header` field. STCOM-727.
 * Fix missing label for MultiSelection hidden value input element. Refs STCOM-726.
+* Fix `<SearchField>` component cannot be disabled. Refs STCOM-730.
 
 ## 7.1.0 (IN PROGRESS)
 

--- a/lib/SearchField/SearchField.js
+++ b/lib/SearchField/SearchField.js
@@ -19,6 +19,7 @@ const propTypes = {
   ariaLabel: PropTypes.string,
   className: PropTypes.string,
   clearSearchId: PropTypes.string,
+  disabled: PropTypes.bool,
   id: PropTypes.string,
   inputClass: PropTypes.string,
   inputRef: PropTypes.object,
@@ -55,6 +56,7 @@ const SearchField = (props) => {
     selectedIndex,
     searchableIndexesPlaceholder,
     inputClass,
+    disabled,
     ...rest
   } = props;
 
@@ -107,7 +109,7 @@ const SearchField = (props) => {
         {...rest}
         aria-label={rest['aria-label'] || ariaLabel}
         clearFieldId={clearSearchId}
-        disabled={loading}
+        disabled={disabled || loading}
         focusedClass={css.isFocused}
         id={id}
         hasClearIcon={typeof onClear === 'function' && loading !== true}


### PR DESCRIPTION
## Purpose
- SearchField component ignores `disabled` prop. Previously `disabled` prop was passed to the input by destructuring `rest` props. Recently there's been an update which added `loading` prop that overrides `disabled`
