### PR TITLE
Upgrade postcss-custom-properties and add automatic import of CSS variables 

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -38,7 +38,9 @@ module.exports = ({ config }) => {
           plugins: () => [
             postCssImport(),
             autoprefixer(),
-            postCssCustomProperties(),
+            postCssCustomProperties({
+              importFrom: './lib/variables.css'
+            }),
             postCssCalc(),
             postCssNesting(),
             postCssCustomMedia(),

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "postcss-calc": "^6.0.1",
     "postcss-color-function": "^4.0.1",
     "postcss-custom-media": "^6.0.0",
-    "postcss-custom-properties": "^6.2.0",
+    "postcss-custom-properties": "^9.1.1",
     "postcss-import": "^11.0.0",
     "postcss-media-minmax": "^3.0.0",
     "postcss-nesting": "^4.2.1",


### PR DESCRIPTION
Upgraded `postcss-custom-properties` to the latest version and added automatic CSS variables import in the storybook webpack config. This means that you no longer have to import variables into your CSS file manually. This only affects Storybook development in stripes-components.

The reason for this update is that I'm working on updating stripes-core to automatically import CSS variables from stripes-components into UI modules. For this purpose, I need a newer version of `postcss-custom-properties` and to avoid having multiple versions of this plugin included I decided to upgrade it here first.

Once my PR in stripes-core is merged, it will be possible to use CSS variables in your CSS files without manually importing them within all UI-modules and stripes-related packages.