### PR TITLE
STCOM-760: added headerProps property to FilterAccordionHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * refactor SingleSelect away from componentWillReceiveProps. Refs STCOM-709.
 * Add `autoFocus` property to `<MultiSelection>`. Refs UIEH-959.
 * refactor SRStatus away from componentWillReceiveProps. Refs STCOM-708.
+* Added `headerProps` property to `FilterAccordionHeader` and `DefaultAccordionHeader`. Refs STCOM-760.
 
 ## 7.1.0 (IN PROGRESS)
 

--- a/lib/Accordion/headers/FilterAccordionHeader.js
+++ b/lib/Accordion/headers/FilterAccordionHeader.js
@@ -15,6 +15,7 @@ class FilterAccordionHeader extends React.Component {
     displayClearButton: PropTypes.bool,
     displayWhenClosed: PropTypes.element,
     displayWhenOpen: PropTypes.element,
+    headerProps: PropTypes.object,
     headingLevel: PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
     id: PropTypes.string,
     intl: PropTypes.object,
@@ -64,6 +65,7 @@ class FilterAccordionHeader extends React.Component {
       intl: {
         formatMessage
       },
+      headerProps,
     } = this.props;
     const clearButtonVisible = displayClearButton && typeof onClearFilter === 'function';
     const labelPropsId = label?.props?.id;
@@ -85,6 +87,7 @@ class FilterAccordionHeader extends React.Component {
             autoFocus={this.props.autoFocus}
             ref={this.props.toggleRef}
             id={`accordion-toggle-button-${this.props.id}`}
+            {...headerProps}
           >
             {
               disabled ? null :


### PR DESCRIPTION
[STCOM-760](https://issues.folio.org/browse/STCOM-760)
`FilterAccordionHeader` ignored `headerProps` property passed from `Accordion`