### PR TITLE
STCOM-659 make use of FormattedDate, FormattedTime

### DIFF
--- a/lib/FormattedUTCDate/FormattedUTCDate.js
+++ b/lib/FormattedUTCDate/FormattedUTCDate.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FormattedDate } from 'react-intl';
+import FormattedDate from '../FormattedDate';
 
 export default function FormattedUTCDate(props) {
   return <FormattedDate timeZone="UTC" {...props} />;

--- a/lib/FormattedUTCDate/readme.md
+++ b/lib/FormattedUTCDate/readme.md
@@ -4,9 +4,8 @@ Displays a date only -- with no time component -- in UTC.
 
 ## Usage
 
-When you would normally use `react-intl`'s `<FormattedDate>` to display a date field interpreted according to the local timezone, `<FormattedUTCDate>` can instead be used to render it interpreted as UTC -- i.e., showing precisely what is actually stored in the back-end. This is appropriate when recording only a date without an associated time, eg a birthdate. For this, UTC is used both for storage and display, so that the displayed date does not vary when crossing timezones.
+When you would normally use `<FormattedDate>` to display a date field interpreted according to the local timezone, `<FormattedUTCDate>` can instead be used to render it interpreted as UTC -- i.e., showing precisely what is actually stored in the back-end. This is appropriate when recording only a date without an associated time, eg a birthdate. For this, UTC is used both for storage and display, so that the displayed date does not vary when crossing timezones.
 
 ## Props
 
 The same as those of [`react-intl`'s `<FormattedDate>`](https://github.com/formatjs/react-intl/blob/master/docs/Components.md#formatteddate).
-

--- a/lib/MetaSection/MetaSection.js
+++ b/lib/MetaSection/MetaSection.js
@@ -1,10 +1,12 @@
 import React, { isValidElement } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedDate, FormattedMessage, FormattedTime } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { get } from 'lodash';
 
 import { Accordion } from '../Accordion';
+import FormattedDate from '../FormattedDate';
+import FormattedTime from '../FormattedTime';
 import MetaAccordionHeader from './MetaAccordionHeader';
 import css from './MetaSection.css';
 


### PR DESCRIPTION
Use the local implementations of `<FormattedDate>` and `<FormattedTime>`
in place of those from `react-intl` to allow the display of values with
non-compliant timezone formats.

Refs [STCOM-659](https://issues.folio.org/browse/STCOM-659)