### PR TITLE
Include error stack in <ErrorBoundary>

### DIFF
--- a/lib/ErrorBoundary/ErrorBoundary.js
+++ b/lib/ErrorBoundary/ErrorBoundary.js
@@ -38,11 +38,11 @@ export default class ErrorBoundary extends Component {
     const lines = `
       ${errorStack.toString()}
       ${componentStack.toString()}
-    `.split('\n');
+    `.split('\n')
+      // Remove empty lines
+      .filter(str => !!str);
 
     const stack = lines
-      // Remove empty lines
-      .filter(str => !!str)
       // Remove the first line because it's the same as the error we get above
       .splice(1, lines.length)
       // Remove whitespace

--- a/lib/ErrorBoundary/ErrorBoundary.js
+++ b/lib/ErrorBoundary/ErrorBoundary.js
@@ -23,7 +23,7 @@ export default class ErrorBoundary extends Component {
 
     this.state = {
       error: undefined,
-      info: undefined,
+      stack: undefined,
     };
   }
 
@@ -31,19 +31,37 @@ export default class ErrorBoundary extends Component {
     if (this.props.onError) {
       this.props.onError(error, info);
     }
-    this.setState({ error: error.toString(), info });
+
+    const { stack: errorStack } = error;
+    const { componentStack } = info;
+
+    const lines = `
+      ${errorStack.toString()}
+      ${componentStack.toString()}
+    `.split('\n');
+
+    const stack = lines
+      // Remove empty lines
+      .filter(str => !!str)
+      // Remove the first line because it's the same as the error we get above
+      .splice(1, lines.length)
+      // Remove whitespace
+      .map(str => str.replace(/\s+/, ''))
+      .join('\n');
+
+    this.setState({ error: error.toString(), stack });
   }
 
   renderError = () => {
     const { forceProductionError, title, subTitle, resetButtonLabel, onReset } = this.props;
-    const { error, info: { componentStack } } = this.state;
+    const { error, stack } = this.state;
     const isDevelopment = process.env.NODE_ENV === 'development';
 
     if (isDevelopment && !forceProductionError) {
       return (
         <ErrorMessage
           error={error}
-          stack={componentStack}
+          stack={stack}
         />
       );
     }

--- a/lib/ErrorBoundary/ErrorBoundary.js
+++ b/lib/ErrorBoundary/ErrorBoundary.js
@@ -40,7 +40,7 @@ export default class ErrorBoundary extends Component {
       ${componentStack.toString()}
     `.split('\n')
       // Remove empty lines
-      .filter(str => !!str);
+      .filter(Boolean);
 
     const stack = lines
       // Remove the first line because it's the same as the error we get above

--- a/lib/ErrorBoundary/ErrorBoundary.js
+++ b/lib/ErrorBoundary/ErrorBoundary.js
@@ -71,7 +71,7 @@ export default class ErrorBoundary extends Component {
         error={error}
         onReset={onReset}
         resetButtonLabel={resetButtonLabel}
-        stackTrace={componentStack}
+        stackTrace={stack}
         subTitle={subTitle}
         title={title}
       />

--- a/lib/ErrorBoundary/components/ErrorMessage/ErrorMessage.css
+++ b/lib/ErrorBoundary/components/ErrorMessage/ErrorMessage.css
@@ -3,7 +3,7 @@
  */
 
 .message {
-  padding: calc(var(--gutter) * 1.5) 0;
+  padding: calc(var(--gutter) * 1.5);
 }
 
 .message__content {
@@ -11,8 +11,7 @@
 }
 
 .error {
-  padding: 0 2.6rem;
-  margin: 0;
+  margin: 0 0 calc(var(--gutter) * 1.5) 0;
 }
 
 .stack {


### PR DESCRIPTION
Until now, we have only been rendering the component stack, when the `<ErrorBoundary>` catches an error. 

This update includes the error stack as well which makes it a lot easier to pinpoint where an error occurred at first glance without having to look in the console.

## Note
The component stack can be made more precise by wrapping each module in an `<ErrorBoundary>`.

## Before
<img width="1097" alt="Screenshot 2021-02-18 at 15 15 21" src="https://user-images.githubusercontent.com/640976/108370157-a0e52080-71fc-11eb-98ac-f36b63c14f15.png">

## After
<img width="1095" alt="Screenshot 2021-02-18 at 14 59 12" src="https://user-images.githubusercontent.com/640976/108370172-a5113e00-71fc-11eb-8104-8bc9a8856c2f.png">
