### PR TITLE
STRIPES-693 Datepicker functionality iOS.

### DIFF
--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -52,7 +52,7 @@ function getCalendar(year, month) {
 function getMonths(intl) {
   const months = [];
   for (let i = 1; i <= 12; i++) {
-    months.push(intl.formatDateToParts(`${i}-01-${new Date().getFullYear()}`, { month: 'long' })[0].value);
+    months.push(intl.formatDateToParts(`${i}/01/${new Date().getFullYear()}`, { month: 'long' })[0].value);
   }
   return months;
 }
@@ -60,7 +60,7 @@ function getMonths(intl) {
 function getWeekDays(intl) {
   const weekDays = [];
   for (let i = 1; i <= 7; i++) {
-    weekDays.push(intl.formatDateToParts(`03-0${i}-${new Date().getFullYear()}`, { weekday: 'short' })[0].value);
+    weekDays.push(intl.formatDateToParts(`03/0${i}/${new Date().getFullYear()}`, { weekday: 'short' })[0].value);
   }
   return weekDays;
 }


### PR DESCRIPTION
Switch from hyphens to slashes in sample string for months and weekdays.

As we've seen in other stories, it's the formatting separator you feed it that makes all the difference.