### PR TITLE
STCOM-758 display KeyValue with NoValue for undefined and empty strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 8.0.0 (IN PROGRESS)
 
+* Display `<NoValue />` in KeyValue if value is undefined or empty string. New FOLIO UX guidelines. Refs STCOM-758
 * Increment `react-router` to `^5.2`.
 * Upgraded `react-overlays` dependency to the latest version. Refs STCOM-650.
 * Add a utility list of language names & helper functions. Refs UIIN-829.

--- a/lib/KeyValue/KeyValue.js
+++ b/lib/KeyValue/KeyValue.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { pickBy } from 'lodash';
 
+import NoValue from '../NoValue';
 import css from './KeyValue.css';
 
 const propTypes = {
@@ -20,6 +21,7 @@ const propTypes = {
 function KeyValue({ children, label, value, subValue, ...rest }) {
   // pull any data-test-* props into a spreadable object
   const dataProps = pickBy(rest, (_, key) => /^data-test/.test(key));
+  const displayValue = value == null || value === '' ? <NoValue /> : value;
 
   return (
     <div className={css.kvRoot} {...dataProps}>
@@ -30,7 +32,7 @@ function KeyValue({ children, label, value, subValue, ...rest }) {
         className={css.kvValue}
         data-test-kv-value
       >
-        {children || value}
+        {children || displayValue}
       </div>
       {subValue && (
         <em

--- a/lib/KeyValue/tests/KeyValue-test.js
+++ b/lib/KeyValue/tests/KeyValue-test.js
@@ -9,7 +9,7 @@ import {
 
 import KeyValue from '../KeyValue';
 
-import { mount } from '../../../tests/helpers';
+import { mount, mountWithContext } from '../../../tests/helpers';
 import KeyValueInteractor from './interactor';
 
 describe('KeyValue', () => {
@@ -63,6 +63,42 @@ describe('KeyValue', () => {
 
     it('should display correct value', () => {
       expect(keyValue.value.text).to.equal('Children');
+    });
+  });
+
+  describe('with undefined value', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <KeyValue label="Label" value={undefined} />
+      );
+    });
+
+    it('should display correct value', () => {
+      expect(keyValue.value.text).to.equal('-');
+    });
+  });
+
+  describe('with empty string value', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <KeyValue label="Label" value={''} />
+      );
+    });
+
+    it('should display correct value', () => {
+      expect(keyValue.value.text).to.equal('-');
+    });
+  });
+
+  describe('with number 0 value', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <KeyValue label="Label" value={0} />
+      );
+    });
+
+    it('should display correct value', () => {
+      expect(keyValue.value.text).to.equal('0');
     });
   });
 });


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-758
Guys, what do you think of displaying NoValue here? In the ticket we have a requirement to do that and it looks like a FOLIO UX guideline to display no value as hyphen.