### PR TITLE
STCOM-733: Fix aria-labelledby prop on <MultiSelect> + docs/examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fix `<SearchField>` component cannot be disabled. Refs STCOM-730.
 * Fix `<Select>` component ignoring `required` property. Refs STCOM-742.
 * Added `aria-hidden` attribute to `<Asterisk>` to prevent screen readers from reading it. Refs STCOM-741.
+* Fix aria-labelledby prop on `<MultiSelection>` and added docs/example of usage with external label (STCOM-733)
 
 ## 7.1.0 (IN PROGRESS)
 

--- a/lib/MultiSelection/MultiSelect.css
+++ b/lib/MultiSelection/MultiSelect.css
@@ -123,7 +123,7 @@
 }
 
 .optionCursor {
-  composes: cursor from '../Selection/Selection.css';
+  background-color: var(--color-fill-hover);
   box-shadow: inset 0 0 0 3px var(--primary);
 }
 

--- a/lib/MultiSelection/MultiSelect.css
+++ b/lib/MultiSelection/MultiSelect.css
@@ -123,10 +123,8 @@
 }
 
 .optionCursor {
-  &::before {
-    background: var(--color-fill-focus);
-    box-shadow: inset 0 0 0 3px var(--color-fill-focus);
-  }
+  composes: cursor from '../Selection/Selection.css';
+  box-shadow: inset 0 0 0 3px var(--primary);
 }
 
 .multiSelectError {

--- a/lib/MultiSelection/MultiSelectValueInput.js
+++ b/lib/MultiSelection/MultiSelectValueInput.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import omit from 'lodash/omit';
 import css from './MultiSelect.css';
 
 const propTypes = {
@@ -17,7 +18,7 @@ const MultiSelectValueInput = ({
   value,
   onFocus,
 }) => {
-  const inputProps = getInputProps({
+  const inputProps = omit(getInputProps({
     'aria-hidden': true,
     type: 'text',
     id,
@@ -26,7 +27,7 @@ const MultiSelectValueInput = ({
     value,
     tabIndex: '-1',
     onFocus
-  });
+  }), ['aria-labelledby']);
 
   return (<input {...inputProps} />);
 };

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -416,7 +416,6 @@ class MultiSelection extends React.Component {
             };
 
             const inputProps = {
-              ariaLabelledBy: `${uiId}-label`,
               id: `multiselect-input-${uiId}`,
               required,
               getInputProps,
@@ -497,7 +496,7 @@ class MultiSelection extends React.Component {
                     onBlur={this.handleBlur}
                     tabIndex="0" // eslint-disable-line
                     ref={this.control}
-                    aria-labelledby={`${label ? labelProps.id + ' ' : ''}${ariaLabelledBy ? ariaLabelledBy + ' ' : ''}${controlValueStatusId}`} // eslint-disable-line
+                    aria-labelledby={`${label ? labelProps.id + ' ' : ''}${(!label && ariaLabelledBy) ? ariaLabelledBy + ' ' : ''}${controlValueStatusId}`} // eslint-disable-line
                     aria-describedby={controlDescriptionId}
                     onClick={handleControlClick}
                   >

--- a/lib/MultiSelection/readme.md
+++ b/lib/MultiSelection/readme.md
@@ -135,3 +135,18 @@ In that case make sure to provide `onBlur` callback like below as built-in one f
     ...
    />
 ```
+
+## Usage with an external label
+In some cases, it can be necessary to render a `<MultiSelect>` without a label-prop – e.g. when used in a search pane. However, you still need to provide some context for screen reader users.
+
+For this purpose, you can apply a custom `aria-labelledby`-prop which references the ID of another element that contains the label or description of the `<MultiSelect>`.
+
+```js
+  <Headline id="my-custom-aria-labelledby">
+    Multiselect with an external label
+  </Headline>
+  <MultiSelection
+    aria-labelledby="my-custom-aria-labelledby"
+    ...
+  />
+```

--- a/lib/MultiSelection/stories/BasicUsage.js
+++ b/lib/MultiSelection/stories/BasicUsage.js
@@ -18,9 +18,6 @@ const BasicUsage = () => {
         dataOptions={optionList}
         value={values}
         onChange={setValues}
-        tether={
-          { attachment: 'top' }
-        }
       />
     </div>
   );

--- a/lib/MultiSelection/stories/CustomAriaLabelledBy.js
+++ b/lib/MultiSelection/stories/CustomAriaLabelledBy.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import MultiSelection from '../MultiSelection';
 import Button from '../../Button';
+import Headline from '../../Headline';
 
 const optionList = [
   { value: 'test0', label: 'Option 0' },
@@ -8,18 +9,17 @@ const optionList = [
   { value: 'test2', label: 'Option 2' },
 ];
 
-const RequiredExmaple = () => {
+const CustomAriaLabelledBy = () => {
   const [values, setValues] = useState([]);
 
   return (
-    <form onSubmit={e => {
-      e.preventDefault();
-      alert('Submitted!'); /* eslint-disable-line */
-    }}
-    >
+    <form onSubmit={e => e.preventDefault()}>
+      <Headline size="large" id="my-custom-aria-labelledby">
+        Multiselect with an external label
+      </Headline>
       <MultiSelection
+        aria-labelledby="my-custom-aria-labelledby"
         required
-        label="Required multi select"
         id="required-multiselect"
         dataOptions={optionList}
         value={values}
@@ -30,4 +30,4 @@ const RequiredExmaple = () => {
   );
 };
 
-export default RequiredExmaple;
+export default CustomAriaLabelledBy;

--- a/lib/MultiSelection/stories/MultiSelection.stories.js
+++ b/lib/MultiSelection/stories/MultiSelection.stories.js
@@ -8,6 +8,7 @@ import { OptionSegment } from '../../Selection';
 import BasicUsage from './BasicUsage';
 import ExternalLabel from './ExternalLabel';
 import Required from './Required';
+import CustomAriaLabelledBy from './CustomAriaLabelledBy';
 
 const optionList = [
   { value: 'test0', label: 'Option 0', extra: 'nulla' },
@@ -138,4 +139,5 @@ storiesOf('MultiSelect', module)
     </div>
   ))
   .add('External label', () => <ExternalLabel />)
-  .add('Required', () => <Required />);
+  .add('Required', () => <Required />)
+  .add('External label', () => <CustomAriaLabelledBy />);

--- a/lib/MultiSelection/tests/MultiSelection-test.js
+++ b/lib/MultiSelection/tests/MultiSelection-test.js
@@ -208,6 +208,28 @@ describe('MultiSelect', () => {
     });
   });
 
+  describe('supplying an aria-labelledby prop', () => {
+    const customLabelledBy = 'custom-aria-labelledby';
+
+    beforeEach(async () => {
+      await mountWithContext(
+        <MultiSelectionHarness
+          id={testId}
+          dataOptions={listOptions}
+          aria-labelledby={customLabelledBy}
+        />
+      );
+    });
+
+    it('applies the aria-labelledby to the control element', () => {
+      expect(multiselection.controlAriaLabelledBy).to.include(customLabelledBy);
+    });
+
+    it('applies the aria-labelledby to the filter input', () => {
+      expect(multiselection.filterInputAriaLabelledBy).to.include(customLabelledBy);
+    });
+  });
+
   describe('MultiSelection, initial value', () => {
     beforeEach(async () => {
       await mountWithContext(

--- a/lib/MultiSelection/tests/interactor.js
+++ b/lib/MultiSelection/tests/interactor.js
@@ -65,6 +65,7 @@ export default interactor(class MultiSelectInteractor {
   inputValue = value(inputClass);
 
   // aria-attributes
+  filterInputAriaLabelledBy = attribute(filterClass, 'aria-labelledby');
   controlAriaLabelledBy = attribute(controlClass, 'aria-labelledby');
   popupAttribute = attribute(`.${css.multiSelectToggleButton}`, 'aria-haspopup');
   filterRole = attribute(filterClass, 'role');


### PR DESCRIPTION
## Ticket
http://issues.folio.org/browse/STCOM-733

## Changes
- Updated the `aria-labelledby`-prop implementation to prevent it from being applied to the hidden input and twice on the control element
- Added Storybook example for testing purposes
- Added section in readme about applying external labels for a `<MultiSelect>`
- Added aria-labelledby tests
- Minor style fix for the cursor style (before you couldn't see which option was highlighted when using arrow keys)

## Test
- Tested with NVDA, JAWS, and Mac screen reader. It seems to be working fine. The aria-labelledby is being applied to both the container, the control, and the filter input. I'm not sure if it's necessary to have it on all three elements.

You can try it out here:
https://ux.folio.org/storybook/iframe.html?id=multiselect--external-label

