### PR TITLE
UISEES-33: Replacing existing query search

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,7 @@ export {
 export { default as ConfirmationModal } from './lib/ConfirmationModal';
 export { default as InfoPopover } from './lib/InfoPopover';
 export { default as SearchField } from './lib/SearchField';
+export { default as MultiSelectSearchField } from './lib/MultiSelectSearchField';
 
 /* specific use */
 export {

--- a/lib/MultiSelectSearchField/MultiSelectSearchField.css
+++ b/lib/MultiSelectSearchField/MultiSelectSearchField.css
@@ -1,0 +1,25 @@
+/**
+ * SearchField
+ */
+
+@import "../variables.css";
+
+/**
+ * Has searchable indexes
+ */
+
+/* Select field */
+.searchFieldWrap .select {
+  /* To make sure it's position is above
+  so the focus style isn't hidden by the input */
+  margin-bottom: -1px;
+
+  &:focus {
+    z-index: 5;
+  }
+}
+
+/* Color search icon on focus */
+.searchFieldWrap .isFocused svg.searchIcon {
+  fill: var(--primary);
+}

--- a/lib/MultiSelectSearchField/MultiSelectSearchField.js
+++ b/lib/MultiSelectSearchField/MultiSelectSearchField.js
@@ -1,0 +1,150 @@
+/**
+ * SearchField
+ *
+ * A universal search field component
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { useIntl } from 'react-intl';
+
+import TextField from '../TextField';
+import Select from '../Select';
+import TextFieldIcon from '../TextField/TextFieldIcon';
+import MultiSelectSearch from './components/MultiSelectSearch';
+import css from './MultiSelectSearchField.css';
+
+// Accepts the same props as TextField
+const propTypes = {
+  ariaLabel: PropTypes.string,
+  className: PropTypes.string,
+  clearSearchId: PropTypes.string,
+  disabled: PropTypes.bool,
+  id: PropTypes.string,
+  inputClass: PropTypes.string,
+  inputRef: PropTypes.object,
+  isAdvancedSearch: PropTypes.bool,
+  loading: PropTypes.bool,
+  onChange: PropTypes.func,
+  onChangeIndex: PropTypes.func,
+  onClear: PropTypes.func,
+  placeholder: PropTypes.string,
+  searchableIndexes: PropTypes.arrayOf(PropTypes.shape({
+    disabled: PropTypes.bool,
+    id: PropTypes.string,
+    label: PropTypes.string,
+    placeholder: PropTypes.string,
+    value: PropTypes.string,
+  })),
+  searchableIndexesPlaceholder: PropTypes.string,
+  searchButtonRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  selectedIndex: PropTypes.string,
+  value: PropTypes.string,
+};
+
+const MultiSelectSearchField = (props) => {
+  const {
+    className,
+    placeholder,
+    id,
+    ariaLabel,
+    value,
+    onChange,
+    onClear,
+    loading,
+    clearSearchId,
+    searchableIndexes,
+    onChangeIndex,
+    selectedIndex,
+    searchableIndexesPlaceholder,
+    inputClass,
+    disabled,
+    isAdvancedSearch,
+    searchButtonRef,
+    ...rest
+  } = props;
+
+  /**
+   * Search field has searchable indexes dropdown
+   */
+  let searchableIndexesDropdown;
+  const hasSearchableIndexes = Array.isArray(searchableIndexes);
+  const intl = useIntl();
+
+  if (hasSearchableIndexes) {
+    const indexLabel = intl.formatMessage({ id: 'stripes-components.searchFieldIndex' });
+
+    searchableIndexesDropdown = (
+      <Select
+        aria-label={indexLabel}
+        dataOptions={searchableIndexes}
+        disabled={loading}
+        id={`${id}-qindex`}
+        marginBottom0
+        onChange={onChangeIndex}
+        placeholder={searchableIndexesPlaceholder}
+        selectClass={css.select}
+        value={selectedIndex}
+      />
+    );
+  }
+
+  // Wrapper styles
+  const rootStyles = classNames(
+    css.searchFieldWrap,
+    { [css.hasSearchableIndexes]: hasSearchableIndexes },
+    className,
+  );
+
+  // Search icon
+  const searchIcon = (<TextFieldIcon iconClassName={css.searchIcon} icon="search" />);
+
+  // Placeholder
+  let inputPlaceholder = placeholder;
+  if (!placeholder && hasSearchableIndexes && selectedIndex) {
+    const selectedIndexConfig = searchableIndexes.find(index => index.value === selectedIndex) || {};
+    inputPlaceholder = selectedIndexConfig.placeholder || '';
+  }
+
+  return (
+    <div className={rootStyles}>
+      {searchableIndexesDropdown}
+      {isAdvancedSearch
+        ? (
+          <MultiSelectSearch
+            onChange={onChange}
+            searchButtonRef={searchButtonRef}
+          />
+        )
+        : (
+          <TextField
+            {...rest}
+            aria-label={rest['aria-label'] || ariaLabel}
+            clearFieldId={clearSearchId}
+            disabled={disabled}
+            focusedClass={css.isFocused}
+            id={id}
+            hasClearIcon={typeof onClear === 'function' && loading !== true}
+            inputClass={classNames(css.input, inputClass)}
+            loading={loading}
+            onChange={onChange}
+            onClearField={onClear}
+            placeholder={inputPlaceholder}
+            startControl={!hasSearchableIndexes ? searchIcon : null}
+            type="search"
+            value={value || ''}
+            readOnly={loading || rest.readOnly}
+          />
+        )
+      }
+    </div>
+  );
+};
+
+MultiSelectSearchField.propTypes = propTypes;
+MultiSelectSearchField.defaultProps = {
+  loading: false,
+};
+
+export default MultiSelectSearchField;

--- a/lib/MultiSelectSearchField/components/MultiSelectSearch/MultiSelectSearch.js
+++ b/lib/MultiSelectSearchField/components/MultiSelectSearch/MultiSelectSearch.js
@@ -16,7 +16,7 @@ const propTypes = {
 const MultiSelectSearch = props => {
   const {
     onChange,
-    searchButtonRef,
+    searchButtonRef = {},
     style = defaultStyle,
   } = props;
 
@@ -31,7 +31,9 @@ const MultiSelectSearch = props => {
     switch (event.keyCode) {
       case 13: // enter
         event.preventDefault();
-        searchButtonRef.current.click();
+        if (searchButtonRef.current) {
+          searchButtonRef.current.click();
+        }
         break;
       default:
     }

--- a/lib/MultiSelectSearchField/components/MultiSelectSearch/MultiSelectSearch.js
+++ b/lib/MultiSelectSearchField/components/MultiSelectSearch/MultiSelectSearch.js
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import TextArea from '../../../TextArea';
+
+const defaultStyle = {
+  height: '20px',
+  resize: 'none',
+};
+
+const propTypes = {
+  onChange: PropTypes.func,
+  searchButtonRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  style: PropTypes.object,
+};
+
+const MultiSelectSearch = props => {
+  const {
+    onChange,
+    searchButtonRef,
+    style = defaultStyle,
+  } = props;
+
+  const [searchTerms, setSearchTerms] = useState('');
+
+  const handleSearchTermsChange = event => {
+    onChange(event);
+    setSearchTerms(event.target.value);
+  };
+
+  const handleKeyDown = event => {
+    switch (event.keyCode) {
+      case 13: // enter
+        event.preventDefault();
+        searchButtonRef.current.click();
+        break;
+      default:
+    }
+  };
+
+  return (
+    <TextArea
+      style={style}
+      marginBottom0
+      value={searchTerms}
+      onChange={handleSearchTermsChange}
+      onKeyDown={handleKeyDown}
+    />
+  );
+};
+
+MultiSelectSearch.propTypes = propTypes;
+
+export default MultiSelectSearch;

--- a/lib/MultiSelectSearchField/components/MultiSelectSearch/index.js
+++ b/lib/MultiSelectSearchField/components/MultiSelectSearch/index.js
@@ -1,0 +1,1 @@
+export { default } from './MultiSelectSearch';

--- a/lib/MultiSelectSearchField/index.js
+++ b/lib/MultiSelectSearchField/index.js
@@ -1,0 +1,1 @@
+export { default } from './MultiSelectSearchField';

--- a/lib/MultiSelectSearchField/readme.md
+++ b/lib/MultiSelectSearchField/readme.md
@@ -1,0 +1,97 @@
+# SearchField
+
+Universal search field component.
+
+## Basic Usage
+
+```
+  import { MultiSelectSearchField } from '@folio/stripes/components';
+
+  <MultiSelectSearchField
+    onChange={...}
+    value={...}
+    onClear={...}
+    placeholder="Search for something"
+  />
+```
+
+## Usage with a MultiSelect component
+The component supports the addition of the isAdvancedSearch boolean property, which changes the TextField component to MultiSelect
+and a searchButtonRef property, which gives the ability to use Enter in textarea field without transfer to the next line.
+
+```
+  import MultiSelectSearchField from '@folio/stripes/components';
+
+  <MultiSelectSearchField
+    onChange={...}
+    value={...}
+    onClear={...}
+    placeholder="Search for something"
+    
+    isAdvancedSearch={true}
+    searchButtonRef={searchButtonRef}
+  />
+```
+
+## Usage with searchable indexes
+The component supports adding an array of searchable indexes which adds a select field to the component.
+
+```
+  import MultiSelectSearchField from '@folio/stripes/components';
+
+  const searchableIndexes = [
+    { label: 'ID', value: 'id' },
+    { label: 'Title', value: 'title', placeholder: 'Search by Title' },
+    { label: 'Identifier', value: 'identifier', localOnly: true },
+  ];
+
+  <MultiSelectSearchField
+    onChange={...}
+    value={...}
+    onClear={...}
+    placeholder="Search for something"
+    isAdvancedSearch="true"
+    searchButtonRef={searchButtonRef}
+
+    searchableIndexes={searchableIndexes}
+    onChangeIndex={() => ...}
+    selectedIndex={...}
+    searchableIndexesPlaceholder="Search for these fields.."
+  />
+```
+
+## Props
+This component supports all props of the SearchField component and isAdvancedSearch.
+
+Name | type | Description
+-- | -- | --
+placeholder | string | Adds a placeholder to the search input field
+id | string | Adds an ID to the input field
+className | string | Adds a className to the root element
+inputClass | string | Adds a className to the input
+aria-label | string | Adds an aria label to the input field. Camel-case `ariaLabel` is also accepted.
+value | string | The value of the input field
+loading | boolean | Adds a loading state to icon (on fetch etc.)
+onChange | function | On change handler for the input field
+onClear | function | On clear search field callback
+clearSearchId | string | Adds id to the clear search icon
+isAdvancedSearch | boolean | Rendering a MultiSelectSearch component instead of the TextField
+searchButtonRef | object | Supplies a ref to the search button
+
+### With the MultiSelect component
+Additional props for adding the MultiSelect component instead of the TextField.
+
+Name | type | Description
+-- | -- | --
+isAdvancedSearch | boolean | Rendering a MultiSelectSearch component instead of the TextField
+searchButtonRef | object | Supplies a ref to the search button
+
+### With searchable indexes
+Additional props for adding searchable indexes/fields.
+
+Name | type | Description
+-- | -- | --
+searchableIndexes | array of objects | Adds a list of searchable indexes/fields
+selectedIndex | string | Currently selected index
+onChangeIndex | function | On change handler for when changing index
+searchableIndexesPlaceholder | string | Control the placeholder of the select field

--- a/lib/MultiSelectSearchField/readme.md
+++ b/lib/MultiSelectSearchField/readme.md
@@ -13,7 +13,6 @@ Universal search field component.
     onClear={...}
     placeholder="Search for something"
     isAdvancedSearch="true"
-    searchButtonRef={searchButtonRef}
   />
 ```
 

--- a/lib/MultiSelectSearchField/readme.md
+++ b/lib/MultiSelectSearchField/readme.md
@@ -12,23 +12,7 @@ Universal search field component.
     value={...}
     onClear={...}
     placeholder="Search for something"
-  />
-```
-
-## Usage with a MultiSelect component
-The component supports the addition of the isAdvancedSearch boolean property, which changes the TextField component to MultiSelect
-and a searchButtonRef property, which gives the ability to use Enter in textarea field without transfer to the next line.
-
-```
-  import MultiSelectSearchField from '@folio/stripes/components';
-
-  <MultiSelectSearchField
-    onChange={...}
-    value={...}
-    onClear={...}
-    placeholder="Search for something"
-    
-    isAdvancedSearch={true}
+    isAdvancedSearch="true"
     searchButtonRef={searchButtonRef}
   />
 ```
@@ -61,7 +45,9 @@ The component supports adding an array of searchable indexes which adds a select
 ```
 
 ## Props
-This component supports all props of the SearchField component and isAdvancedSearch.
+This component supports all props of the SearchField component and isAdvancedSearch boolean property, which changes the 
+TextField component to MultiSelect, and a searchButtonRef property, which gives the ability to use Enter in textarea 
+field without transfer to the next line.
 
 Name | type | Description
 -- | -- | --
@@ -75,14 +61,6 @@ loading | boolean | Adds a loading state to icon (on fetch etc.)
 onChange | function | On change handler for the input field
 onClear | function | On clear search field callback
 clearSearchId | string | Adds id to the clear search icon
-isAdvancedSearch | boolean | Rendering a MultiSelectSearch component instead of the TextField
-searchButtonRef | object | Supplies a ref to the search button
-
-### With the MultiSelect component
-Additional props for adding the MultiSelect component instead of the TextField.
-
-Name | type | Description
--- | -- | --
 isAdvancedSearch | boolean | Rendering a MultiSelectSearch component instead of the TextField
 searchButtonRef | object | Supplies a ref to the search button
 

--- a/lib/MultiSelectSearchField/stories/BasicUsage.js
+++ b/lib/MultiSelectSearchField/stories/BasicUsage.js
@@ -88,6 +88,8 @@ export default class SearchFieldUsage extends Component {
           onChangeIndex={hasSearchableIndexes ? this.changeIndex : null}
           selectedIndex={hasSearchableIndexes ? this.state.selectedIndex : null}
           searchableIndexesPlaceholder="Search all.."
+          isAdvancedSearch="true"
+          searchButtonRef={this.props.searchButtonRef}
         />
         <div style={{ marginTop: '1rem', color: '#888' }}>
           { this.state.value ? `You typed: ${this.state.value}` : 'Try entering a value in the search field.'}

--- a/lib/MultiSelectSearchField/stories/BasicUsage.js
+++ b/lib/MultiSelectSearchField/stories/BasicUsage.js
@@ -1,0 +1,98 @@
+/**
+ * SearchField Usage
+ */
+
+import React, { Component } from 'react';
+import MultiSelectSearchField from '../MultiSelectSearchField';
+import Checkbox from '../../Checkbox';
+
+export default class SearchFieldUsage extends Component {
+  constructor() {
+    super();
+    this.state = {
+      value: '',
+      loading: false,
+      selectedIndex: '',
+      hasSearchableIndexes: false,
+    };
+    this.clearValue = this.clearValue.bind(this);
+    this.changeValue = this.changeValue.bind(this);
+    this.changeIndex = this.changeIndex.bind(this);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.asyncFaker);
+  }
+
+  clearValue() {
+    this.setState({
+      value: '',
+    });
+  }
+
+  changeValue(e) {
+    clearInterval(this.asyncFaker);
+
+    this.setState({
+      value: e.target.value,
+      loading: true,
+    });
+
+    this.asyncFaker = setInterval(() => {
+      this.setState({
+        loading: false,
+      });
+    }, 250);
+  }
+
+  changeIndex(e) {
+    this.setState({
+      selectedIndex: e.target.value,
+    });
+  }
+
+  render() {
+    const { hasSearchableIndexes } = this.state;
+    const searchableIndexes = [
+      { label: 'ID', value: 'id' },
+      { label: 'Title', value: 'title', placeholder: 'Please input title...' },
+      { label: 'Identifier', value: 'identifier', localOnly: true },
+      { label: 'ISBN', value: 'identifier/type=isbn' },
+      { label: 'ISSN', value: 'identifier/type=issn' },
+      { label: 'Contributor', value: 'contributor', localOnly: true },
+      { label: 'Subject', value: 'subject', localOnly: true },
+      { label: 'Classification', value: 'classification', localOnly: true },
+      { label: 'Publisher', value: 'publisher' },
+    ];
+
+    return (
+      <div>
+        <Checkbox
+          label="Toggle searchable indexes"
+          id="toggle-searchable-indexes"
+          checked={this.state.hasSearchableIndexes}
+          onChange={() => { this.setState({ hasSearchableIndexes: !hasSearchableIndexes }); }}
+        />
+        <br />
+        <br />
+        <MultiSelectSearchField
+          onClear={this.clearValue}
+          value={this.state.value}
+          loading={this.state.loading}
+          onChange={this.changeValue}
+          placeholder="Enter search term.."
+          aria-label="Search for stuff."
+          clearSearchId="clear-search-button"
+          id="clear-sesrch-field"
+          searchableIndexes={hasSearchableIndexes ? searchableIndexes : null}
+          onChangeIndex={hasSearchableIndexes ? this.changeIndex : null}
+          selectedIndex={hasSearchableIndexes ? this.state.selectedIndex : null}
+          searchableIndexesPlaceholder="Search all.."
+        />
+        <div style={{ marginTop: '1rem', color: '#888' }}>
+          { this.state.value ? `You typed: ${this.state.value}` : 'Try entering a value in the search field.'}
+        </div>
+      </div>
+    );
+  }
+}

--- a/lib/MultiSelectSearchField/stories/BasicUsage.js
+++ b/lib/MultiSelectSearchField/stories/BasicUsage.js
@@ -89,7 +89,6 @@ export default class SearchFieldUsage extends Component {
           selectedIndex={hasSearchableIndexes ? this.state.selectedIndex : null}
           searchableIndexesPlaceholder="Search all.."
           isAdvancedSearch="true"
-          searchButtonRef={this.props.searchButtonRef}
         />
         <div style={{ marginTop: '1rem', color: '#888' }}>
           { this.state.value ? `You typed: ${this.state.value}` : 'Try entering a value in the search field.'}

--- a/lib/MultiSelectSearchField/stories/MultiSelectSearchField.stories.js
+++ b/lib/MultiSelectSearchField/stories/MultiSelectSearchField.stories.js
@@ -4,6 +4,6 @@ import withReadme from 'storybook-readme/with-readme';
 import readme from '../readme.md';
 import BasicUsage from './BasicUsage';
 
-storiesOf('SearchField', module)
+storiesOf('MultiSelectSearchField', module)
   .addDecorator(withReadme(readme))
   .add('Basic Usage', () => <BasicUsage />);

--- a/lib/MultiSelectSearchField/stories/SearchField.stories.js
+++ b/lib/MultiSelectSearchField/stories/SearchField.stories.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import withReadme from 'storybook-readme/with-readme';
+import readme from '../readme.md';
+import BasicUsage from './BasicUsage';
+
+storiesOf('SearchField', module)
+  .addDecorator(withReadme(readme))
+  .add('Basic Usage', () => <BasicUsage />);

--- a/lib/MultiSelectSearchField/tests/MultiSelectSearchField-test.js
+++ b/lib/MultiSelectSearchField/tests/MultiSelectSearchField-test.js
@@ -1,0 +1,150 @@
+import React from 'react';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { mountWithContext } from '../../../tests/helpers';
+import MultiSelectSearchField from '../MultiSelectSearchField';
+import MultiSelectSearchFieldInteractor from './interactor';
+
+const LABEL_PUBLISHER = 'Publisher';
+const LABEL_SUBJECT = 'Subject';
+const PLACEHOLDER_SUBJECT = 'Subject...';
+
+describe('MultiSelectSearchField', () => {
+  const searchField = new MultiSelectSearchFieldInteractor();
+
+  describe('rendering a MultiSelectSearchField', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <MultiSelectSearchField id="searchFieldTest" />
+      );
+    });
+
+    it('applies the supplied id prop to the input', () => {
+      expect(searchField.id).to.equal('searchFieldTest');
+      expect(searchField.inputReadOnly).to.be.null;
+    });
+
+    it('renders the input field', () => {
+      expect(searchField.textareaPresent).to.be.false;
+      expect(searchField.inputPresent).to.be.true;
+    });
+
+    describe('applying advanced search', () => {
+      beforeEach(async () => {
+        await mountWithContext(
+          <MultiSelectSearchField isAdvancedSearch="true" />
+        );
+      });
+
+      it('renders the textarea field', () => {
+        expect(searchField.textareaPresent).to.be.true;
+        expect(searchField.inputPresent).to.be.false;
+      });
+    });
+  });
+
+  describe('supplying an onChange handler', () => {
+    let fieldValue = '';
+
+    beforeEach(async () => {
+      await mountWithContext(
+        <MultiSelectSearchField
+          onChange={(e) => { fieldValue = e.target.value; }}
+        />
+      );
+    });
+
+    describe('changing the field', () => {
+      beforeEach(async () => {
+        await searchField.fillInput('testing text');
+      });
+
+      it('should update value', () => {
+        expect(fieldValue).to.equal('testing text');
+      });
+    });
+
+    describe('rendering a MultiSelectSearchField in loading state', () => {
+      beforeEach(async () => {
+        await mountWithContext(
+          <MultiSelectSearchField
+            id="searchFieldTest"
+            loading
+            searchableIndexes={[{ label: 'ID', value: 'id' }]}
+          />
+        );
+      });
+
+      it('input and select are disabled', () => {
+        expect(searchField.inputReadOnly).to.equal('');
+        expect(searchField.isDisabledIndex).to.be.true;
+      });
+    });
+  });
+
+  describe('using with indexes', () => {
+    const searchableIndexes = [
+      { label: 'ID', value: 'id' },
+      { label: 'Title', value: 'title' },
+      { label: 'Identifier', value: 'identifier' },
+      { label: 'ISBN', value: 'identifier/type=isbn' },
+      { label: 'ISSN', value: 'identifier/type=issn' },
+      { label: 'Contributor', value: 'contributor' },
+      { label: LABEL_SUBJECT, value: 'subject', placeholder: PLACEHOLDER_SUBJECT },
+      { label: 'Classification', value: 'classification' },
+      { label: LABEL_PUBLISHER, value: 'publisher' },
+    ];
+
+    class SearchFieldHarness extends React.Component {
+      constructor(props) {
+        super(props);
+
+        this.state = {
+          searchFieldIndex: 'identifier',
+        };
+      }
+
+      render() {
+        return (
+          <MultiSelectSearchField
+            onChangeIndex={(e) => { this.setState({ searchFieldIndex: e.target.value }); }}
+            searchableIndexes={searchableIndexes}
+            selectedIndex={this.state.searchFieldIndex}
+          />
+        );
+      }
+    }
+
+    beforeEach(async () => {
+      await mountWithContext(
+        <SearchFieldHarness />
+      );
+    });
+
+    it('input and select are not disabled', () => {
+      expect(searchField.isDisabled).to.be.false;
+      expect(searchField.isDisabledIndex).to.be.false;
+    });
+
+    describe('changing the index', () => {
+      beforeEach(async () => {
+        await searchField.selectIndex(LABEL_PUBLISHER);
+      });
+
+      it('should update the placeholder', () => {
+        expect(searchField.placeholder).to.be.empty;
+      });
+    });
+
+    describe('changing the index with placeholder', () => {
+      beforeEach(async () => {
+        await searchField.selectIndex(LABEL_SUBJECT);
+      });
+
+      it('should update the placeholder', () => {
+        expect(searchField.placeholder).to.equal(PLACEHOLDER_SUBJECT);
+      });
+    });
+  });
+});

--- a/lib/MultiSelectSearchField/tests/interactor.js
+++ b/lib/MultiSelectSearchField/tests/interactor.js
@@ -1,0 +1,22 @@
+import {
+  attribute,
+  fillable,
+  interactor,
+  isPresent,
+  property,
+  selectable
+} from '@bigtest/interactor';
+import textAreaCSS from '../../TextArea/TextArea.css';
+import textFieldCSS from '../../TextField/TextField.css';
+
+export default interactor(class MultiSelectSearchFieldInteractor {
+  id = attribute('input', 'id');
+  fillInput = fillable('input');
+  selectIndex = selectable('select');
+  placeholder = attribute('input', 'placeholder');
+  isDisabled = property('input', 'disabled');
+  inputReadOnly = attribute('input', 'readonly');
+  isDisabledIndex = property('select', 'disabled');
+  textareaPresent = isPresent(`.${textAreaCSS.textArea}`);
+  inputPresent = isPresent(`.${textFieldCSS.textField}`);
+});


### PR DESCRIPTION
This PR for ElasticSearch POC.
MultiSelectSearch is a new component for ElasticSearch POC - it is at the initial stage of development.

When a user selects the 'Advanced Search' mode, I need to change the TextField component to the new MultiSelectSearch. 
For this, I need to make changes to the SearchField component of stripes-components.
Since this is a proof of concept, I created a clone of the SearchField component, I named it MultiSelectSearchField and worked with it. 
I expanded it by adding a condition for rendering the desired component (113-139 lines) [https://github.com/folio-org/stripes-components/compare/UISEES-33?expand=1#diff-fa839c4a3fe6f46677966c3d9b48f406424a903348bfb27305dee157b0fb6b50](url)

Wrote two tests into cloned tests to check if the condition works (28 - 45 lines) https://github.com/folio-org/stripes-components/compare/UISEES-33?expand=1#diff-5dda0dc10a42ea40d5f7fd96799e4b6923160cb71c25e7f3fa864c5d916a154d

I expanded the cloned storybook with new properties (isAdvancedSearch, searchButtonRef) https://github.com/folio-org/stripes-components/compare/UISEES-33?expand=1#diff-b029b0edd8fbef10c15aa114289913f10f93a3e2406881adb34f0136d05a9a09

Refs [UISEES-33](https://issues.folio.org/browse/UISEES-33)