### PR TITLE
STCOM-792: Extend `Button` interactor with `isDisabled` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix Dropdown moving focus when external state changes. Fixes STCOM-778.
 * Add Storybook example for <SRStatus>. Refs STCOM-424.
 * Fix alignment of head labels in RepeatableField. Refs STCOM-787.
+* Extend `Button` interactor with `isDisabled` field. Refs STCOM-792.
 
 ## [8.0.0](https://github.com/folio-org/stripes-components/tree/v8.0.0) (2020-10-05)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v7.0.1...v8.0.0)

--- a/lib/Button/tests/interactor.js
+++ b/lib/Button/tests/interactor.js
@@ -5,6 +5,7 @@ import {
   hasClass,
   text,
   focusable,
+  property,
 } from '@bigtest/interactor';
 
 import css from '../Button.css';
@@ -21,6 +22,7 @@ export default interactor(class ButtonInteractor {
   isAnchor = is('a');
   isButton = is('button');
   isFocused = is(':focus');
+  isDisabled = property('disabled');
   focus = focusable();
   rendersDefault = hasClass(css.default);
   rendersPrimary = hasClass(css.primary);


### PR DESCRIPTION
## Purpose

Extend `Button` interactor with `isDisabled` field in the scope of the [STCOM-792](https://issues.folio.org/browse/STCOM-792).