### PR TITLE
Revert "STCOM-756 Accordion css implementation"

### DIFF
--- a/lib/Accordion/Accordion.css
+++ b/lib/Accordion/Accordion.css
@@ -67,43 +67,20 @@
 }
 
 /**
- * Inner
+ * Content
  */
-
-.content-wrap {
-  max-height: 0;
-  overflow: hidden;
-  z-index: 1;
-  position: relative;
-  transition: max-height 0.3s;
-
-  &.expanded {
-    max-height: 150rem;
-    transition: max-height 0.2s cubic-bezier(0.895, 0.03, 0.685, 0.22);
-  }
-}
-
-/**
- * Content - hidden by default
- */
-
 .content {
-  opacity: 0;
-  visibility: hidden; /* inputs within will not be focusable */
-  transition: transform 0.1s ease 0.5s, opacity 0.1s linear 0.5s, visibility 0.2s linear 0.5s;
+  max-height: 0; /* hidden */
+  overflow: hidden;
+  transition: max-height 0.25s ease;
+  width: 100%;
 
   &.expanded {
-    opacity: 1;
-    visibility: visible;
-    transform: translateY(0);
-    transition: transform 0.15s ease-in-out 0.2s, opacity 0.15s ease-in-out;
-  }
-
-  &::after {
-    content: '';
-    height: 1rem;
-    display: block;
-    width: 100%;
+    flex: 1;
+    min-height: 0;
+    max-height: none; /* max-height applied inline */
+    overflow: visible;
+    margin: 0 0 1em 0;
   }
 }
 

--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {
@@ -35,124 +35,257 @@ const propTypes = {
   toggleKeyMap: PropTypes.object,
 };
 
-function getContentClass(open) {
-  return classNames(
-    css.content,
-    { [`${css.expanded}`]: open },
-  );
-}
+class Accordion extends React.Component {
+  static defaultProps = {
+    header: DefaultAccordionHeader,
+    headerProps: {},
+    separator: true,
+  }
 
-function getRootClasses(separator, disabled) {
-  return classNames(
-    css.accordion,
-    { [css.hasSeparator]: separator },
-    { [`${css.disabled}`]: disabled },
-  );
-}
+  constructor(props) {
+    super(props);
 
-function getWrapClass(open) {
-  return classNames(
-    css['content-wrap'],
-    { [`${css.expanded}`]: open },
-  );
-}
+    // ref to content div.
+    this.content = null;
+    // ref to toggle.
+    this.toggle = null;
 
-const Accordion = (props) => {
-  const {
-    accordionSet,
-    children,
-    closedByDefault,
-    contentId: contentIdProp,
-    contentRef,
-    disabled,
-    header,
-    headerProps,
-    id,
-    onToggle: onToggleProp,
-    open,
-    separator,
-    toggleKeyHandlers,
-    toggleKeyMap
-  } = props;
+    // tracked scrollHeight of content div
+    this.contentHeight = 0;
+    // whether this.contentHeight should be updated (false indicates difference.)
+    this.syncedHeight = true;
 
-  const toggle = useRef(null);
-  const content = useRef(null);
-  const setContentRef = useRef((ref) => {
-    content.current = ref;
-    if (typeof contentRef === 'function') {
-      contentRef(ref);
+    // animation callback for expansion requestAnimationFrame (RAF)
+    this.expandRAFCallback = null;
+    // animation callback for collapsing requestAnimationFrame (RAF)
+    this.collapseRAFCallback = null;
+
+    // callback for syncing
+    this.syncHeightCallback = null;
+
+    // status indicators for transition - true = mid transition.
+    this.transitioningOpen = false;
+    this.transitioningClosed = false;
+
+    this.state = {
+      isOpen: props.open || !props.closedByDefault
+    };
+
+    // id for content div needed for proper area support - either supplied or auto-generated.
+    this.contentId = props.contentId || uniqueId('accordion');
+
+    this.trackingId = props.id || uniqueId('acc');
+  }
+
+  static getDerivedStateFromProps(props) {
+    if (typeof props.open !== 'undefined') {
+      return { isOpen: props.open };
     }
-  }).current;
-  const contentId = useRef(contentIdProp || uniqueId('accordion')).current;
-  const trackingId = useRef(id || uniqueId('acc')).current;
+    return null;
+  }
 
-  const getRef = useRef(() => toggle.current).current;
-  const [isOpen, updateOpen] = useState(open || !closedByDefault);
-  const uncontrolledToggle = useRef(() => {
-    updateOpen(current => !current);
-  }).current;
-
-  const onToggle = typeof openProp === 'undefined' ? uncontrolledToggle : onToggleProp;
-
-  useEffect(() => {
-    if (open !== undefined) {
-      updateOpen(open);
+  componentDidMount() {
+    this.syncMaxHeight();
+    // fix issue with accordion not animating open if closed on mount.
+    if (!this.state.isOpen) {
+      this.content.style.maxHeight = '0';
+      this.content.style.visibility = 'hidden';
+      this.content.style.position = 'static';
+      this.content.style.maxWidth = 'inherit';
     }
-  }, [open]);
 
-  useEffect(() => { // eslint-disable-line 
-    if (accordionSet) {
-      accordionSet.registerAccordion(getRef, trackingId, closedByDefault);
-      return () => {
-        accordionSet.unregisterAccordion(trackingId);
-      };
+    if (this.props.accordionSet) {
+      this.props.accordionSet.registerAccordion(this.getRef, this.trackingId, this.props.closedByDefault);
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }
 
-  const accordionHeaderProps = Object.assign({}, props, {
-    contentId,
-    toggleRef: (ref) => { toggle.current = ref; },
-    open: isOpen,
-    onToggle,
-    ...headerProps
-  });
-  const headerElement = React.createElement(header, accordionHeaderProps);
+  componentDidUpdate(prevProps, prevState) {
+    // prop/state changes to open status set off the animation callbacks.
+    // if using state...
+    if (this.state.isOpen !== prevState.isOpen) {
+      this.setAnimationCallbacks(this.state.isOpen);
+    }
+  }
 
-  return (
-    <section
-      id={trackingId}
-      className={getRootClasses(separator, disabled)}
-      data-test-accordion-section
-    >
-      <HotKeys
-        id={`${trackingId}-hotkeys`}
-        keyMap={toggleKeyMap}
-        handlers={toggleKeyHandlers}
-        noWrapper
-      >
-        {headerElement}
-      </HotKeys>
-      <div className={getWrapClass(isOpen)}>
+  componentWillUnmount() {
+    this.tearDownHandlers();
+
+    if (this.props.accordionSet) {
+      this.props.accordionSet.unregisterAccordion(this.trackingId);
+    }
+  }
+
+  getRef = () => this.toggle;
+
+  setAnimationCallbacks = (isOpen) => {
+    if (isOpen) {
+      this.transitioningOpen = true;
+      this.syncedHeight = false;
+      this.expandRaf();
+    } else {
+      this.transitioningClosed = true;
+      this.collapseRaf();
+      this.syncMaxHeight();
+    }
+  }
+
+  syncMaxHeight = () => {
+    this.syncHeightCallback = window.requestAnimationFrame(() => {
+      this.contentHeight = this.content ? this.content.scrollHeight : 0;
+      this.syncedHeight = true;
+      this.forceUpdate();
+    });
+  }
+
+  collapseRaf = () => {
+    if (this.collapseCallback) { // if there's a collapse in progress, let it finish...
+      this.transitioningClosed = false;
+      return;
+    }
+
+    // if there is no content ref, we might get errors
+    if (!this.content) return;
+
+    this.transitioningOpen = false;
+    this.content.style.overflow = 'hidden';
+    this.collapseCallback = window.requestAnimationFrame(() => {
+      this.content.style.maxHeight = `${this.contentHeight}px`;
+      window.cancelAnimationFrame(this.collapseCallback);
+      this.collapseCallback = window.requestAnimationFrame(() => {
+        this.content.style.maxHeight = '0';
+        window.cancelAnimationFrame(this.collapseCallback);
+        this.collapseCallback = null;
+      });
+    });
+  }
+
+  expandRaf = () => {
+    if (this.expandCallback) {
+      this.transitioningOpen = false;
+      return;
+    }
+    this.transitioningClosed = false;
+    this.content.style.display = '';
+    this.expandCallback = window.requestAnimationFrame(() => {
+      // update contentHeight...
+      this.contentHeight = this.content.scrollHeight;
+      this.content.style.maxHeight = this.contentHeight === 0 ? 'none' : `${this.contentHeight}px`;
+      window.cancelAnimationFrame(this.expandCallback);
+      this.expandCallback = null;
+    });
+  }
+
+  tearDownHandlers = () => {
+    window.cancelAnimationFrame(this.syncHeightCallback);
+    window.cancelAnimationFrame(this.expandCallback);
+    window.cancelAnimationFrame(this.collapseCallback);
+  }
+
+  uncontrolledToggle = () => {
+    this.setState((curState) => {
+      const newState = { ...curState };
+      newState.isOpen = !curState.isOpen;
+      return newState;
+    });
+  }
+
+  setContentRef = (ref) => {
+    this.content = ref;
+    if (this.props.contentRef) {
+      this.props.contentRef(ref);
+    }
+  }
+
+  handleTransitionEnd = () => {
+    if (this.transitioningOpen) {
+      this.transitioningOpen = false;
+      this.content.style.maxHeight = 'none';
+      this.content.style.overflow = 'visible';
+    }
+    if (this.transitioningClosed) {
+      this.transitioningClosed = false;
+      this.content.style.visibility = 'hidden';
+      this.content.style.position = 'fixed';
+    }
+  }
+
+  getContentClass = (open) => {
+    return classNames(
+      css.content,
+      { [`${css.expanded}`]: open },
+    );
+  }
+
+  getRootClasses = () => {
+    return classNames(
+      css.accordion,
+      { [css.hasSeparator]: this.props.separator },
+      { [`${css.disabled}`]: this.props.disabled },
+    );
+  }
+
+  renderChildren = (children, open) => {
+    return typeof children === 'function' ? children(open) : children;
+  }
+
+  render() {
+    const {
+      children,
+      header,
+      headerProps,
+      onToggle: onToggleProp,
+      open: openProp,
+      toggleKeyHandlers,
+      toggleKeyMap,
+    } = this.props;
+
+    const {
+      isOpen : open
+    } = this.state;
+
+    const onToggle = typeof openProp === 'undefined' ? this.uncontrolledToggle : onToggleProp;
+
+    const accordionHeaderProps = Object.assign({}, this.props, {
+      contentId: this.contentId,
+      toggleRef: (ref) => { this.toggle = ref; },
+      open,
+      onToggle,
+      ...headerProps
+    });
+    const headerElement = React.createElement(header, accordionHeaderProps);
+
+    return (
+      <section id={this.trackingId} className={this.getRootClasses()} data-test-accordion-section>
+        <HotKeys
+          id={`${this.trackingId}-hotkeys`}
+          keyMap={toggleKeyMap}
+          handlers={toggleKeyHandlers}
+          noWrapper
+        >
+          {headerElement}
+        </HotKeys>
         <div
           role="region"
-          className={getContentClass(isOpen)}
-          ref={setContentRef}
-          id={contentId}
-          aria-labelledby={`accordion-toggle-button-${trackingId}`}
+          className={this.getContentClass(open)}
+          ref={this.setContentRef}
+          id={this.contentId}
+          aria-labelledby={`accordion-toggle-button-${this.trackingId}`}
+          onTransitionEnd={this.handleTransitionEnd}
+          // effectively hides any tab-able elements within a collapsed accordion...
+          style={{
+            visibility: open ? 'visible' : 'hidden',
+            position: open ? 'static' : 'fixed'
+          }}
           data-test-accordion-wrapper
         >
-          {typeof children === 'function' ? children(isOpen) : children}
+          {this.renderChildren(children, open)}
         </div>
-      </div>
-    </section>
-  );
-};
+      </section>
+    );
+  }
+}
+// {this.props.separator && <div className={css.separator} />}
 
 Accordion.propTypes = propTypes;
-Accordion.defaultProps = {
-  header: DefaultAccordionHeader,
-  headerProps: {},
-  separator: true,
-};
 
 export default withAccordionSet(Accordion);

--- a/lib/Accordion/headers/DefaultAccordionHeader.js
+++ b/lib/Accordion/headers/DefaultAccordionHeader.js
@@ -43,7 +43,7 @@ const DefaultAccordionHeader = (props) => {
     displayWhenOpen,
     displayWhenClosed,
     id,
-    headerProps: { headingLevel, ...restHeaderProps },
+    headerProps,
   } = props;
 
   // Content in the right side of the header
@@ -56,7 +56,7 @@ const DefaultAccordionHeader = (props) => {
   return (
     <div className={css.headerWrapper}>
       <div className={`${css.header} ${css.default}`}>
-        <Headline size="medium" margin="none" tag={headingLevel ? `h${headingLevel}` : 'div'} block>
+        <Headline size="medium" tag={`h${props.headingLevel}`} block>
           <button
             type="button"
             onClick={handleHeaderClick}
@@ -67,7 +67,7 @@ const DefaultAccordionHeader = (props) => {
             aria-expanded={open}
             aria-controls={props.contentId}
             id={`accordion-toggle-button-${id}`}
-            {...restHeaderProps}
+            {...headerProps}
           >
             <span className={css.headerInner}>
               <span className={css.defaultHeaderIcon}>

--- a/lib/Accordion/stories/BasicUsage.js
+++ b/lib/Accordion/stories/BasicUsage.js
@@ -16,7 +16,6 @@ const BasicUsage = () => (
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas vitae fringilla felis, sed commodo tellus. Sed bibendum mi id lorem sagittis sodales. Quisque ac lectus gravida, viverra ante et, iaculis sapien. Praesent eget ligula tortor. Praesent vitae ipsum placerat, blandit quam quis, tempus tortor. Aliquam erat volutpat. Fusce hendrerit lectus sed ex dictum, in pretium eros vestibulum. Nulla semper vehicula leo at varius. Quisque bibendum mauris sit amet tellus lobortis ultricies. Mauris eleifend sapien vel est posuere tincidunt. Proin ut nunc ut enim rhoncus elementum vitae in mauris. Nullam ultrices dictum nulla in commodo. Suspendisse potenti. Donec et velit ac quam consequat cursus. Pellentesque quis elit magna. Fusce velit libero, mattis ac placerat eget, aliquam a ante.
       <br />
       <br />
-      <input aria-label="I'm hidden! when closed!" type="text" />
       {faker.lorem.paragraph()}
     </Accordion>
     <Accordion label="Extended Information" closedByDefault>

--- a/lib/Accordion/tests/Accordion-test.js
+++ b/lib/Accordion/tests/Accordion-test.js
@@ -23,6 +23,7 @@ describe('Accordion', () => {
 
   it('is open by default', () => {
     expect(accordion.isOpen).to.be.true;
+    expect(accordion.contentHeight).to.equal(100);
   });
 
   it('has a label', () => {
@@ -62,6 +63,7 @@ describe('Accordion', () => {
 
       it('opens the accordion', () => {
         expect(accordion.isOpen).to.be.true;
+        expect(accordion.contentHeight).to.equal(100);
       });
     });
   });
@@ -89,7 +91,7 @@ describe('Accordion', () => {
 
       it('opens the accordion', () => {
         expect(accordion.isOpen).to.be.true;
-        expect(accordion.contentHeight).to.be.gt(100);
+        expect(accordion.contentHeight).to.equal(100);
       });
 
       describe('clicking the header again', () => {
@@ -120,7 +122,7 @@ describe('Accordion', () => {
 
     it('is open by default', () => {
       expect(accordion.isOpen).to.be.true;
-      expect(accordion.contentHeight).to.be.gt(100);
+      expect(accordion.contentHeight).to.equal(100);
     });
   });
 

--- a/lib/Accordion/tests/interactor.js
+++ b/lib/Accordion/tests/interactor.js
@@ -22,7 +22,7 @@ export const AccordionInteractor = interactor(class AccordionInteractor {
 
   label = text(`.${css.labelArea}`)
   isOpen = hasClass(`.${css.content}`, css.expanded)
-  contentHeight = property(`.${css['content-wrap']}`, 'offsetHeight')
+  contentHeight = property(`.${css.content}`, 'offsetHeight')
   clickHeader = clickable(triggerCollapse)
   id = attribute('[data-test-accordion-wrapper]', 'id')
   accordions = scoped(triggerCollapse, {


### PR DESCRIPTION
Reverts folio-org/stripes-components#1422

This `<Accordion>` update broke the ["should call onToggle" test](https://github.com/folio-org/stripes-smart-components/blob/210a5247caf807cfde315bd961a3731c5dc7687c/lib/CustomFields/pages/ViewCustomFieldsRecord/tests/ViewCustomFieldsRecord-test.js#L89-L91) in stripes-smart-components. Hopefully, there is a simple fix, but it isn't clear to me what it is ATM. 

Ordinarily, I'd take the time to figure out how to patch the test, but this error cropped up in the middle of a set of PRs to update the major version of stripes. @JohnC-80, I will un-revert this as soon as soon as the major version update is complete.