### PR TITLE
STCOM-785: interactors update: text-field

### DIFF
--- a/lib/TextField/tests/TextField-ReduxForm-test.js
+++ b/lib/TextField/tests/TextField-ReduxForm-test.js
@@ -1,15 +1,16 @@
 import React from 'react';
-import { describe, beforeEach, it } from '@bigtest/mocha';
-import { expect } from 'chai';
 
+import { expect } from 'chai';
+import { describe, beforeEach, it } from 'mocha';
 import { Field } from 'redux-form';
+
+import { TextField as Interactor, IconButton as IconButtonInteractor } from '@folio/stripes-testing';
+import TextField from '../TextField';
 import { mountWithContext } from '../../../tests/helpers';
 import TestForm from '../../../tests/TestForm';
-import TextField from '../TextField';
-import TextFieldInteractor from './interactor';
 
 describe('TextField with ReduxForm', () => {
-  const textfield = new TextFieldInteractor();
+  const textField = Interactor();
 
   describe('using with redux-form', () => {
     describe('inputting a value', () => {
@@ -28,38 +29,25 @@ describe('TextField with ReduxForm', () => {
         );
       });
 
-      it('should render the TextField normally', () => {
-        expect(textfield.type).to.equal('text');
-      });
+      it('should render the TextField normally', () => textField.has({ type: 'text' }));
 
       describe('changing the value', () => {
-        beforeEach(async () => {
-          await textfield.fillInput('anything')
-            .focusInput();
-        });
+        beforeEach(() => textField.fillIn('anything'));
 
         it('applies a changed class', () => {
-          expect(textfield.hasChangedStyle).to.be.true;
+          textField.perform(el => expect(el.querySelector('[class*=isChanged-]')).to.exist);
         });
 
-        it('renders a clear button', () => {
-          expect(textfield.hasClearButton).to.be.true;
+        it('renders a clear button', async () => {
+          await textField.find(IconButtonInteractor({ icon: 'times-circle-solid' })).exists();
         });
 
         describe('clicking the clear button', () => {
-          beforeEach(async () => {
-            await textfield
-              .clickClearButton()
-              .blurInput();
-          });
+          beforeEach(() => textField.clear());
 
-          it('clears the field', () => {
-            expect(textfield.val).to.equal('');
-          });
+          it('clears the field', () => textField.has({ value: '' }));
 
-          it('fires the onClearField event', () => {
-            expect(fieldCleared).to.be.true;
-          });
+          it('fires the onClearField event', () => expect(fieldCleared).to.be.true);
         });
       });
     });
@@ -78,12 +66,13 @@ describe('TextField with ReduxForm', () => {
       });
 
       beforeEach(async () => {
-        await textfield.fillAndBlur('invalid');
+        await textField.fillIn('invalid');
+        await textField.blur();
       });
 
-      it('renders an error message', () => {
-        expect(textfield.inputError).to.be.true;
-      });
+      it('marks the field as invalid', () => textField.is({ valid: false }));
+
+      it('renders an error message', () => textField.has({ error: 'testField is Invalid' }));
     });
 
     describe('inputting an valid value with validStylesEnabled', () => {
@@ -101,21 +90,25 @@ describe('TextField with ReduxForm', () => {
       });
 
       beforeEach(async () => {
-        await textfield.fillAndBlur('valid');
+        await textField.fillIn('invalid');
+        await textField.blur();
       });
 
-      it('applies a valid class', () => {
-        expect(textfield.hasValidStyle).to.be.true;
+      it('applies a valid class', async () => {
+        await textField.perform(el => expect(el.querySelector('[class*=isValid-]')).to.exist);
       });
+
+      it('marks the field as valid', () => textField.is({ valid: true }));
+
+      it('has no error message', () => textField.has({ error: undefined }));
 
       describe('then removing the text', () => {
         beforeEach(async () => {
-          await textfield.fillAndBlur('');
+          await textField.fillIn('');
+          await textField.blur();
         });
 
-        it('renders an error message', () => {
-          expect(textfield.inputError).to.be.true;
-        });
+        it('renders an error message', () => textField.has({ error: 'testField cannot be blank' }));
       });
     });
   });

--- a/lib/TextField/tests/TextField-test.js
+++ b/lib/TextField/tests/TextField-test.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import { describe, beforeEach, it } from '@bigtest/mocha';
+import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
 
+import { TextField as Interactor, Label as LabelInteractor } from '@folio/stripes-testing';
 import { mountWithContext } from '../../../tests/helpers';
 import TextField from '../TextField';
 import TextFieldHarness from './TextFieldHarness';
-import TextFieldInteractor from './interactor';
 
 describe('TextField', () => {
-  const textfield = new TextFieldInteractor();
+  const textField = Interactor();
 
   beforeEach(async () => {
     await mountWithContext(
@@ -16,42 +16,23 @@ describe('TextField', () => {
     );
   });
 
-  it('renders an input type="text" by default', () => {
-    expect(textfield.type).to.equal('text');
-  });
+  it('renders an input type="text" by default', () => textField.has({ type: 'text' }));
 
-  it('renders no label tag by default', () => {
-    expect(textfield.labelRendered).to.be.false;
-  });
+  it('renders no label tag by default', () => textField.has({ label: undefined }));
 
-  it('applies the supplied id prop to the input', () => {
-    expect(textfield.id).to.equal('tfTest');
-  });
+  it('applies the supplied id prop to the input', () => textField.has({ id: 'tfTest' }));
 
   describe('entering text into the field', () => {
-    beforeEach(async () => {
-      await textfield.fillInput('test');
-    });
+    beforeEach(() => textField.fillIn('test'));
 
-    it('updates the value', () => {
-      expect(textfield.val).to.equal('test');
-    });
+    it('updates the value', () => textField.has({ value: 'test' }));
 
     describe('then clicking clear', () => {
-      beforeEach(async () => {
-        await textfield
-          .focusInput() // clear is only visible when focused
-          .when(() => !!textfield.val) // wait for a value
-          .clickClearButton(); // click clear
-      });
+      beforeEach(() => textField.clear());
 
-      it('clears the value', () => {
-        expect(textfield.val).to.be.empty;
-      });
+      it('clears the value', () => textField.has({ value: '' }));
 
-      it('focuses the input', () => {
-        expect(textfield.isFocused).to.be.true;
-      });
+      it('focuses the input', () => textField.is({ focused: true }));
     });
   });
 
@@ -62,13 +43,10 @@ describe('TextField', () => {
       );
     });
 
-    it('renders a proper label element', () => {
-      expect(textfield.labelRendered).to.be.true;
-      expect(textfield.label).to.equal('my test label');
-    });
+    it('renders the proper label', () => textField.has({ label: 'my test label' }));
 
-    it('with a filled htmlFor attribute', () => {
-      expect(textfield.labelFor).to.equal('myTestInput');
+    it('with a filled htmlFor attribute', async () => {
+      await textField.find(LabelInteractor({ for: 'myTestInput' })).exists();
     });
   });
 
@@ -79,9 +57,7 @@ describe('TextField', () => {
       );
     });
 
-    it('renders the supplied element in the end-control container', () => {
-      expect(textfield.endControl).to.be.true;
-    });
+    it('renders the supplied endControl', () => textField.has({ endControl: 'testEnd' }));
   });
 
   describe('supplying a startControl', () => {
@@ -91,9 +67,7 @@ describe('TextField', () => {
       );
     });
 
-    it('renders the supplied element in the start-control container', () => {
-      expect(textfield.startControl).to.be.true;
-    });
+    it('renders the supplied startControl', () => textField.has({ startControl: 'testStart' }));
   });
 
   describe('supplying a value prop with readOnly', () => {
@@ -103,13 +77,9 @@ describe('TextField', () => {
       );
     });
 
-    it('displays a value in the textfield', () => {
-      expect(textfield.val).to.equal('test value prop');
-    });
+    it('displays a value in the textfield', () => textField.has({ value: 'test value prop' }));
 
-    it('sets the readonly attribute', () => {
-      expect(textfield.inputReadOnly).to.equal('');
-    });
+    it('sets the readonly attribute', () => textField.is({ readOnly: true }));
   });
 
   describe('supplying an onChange handler', () => {
@@ -120,48 +90,34 @@ describe('TextField', () => {
     });
 
     describe('changing the field', () => {
-      beforeEach(async () => {
-        await textfield.fillInput('testing text');
-      });
+      beforeEach(() => textField.fillIn('testing text'));
 
-      it('should update value', () => {
-        expect(textfield.val).to.equal('testing text');
-      });
+      it('should update value', () => textField.has({ value: 'testing text' }));
     });
   });
 
   describe('supplying an onFocus handler', () => {
-    let focusEventFired;
+    let focusEventFired = false;
 
     beforeEach(async () => {
-      focusEventFired = false;
-
       await mountWithContext(
         <TextField onFocus={() => { focusEventFired = true; }} />
       );
     });
 
     describe('focusing the field', () => {
-      beforeEach(async () => {
-        await textfield.focusInput();
-      });
+      beforeEach(() => textField.focus());
 
-      it('focuses the field', () => {
-        expect(textfield.isFocused).to.be.true;
-      });
+      it('focuses the field', () => textField.is({ focused: true }));
 
-      it('fires the event', () => {
-        expect(focusEventFired).to.be.true;
-      });
+      it('fires the event', () => expect(focusEventFired).to.be.true);
     });
   });
 
   describe('supplying an onBlur handler', () => {
-    let blurEventFired;
+    let blurEventFired = false;
 
     beforeEach(async () => {
-      blurEventFired = false;
-
       await mountWithContext(
         <TextField onBlur={() => { blurEventFired = true; }} />
       );
@@ -169,14 +125,13 @@ describe('TextField', () => {
 
     describe('blurring the field', () => {
       beforeEach(async () => {
-        await textfield
-          .focusInput()
-          .blurInput();
+        await textField.focus();
+        await textField.blur();
       });
 
-      it('fires the event', () => {
-        expect(blurEventFired).to.be.true;
-      });
+      it('blurs the field', () => textField.is({ focused: false }));
+
+      it('fires the event', () => expect(blurEventFired).to.be.true);
     });
   });
 
@@ -190,13 +145,9 @@ describe('TextField', () => {
     });
 
     describe('focusing the field programmatically', () => {
-      beforeEach(async () => {
-        await textFieldComponent.focusInput();
-      });
+      beforeEach(() => textFieldComponent.focusInput());
 
-      it('focuses the input', () => {
-        expect(textfield.isFocused).to.be.true;
-      });
+      it('focuses the input', () => textField.is({ focused: true }));
     });
   });
 
@@ -210,13 +161,9 @@ describe('TextField', () => {
     });
 
     describe('focusing the field programmatically', () => {
-      beforeEach(async () => {
-        await textFieldComponent.current.focus();
-      });
+      beforeEach(() => textFieldComponent.current.focus());
 
-      it('focuses the input', () => {
-        expect(textfield.isFocused).to.be.true;
-      });
+      it('focuses the input', () => textField.is({ focused: true }));
     });
   });
 });


### PR DESCRIPTION
## Motivation
`TextField` is one of the critical path interactors listed in https://issues.folio.org/browse/STCOM-785.

Depends on: https://github.com/folio-org/stripes-testing/pull/90

## Approach
Consumed the new interactor and migrated all assertions to the new api.