### PR TITLE
STCOM-745: Fix a bug in language name translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fix `<SearchField>` component cannot be disabled. Refs STCOM-730.
 * Fix `<Select>` component ignoring `required` property. Refs STCOM-742.
 * Added `aria-hidden` attribute to `<Asterisk>` to prevent screen readers from reading it. Refs STCOM-741.
+* Fix a bug causing language name translation to crash if input is invalid. Fixes STCOM-745.
 
 ## 7.1.0 (IN PROGRESS)
 

--- a/util/languages.js
+++ b/util/languages.js
@@ -500,6 +500,9 @@ const languages = [
 // @intl is really useIntl(), which can't be invoked outside a functional component
 export const formattedLanguageName = (code, intl) => {
   const language = find(languages, entry => entry.alpha3 === code || entry.alpha2 === code);
+  if (language === undefined) {
+    return intl.formatMessage({ id: 'stripes-components.languages.und' });
+  }
   const translationId = `stripes-components.languages.${language.alpha3}`;
   const translatedName = intl.formatMessage({ id: translationId });
 


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-745

The language name translation code was insufficiently protected against invalid input. This is causing Inventory to crash when viewing details for specific records with bad language codes.