### PR TITLE
STCOM-785 Pin stripes-components dependency to branch with new interactors

### DIFF
--- a/lib/Button/tests/Button-test.js
+++ b/lib/Button/tests/Button-test.js
@@ -2,12 +2,12 @@ import React from 'react';
 import { StaticRouter } from 'react-router'; /* eslint-disable-line import/no-extraneous-dependencies */
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
+import { Button as Interactor } from '@folio/stripes-testing';
 
 import { mount } from '../../../tests/helpers';
 
 import Button from '../Button';
 import css from '../Button.css';
-import { Button as Interactor } from '@folio/stripes-testing';
 
 describe('Button', () => {
   const button = Interactor('test');

--- a/lib/Select/tests/Select-test.js
+++ b/lib/Select/tests/Select-test.js
@@ -14,7 +14,7 @@ const testOptions = [
 ];
 
 describe('Select', () => {
-  let select = Interactor('select');
+  const select = Interactor('select');
   let label = LabelInteractor('Test-select');
   describe('rendering a basic Select', async () => {
     beforeEach(async () => {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@bigtest/mocha": "^0.5.0",
     "@folio/eslint-config-stripes": "^5.2.0",
     "@folio/stripes-cli": "^1.6.0",
-    "@folio/stripes-testing": "^2.0.100075",
+    "@folio/stripes-testing": "folio-org/stripes-testing#new-bigtest-interactors",
     "@storybook/addon-actions": "^5.3.19",
     "@storybook/addon-knobs": "^5.3.19",
     "@storybook/addon-options": "^5.3.19",


### PR DESCRIPTION
In order to get this build clean, we need to point to the version of stripes-testing that actually has the interactors we seek.

Also, this keeps the linting clean as well