### PR TITLE
Fix SingleSelection interactor

### DIFF
--- a/lib/Selection/tests/SingleSelection-test.js
+++ b/lib/Selection/tests/SingleSelection-test.js
@@ -197,7 +197,7 @@ describe('Selection, Single select', () => {
 
     describe('clicking an option', () => {
       beforeEach(async () => {
-        await selection.clickOption(3);
+        await selection.clickOption(2);
       });
 
       it(`sets control value to ${listOptions[2].label}`, () => {
@@ -236,7 +236,7 @@ describe('Selection, Single select', () => {
 
       describe('clicking a filtered option', () => {
         beforeEach(async () => {
-          await selection.clickOption(3);
+          await selection.clickOption(2);
         });
 
         it('sets the value appropriately', () => {

--- a/lib/Selection/tests/interactor.js
+++ b/lib/Selection/tests/interactor.js
@@ -31,6 +31,16 @@ const OptionInteractor = interactor(class OptionInteractor {
   hasOutsideAlignment = hasClass(css.optionOutside);
 });
 
+const SelectionListRootInteractor = interactor(class SelectionListRootInteractor {
+  options = collection('[class^="option--"]', {
+    click: clickable(),
+  });
+
+  clickOption(index) {
+    return this.options(index).click();
+  }
+});
+
 export const OptionSegmentInteractor = interactor(class OptionSegmentInteractor {
   static defaultScope = '[data-test-selection-option-segment]';
 });
@@ -43,6 +53,7 @@ export default interactor(class SingleSelectInteractor {
   controlId = attribute('button', 'id');
   options = collection('li', OptionInteractor);
   emptyMessagePresent = isPresent(`.${css.selectionEmptyMessage}`);
+  selectionListRoot = new SelectionListRootInteractor('[class^="selectionListRoot--"]');
 
   // aria-attributes
   ariaLabelledBy = attribute('button', 'aria-labelledby');
@@ -73,13 +84,13 @@ export default interactor(class SingleSelectInteractor {
 
   // css index of elements is one-based
   clickOption(index) {
-    return this.click(`li:nth-of-type(${index})`);
+    return this.selectionListRoot.clickOption(index);
   }
 
   expandAndClick(index) {
     return this
       .click('button')
-      .click(`li:nth-of-type(${index}`)
+      .selectionListRoot.clickOption(index)
       .blur('button');
   }
 


### PR DESCRIPTION
## Purpose
`<SingleSelection>`  interactor throws errors when used in tests outside of `stripes-components`. This is caused by options list being rendered outside of component's markup through a portal, which causes app tests to fail when selecting `li:nth-of-child` elements

## Issue
[UIEH-908](https://issues.folio.org/browse/UIEH-908)