### PR TITLE
UIEH-959: Add autoFocus property to <MultiSelection>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * MultiColumnList `columnWidth` prop's keys will accept an object with `min` and `max` keys that can vary the size of the column based on necessity. Refs STCOM-631
 * Fix a bug causing language name translation to crash if input is invalid. Fixes STCOM-745.
 * Provide `<FormattedDate>` and `<FormattedTime>` to handle dates without properly formatted timezones. Refs STCOM-659.
+* Add `autoFocus` property to `<MultiSelection>`. Refs UIEH-959.
 
 ## 7.1.0 (IN PROGRESS)
 

--- a/lib/MultiSelection/MultiSelectValueInput.js
+++ b/lib/MultiSelection/MultiSelectValueInput.js
@@ -4,6 +4,7 @@ import omit from 'lodash/omit';
 import css from './MultiSelect.css';
 
 const propTypes = {
+  autoFocus: PropTypes.bool,
   getInputProps: PropTypes.func.isRequired,
   id: PropTypes.string.isRequired,
   onFocus: PropTypes.func,
@@ -17,6 +18,7 @@ const MultiSelectValueInput = ({
   getInputProps,
   value,
   onFocus,
+  autoFocus,
 }) => {
   const inputProps = omit(getInputProps({
     'aria-hidden': true,
@@ -26,7 +28,8 @@ const MultiSelectValueInput = ({
     required,
     value,
     tabIndex: '-1',
-    onFocus
+    onFocus,
+    autoFocus,
   }), ['aria-labelledby']);
 
   return (<input {...inputProps} />);
@@ -35,6 +38,7 @@ const MultiSelectValueInput = ({
 MultiSelectValueInput.propTypes = propTypes;
 
 MultiSelectValueInput.defaultProps = {
+  autoFocus: false,
   required: false,
 };
 

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -40,6 +40,7 @@ class MultiSelection extends React.Component {
     actions: PropTypes.arrayOf(PropTypes.object),
     ariaLabelledBy: PropTypes.string,
     asyncFiltering: PropTypes.bool,
+    autoFocus: PropTypes.bool,
     backspaceDeletes: PropTypes.bool,
     dataOptions: PropTypes.arrayOf(PropTypes.any),
     dirty: PropTypes.bool,
@@ -74,6 +75,7 @@ class MultiSelection extends React.Component {
 
   static defaultProps = {
     actions: [],
+    autoFocus: false,
     backspaceDeletes: true,
     dataOptions: [],
     onChange: noop,
@@ -314,6 +316,7 @@ class MultiSelection extends React.Component {
       required,
       disabled,
       modifiers,
+      autoFocus,
       ...rest
     } = this.props;
 
@@ -420,6 +423,7 @@ class MultiSelection extends React.Component {
               required,
               getInputProps,
               value: Array.isArray(value) ? value.map(this.props.itemToString).join(',') : value,
+              autoFocus,
             };
 
             const optionListProps = {


### PR DESCRIPTION
## Description
Able to autofocus input in MultiSelection component

## Issue
Part of [UIEH-959](https://issues.folio.org/browse/UIEH-959)

## Screenshot
![KDPGqT9O06](https://user-images.githubusercontent.com/55701515/93340359-646c5d80-f835-11ea-87fc-bf8c3a846d26.gif)


