### PR TITLE
Updating postcss-custom-properties to v10 fixing DoS security warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "storybook-build": "build-storybook -c .storybook -o .out"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=10.0.0"
   },
   "stripes": {
     "type": "components",
@@ -65,13 +65,14 @@
     "file-loader": "^2.0.0",
     "jest-mock": "23.2.0",
     "karma-viewport": "^1.0.4",
+    "karma-webpack": "^4.0.2",
     "mocha": "^5.2.0",
     "moment": "^2.29.0",
     "postcss": "^7.0.2",
     "postcss-calc": "^6.0.1",
     "postcss-color-function": "^4.0.1",
     "postcss-custom-media": "^6.0.0",
-    "postcss-custom-properties": "^9.1.1",
+    "postcss-custom-properties": "^10.0.0",
     "postcss-import": "^11.0.0",
     "postcss-media-minmax": "^3.0.0",
     "postcss-nesting": "^4.2.1",


### PR DESCRIPTION
Also updating node version runtime to v10 since that is a requirement of postcss-custom-properties v10: https://github.com/postcss/postcss-custom-properties/releases/tag/10.0.0