### PR TITLE
Datepicker: delay/cancel blur events

### DIFF
--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -85,6 +85,7 @@ const propTypes = {
   intl: PropTypes.object,
   locale: PropTypes.string,
   onBlur: PropTypes.func,
+  onFocus: PropTypes.func,
   onKeyDown: PropTypes.func,
   onRequestClose: PropTypes.func,
   onSetDate: PropTypes.func,
@@ -101,7 +102,8 @@ const defaultProps = {
   dateFormat: 'MM DD YYYY',
   locale: 'en',
   onSetDate: () => null,
-  exclude: () => false
+  exclude: () => false,
+  onFocus: () => {},
 };
 
 class Calendar extends React.Component {
@@ -478,6 +480,7 @@ class Calendar extends React.Component {
         id={`datepicker-calendar-container-${id}`}
         ref={rootRef}
         tabIndex="-1"
+        onFocus={this.props.onFocus}
         onKeyDown={this.handleKeyDown}
         data-test-calendar
       >{/* eslint-disable jsx-a11y/no-noninteractive-tabindex */}

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -122,6 +122,7 @@ const propTypes = {
   modifiers: PropTypes.object,
   onBlur: PropTypes.func,
   onChange: PropTypes.func,
+  onFocus: PropTypes.func,
   onSetDate: PropTypes.func,
   outputBackendValue: PropTypes.bool,
   outputFormatter: PropTypes.func,
@@ -176,6 +177,7 @@ const Datepicker = (
     modifiers,
     onBlur,
     onChange,
+    onFocus,
     outputBackendValue,
     outputFormatter,
     parser,
@@ -215,6 +217,7 @@ const Datepicker = (
 
   const input = useRef(null);
   const pickerRef = useRef(null);
+  const blurTimeout = useRef(null);
   const hiddenInput = useRef(null);
   const testId = useRef(id || uniqueId('dp-')).current;
   const calendarFirstField = useRef(null);
@@ -338,6 +341,40 @@ const Datepicker = (
     setShowCalendar(cur => !cur);
   };
 
+
+  const queueBlur = (e) => {
+    blurTimeout.current = setTimeout(() => {
+      if (onBlur) {
+        if (useInput) {
+          onBlur({
+            target: outputBackendValue ? hiddenInput.current : input.current,
+            stopPropagation: () => {},
+            preventDefault: () => {},
+            defaultPrevented: true,
+          });
+        } else {
+          onBlur(e);
+        }
+      }
+    });
+  };
+
+  const cancelBlur = () => {
+    clearTimeout(blurTimeout.current);
+  };
+
+  const handleInternalBlur = (e) => {
+    e.preventDefault();
+    queueBlur(e);
+  };
+
+  const handleInternalFocus = (e) => {
+    cancelBlur();
+    if (onFocus) {
+      onFocus(e);
+    }
+  };
+
   const handleRootClose = (e) => {
     if (!contains(container.current, e.target) || !contains(pickerRef.current, e.target)) {
       if (!datePickerIsFocused()) {
@@ -361,6 +398,7 @@ const Datepicker = (
         selectedDate={datePair.dateString}
         dateFormat={format}
         firstFieldRef={calendarFirstField}
+        onFocus={handleInternalFocus}
         onRequestClose={handleRequestClose}
         rootRef={pickerRef}
         locale={locale || intl.locale}
@@ -369,22 +407,6 @@ const Datepicker = (
       />
     </RootCloseWrapper>
   );
-
-  const handleInputBlur = (e) => {
-    e.preventDefault();
-    if (onBlur) {
-      if (useInput) {
-        onBlur({
-          target: outputBackendValue ? hiddenInput.current : input.current,
-          stopPropagation: () => {},
-          preventDefault: () => {},
-          defaultPrevented: true,
-        });
-      } else {
-        onBlur(e);
-      }
-    }
-  };
 
   // renders clear button and calendar button
   const renderEndElement = () => {
@@ -424,7 +446,13 @@ const Datepicker = (
   };
 
   const content = (
-    <div className={css.container} ref={container} data-test-datepicker-container>
+    <div
+      className={css.container}
+      ref={container}
+      data-test-datepicker-container
+      onFocus={handleInternalFocus}
+      onBlur={handleInternalBlur}
+    >
       <TextField
         {...props}
         id={testId}
@@ -433,7 +461,6 @@ const Datepicker = (
         value={datePair.dateString}
         onChange={internalHandleChange}
         endControl={renderEndElement()}
-        onBlur={handleInputBlur}
         hasClearIcon={false}
         inputRef={input}
         placeholder={format}

--- a/lib/Datepicker/readme.md
+++ b/lib/Datepicker/readme.md
@@ -114,3 +114,38 @@ The value flow happens in 3 stages
 * **Right arrow** - Move cursor right 1 day in the calendar (forwards 1 day)
 * **Enter** - Select date at cursor
 * **Esc** - Close calendar
+
+## Custom Circumstances with RFF
+
+If the provided defaults and base behaviors don't quite cover your requirements, you may need write an additional function in order to wrap the datepicker and modify props from `<Field>`. Simply supplying a function that accepts the input, and meta props that components usually receive from RFF. In this example, we want validation errors to 
+to show only if there are no warnings. Note the passing of a `useInput` prop to Datepicker. This is typically and internal prop for Datepicker to know when it's being used within a `<Field>` and act accordingly - otherwise, you may see date output coming through in the incorrect format.
+
+```
+<Field
+  name={`${name}.startDate`}
+  validate={composeValidators(
+    validators.requiredStartDate,
+    validators.dateOrder,
+    multipleOpenEndedCoverages,
+    overlappingCoverages,
+  )}
+>
+  {({ input, meta }) => {
+    return (
+      <Datepicker
+        backendDateStandard="YYYY-MM-DD"
+        error={!meta?.data?.warning && meta.touched && meta.error}
+        id={`cc-start-date-${index}`}
+        input={input}
+        inputRef={this.inputRef}
+        label={<FormattedMessage id="ui-agreements.agreements.startDate" />}
+        parser={parseDateOnlyString}
+        useInput  /* supremely important */
+        required
+        usePortal
+        warning={meta.touched && input.value && meta?.data?.warning}
+      />
+    );
+  }}
+</Field>
+```


### PR DESCRIPTION
A few have reported issues with Redux-form/ RFF validation on Datepicker. The new behavior of Datepicker moves focus to the calendar widget when it is summoned. This can cause R-F's `onBlur` handler to trigger unwantedly, causing premature validations and potentially messing up the state of Redux-form.
This PR saves an onBlur trigger for once focus leaves the entire control (setTimeout instanciated on blur, canceled if focus happens within the component)