### PR TITLE
Handle DST in timepicker tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix focusing SearchField when loading - make it readOnly. Refs STCOM-762
 * Refactor `Timepicker` away from `componentWillReceiveProps` lifecycle hook. Refs STCOM-275
+* Handle DST in `Timepicker` tests.
 
 ## [8.0.0](https://github.com/folio-org/stripes-components/tree/v8.0.0) (2020-10-05)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v7.0.1...v8.0.0)

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
+import moment from 'moment';
 
 import { mountWithContext } from '../../../tests/helpers';
 
@@ -134,7 +135,7 @@ describe('Timepicker', () => {
       });
 
       it('returns an ISO 8601 time string for specific time zone', () => {
-        expect(timeOutput).to.equal('00:00:00.000Z');
+        expect(timeOutput).to.equal(moment().isDST() ? '00:00:00.000Z' : '01:00:00.000Z');
       });
     });
   });


### PR DESCRIPTION
Comparisons between times from a specific timezone and times in UTC must
accommodate DST.