### PR TITLE
Fixed <SRStatus> issue on Mac screen readers

### DIFF
--- a/lib/SRStatus/SRStatus.js
+++ b/lib/SRStatus/SRStatus.js
@@ -20,6 +20,7 @@ class SRStatus extends React.Component {
     this.startUpdateTimer = this.startUpdateTimer.bind(this);
     this.state = {
       updates: [],
+      element: 'div'
     };
   }
 
@@ -62,16 +63,25 @@ class SRStatus extends React.Component {
 
   allowRepeatMessage() {
     this.willUpdateRepeats = true;
-    // this.setState({ updates: [] }, () => { this.forceUpdate(); });
+    this.setState(({ element }) => ({
+      updates: [],
+      // Changing the HTML element of the aria-live region after each announcement
+      // enables the Mac screen reader to repeat the same message twice if needed.
+      // Without this, the message will only be read once which can be problematic when used in e.g. a form validation.
+      element: element === 'div' ? 'span' : 'div'
+    }), () => {
+      this.forceUpdate();
+    });
   }
 
   render() {
     const { ariaLive, ...rest } = this.props;
+    const { element: Element } = this.state;
 
     return (
-      <div aria-live={rest['aria-live'] || ariaLive} aria-relevant="additions" className="sr-only">
+      <Element aria-live={rest['aria-live'] || ariaLive} aria-relevant="additions" className="sr-only">
         {this.state.updates}
-      </div>
+      </Element>
     );
   }
 }


### PR DESCRIPTION
I originally noticed a bug in NVDA/JAWS that caused messages from being read out multiple times because they were being appended and never reset.

Once I fixed this, I noticed that the Mac screen reader did not announce the same message twice. I did some research and found out that it was possible to force this by switching between two aria-live region elements or by changing the root element of the aria-live region which forces a rerender and the Mac screen reader recognizes it as a newly inserted element.

This fixes the issue on the Mac screen reader while fixing the incremental announcement bug in NVDA/JAWS. Tested and working in all 3 screen readers.