### PR TITLE
STCOM-815: Landmarks must have a unique role or role/label/title (AxeDevTools Error)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * `<ErrorBoundary>` accepts a callback to receive the arguments to `componentDidCatch`. Refs STCOM-753.
 * Increment `@folio/stripes-cli` to `v2`. Refs STCOM-806.
 * Added `refresh`-icon. Refs UX-426.
+* Fix rendering default heading as `h3` tag for accordion of `<DefaultAccordionHeader>` component. Refs STCOM-815
 
 ## [8.0.0](https://github.com/folio-org/stripes-components/tree/v8.0.0) (2020-10-05)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v7.0.1...v8.0.0)

--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -171,7 +171,6 @@ Accordion.propTypes = propTypes;
 Accordion.defaultProps = {
   className: '',
   header: DefaultAccordionHeader,
-  headerProps: {},
   separator: true,
 };
 

--- a/lib/Accordion/headers/DefaultAccordionHeader.js
+++ b/lib/Accordion/headers/DefaultAccordionHeader.js
@@ -19,7 +19,9 @@ const propTypes = {
 };
 
 const defaultProps = {
-  headingLevel: 3
+  headerProps: {
+    headingLevel: 3,
+  }
 };
 
 const DefaultAccordionHeader = (props) => {


### PR DESCRIPTION
## Ticket
https://issues.folio.org/browse/STCOM-815

## Changes
- Add `aria-label` attribute to default accordion header of `<DefaultAccordionHeader>` component to fix error about uniqueness of landmarks.

## Before
![image](https://user-images.githubusercontent.com/40805351/110627717-f634a200-81aa-11eb-810f-495ec15134ad.png)

## After
![image](https://user-images.githubusercontent.com/40805351/110627823-17958e00-81ab-11eb-802f-e89e19294592.png)

