### PR TITLE
Share nativeChangeFieldValue utility function between components

### DIFF
--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -8,6 +8,7 @@ import contains from 'dom-helpers/query/contains';
 import uniqueId from 'lodash/uniqueId';
 import pick from 'lodash/pick';
 import RootCloseWrapper from '../../util/RootCloseWrapper';
+import nativeChangeField from '../../util/nativeChangeFieldValue';
 import formField from '../FormField';
 import Popper, { AVAILABLE_PLACEMENTS } from '../Popper';
 import IconButton from '../IconButton';
@@ -22,22 +23,6 @@ export function getMomentLocalizedFormat(intl) {
   const format = moment.localeData()._longDateFormat.L;
   return format;
 }
-
-// Programmatically change a field value and trigger the onChange event so that external state can be updated...
-const nativeChangeField = (inputRef, focus, value = '', triggerChange = true) => {
-  if (inputRef.current) {
-    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
-    nativeInputValueSetter.call(inputRef.current, value);
-
-    if (triggerChange) {
-      const ev = new Event('change', { bubbles: true });
-      inputRef.current.dispatchEvent(ev);
-      if (focus) {
-        inputRef.current.focus();
-      }
-    }
-  }
-};
 
 // Returns a localized format.
 export const getLocalFormat = ({ intl }) => {

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 
 import formField from '../FormField';
 import Label from '../Label';
+import nativeChangeField from '../../util/nativeChangeFieldValue';
 import TextFieldIcon from './TextFieldIcon';
 import css from './TextField.css';
 import formStyles from '../sharedStyles/form.css';
@@ -164,6 +165,7 @@ class TextField extends Component {
     hasClearIcon: true,
     type: 'text',
     validationEnabled: true,
+    autoComplete: 'off',
     value: ''
   };
 
@@ -276,12 +278,7 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
 
     // Clear value on input natively, dispatch an event to be picked up by handleChange, and focus on input again
     if (this.input.current) {
-      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
-      nativeInputValueSetter.call(this.input.current, '');
-
-      const ev = new Event('change', { bubbles: true });
-      this.input.current.dispatchEvent(ev);
-      this.input.current.focus();
+      nativeChangeField(this.input, true, '');
     }
   }
 

--- a/util/nativeChangeFieldValue.js
+++ b/util/nativeChangeFieldValue.js
@@ -1,0 +1,21 @@
+/* Programmatically change a field value and trigger the onChange event so that external state can be updated...
+*  input ref - reference object
+*  focus - boolean - send focus to the field after clearing.
+*  value - new value for the field.
+*  triggerChange - defaults true - whether or not to trigger the change event.
+*/
+
+export default (inputRef, focus, value = '', triggerChange = true) => {
+  if (inputRef.current) {
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+    nativeInputValueSetter.call(inputRef.current, value);
+
+    if (triggerChange) {
+      const ev = new Event('change', { bubbles: true });
+      inputRef.current.dispatchEvent(ev);
+      if (focus) {
+        inputRef.current.focus();
+      }
+    }
+  }
+};


### PR DESCRIPTION
## In this PR
A tiny bit of cleanup since both TextField and Datepicker manipulate the value of their rendered HTML Input in the same way. 
Additionally: setting autocomplete to 'off' by default on TextField in the hopes that it will resolve some automatic re-filling that we're seeing on iOS.