### PR TITLE
STCOM-794: Add ErrorModal component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## [9.1.0] IN PROGRESS
 
 * Fix Accordion content is displayed below other accordions when using scrollbar. Fixes STCOM-812. 
-* Add languageOptionsES for the laguage facet. Refs UISEES-29: Update filters options for Instances with the facet data.
-* Fix Pane behavior on window resize/3rd pane/nested paneset resize. Fixes STCOM-808
+* Add languageOptionsES for the laguage facet. Refs UISEES-29.
+* Fix Pane behavior on window resize/3rd pane/nested paneset resize. Fixes STCOM-808.
+* Add the `<ErrorModal>` component. Refs STCOM-794.
 
 ## [9.0.0](https://github.com/folio-org/stripes-components/tree/v9.0.0) (2021-02-25)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v8.0.0...v9.0.0)

--- a/index.js
+++ b/index.js
@@ -97,6 +97,7 @@ export {
 
 /* structures */
 export { default as ConfirmationModal } from './lib/ConfirmationModal';
+export { default as ErrorModal } from './lib/ErrorModal';
 export { default as InfoPopover } from './lib/InfoPopover';
 export { default as SearchField } from './lib/SearchField';
 

--- a/lib/ErrorModal/ErrorModal.js
+++ b/lib/ErrorModal/ErrorModal.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import Button from '../Button';
+import Modal from '../Modal';
+import ModalFooter from '../ModalFooter';
+
+const ErrorModal = ({
+  ariaLabel,
+  bodyTag: Element,
+  open,
+  content,
+  label,
+  onClose,
+  ...rest
+}) => {
+  const footer = (
+    <ModalFooter>
+      <Button
+        data-test-error-modal-close-button
+        onClick={onClose}
+      >
+        <FormattedMessage id="stripes-components.close" />
+      </Button>
+    </ModalFooter>
+  );
+
+  return (
+    <Modal
+      data-test-error-modal
+      aria-label={rest['aria-label'] || ariaLabel}
+      open={open}
+      size="small"
+      label={label}
+      footer={footer}
+    >
+      <Element data-test-error-modal-content>
+        {content}
+      </Element>
+    </Modal>
+  );
+};
+
+ErrorModal.propTypes = {
+  ariaLabel: PropTypes.string,
+  bodyTag: PropTypes.string,
+  content: PropTypes.node.isRequired,
+  label: PropTypes.node.isRequired,
+  onClose: PropTypes.func.isRequired,
+  open: PropTypes.bool.isRequired,
+};
+
+ErrorModal.defaultProps = {
+  bodyTag: 'div',
+};
+
+export default ErrorModal;

--- a/lib/ErrorModal/index.js
+++ b/lib/ErrorModal/index.js
@@ -1,0 +1,1 @@
+export { default } from './ErrorModal';

--- a/lib/ErrorModal/readme.md
+++ b/lib/ErrorModal/readme.md
@@ -1,0 +1,45 @@
+# ErrorModal
+
+A basic error modal with props to support label (required) and content (required).
+
+## Basic usage
+
+```
+// Show/hide handlers for the application.
+
+showError() {
+  this.setState({
+    isOpen: true,
+  });
+}
+
+hideError() {
+  this.setState({
+    isOpen: false,
+  });
+}
+
+onClose() {
+  this.hideError();
+}
+
+// ...in JSX...
+
+<ErrorModal
+  open={this.state.isOpen}
+  label="Something went wrong"
+  content="Here is a detailed message that explains why the error occurred."
+  onClose={this.onClose}
+/>
+```
+
+## Properties
+
+Name | type | description | default | required
+--- | --- | --- | --- | ---
+`aria-label` | string | Fills aria-label attribute for screen readers. Camel-case prop name `ariaLabel` is also supported |  |
+`bodyTag` | string | String to set the HTML tag used to wrap the modal content | "div" |
+`content` | node | Renderable content that displayed in the `<div>` tag by default |  | &#10004;
+`label` | string | String displayed at the top of the modal as an H1 tag |  | &#10004;
+`onClose` | func | Callback fired when the Close button is clicked |  | &#10004;
+`open` | bool | Boolean reflecting modal's open/closed status |  | &#10004;

--- a/lib/ErrorModal/stories/ErrorModalExample.js
+++ b/lib/ErrorModal/stories/ErrorModalExample.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+import ErrorModal from '..';
+
+export default () => (
+  <ErrorModal
+    open
+    label="Something went wrong"
+    content="Here is a detailed message that explains why the error occurred."
+    bodyTag="div"
+    onClose={action('Closed')}
+  />
+);

--- a/lib/ErrorModal/tests/ErrorModal-test.js
+++ b/lib/ErrorModal/tests/ErrorModal-test.js
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { describe, beforeEach, it } from '@bigtest/mocha';
+import { mountWithContext } from '../../../tests/helpers';
+
+import ErrorModal from '../ErrorModal';
+import ErrorModalInteractor from './interactor';
+
+describe('ErrorModal', () => {
+  const errorModal = new ErrorModalInteractor();
+  const onClose = sinon.spy();
+
+  const label = 'Something went wrong';
+  const content = 'Here is a detailed message that explains why the error occurred.';
+
+  beforeEach(async () => {
+    await mountWithContext(
+      <ErrorModal
+        open
+        label={label}
+        content={content}
+        onClose={onClose}
+      />
+    );
+  });
+
+  it('the label text should be correct', () => {
+    expect(errorModal.label.text).to.equal(label);
+  });
+
+  it('the content text should be correct', () => {
+    expect(errorModal.content.text).to.equal(content);
+  });
+
+  it('the content tagName should be div', () => {
+    expect(errorModal.bodyTagName).to.equal('div');
+  });
+
+  describe('when clicking the close button', () => {
+    beforeEach(async () => {
+      await errorModal.closeButton.click();
+    });
+
+    it('the onClose callback should be fired', () => {
+      expect(onClose.called).to.be.true;
+    });
+  });
+});

--- a/lib/ErrorModal/tests/interactor.js
+++ b/lib/ErrorModal/tests/interactor.js
@@ -1,0 +1,20 @@
+import {
+  interactor,
+  scoped,
+  computed,
+  Interactor,
+} from '@bigtest/interactor';
+import ButtonInteractor from '../../Button/tests/interactor';
+
+import css from '../../Modal/Modal.css';
+
+const tagName = selector => computed(function () {
+  return this.$(selector).tagName.toLowerCase();
+});
+
+export default interactor(class ErrorModalInteractor {
+  label = new Interactor(`.${css.modalLabel}`);
+  content = new Interactor('[data-test-error-modal-content]');
+  bodyTagName = tagName('[data-test-error-modal-content]');
+  closeButton = scoped('[data-test-error-modal-close-button]', ButtonInteractor);
+});

--- a/lib/Modal/stories/Modal.stories.js
+++ b/lib/Modal/stories/Modal.stories.js
@@ -11,8 +11,12 @@ import WithModalFooterReadme from '../../ModalFooter/readme.md';
 import ConfirmationModalExample from '../../ConfirmationModal/stories/ConfirmationModalExample';
 import ConfirmationModalReadme from '../../ConfirmationModal/readme.md';
 
+import ErrorModalExample from '../../ErrorModal/stories/ErrorModalExample';
+import ErrorModalReadme from '../../ErrorModal/readme.md';
+
 storiesOf('Modal', module)
   .addDecorator(withKnobs)
   .add('Basic Usage', withReadme(Readme, BasicUsage))
   .add('ConfirmationModal', withReadme(ConfirmationModalReadme, ConfirmationModalExample))
+  .add('ErrorModal', withReadme(ErrorModalReadme, ErrorModalExample))
   .add('ModalFooter', withReadme(WithModalFooterReadme, WithModalFooter));


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-794

## Purpose
Create `ErrorModal` component.

## Approach
These changes are made as part of the concept of creating a small, simple, and rather "dumb" (highly specialized) component in order to display the error in a friendly way.
Therefore, the number of passed properties has been minimized. And as a consequence, in this version, there is **no** possibility:
- to pass your own footer;
- to customize the `Close` button (stylize, change its title);
- to make this modal `dismissible`;
- to have the `closeOnBackgroundClick` prop;
- etc...

It’s not claimed that is the only correct approach. Any suggestions and objections are greatly appreciated. As well as suggestions for the naming of some passed props:

`label`: variants - `heading`, `header`, `title` ...
`content`: variants - `message`, `body` ...
`open`: variant - `isOpen`

For reference, here is a list of the local `ErrorModal` components that were taken as a basis
(name as a link to the local `ErrorModal`):

[ui-users](https://github.com/folio-org/ui-users/blob/master/src/components/ErrorModal/ErrorModal.js)
[ui-inventory](https://github.com/folio-org/ui-inventory/blob/master/src/components/ErrorModal/ErrorModal.js)
[ui-requests](https://github.com/folio-org/ui-requests/blob/master/src/components/ErrorModal.js)
[ui-orders](https://github.com/folio-org/ui-orders/blob/master/src/components/PurchaseOrder/UpdateOrderErrorModal/UpdateOrderErrorModal.js)
[ui-checkin](https://github.com/folio-org/ui-checkin/blob/6ed8c7ff08fa8dc89c81a36ca6f02ba6afec395c/src/Scan.js#L749)
[ui-checkout](https://github.com/folio-org/ui-checkout/blob/master/src/components/ErrorModal/ErrorModal.js)

### Screenshots
![ErrorModal](https://user-images.githubusercontent.com/49517355/111995696-e3628b80-8b21-11eb-81f4-8d2046cafcdb.png)

