### PR TITLE
STCOM-753 log errors caught by ErrorBoundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * MultiColumnList `columnWidth` prop's keys will accept an object with `min` and `max` keys that can vary the size of the column based on necessity. Refs STCOM-631
 * Fix a bug causing language name translation to crash if input is invalid. Fixes STCOM-745.
 * Provide `<FormattedDate>` and `<FormattedTime>` to handle dates without properly formatted timezones. Refs STCOM-659.
+* Log errors captured by `<ErrorBoundary>` to logging services, when configured via `stripes.config.js`. Refs STCOM-753.
 
 ## 7.1.0 (IN PROGRESS)
 

--- a/lib/ErrorBoundary/ErrorBoundary.js
+++ b/lib/ErrorBoundary/ErrorBoundary.js
@@ -1,6 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import Bugsnag from '@bugsnag/js';
+import BugsnagPluginReact from '@bugsnag/plugin-react';
+import * as Sentry from "@sentry/react";
+import Rollbar from 'rollbar';
+
+import { errorLogging } from 'stripes-config';
+
+
 class ErrorBoundary extends React.Component {
   static propTypes = {
     children: PropTypes.node,
@@ -13,10 +21,38 @@ class ErrorBoundary extends React.Component {
       error: undefined,
       info: undefined,
     };
+
+    // list of available error handlers
+    this.handlers = [];
+
+    // bugsnag
+    if (errorLogging.bugsnag) {
+      const { apiKey } = errorLogging.bugsnag;
+      Bugsnag.start({
+        apiKey,
+        plugins: [new BugsnagPluginReact()],
+      });
+      this.handlers.push((e) => Bugsnag.notify(e));
+    }
+
+    // rollbar
+    if (errorLogging.rollbar) {
+      const rollbar = new Rollbar({ ...errorLogging.rollbar });
+      this.handlers.push((e) => rollbar.error(e));
+    }
+
+    // sentry
+    if (errorLogging.sentry) {
+      Sentry.init({ ...errorLogging.sentry });
+      this.handlers.push((e) => Sentry.captureException(e));
+    }
   }
 
   componentDidCatch(error, info) {
     this.setState({ error, info });
+
+    // notify all handlers
+    this.handlers.forEach(h => h(error));
   }
 
   render() {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,10 @@
     "webpack": "^4.41.2"
   },
   "dependencies": {
+    "@bugsnag/js": "^7.3.3",
+    "@bugsnag/plugin-react": "^7.3.3",
     "@folio/stripes-react-hotkeys": "^3.0.5",
+    "@sentry/react": "^5.22.3",
     "classnames": "^2.2.5",
     "currency-codes": "^1.5.0",
     "dom-helpers": "^3.2.1",
@@ -120,6 +123,7 @@
     "react-tether": "^1.0.1",
     "react-transition-group": "^2.2.1",
     "react-virtualized-auto-sizer": "^1.0.2",
+    "rollbar": "^2.19.3",
     "tai-password-strength": "^1.1.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Log errors in `<ErrorBoundary>` when handlers for Rollbar, Sentry, or
BugSnag are configured via stripes-config in `stripes.config.js` in the
`errorLogging` property.

Refs [STCOM-753](https://issues.folio.org/browse/STCOM-753), [STCOR-455](https://issues.folio.org/browse/STCOR-455)