### PR TITLE
STCOM-817 sync timezones in timepicker tests

### DIFF
--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -116,7 +116,7 @@ describe('Timepicker', () => {
       });
     });
 
-    describe.only('selecting a time with timeZone prop', () => {
+    describe('selecting a time with timeZone prop', () => {
       let timeOutput;
       const tz = 'America/Los_Angeles';
 

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
-import moment from 'moment';
+import moment from 'moment-timezone';
 
 import { mountWithContext } from '../../../tests/helpers';
 
@@ -116,8 +116,9 @@ describe('Timepicker', () => {
       });
     });
 
-    describe('selecting a time with timeZone prop', () => {
+    describe.only('selecting a time with timeZone prop', () => {
       let timeOutput;
+      const tz = 'America/Los_Angeles';
 
       beforeEach(async () => {
         timeOutput = '';
@@ -127,7 +128,7 @@ describe('Timepicker', () => {
             input={{
               onChange: (value) => { timeOutput = value; },
             }}
-            timeZone="America/Los_Angeles"
+            timeZone={tz}
           />
         );
 
@@ -135,7 +136,7 @@ describe('Timepicker', () => {
       });
 
       it('returns an ISO 8601 time string for specific time zone', () => {
-        expect(timeOutput).to.equal(moment().isDST() ? '00:00:00.000Z' : '01:00:00.000Z');
+        expect(timeOutput).to.equal(moment().tz(tz).isDST() ? '00:00:00.000Z' : '01:00:00.000Z');
       });
     });
   });


### PR DESCRIPTION
Sync the timezone given to the `<Timepicker>` and used to check its
output. The dates when DST is observed are not consistent across
timezones, e.g. the US starts DST a week before and ends it a week after
most other countries in the world. Thus, this test would fail if it ran
during one of those weeks in an environment where the local timezone is
a non-US timezone.

Refs [STCOM-817](https://issues.folio.org/browse/STCOM-817)