### PR TITLE
STCOM-803 spell correctly; import correctly

### DIFF
--- a/lib/PasswordStrength/PasswordStrength.css
+++ b/lib/PasswordStrength/PasswordStrength.css
@@ -1,4 +1,4 @@
-@import '@folio/stripes-components/lib/variables';
+@import '../variables.css';
 
 .password-strength__label {
   font-size: var(--font-size-small);

--- a/lib/PasswordStrength/PasswordStrength.js
+++ b/lib/PasswordStrength/PasswordStrength.js
@@ -14,7 +14,7 @@ import {
   Row,
 } from '../LayoutGrid';
 
-import css from './PasswordSrength.css';
+import css from './PasswordStrength.css';
 
 const passwordStrengthTypes = ['VERY_WEAK', 'WEAK', 'REASONABLE', 'STRONG', 'VERY_STRONG'];
 const defaultPasswordStrengthType = camelCase(passwordStrengthTypes[0]);


### PR DESCRIPTION
* The file `PasswordSrength.css` is misspelled
* The same file incorrectly imports CSS values via a higher-level scope.
While that is appropriate for modules that depend on `@folio/stripes`,
for the modules that _constitute_ `@folio/stripes`, they must use local
references.

Fixes [STCOM-803](https://issues.folio.org/browse/STCOM-803)