### PR TITLE
STCOM-806 increment @folio/stripes-cli to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Settings > Panes are off. Refs STCOM-795.
 * Fix overflow in `sr-only` elements. Refs STCOM-801.
 * `<ErrorBoundary>` accepts a callback to receive the arguments to `componentDidCatch`. Refs STCOM-753.
+* Increment `@folio/stripes-cli` to `v2`. Refs STCOM-806.
 
 ## [8.0.0](https://github.com/folio-org/stripes-components/tree/v8.0.0) (2020-10-05)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v7.0.1...v8.0.0)

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@bigtest/interactor": "0.7.2",
     "@bigtest/mocha": "^0.5.0",
     "@folio/eslint-config-stripes": "^5.2.0",
-    "@folio/stripes-cli": "^1.6.0",
+    "@folio/stripes-cli": "^2.0.0",
     "@storybook/addon-actions": "^5.3.19",
     "@storybook/addon-knobs": "^5.3.19",
     "@storybook/addon-options": "^5.3.19",


### PR DESCRIPTION
Build with `@folio/stripes-cli` `v2`, which (huzzah!) does not depend
internally on stripes-core like `v1`, because `stripes-core` depends on
`stripes-components`, which depdends on `stripes-cli`, which depended
on `stripes-core`, which depends on `stripes-components`, which depends
on `stripes-cli`, which depended on `stripes-core`, which depends on
`stripes-components`.

Refs [STCOM-806](https://issues.folio.org/browse/STCOM-806)