### PR TITLE
STCOM-785: interactors update: searchField

### DIFF
--- a/lib/SearchField/tests/SearchField-test.js
+++ b/lib/SearchField/tests/SearchField-test.js
@@ -1,17 +1,16 @@
 import React from 'react';
-import { describe, beforeEach, it } from '@bigtest/mocha';
-import { expect } from 'chai';
+import { describe, beforeEach, it } from 'mocha';
+import { SearchField as Interactor } from '@folio/stripes-testing';
 
 import { mountWithContext } from '../../../tests/helpers';
 import SearchField from '../SearchField';
-import SearchFieldInteractor from './interactor';
 
 const LABEL_PUBLISHER = 'Publisher';
 const LABEL_SUBJECT = 'Subject';
 const PLACEHOLDER_SUBJECT = 'Subject...';
 
 describe('SearchField', () => {
-  const searchField = new SearchFieldInteractor();
+  const searchField = Interactor();
 
   describe('rendering a SearchField', () => {
     beforeEach(async () => {
@@ -20,10 +19,12 @@ describe('SearchField', () => {
       );
     });
 
-    it('applies the supplied id prop to the input', () => {
-      expect(searchField.id).to.equal('searchFieldTest');
-      expect(searchField.inputReadOnly).to.be.null;
-    });
+    it('applies the supplied id prop to the input', () => searchField.has(
+      {
+        id: 'searchFieldTest',
+        readOnly: false
+      }
+    ));
   });
 
   describe('supplying an onChange handler', () => {
@@ -32,6 +33,7 @@ describe('SearchField', () => {
     beforeEach(async () => {
       await mountWithContext(
         <SearchField
+          id="searchFieldTest"
           onChange={(e) => { fieldValue = e.target.value; }}
         />
       );
@@ -39,12 +41,10 @@ describe('SearchField', () => {
 
     describe('changing the field', () => {
       beforeEach(async () => {
-        await searchField.fillInput('testing text');
+        await searchField.fillIn('testing text');
       });
 
-      it('should update value', () => {
-        expect(fieldValue).to.equal('testing text');
-      });
+      it('should update value', () => searchField.has({ value: 'testing text'}))
     });
 
     describe('rendering a SearchField in loading state', () => {
@@ -58,10 +58,12 @@ describe('SearchField', () => {
         );
       });
 
-      it('input and select are disabled', () => {
-        expect(searchField.inputReadOnly).to.equal('');
-        expect(searchField.isDisabledIndex).to.be.true;
-      });
+      it('input and select are disabled', () => searchField.has(
+        {
+          readOnly: true,
+          isDisabledIndex: true
+        }
+      ));
     });
   });
 
@@ -104,19 +106,19 @@ describe('SearchField', () => {
       );
     });
 
-    it('input and select are not disabled', () => {
-      expect(searchField.isDisabled).to.be.false;
-      expect(searchField.isDisabledIndex).to.be.false;
-    });
+    it('input and select are not disabled', () => searchField.has(
+      {
+        isDisabled: false,
+        isDisabledIndex: false
+      }
+    ));
 
     describe('changing the index', () => {
       beforeEach(async () => {
         await searchField.selectIndex(LABEL_PUBLISHER);
       });
 
-      it('should update the placeholder', () => {
-        expect(searchField.placeholder).to.be.empty;
-      });
+      it('should update the placeholder', () => searchField.has({ placeholder: '' }));
     });
 
     describe('changing the index with placeholder', () => {
@@ -124,9 +126,7 @@ describe('SearchField', () => {
         await searchField.selectIndex(LABEL_SUBJECT);
       });
 
-      it('should update the placeholder', () => {
-        expect(searchField.placeholder).to.equal(PLACEHOLDER_SUBJECT);
-      });
+      it('should update the placeholder', () => searchField.has({ placeholder: PLACEHOLDER_SUBJECT}));
     });
   });
 });

--- a/lib/SearchField/tests/SearchField-test.js
+++ b/lib/SearchField/tests/SearchField-test.js
@@ -28,13 +28,10 @@ describe('SearchField', () => {
   });
 
   describe('supplying an onChange handler', () => {
-    let fieldValue = '';
-
     beforeEach(async () => {
       await mountWithContext(
         <SearchField
           id="searchFieldTest"
-          onChange={(e) => { fieldValue = e.target.value; }}
         />
       );
     });
@@ -44,7 +41,7 @@ describe('SearchField', () => {
         await searchField.fillIn('testing text');
       });
 
-      it('should update value', () => searchField.has({ value: 'testing text'}))
+      it('should update value', () => searchField.has({ value: 'testing text' }));
     });
 
     describe('rendering a SearchField in loading state', () => {
@@ -61,7 +58,7 @@ describe('SearchField', () => {
       it('input and select are disabled', () => searchField.has(
         {
           readOnly: true,
-          isDisabledIndex: true
+          isDisabled: true
         }
       ));
     });
@@ -106,10 +103,9 @@ describe('SearchField', () => {
       );
     });
 
-    it('input and select are not disabled', () => searchField.has(
+    it('select is not disabled', () => searchField.has(
       {
         isDisabled: false,
-        isDisabledIndex: false
       }
     ));
 
@@ -126,7 +122,7 @@ describe('SearchField', () => {
         await searchField.selectIndex(LABEL_SUBJECT);
       });
 
-      it('should update the placeholder', () => searchField.has({ placeholder: PLACEHOLDER_SUBJECT}));
+      it('should update the placeholder', () => searchField.has({ placeholder: PLACEHOLDER_SUBJECT }));
     });
   });
 });


### PR DESCRIPTION
### Motivation

`SearchField` is one of the critical path interactors listed in https://issues.folio.org/browse/STCOM-785.

Depends on: folio-org/stripes-testing#93

### Approach

Consumed the new interactor and migrate all assertions to the new api.