### PR TITLE
STCOM-824 set max-width for textarea elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add the `<ErrorModal>` component. Refs STCOM-794.
 * Add `check-in` icon. Refs UX-427.
 * Add `check-out` icon. Refs UX-428.
+* Set `max-width` on `textarea` elements, not just on their wrappers. Refs STCOM-824.
 
 ## [9.0.0](https://github.com/folio-org/stripes-components/tree/v9.0.0) (2021-02-25)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v8.0.0...v9.0.0)

--- a/lib/TextArea/TextArea.css
+++ b/lib/TextArea/TextArea.css
@@ -12,5 +12,6 @@
     padding: var(--input-vertical-padding) var(--input-horizontal-padding);
     font-size: var(--font-size-medium);
     line-height: var(--line-height);
+    max-width: 100%;
   }
 }


### PR DESCRIPTION
Previously, `max-width` applied only on the container element, not on
the `textarea` element itself. This allowed `textarea`s to be resized
beyond the widths of their containers, which was terrible.

Refs [STCOM-824](https://issues.folio.org/browse/STCOM-824)