### PR TITLE
STCOM-785: interactors update - checkbox

### DIFF
--- a/lib/Checkbox/tests/Checkbox-test.js
+++ b/lib/Checkbox/tests/Checkbox-test.js
@@ -3,15 +3,15 @@ import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
 
 import { Field } from 'redux-form';
+import { Checkbox as Interactor } from '@folio/stripes-testing';
 import { mount, mountWithContext } from '../../../tests/helpers';
 import TestForm from '../../../tests/TestForm';
 import Harness from '../../../tests/Harness';
 
 import Checkbox from '../Checkbox';
-import { Checkbox as CheckboxInteractor } from '@folio/stripes-testing';
 
 describe('Checkbox', () => {
-  const checkbox = CheckboxInteractor('My label');
+  const checkboxWithLabel = Interactor('My label');
 
   describe('render a checkbox', () => {
     let focused;
@@ -27,25 +27,20 @@ describe('Checkbox', () => {
           vertical
         />
       );
-      await checkbox.focus();
+      await checkboxWithLabel.focus();
     });
 
-    it('has an id on the input element', async () =>
-      await checkbox.has({ id: 'checkbox-test' }));
+    it('has an id on the input element', () => checkboxWithLabel.has({ id: 'checkbox-test' }));
 
-    it('has a custom className applied', async () =>
-      await checkbox.perform((el) => expect(el.className).to.have.string('custom-class')));
+    it('has a custom className applied', () => checkboxWithLabel.perform((el) => expect(el.className).to.have.string('custom-class')));
 
-    it('is full width', async () =>
-      await checkbox.perform((el) => expect(el.className).to.have.string('fullWidth')));
+    it('is full width', () => checkboxWithLabel.perform((el) => expect(el.className).to.have.string('fullWidth')));
 
-    it('has a label', async () => await checkbox.has({ label: 'My label' }));
+    it('has a label', () => checkboxWithLabel.has({ label: 'My label' }));
 
-    it('is rendered vertically', async () =>
-      await checkbox.perform((el) => expect(el.className).to.have.string('vertical')));
+    it('is rendered vertically', () => checkboxWithLabel.perform((el) => expect(el.className).to.have.string('vertical')));
 
-    it('is has an aria-label', async () =>
-      await checkbox.has({ ariaLabel: 'My aria label' }));
+    it('is has an aria-label', () => checkboxWithLabel.has({ ariaLabel: 'My aria label' }));
 
     it('should fire an onFocus callback', () => {
       expect(focused).to.be.true;
@@ -53,35 +48,29 @@ describe('Checkbox', () => {
   });
 
   describe('with warning text', () => {
-    const checkboxNoLabel = CheckboxInteractor();
+    const checkboxNoLabel = Interactor();
     beforeEach(async () => {
       await mount(<Checkbox warning="That's not a great value." />);
     });
 
-    it('displays the warning text', async () =>
-      await checkboxNoLabel.has({ feedbackText: `That's not a great value.` }));
+    it('displays the warning text', () => checkboxNoLabel.has({ feedbackText: 'That\'s not a great value.' }));
 
-    it('applies a warning class', async () =>
-      await checkboxNoLabel.has({ hasWarning: true }));
+    it('applies a warning class', () => checkboxNoLabel.has({ hasWarning: true }));
 
-    it('leaves the aria-invalid attribute as false', async () =>
-      await checkboxNoLabel.has({ ariaInvalid: false }));
+    it('leaves the aria-invalid attribute as false', () => checkboxNoLabel.has({ ariaInvalid: false }));
   });
 
   describe('with error text', () => {
-    const checkboxNoLabel = CheckboxInteractor();
+    const checkboxNoLabel = Interactor();
     beforeEach(async () => {
       await mount(<Checkbox error="That's a bad value." />);
     });
 
-    it('displays the error text', async () =>
-      await checkboxNoLabel.has({ feedbackText: `That's a bad value.` }));
+    it('displays the error text', () => checkboxNoLabel.has({ feedbackText: 'That\'s a bad value.' }));
 
-    it('applies an error class', async () =>
-      await checkboxNoLabel.has({ hasError: true }));
+    it('applies an error class', () => checkboxNoLabel.has({ hasError: true }));
 
-    it('sets the aria-invalid attribute to true', async () =>
-      await checkboxNoLabel.has({ ariaInvalid: true }));
+    it('sets the aria-invalid attribute to true', () => checkboxNoLabel.has({ ariaInvalid: true }));
   });
 
   describe('with a value', () => {
@@ -92,30 +81,28 @@ describe('Checkbox', () => {
         <Checkbox
           value="bananas"
           label="My label"
-          onChange={(event) => { output = event.target.value }}
+          onChange={(event) => { output = event.target.value; }}
         />
       );
     });
 
-    it('displays the input as unchecked', async () =>
-      await checkbox.is({ checked: false }));
+    it('displays the input as unchecked', () => checkboxWithLabel.is({ checked: false }));
 
     describe('clicking the label', () => {
       beforeEach(async () => {
-        await checkbox.click();
+        await checkboxWithLabel.click();
       });
 
-      it('toggles the value', async () => await checkbox.has({ value: 'bananas' }));
+      it('toggles the value', () => checkboxWithLabel.has({ value: 'bananas' }));
 
-      it('fires the onChange with value', async () => expect(output).to.equal('bananas'));
+      it('fires the onChange with value', () => expect(output).to.equal('bananas'));
 
-      it('displays the input as checked', async () =>
-        await checkbox.is({ checked: true }));
+      it('displays the input as checked', () => checkboxWithLabel.is({ checked: true }));
     });
   });
 
   describe('coupled to redux-form', () => {
-    const checkboxBananas = CheckboxInteractor('Bananas');
+    const checkboxBananas = Interactor('Bananas');
     let output = false;
 
     beforeEach(async () => {
@@ -134,8 +121,7 @@ describe('Checkbox', () => {
       );
     });
 
-    it('displays the input as unchecked', async () =>
-    checkboxBananas.is({ checked: false }));
+    it('displays the input as unchecked', () => checkboxBananas.is({ checked: false }));
 
     describe('clicking the label', () => {
       beforeEach(async () => {
@@ -146,8 +132,7 @@ describe('Checkbox', () => {
         expect(output).to.be.true;
       });
 
-      it('displays the input as checked', async () =>
-        await checkboxBananas.is({ checked: true }));
+      it('displays the input as checked', () => checkboxBananas.is({ checked: true }));
 
       describe('toggling the checkbox back to off', () => {
         beforeEach(async () => {
@@ -158,11 +143,9 @@ describe('Checkbox', () => {
           expect(output).to.be.false;
         });
 
-        it('displays the error text', async () =>
-          await checkboxBananas.has({ feedbackText: 'Required' }));
+        it('displays the error text', () => checkboxBananas.has({ feedbackText: 'Required' }));
 
-        it('applies an error class', async () =>
-          await checkboxBananas.perform((el) => expect(el.className).to.have.string('hasError')));
+        it('applies an error class', () => checkboxBananas.perform((el) => expect(el.className).to.have.string('hasError')));
       });
     });
   });
@@ -171,7 +154,7 @@ describe('Checkbox', () => {
     const ref = React.createRef();
 
     beforeEach(async () => {
-      await mount(<Checkbox id='checkbox-ref-test' inputRef={ref} />);
+      await mount(<Checkbox id="checkbox-ref-test" inputRef={ref} />);
     });
 
     it('should return a valid ref', () => {
@@ -208,7 +191,7 @@ describe('Checkbox', () => {
         </Harness>
       );
 
-      await CheckboxInteractor().click();
+      await Interactor().click();
     });
 
     it('should not fire the onChange callback', () => {
@@ -217,7 +200,7 @@ describe('Checkbox', () => {
   });
 
   describe('a checkbox without a label-prop', () => {
-    const checkboxWithoutLabel = CheckboxInteractor();
+    const checkboxWithoutLabel = Interactor();
     let output;
     beforeEach(async () => {
       await mount(
@@ -230,11 +213,9 @@ describe('Checkbox', () => {
       await checkboxWithoutLabel.clickInput();
     });
 
-    it('should not render a <label>-element', async () =>
-      await checkbox.absent());
+    it('should not render a <label>-element', () => Interactor('').absent());
 
-    it('toggles the value', async () =>
-      await checkboxWithoutLabel.has({ value: 'no-label-checkbox' }));
+    it('toggles the value', () => checkboxWithoutLabel.has({ value: 'no-label-checkbox' }));
 
     it('should fire onChange callback when clicking the <input>', () => {
       expect(output).to.equal('no-label-checkbox');

--- a/lib/Checkbox/tests/Checkbox-test.js
+++ b/lib/Checkbox/tests/Checkbox-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { describe, beforeEach, it } from '@bigtest/mocha';
+import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
 
 import { Field } from 'redux-form';
@@ -8,10 +8,10 @@ import TestForm from '../../../tests/TestForm';
 import Harness from '../../../tests/Harness';
 
 import Checkbox from '../Checkbox';
-import CheckboxInteractor from './interactor';
+import { Checkbox as CheckboxInteractor } from '@folio/stripes-testing';
 
 describe('Checkbox', () => {
-  const checkbox = new CheckboxInteractor();
+  const checkbox = CheckboxInteractor('My label');
 
   describe('render a checkbox', () => {
     let focused;
@@ -27,32 +27,25 @@ describe('Checkbox', () => {
           vertical
         />
       );
-      await checkbox.focusInput();
+      await checkbox.focus();
     });
 
-    it('has an id on the input element', () => {
-      expect(checkbox.id).to.equal('checkbox-test');
-    });
+    it('has an id on the input element', async () =>
+      await checkbox.has({ id: 'checkbox-test' }));
 
-    it('has a custom className applied', () => {
-      expect(checkbox.className).to.include('custom-class');
-    });
+    it('has a custom className applied', async () =>
+      await checkbox.perform((el) => expect(el.className).to.have.string('custom-class')));
 
-    it('is full width', () => {
-      expect(checkbox.isFullWidth).to.be.true;
-    });
+    it('is full width', async () =>
+      await checkbox.perform((el) => expect(el.className).to.have.string('fullWidth')));
 
-    it('is has a label', () => {
-      expect(checkbox.label).to.equal('My label');
-    });
+    it('has a label', async () => await checkbox.has({ label: 'My label' }));
 
-    it('is rendered vertically', () => {
-      expect(checkbox.isVertical).to.be.true;
-    });
+    it('is rendered vertically', async () =>
+      await checkbox.perform((el) => expect(el.className).to.have.string('vertical')));
 
-    it('is has an aria-label', () => {
-      expect(checkbox.ariaLabel).to.equal('My aria label');
-    });
+    it('is has an aria-label', async () =>
+      await checkbox.has({ ariaLabel: 'My aria label' }));
 
     it('should fire an onFocus callback', () => {
       expect(focused).to.be.true;
@@ -60,39 +53,35 @@ describe('Checkbox', () => {
   });
 
   describe('with warning text', () => {
+    const checkboxNoLabel = CheckboxInteractor();
     beforeEach(async () => {
-      await mount(
-        <Checkbox warning="That's not a great value." />
-      );
+      await mount(<Checkbox warning="That's not a great value." />);
     });
 
-    it('displays the warning text', () => {
-      expect(checkbox.feedbackText).to.equal('That\'s not a great value.');
-    });
+    it('displays the warning text', async () =>
+      await checkboxNoLabel.has({ feedbackText: `That's not a great value.` }));
 
-    it('applies a warning class', () => {
-      expect(checkbox.hasWarningStyle).to.be.true;
-    });
+    it('applies a warning class', async () =>
+      await checkboxNoLabel.has({ hasWarning: true }));
+
+    it('leaves the aria-invalid attribute as false', async () =>
+      await checkboxNoLabel.has({ ariaInvalid: false }));
   });
 
   describe('with error text', () => {
+    const checkboxNoLabel = CheckboxInteractor();
     beforeEach(async () => {
-      await mount(
-        <Checkbox error="That's a bad value." />
-      );
+      await mount(<Checkbox error="That's a bad value." />);
     });
 
-    it('displays the error text', () => {
-      expect(checkbox.feedbackText).to.equal('That\'s a bad value.');
-    });
+    it('displays the error text', async () =>
+      await checkboxNoLabel.has({ feedbackText: `That's a bad value.` }));
 
-    it('applies an error class', () => {
-      expect(checkbox.hasErrorStyle).to.be.true;
-    });
+    it('applies an error class', async () =>
+      await checkboxNoLabel.has({ hasError: true }));
 
-    it('sets the aria-invalid attribute to true', () => {
-      expect(checkbox.ariaInvalid).to.equal('true');
-    });
+    it('sets the aria-invalid attribute to true', async () =>
+      await checkboxNoLabel.has({ ariaInvalid: true }));
   });
 
   describe('with a value', () => {
@@ -103,31 +92,30 @@ describe('Checkbox', () => {
         <Checkbox
           value="bananas"
           label="My label"
-          onChange={(event) => { output = event.target.value; }}
+          onChange={(event) => { output = event.target.value }}
         />
       );
     });
 
-    it('displays the input as unchecked', () => {
-      expect(checkbox.isChecked).to.be.false;
-    });
+    it('displays the input as unchecked', async () =>
+      await checkbox.is({ checked: false }));
 
     describe('clicking the label', () => {
       beforeEach(async () => {
-        await checkbox.clickLabel();
+        await checkbox.click();
       });
 
-      it('toggles the value', () => {
-        expect(output).to.equal('bananas');
-      });
+      it('toggles the value', async () => await checkbox.has({ value: 'bananas' }));
 
-      it('displays the input as checked', () => {
-        expect(checkbox.isChecked).to.be.true;
-      });
+      it('fires the onChange with value', async () => expect(output).to.equal('bananas'));
+
+      it('displays the input as checked', async () =>
+        await checkbox.is({ checked: true }));
     });
   });
 
   describe('coupled to redux-form', () => {
+    const checkboxBananas = CheckboxInteractor('Bananas');
     let output = false;
 
     beforeEach(async () => {
@@ -146,35 +134,35 @@ describe('Checkbox', () => {
       );
     });
 
-    it('displays the input as unchecked', () => {
-      expect(checkbox.isChecked).to.be.false;
-    });
+    it('displays the input as unchecked', async () =>
+    checkboxBananas.is({ checked: false }));
 
     describe('clicking the label', () => {
       beforeEach(async () => {
-        await checkbox.clickLabel();
+        await checkboxBananas.click();
       });
 
-      it('toggles the value', () => {
+      it('toggles the onChange value', () => {
         expect(output).to.be.true;
       });
 
-      it('displays the input as checked', () => {
-        expect(checkbox.isChecked).to.be.true;
-      });
+      it('displays the input as checked', async () =>
+        await checkboxBananas.is({ checked: true }));
 
       describe('toggling the checkbox back to off', () => {
         beforeEach(async () => {
-          await checkbox.clickAndBlur();
+          await checkboxBananas.clickAndBlur();
         });
 
-        it('displays the error text', () => {
-          expect(checkbox.feedbackText).to.equal('Required');
+        it('toggles the onChange value off', () => {
+          expect(output).to.be.false;
         });
 
-        it('applies an error class', () => {
-          expect(checkbox.hasErrorStyle).to.be.true;
-        });
+        it('displays the error text', async () =>
+          await checkboxBananas.has({ feedbackText: 'Required' }));
+
+        it('applies an error class', async () =>
+          await checkboxBananas.perform((el) => expect(el.className).to.have.string('hasError')));
       });
     });
   });
@@ -183,12 +171,7 @@ describe('Checkbox', () => {
     const ref = React.createRef();
 
     beforeEach(async () => {
-      await mount(
-        <Checkbox
-          id="checkbox-ref-test"
-          inputRef={ref}
-        />
-      );
+      await mount(<Checkbox id='checkbox-ref-test' inputRef={ref} />);
     });
 
     it('should return a valid ref', () => {
@@ -225,7 +208,7 @@ describe('Checkbox', () => {
         </Harness>
       );
 
-      await checkbox.clickLabel();
+      await CheckboxInteractor().click();
     });
 
     it('should not fire the onChange callback', () => {
@@ -234,6 +217,7 @@ describe('Checkbox', () => {
   });
 
   describe('a checkbox without a label-prop', () => {
+    const checkboxWithoutLabel = CheckboxInteractor();
     let output;
     beforeEach(async () => {
       await mount(
@@ -243,12 +227,14 @@ describe('Checkbox', () => {
           onChange={(event) => { output = event.target.value; }}
         />
       );
-      await checkbox.clickInput();
+      await checkboxWithoutLabel.clickInput();
     });
 
-    it('should not render a <label>-element', () => {
-      expect(checkbox.hasLabelElement).to.be.false;
-    });
+    it('should not render a <label>-element', async () =>
+      await checkbox.absent());
+
+    it('toggles the value', async () =>
+      await checkboxWithoutLabel.has({ value: 'no-label-checkbox' }));
 
     it('should fire onChange callback when clicking the <input>', () => {
       expect(output).to.equal('no-label-checkbox');


### PR DESCRIPTION
This upgrades the `Checkbox` to work with the new interactors. This requires the new interactor as PRed in https://github.com/folio-org/stripes-testing/pull/78.

/cc @JohnC-80 