### PR TITLE
STCOM-659 provide FormattedDate, FormattedTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fix `<SearchField>` component cannot be disabled. Refs STCOM-730.
 * Fix `<Select>` component ignoring `required` property. Refs STCOM-742.
 * Added `aria-hidden` attribute to `<Asterisk>` to prevent screen readers from reading it. Refs STCOM-741.
+* Provide `<FormattedDate>` and `<FormattedTime>` to handle dates without properly formatted timezones. Refs STCOM-659.
 
 ## 7.1.0 (IN PROGRESS)
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ export { default as CurrencySelect } from './lib/CurrencySelect';
 export { default as CountrySelection } from './lib/CountrySelection';
 export { default as Datepicker, Calendar } from './lib/Datepicker';
 export { default as DateRangeWrapper } from './lib/DateRangeWrapper';
+export { default as FormattedDate } from './lib/FormattedDate';
+export { default as FormattedTime } from './lib/FormattedTime';
 export { default as EmptyMessage } from './lib/EmptyMessage';
 export { default as FormattedUTCDate } from './lib/FormattedUTCDate';
 export { default as Label } from './lib/Label';

--- a/lib/FormattedDate/FormattedDate.js
+++ b/lib/FormattedDate/FormattedDate.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedDate as FT } from 'react-intl';
+import { FormattedDate as FD } from 'react-intl';
 import iso8601Timestamp from '../../util/iso8601Timestamp';
 
 /**

--- a/lib/FormattedDate/FormattedDate.js
+++ b/lib/FormattedDate/FormattedDate.js
@@ -25,7 +25,7 @@ import iso8601Timestamp from '../../util/iso8601Timestamp';
 const FormattedDate = props => {
   const { value, ...rest } = props;
   const tweakedValue = iso8601Timestamp(value);
-  return <FT value={tweakedValue} {...rest} />;
+  return <FD value={tweakedValue} {...rest} />;
 };
 
 FormattedDate.propTypes = {

--- a/lib/FormattedDate/FormattedDate.js
+++ b/lib/FormattedDate/FormattedDate.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { FormattedDate as FT } from 'react-intl';
 import iso8601Timestamp from '../../util/iso8601Timestamp';
 
@@ -25,6 +26,10 @@ const FormattedDate = props => {
   const { value, ...rest } = props;
   const tweakedValue = iso8601Timestamp(value);
   return <FT value={tweakedValue} {...rest} />;
+};
+
+FormattedDate.propTypes = {
+  value: PropTypes.string.isRequired,
 };
 
 export default FormattedDate;

--- a/lib/FormattedDate/FormattedDate.js
+++ b/lib/FormattedDate/FormattedDate.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { FormattedDate as FT } from 'react-intl';
+import iso8601Timestamp from '../../util/iso8601Timestamp';
+
+/**
+ * Take a date-string formatted like
+ *     2020-03-24T17:59:57.369+0000
+ * and reformat it like
+ *     2020-03-24T17:59:57.369+00:00
+ * because ISO-8601 is ambiguous about the timezone format and the W3C, in
+ * its infinite wisdom, thought that instead of handling the full slate
+ * of formats it would be better to restrict the list of formats to a small
+ * number. Sadly, so so sadly, our backend modules return timestamp strings
+ * in the one ISO-8601 compliant format that the W3C decided not to implement,
+ * so we have to tweak those values in order for react-intl to recognize them
+ * and format them.
+ *
+ * It turns out that Chrome will usually handle timestamp strings without the
+ * colon, but not on iOS. Ditto for Firefox. Safari always chokes on them.
+ *
+ * @see https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC
+ * @see https://www.w3.org/TR/NOTE-datetime
+ */
+const FormattedDate = props => {
+  const { value, ...rest } = props;
+  const tweakedValue = iso8601Timestamp(value);
+  return <FT value={tweakedValue} {...rest} />;
+};
+
+export default FormattedDate;

--- a/lib/FormattedDate/index.js
+++ b/lib/FormattedDate/index.js
@@ -1,0 +1,1 @@
+export { default } from './FormattedDate';

--- a/lib/FormattedTime/FormattedTime.js
+++ b/lib/FormattedTime/FormattedTime.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { FormattedTime as FT } from 'react-intl';
 import iso8601Timestamp from '../../util/iso8601Timestamp';
 
@@ -25,6 +26,10 @@ const FormattedTime = props => {
   const { value, ...rest } = props;
   const tweakedValue = iso8601Timestamp(value);
   return <FT value={tweakedValue} {...rest} />;
+};
+
+FormattedTime.propTypes = {
+  value: PropTypes.string.isRequired,
 };
 
 export default FormattedTime;

--- a/lib/FormattedTime/FormattedTime.js
+++ b/lib/FormattedTime/FormattedTime.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { FormattedTime as FT } from 'react-intl';
+import iso8601Timestamp from '../../util/iso8601Timestamp';
+
+/**
+ * Take a date-string formatted like
+ *     2020-03-24T17:59:57.369+0000
+ * and reformat it like
+ *     2020-03-24T17:59:57.369+00:00
+ * because ISO-8601 is ambiguous about the timezone format and the W3C, in
+ * its infinite wisdom, thought that instead of handling the full slate
+ * of formats it would be better to restrict the list of formats to a small
+ * number. Sadly, so so sadly, our backend modules return timestamp strings
+ * in the one ISO-8601 compliant format that the W3C decided not to implement,
+ * so we have to tweak those values in order for react-intl to recognize them
+ * and format them.
+ *
+ * It turns out that Chrome will usually handle timestamp strings without the
+ * colon, but not on iOS. Ditto for Firefox. Safari always chokes on them.
+ *
+ * @see https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC
+ * @see https://www.w3.org/TR/NOTE-datetime
+ */
+const FormattedTime = props => {
+  const { value, ...rest } = props;
+  const tweakedValue = iso8601Timestamp(value);
+  return <FT value={tweakedValue} {...rest} />;
+};
+
+export default FormattedTime;

--- a/lib/FormattedTime/index.js
+++ b/lib/FormattedTime/index.js
@@ -1,0 +1,1 @@
+export { default } from './FormattedTime';

--- a/util/iso8601Timestamp.js
+++ b/util/iso8601Timestamp.js
@@ -1,0 +1,19 @@
+/**
+* Take a date-string formatted like
+*     2020-03-24T17:59:57.369+0000
+* and reformat it like
+*     2020-03-24T17:59:57.369+00:00
+ * A more careful implementation would use a gnarly regular expression to
+ * be more certain about the format of the input string. such an impl
+ * would also be waaaaaay slower.
+ *
+ * @param value string
+ */
+export default function iso8601Timestamp(value) {
+  let tweakedValue = value;
+  if (value.indexOf('+') === 23 && value.length === 28) {
+    tweakedValue = value.substring(0, 26) + ':' + value.substring(26, 28);
+  }
+
+  return tweakedValue;
+}

--- a/util/tests/iso8601Timestamp-test.js
+++ b/util/tests/iso8601Timestamp-test.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 

--- a/util/tests/iso8601Timestamp-test.js
+++ b/util/tests/iso8601Timestamp-test.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { describe, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import iso8601Timestamp from '../iso8601Timestamp';
+
+describe('iso8601Timestamp', () => {
+  const validT = '2020-03-24T17:59:57.369+00:00';
+
+  describe('values like "2020-03-24T17:59:57.369+0000" are reformatted', () => {
+    const invalidT = '2020-03-24T17:59:57.369+0000';
+    it('an invalid timestamp is reformated', () => {
+      expect(iso8601Timestamp(invalidT)).to.equal(validT);
+    });
+  });
+
+  describe('other date values are left as-is', () => {
+    it('a valid timestamp is left as-is', () => {
+      expect(iso8601Timestamp(validT)).to.equal(validT);
+    });
+
+    // length < 28
+    it('too-short input is left as-is', () => {
+      const value = 'abc';
+      expect(iso8601Timestamp(value)).to.equal(value);
+    });
+
+    // length > 28
+    it('too-long input is left as-is', () => {
+      const value = '2020-03-24T17:59:57.369+0000abc';
+      expect(iso8601Timestamp(value)).to.equal(value);
+    });
+
+    // length == 28 but missing +
+    it('input without a "+" is left as-is', () => {
+      const value = '2020-03-24T17:59:57.369-0000';
+      expect(iso8601Timestamp(value)).to.equal(value);
+    });
+
+    // length == 28 but + in wrong location
+    it('input with misplaced "+" is left as-is', () => {
+      const value = '2020-03-24T17:59:57+369-0000';
+      expect(iso8601Timestamp(value)).to.equal(value);
+    });
+  });
+});


### PR DESCRIPTION
ISO-8601 is ambiguous about how timezones in timestamps should be
formatted. In short, the spec says a timezone can be formatted as an
offset like `+HHMM` or `+HH:MM`, but the W3C opted to only require
browsers to implement the latter. Unfortunately, our backend APIs chose
to implement the former.

Some browsers handle both, and for them we are grateful. Others, like
Safari, or Chrome on iOS, do not, and for them we provide
`<FormattedDate>` and `<FormattedTime>` to provide that missing colon.

So much work for two little dots, eh? Sheesh.

Refs [STCOM-659](https://issues.folio.org/browse/STCOM-659)