### PR TITLE
[STCOM-742]  Select: missing required attribute after passing required property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
 * Extend `Pane` interactor with `header` field. STCOM-727.
 * Fix missing label for MultiSelection hidden value input element. Refs STCOM-726.
 * Fix `<SearchField>` component cannot be disabled. Refs STCOM-730.
-* Fix `<Select>` component ignoring `required` property. Refs STCOM-742.
 
 ## 7.1.0 (IN PROGRESS)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Extend `Pane` interactor with `header` field. STCOM-727.
 * Fix missing label for MultiSelection hidden value input element. Refs STCOM-726.
 * Fix `<SearchField>` component cannot be disabled. Refs STCOM-730.
+* Fix `<Select>` component ignoring `required` property. Refs STCOM-742.
 
 ## 7.1.0 (IN PROGRESS)
 

--- a/lib/Select/Select.js
+++ b/lib/Select/Select.js
@@ -144,8 +144,10 @@ class Select extends Component {
         {...omitProps(selectCustom, ['selectClass', 'aria-labelledby', 'aria-label'])}
         aria-labelledby={this.getAriaLabelledBy()}
         aria-invalid={!!this.props.error}
+        aria-required={required}
         id={this.id}
         readOnly={this.props.readOnly}
+        required={required}
       >
         {options}
         {

--- a/lib/Select/Select.js
+++ b/lib/Select/Select.js
@@ -144,10 +144,8 @@ class Select extends Component {
         {...omitProps(selectCustom, ['selectClass', 'aria-labelledby', 'aria-label'])}
         aria-labelledby={this.getAriaLabelledBy()}
         aria-invalid={!!this.props.error}
-        aria-required={required}
         id={this.id}
         readOnly={this.props.readOnly}
-        required={required}
       >
         {options}
         {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "tai-password-strength": "^1.1.1"
   },
   "peerDependencies": {
-    "react-intl": "^5.7.1",
+    "react-intl": "^4.5.1",
     "react-router-dom": "^5.2.0"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "tai-password-strength": "^1.1.1"
   },
   "peerDependencies": {
-    "react-intl": "^4.5.1",
+    "react-intl": "^5.7.1",
     "react-router-dom": "^5.2.0"
   },
   "resolutions": {


### PR DESCRIPTION
[[STCOM-742]](https://issues.folio.org/browse/STCOM-742)  Select: missing required attribute after passing required property

## Purpose

Fix `Select` component ignoring  passed `required` property