### PR TITLE
UIDEXP-178: Add isDisabled property to CheckboxInteractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix focusing SearchField when loading - make it readOnly. Refs STCOM-762
 * Refactor `Timepicker` away from `componentWillReceiveProps` lifecycle hook. Refs STCOM-275
 * Handle DST in `Timepicker` tests.
+* Add `isDisabled` property to `CheckboxInteractor`. Refs UIDEXP-178.
 
 ## [8.0.0](https://github.com/folio-org/stripes-components/tree/v8.0.0) (2020-10-05)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v7.0.1...v8.0.0)

--- a/lib/Checkbox/tests/interactor.js
+++ b/lib/Checkbox/tests/interactor.js
@@ -22,6 +22,7 @@ export default interactor(class CheckboxInteractor {
   focusInput = focusable('input');
   inputValue = value('input');
   isChecked = property('input', 'checked');
+  isDisabled = property('input', 'disabled');
   label = text(`.${styles.label}`);
   hasLabelElement = isPresent('label');
   feedbackText = text(`.${styles.checkboxFeedback}`);


### PR DESCRIPTION
In scope of [UIDEXP-178](https://issues.folio.org/browse/UIDEXP-178)

## Puprose
Add `isDisabled` propery to `CheckboxInteractor`