### PR TITLE
STCOM-778 Dropdown only uses focusHandler.open if trigger is focused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Implement info callout. Refs STCOM-776.
 * Set modalRoot position to absolute to allow for modals to stack. Refs STCOM-771.
 * Provide `useDateFormatter` and `useTimeFormatter` hooks. Refs STCOM-775.
+* Fix Dropdown moving focus when external state changes. Fixes STCOM-778.
 
 ## [8.0.0](https://github.com/folio-org/stripes-components/tree/v8.0.0) (2020-10-05)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v7.0.1...v8.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Handle DST in `Timepicker` tests.
 * Add `isDisabled` property to `CheckboxInteractor`. Refs STCOM-777.
 * Implement info callout. Refs STCOM-776.
+* Set modalRoot position to absolute to allow for modals to stack. Refs STCOM-771.
 * Provide `useDateFormatter` and `useTimeFormatter` hooks. Refs STCOM-775.
 
 ## [8.0.0](https://github.com/folio-org/stripes-components/tree/v8.0.0) (2020-10-05)

--- a/lib/Dropdown/Popdown.js
+++ b/lib/Dropdown/Popdown.js
@@ -76,7 +76,9 @@ const Popdown = ({
         if (keyCode === 38) {
           elem = getLastFocusable(menu);
         }
-        _focusHandlers.open(triggerRef.current, menu, elem);
+        if (document.activeElement === triggerRef.current) {
+          _focusHandlers.open(triggerRef.current, menu, elem);
+        }
       }
     }
   }, [open, overlayRef, triggerRef, _focusHandlers, keyCode]);

--- a/lib/Dropdown/tests/dropdown-test.js
+++ b/lib/Dropdown/tests/dropdown-test.js
@@ -570,7 +570,7 @@ describe('Dropdown', () => {
   describe('controlled functionality', () => {
     beforeEach(async () => {
       await mount(
-        <DropdownHarness label="controlled" controlled>
+        <DropdownHarness label="controlled" controlled buttonProps={{autoFocus: true}}>
           <DropdownMenu>
             <Button buttonStyle="dropdownItem" id="ddItem">Select All</Button>
           </DropdownMenu>
@@ -584,7 +584,7 @@ describe('Dropdown', () => {
 
     describe('clicking the trigger', () => {
       beforeEach(async () => {
-        await dropdown.clickTrigger();
+        await dropdown.focusAndClickOpen();
       });
 
       it('displays the dropdown menu', () => {

--- a/lib/Dropdown/tests/interactor.js
+++ b/lib/Dropdown/tests/interactor.js
@@ -44,6 +44,12 @@ export default @interactor class DropdownInteractor {
       .focusTrigger()
       .pressDownKey();
   }
+
+  focusAndClickOpen() {
+    return this
+      .focusTrigger()
+      .clickTrigger();
+  }
 }
 
 export { DropdownMenuInteractor };

--- a/lib/Modal/Modal.css
+++ b/lib/Modal/Modal.css
@@ -1,7 +1,7 @@
 @import '../variables.css';
 
 .modalRoot {
-  position: relative;
+  position: absolute;
   display: flex;
   justify-content: center;
   top: 0;


### PR DESCRIPTION
### Before
Dropdown would just look at its open prop and feel like it would need to move focus when state changes occurred outside...
![DD-before](https://user-images.githubusercontent.com/20704067/98842146-bc2add80-240e-11eb-9ce9-3259b8ff1575.gif)
### After
Dropdown only moves focus to the menu if the trigger is clicked/focused. The focus changes here were done with the keyboard, so that still works...
![DD-after](https://user-images.githubusercontent.com/20704067/98842157-c2b95500-240e-11eb-9266-92315d0b817f.gif)
