### PR TITLE
STCOM-785: interactors update - radio button

### DIFF
--- a/lib/RadioButton/tests/RadioButton-ReduxForm-test.js
+++ b/lib/RadioButton/tests/RadioButton-ReduxForm-test.js
@@ -1,17 +1,17 @@
 import React from 'react';
-import { describe, beforeEach, it } from '@bigtest/mocha';
+import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
 
 import { Field } from 'redux-form';
+import { RadioButton as Interactor } from '@folio/stripes-testing';
 import { mountWithContext } from '../../../tests/helpers';
 import TestForm from '../../../tests/TestForm';
 
 import RadioButton from '../RadioButton';
-import RadioButtonInteractor from './interactor';
 
 describe('RadioButton with Redux Form', () => {
-  const radioButton1 = new RadioButtonInteractor('#radio-button-1');
-  const radioButton2 = new RadioButtonInteractor('#radio-button-2');
+  const radioButton1 = Interactor('green');
+  const radioButton2 = Interactor('ripe');
   let output = false;
 
   beforeEach(async () => {
@@ -44,43 +44,31 @@ describe('RadioButton with Redux Form', () => {
     );
   });
 
-  it('displays the input as unchecked', () => {
-    expect(radioButton1.isChecked).to.be.false;
-  });
+  it('displays the input as unchecked', () => radioButton1.is({ checked: false }));
 
   describe('clicking the label', () => {
     beforeEach(async () => {
-      await radioButton1.clickAndBlur();
+      await radioButton1.click();
+      await radioButton1.blur();
     });
 
-    it('toggles the value', () => {
-      expect(output).to.be.true;
-    });
+    it('toggles the value', () => expect(output).to.be.true);
 
-    it('displays the input as checked', () => {
-      expect(radioButton1.isChecked).to.be.true;
-    });
+    it('displays the input as checked', () => radioButton1.is({ checked: true }));
 
-    it('displays the error text', () => {
-      expect(radioButton1.feedbackText).to.equal('Not ready to eat');
-    });
+    it('displays the error text', () => radioButton1.has({ feedbackText: 'Not ready to eat' }));
 
-    it('applies an error class', () => {
-      expect(radioButton1.hasErrorStyle).to.be.true;
-    });
+    it('applies an error class', () => radioButton1.has({ hasError: true }));
 
     describe('toggling to a different radio button', () => {
       beforeEach(async () => {
-        await radioButton2.clickAndBlur();
+        await radioButton2.click();
+        await radioButton2.blur();
       });
 
-      it('displays warning text', () => {
-        expect(radioButton2.feedbackText).to.equal('Warning: may be mushy');
-      });
+      it('displays warning text', () => radioButton2.has({ feedbackText: 'Warning: may be mushy' }));
 
-      it('applies a warning class', () => {
-        expect(radioButton2.hasWarningStyle).to.be.true;
-      });
+      it('applies a warning class', () => radioButton2.has({ hasWarning: true }));
     });
   });
 });

--- a/lib/RadioButton/tests/RadioButton-test.js
+++ b/lib/RadioButton/tests/RadioButton-test.js
@@ -2,24 +2,23 @@ import React from 'react';
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
 
+import { RadioButton as Interactor } from '@folio/stripes-testing';
 import { mount } from '../../../tests/helpers';
 
 import RadioButton from '../RadioButton';
-import { RadioButton as RadioButtonInteractor } from '@folio/stripes-testing';
 
 describe('RadioButton', () => {
-  const radioButton = new RadioButtonInteractor();
+  const radioButton = new Interactor();
 
   describe('with an id', () => {
-    const radioButtonId = new RadioButtonInteractor({ id: 'checkbox-test' });
+    const radioButtonId = new Interactor({ id: 'checkbox-test' });
     beforeEach(async () => {
       await mount(
         <RadioButton id="checkbox-test" />
       );
     });
 
-    it('has an id on the input element', async () =>
-      await radioButtonId.has({ id: 'checkbox-test' }));
+    it('has an id on the input element', () => radioButtonId.has({ id: 'checkbox-test' }));
   });
 
   describe('with warning text', () => {
@@ -29,11 +28,9 @@ describe('RadioButton', () => {
       );
     });
 
-    it('displays the warning text', async () =>
-      await radioButton.has({ feedbackText: `That's not a great value.` }));
+    it('displays the warning text', () => radioButton.has({ feedbackText: 'That\'s not a great value.' }));
 
-    it('applies a warning class', async () =>
-      await radioButton.has({ hasWarning: true }));
+    it('applies a warning class', () => radioButton.has({ hasWarning: true }));
   });
 
   describe('with error text', () => {
@@ -43,11 +40,9 @@ describe('RadioButton', () => {
       );
     });
 
-    it('displays the error text', async () =>
-      await radioButton.has({ feedbackText: `That's a bad value.` }));
+    it('displays the error text', () => radioButton.has({ feedbackText: 'That\'s a bad value.' }));
 
-    it('applies an error class', async () =>
-      await radioButton.has({ hasError: true }));
+    it('applies an error class', () => radioButton.has({ hasError: true }));
   });
 
   describe('with a value', () => {
@@ -64,22 +59,18 @@ describe('RadioButton', () => {
       );
     });
 
-    it('displays the input as unchecked', async () =>
-      await radioButton.is({ checked: false }));
+    it('displays the input as unchecked', () => radioButton.is({ checked: false }));
 
     describe('clicking the label', () => {
       beforeEach(async () => {
         await radioButton.click();
       });
 
-      it('toggles the value', async () =>
-        await radioButton.has({ value: 'bananas' }));
+      it('toggles the value', () => radioButton.has({ value: 'bananas' }));
 
-      it('fires the onChange callback', () =>
-        expect(output).to.equal('bananas'));
+      it('fires the onChange callback', () => expect(output).to.equal('bananas'));
 
-      it('displays the input as checked', async () =>
-        await radioButton.is({ checked: true }));
+      it('displays the input as checked', () => radioButton.is({ checked: true }));
     });
   });
 });

--- a/lib/RadioButton/tests/RadioButton-test.js
+++ b/lib/RadioButton/tests/RadioButton-test.js
@@ -8,10 +8,10 @@ import { mount } from '../../../tests/helpers';
 import RadioButton from '../RadioButton';
 
 describe('RadioButton', () => {
-  const radioButton = new Interactor();
+  const radioButton = Interactor();
 
   describe('with an id', () => {
-    const radioButtonId = new Interactor({ id: 'checkbox-test' });
+    const radioButtonId = Interactor({ id: 'checkbox-test' });
     beforeEach(async () => {
       await mount(
         <RadioButton id="checkbox-test" />

--- a/lib/RadioButton/tests/RadioButton-test.js
+++ b/lib/RadioButton/tests/RadioButton-test.js
@@ -1,25 +1,25 @@
 import React from 'react';
-import { describe, beforeEach, it } from '@bigtest/mocha';
+import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
 
 import { mount } from '../../../tests/helpers';
 
 import RadioButton from '../RadioButton';
-import RadioButtonInteractor from './interactor';
+import { RadioButton as RadioButtonInteractor } from '@folio/stripes-testing';
 
 describe('RadioButton', () => {
   const radioButton = new RadioButtonInteractor();
 
   describe('with an id', () => {
+    const radioButtonId = new RadioButtonInteractor({ id: 'checkbox-test' });
     beforeEach(async () => {
       await mount(
         <RadioButton id="checkbox-test" />
       );
     });
 
-    it('has an id on the input element', () => {
-      expect(radioButton.id).to.equal('checkbox-test');
-    });
+    it('has an id on the input element', async () =>
+      await radioButtonId.has({ id: 'checkbox-test' }));
   });
 
   describe('with warning text', () => {
@@ -29,13 +29,11 @@ describe('RadioButton', () => {
       );
     });
 
-    it('displays the warning text', () => {
-      expect(radioButton.feedbackText).to.equal('That\'s not a great value.');
-    });
+    it('displays the warning text', async () =>
+      await radioButton.has({ feedbackText: `That's not a great value.` }));
 
-    it('applies a warning class', () => {
-      expect(radioButton.hasWarningStyle).to.be.true;
-    });
+    it('applies a warning class', async () =>
+      await radioButton.has({ hasWarning: true }));
   });
 
   describe('with error text', () => {
@@ -45,13 +43,11 @@ describe('RadioButton', () => {
       );
     });
 
-    it('displays the error text', () => {
-      expect(radioButton.feedbackText).to.equal('That\'s a bad value.');
-    });
+    it('displays the error text', async () =>
+      await radioButton.has({ feedbackText: `That's a bad value.` }));
 
-    it('applies an error class', () => {
-      expect(radioButton.hasErrorStyle).to.be.true;
-    });
+    it('applies an error class', async () =>
+      await radioButton.has({ hasError: true }));
   });
 
   describe('with a value', () => {
@@ -68,22 +64,22 @@ describe('RadioButton', () => {
       );
     });
 
-    it('displays the input as unchecked', () => {
-      expect(radioButton.isChecked).to.be.false;
-    });
+    it('displays the input as unchecked', async () =>
+      await radioButton.is({ checked: false }));
 
     describe('clicking the label', () => {
       beforeEach(async () => {
-        await radioButton.clickLabel();
+        await radioButton.click();
       });
 
-      it('toggles the value', () => {
-        expect(output).to.equal('bananas');
-      });
+      it('toggles the value', async () =>
+        await radioButton.has({ value: 'bananas' }));
 
-      it('displays the input as checked', () => {
-        expect(radioButton.isChecked).to.be.true;
-      });
+      it('fires the onChange callback', () =>
+        expect(output).to.equal('bananas'));
+
+      it('displays the input as checked', async () =>
+        await radioButton.is({ checked: true }));
     });
   });
 });


### PR DESCRIPTION
This upgrades the `RadioButton` to work with the new interactors. This requires the new interactor as PRed in https://github.com/folio-org/stripes-testing/pull/79.

/cc @JohnC-80