### PR TITLE
STCOM-753 pass componentDidCatch arguments to a callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Add `className` prop to `<Accordion>`. Refs UIEH-926.
 * Settings > Panes are off. Refs STCOM-795.
 * Fix overflow in `sr-only` elements. Refs STCOM-801.
+* `<ErrorBoundary>` accepts a callback to receive the arguments to `componentDidCatch`. Refs STCOM-753.
 
 ## [8.0.0](https://github.com/folio-org/stripes-components/tree/v8.0.0) (2020-10-05)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v7.0.1...v8.0.0)

--- a/lib/ErrorBoundary/ErrorBoundary.js
+++ b/lib/ErrorBoundary/ErrorBoundary.js
@@ -11,6 +11,7 @@ export default class ErrorBoundary extends Component {
   static propTypes = {
     children: PropTypes.node,
     forceProductionError: PropTypes.bool,
+    onError: PropTypes.func,
     onReset: PropTypes.func,
     resetButtonLabel: PropTypes.node,
     subTitle: PropTypes.node,
@@ -27,6 +28,9 @@ export default class ErrorBoundary extends Component {
   }
 
   componentDidCatch(error, info) {
+    if (this.props.onError) {
+      this.props.onError(error, info);
+    }
     this.setState({ error: error.toString(), info });
   }
 

--- a/lib/ErrorBoundary/readme.md
+++ b/lib/ErrorBoundary/readme.md
@@ -1,5 +1,5 @@
 # ErrorBoundary
-Catches JavaScript errors in child components and renders an error message instead of the actual content. 
+Catches JavaScript errors in child components and renders an error message instead of the actual content.
 
 The component will automatically render a more user-friendly error in production which hides technical information such as the error stack at first glance but enables the option to reveal it and copy it for debugging purposes.
 
@@ -45,6 +45,7 @@ Name | Type | Description | Options | Default
 children | node | Pass any component as a child to ErrorBoundary to enable error catching | |
 forceProductionError | boolean | Forces the production error in development. Mainly for demo purposes. | true/false | false
 onCopyError | func | Callback fired when the user clicks the 'Copy'-button. The callback will receive the copied contents as the only parameter.  | |
+onError | func | Callback fired from `componentDidCatch` that passes along its arguments (`error`, `info`). | |
 onReset | func | Callback fired when the user clicks the primary button. This defaults to a page refresh.  | |
 resetButtonLabel | node | The label for the primary/reset button | | `"Refresh page"`
 subTitle | node | Renders the sub title of the error boundary in production | | `"Something went wrong"`


### PR DESCRIPTION
Given the callback function `onError` as a prop, call it from
`componentDidCatch` with the same arguments. While this does not
directly address STCOM-753 by logging the errors, it does allow the
component that instantiated this error boundary to provide a callback
that _does_ log the errors.

Refs [STCOM-753](https://issues.folio.org/browse/STCOM-753), [STCOR-455](https://issues.folio.org/browse/STCOR-455), [STCOR-493](https://issues.folio.org/browse/STCOR-493)