### PR TITLE
Use input and manually adjust state for clearing TextField

### DIFF
--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -279,6 +279,9 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
     // Clear value on input natively, dispatch an event to be picked up by handleChange, and focus on input again
     if (this.input.current) {
       nativeChangeField(this.input, true, '');
+      if (this.state.value !== '') {
+        this.setState({ value: '' });
+      }
     }
   }
 

--- a/util/nativeChangeFieldValue.js
+++ b/util/nativeChangeFieldValue.js
@@ -11,7 +11,7 @@ export default (inputRef, focus, value = '', triggerChange = true) => {
     nativeInputValueSetter.call(inputRef.current, value);
 
     if (triggerChange) {
-      const ev = new Event('change', { bubbles: true });
+      const ev = new Event('input', { bubbles: true });
       inputRef.current.dispatchEvent(ev);
       if (focus) {
         inputRef.current.focus();


### PR DESCRIPTION
More efforts to get TextField clearing on iOS... 
This time we update TextField's internal state and use the `input` event vs `onChange`.