### PR TITLE
STRIPES-709 displace date/time used to build weekday array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Implement info callout. Refs STCOM-776.
 * Set modalRoot position to absolute to allow for modals to stack. Refs STCOM-771.
 * Provide `useDateFormatter` and `useTimeFormatter` hooks. Refs STCOM-775.
+* `Datepicker` calendar weekday rendering bug. Fixes STRIPES-709.
 
 ## [8.0.0](https://github.com/folio-org/stripes-components/tree/v8.0.0) (2020-10-05)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v7.0.1...v8.0.0)

--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -64,8 +64,10 @@ function getMonths(intl) {
 function getWeekDays(intl) {
   const weekDays = [];
   // a static week that will give us Sunday - Saturday as an array[7]
+  // The supplied static value is a UTC date so no localizing offset would occur - this 
+  // would result in offset weekdays...
   for (let i = 15; i <= 22; i++) {
-    weekDays.push(intl.formatDateToParts(new Date(Date.UTC(2020, 2, i, 13, 0, 0)), { weekday: 'short', timeZone: 'UTC' })[0].value);
+    weekDays.push(intl.formatDateToParts(new Date(Date.UTC(2020, 2, i)), { weekday: 'short', timeZone: 'UTC' })[0].value);
   }
   return weekDays;
 }

--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -65,7 +65,7 @@ function getWeekDays(intl) {
   const weekDays = [];
   // a static week that will give us Sunday - Saturday as an array[7]
   for (let i = 15; i <= 22; i++) {
-    weekDays.push(intl.formatDateToParts(`03/${i}/2020`, { weekday: 'short', timeZone: 'UTC' })[0].value);
+    weekDays.push(intl.formatDateToParts(new Date(Date.UTC(2020, 2, i, 13, 0, 0)), { weekday: 'short', timeZone: 'UTC' })[0].value);
   }
   return weekDays;
 }


### PR DESCRIPTION
As the JIRA describes, if the Timezone was at UTC-1, the weekdays would be off. ~The date used to build the week days was at midnight, so it would end up using yesterday's weekday. Displacing the date used by 13 hrs resolved so that in en-US locale, Sunday would consistently be the first day, regardless of OS time zone setting.~

Slightly different approach - rather than offset the time, use a UTC time via Date.UTC... lone strings (previous code i.e. '03/15/2020') will be localized by the browser (which is kindof ugly!) so '2020/03/15' assumed midnight UTC, localized to a time of UTC +1 (which means it ends up -1) and boom, you're into yesterday when you needed to be today... but a Date.UTC is consistent everywhere.. no bones about it - no wiggle room for the browser to manipulate.

Additionally, in this format, months are 0-based, days are still 1-31 🙄 so yeah... not at all confusing.