### PR TITLE
STCOM-812 Title Record: Search within Packages Modal. Scrolling list of Packages is overlay with Selection filter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,7 @@
   "extends": "@folio/eslint-config-stripes",
   "overrides": [
     {
-      "files": ["lib/**/tests/**", "util/tests/*"],
+      "files": ["lib/**/tests/**", "util/tests/*", "hooks/tests/*"],
       "rules": {
         "func-names": "off",
         "max-classes-per-file": "off",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-components
 
+## [9.1.0] IN PROGRESS
+
+* Fix Accordion content is displayed below other accordions when using scrollbar. Fixes STCOM-812.
+
 ## [9.0.0](https://github.com/folio-org/stripes-components/tree/v9.0.0) (2021-02-25)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v8.0.0...v9.0.0)
 

--- a/hooks/tests/useClickOutside-test.js
+++ b/hooks/tests/useClickOutside-test.js
@@ -1,0 +1,71 @@
+import React, { useRef } from 'react';
+import {
+  describe,
+  it,
+  beforeEach,
+} from '@bigtest/mocha';
+import {
+  interactor,
+  clickable,
+} from '@bigtest/interactor';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { mountWithContext } from '../../tests/helpers';
+
+import useClickOutside from '../useClickOutside';
+
+const UseClickOutsideInteractor = interactor(class UseClickOutsideInteractor {
+  static defaultScope ='#test-component';
+  clickOutsideElement = clickable('#click-outside-element');
+  clickInsideElement = clickable('#click-inside-element');
+});
+
+describe('useClickOutside', () => {
+  const useClickOutsideInteractor = new UseClickOutsideInteractor();
+  const onClickSpy = sinon.spy();
+
+  const TestComponent = ({ onClick }) => {
+    const content = useRef(null);
+
+    useClickOutside(content, () => {
+      onClick();
+    });
+
+    return (
+      <div ref={content}>
+        <span id="click-inside-element">Inside element</span>
+      </div>
+    );
+  };
+
+  beforeEach(async () => {
+    onClickSpy.resetHistory();
+
+    await mountWithContext(
+      <div id="test-component">
+        <TestComponent onClick={onClickSpy} />
+        <p id="click-outside-element">Outside element</p>
+      </div>
+    );
+  });
+
+  describe('when clicking outside element', () => {
+    beforeEach(async () => {
+      await useClickOutsideInteractor.clickOutsideElement();
+    });
+
+    it('should call onClick', () => {
+      expect(onClickSpy.called).to.be.true;
+    });
+  });
+
+  describe('when clicking inside element', () => {
+    beforeEach(async () => {
+      await useClickOutsideInteractor.clickInsideElement();
+    });
+
+    it('should not call onClick', () => {
+      expect(onClickSpy.called).to.be.false;
+    });
+  });
+});

--- a/hooks/useClickOutside/index.js
+++ b/hooks/useClickOutside/index.js
@@ -1,0 +1,1 @@
+export { default } from './useClickOutside';

--- a/hooks/useClickOutside/useClickOutside.js
+++ b/hooks/useClickOutside/useClickOutside.js
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+const useClickOutside = (ref, onClickOutside) => {
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) {
+        onClickOutside(e);
+      }
+    };
+
+    document.addEventListener('click', handleClickOutside);
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  }, [ref, onClickOutside]);
+};
+
+export default useClickOutside;

--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -8,6 +8,7 @@ import {
 import { DefaultAccordionHeader } from './headers';
 import css from './Accordion.css';
 import { HotKeys } from '../HotKeys';
+import useClickOutside from '../../hooks/useClickOutside';
 import { withAccordionSet } from './AccordionSetContext';
 import omitProps from '../../util/omitProps';
 
@@ -118,7 +119,12 @@ const Accordion = (props) => {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleFocus = () => updateFocus(true);
-  const handleBlur = () => updateFocus(false);
+
+  // use click outside instead of blur
+  // blur has issues with clicking on scroll bars, where event's target is
+  // the whole document instead of the scrollable content. because of this we can't
+  // use blur to determine whether user clicked inside the accordion component tree
+  useClickOutside(content, () => updateFocus(false));
 
   const accordionHeaderProps = Object.assign({}, omitProps(props, ['contentHeight']), {
     contentId,
@@ -151,7 +157,6 @@ const Accordion = (props) => {
           id={contentId}
           aria-labelledby={`accordion-toggle-button-${trackingId}`}
           onFocus={handleFocus}
-          onBlur={handleBlur}
           style={contentHeight ? { height: contentHeight } : null}
           data-test-accordion-wrapper
         >


### PR DESCRIPTION
## Description
Fix an issue with `<Accordion>` where if you have scrollable content as child of accordion and you try scrolling it using the scrollbar then this content will display below other accordions next to it

## Approach
This issue is caused by elements losing focus when their content is scrolled using a scrollbar. This is possibly a browser issue - I've found Chromium issue that describes similar behavior with status Won't Fix (https://bugs.chromium.org/p/chromium/issues/detail?id=6759)

The solution that I propose is checking when a user has clicked outside of accordion's component tree using a `click` event listener on the document instead of `blur` event. In the handler of `click` we can check whether the event originated inside the component tree or not. And then based on that we can set `z-index` of accordion.

## Screenshots
With bug
![eHoldings - Journal - FOLIO (1)](https://user-images.githubusercontent.com/19309423/109508383-79b60b00-7aa8-11eb-81aa-b234da77c976.gif)

No bug
![eHoldings - Journal - FOLIO](https://user-images.githubusercontent.com/19309423/109508351-702ca300-7aa8-11eb-8130-074eaf2b84f8.gif)


## Issues
[STCOM-812](https://issues.folio.org/browse/STCOM-812)
