### PR TITLE
STCOM-832 TextField: don't call setState on unmounted components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-components
 
+## 9.2.0 (IN PROGRESS)
+
+* `TextField`: Do not call `setState` on unmounted component. Refs STCOM-832.
+
 ## [9.1.0](https://github.com/folio-org/stripes-components/tree/v9.1.0) (2021-04-08)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.0.0...v9.1.0)
 

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -137,8 +137,8 @@ class TextField extends Component {
      */
     required: PropTypes.bool,
     /**
-     * Toggle browser spellchecking
-     */
+    * Toggle browser spellchecking
+    */
     spellCheck: PropTypes.bool,
     /**
      * Control or Icon to display at the start of the textfield.
@@ -163,7 +163,10 @@ class TextField extends Component {
     /**
      * String of text to display after input.
      */
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]),
     /**
      * Warning string.
      */
@@ -178,7 +181,7 @@ class TextField extends Component {
     autoCorrect: 'off',
     autoCapitalize: 'off',
     spellCheck: false,
-    value: '',
+    value: ''
   };
 
   constructor(props) {
@@ -193,7 +196,7 @@ class TextField extends Component {
     this.state = {
       focused: false,
       prevPropsValue: props.value, // eslint-disable-line react/no-unused-state
-      value: props.value,
+      value: props.value
     };
 
     // typecheck for ref callbacks...
@@ -218,7 +221,7 @@ class TextField extends Component {
     if (props.value !== state.prevPropsValue) {
       return {
         prevPropsValue: props.value,
-        value: props.value,
+        value: props.value
       };
     }
     return null;
@@ -243,13 +246,13 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
     if (/\s/.test(this.props.inputStyle)) {
       const tempClasses = this.props.inputStyle.split(/\s+/);
       const csslist = [];
-      tempClasses.forEach((classname) => csslist.push(`${css[classname]}`));
+      tempClasses.forEach(classname => csslist.push(`${css[classname]}`));
       classStringFromProps = csslist.join(' ');
     }
 
     return classNames(
       classStringFromProps,
-      sharedInputStylesHelper(this.props)
+      sharedInputStylesHelper(this.props),
     );
   }
 
@@ -259,21 +262,23 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
     this.input.current.focus();
   }
 
-  onFocus = (event) => {
+  onFocus = event => {
     const { onFocus } = this.props;
 
     if (!this.state.focused) {
-      this.setState({
-        focused: true,
-      });
+      if (this._isMounted) {
+        this.setState({
+          focused: true
+        });
+      }
 
       if (typeof onFocus === 'function') {
         onFocus(event);
       }
     }
-  };
+  }
 
-  onBlur = (event) => {
+  onBlur = event => {
     const { onBlur } = this.props;
     const { currentTarget, relatedTarget } = event;
 
@@ -281,18 +286,17 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
       // delay focus stay setting for a whole tick. This is intended to keep the clear button around long enough for its
       // click event to fire on iOS devices.
       setTimeout(() => {
-        if (this._isMounted) {
-          this.setState({
-            focused: false,
-          });
-        }
+        this.setState({
+          focused: false
+        });
       });
+
 
       if (typeof onBlur === 'function') {
         onBlur(event);
       }
     }
-  };
+  }
 
   clearField() {
     const { onClearField } = this.props;
@@ -314,7 +318,7 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
   handleChange(event) {
     const { onChange } = this.props;
     this.setState({
-      value: event.target.value,
+      value: event.target.value
     });
 
     // Fire callback
@@ -332,7 +336,7 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
       required,
       readOnly,
       startControl,
-      validationEnabled,
+      validationEnabled
     } = this.props;
 
     // Use omitProps here instead of separateComponentProps because
@@ -341,39 +345,40 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
     // know the names of all the props we want to pass along, but we don't
     // know them.
     // this still feels kinda clumsy, but at least it's not broken.
-    const inputCustom = omitProps(this.props, [
-      'ariaLabel',
-      'ariaLabelledBy',
-      'clearFieldId',
-      'dirty',
-      'endControl',
-      'focusedClass',
-      'fullWidth',
-      'hasClearIcon',
-      'inputClass',
-      'inputRef',
-      'label',
-      'loading',
-      'marginBottom0',
-      'noBorder',
-      'onClearField',
-      'onFocus',
-      'required',
-      'startControl',
-      'valid',
-      'validationEnabled',
-      'validStylesEnabled',
-    ]);
+    const inputCustom = omitProps(
+      this.props,
+      [
+        'ariaLabel',
+        'ariaLabelledBy',
+        'clearFieldId',
+        'dirty',
+        'endControl',
+        'focusedClass',
+        'fullWidth',
+        'hasClearIcon',
+        'inputClass',
+        'inputRef',
+        'label',
+        'loading',
+        'marginBottom0',
+        'noBorder',
+        'onClearField',
+        'onFocus',
+        'required',
+        'startControl',
+        'valid',
+        'validationEnabled',
+        'validStylesEnabled'
+      ]
+    );
 
     const component = (
       <input
         {...inputCustom}
         aria-label={inputCustom['aria-label'] || this.props.ariaLabel}
-        aria-labelledby={
-          inputCustom['aria-labelledby'] || this.props.ariaLabelledBy
-        }
+        aria-labelledby={inputCustom['aria-labelledby'] || this.props.ariaLabelledBy}
         aria-required={inputCustom['aria-required'] || required}
-        aria-invalid={inputCustom['aria-invalid'] || !!this.props.error}
+        aria-invalid={inputCustom['aria-invalid'] || !!(this.props.error)}
         autoComplete={this.props.autoComplete}
         autoFocus={this.props.autoFocus}
         autoCorrect={this.props.autoCorrect}
@@ -394,12 +399,10 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
     let startControlElement;
     let endControlElement;
 
-    if (
-      this.props.hasClearIcon &&
-      !this.props.loading &&
-      this.state.focused &&
-      this.state.value
-    ) {
+    if (this.props.hasClearIcon
+      && !this.props.loading
+      && this.state.focused
+      && this.state.value) {
       clearField = (
         <FormattedMessage id="stripes-components.clearThisField">
           {([ariaLabel]) => (
@@ -418,11 +421,9 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
     // If validStylesEnabled is enabled we add some styling if the field is valid
     // This is disabled by default because it's primarily used when something is
     // getting validated on the server - e.g. checking for an email or similar.
-    if (
-      this.props.validStylesEnabled &&
-      validationEnabled &&
-      this.props.valid
-    ) {
+    if (this.props.validStylesEnabled
+      && validationEnabled
+      && this.props.valid) {
       validation = (
         <FormattedMessage id="stripes-components.fieldIsValid">
           {([ariaLabel]) => (
@@ -499,22 +500,23 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
 
     const wrapperStyles = classNames(
       css.textField,
-      {
-        [this.props.focusedClass]:
-          this.state.focused && this.props.focusedClass,
-      },
-      this.props.className
+      { [this.props.focusedClass]: this.state.focused && this.props.focusedClass },
+      this.props.className,
     );
 
     const inputGroupStyles = classNames(this.getInputStyle(), css.inputGroup, {
       [formStyles.isDisabled]: this.props.disabled,
-      [formStyles.isFocused]: this.state.focused,
+      [formStyles.isFocused]: this.state.focused
     });
 
     return (
       <div className={wrapperStyles}>
         {label && (
-          <Label htmlFor={this.testId} required={required} readOnly={readOnly}>
+          <Label
+            htmlFor={this.testId}
+            required={required}
+            readOnly={readOnly}
+          >
             {label}
           </Label>
         )}

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -172,13 +172,13 @@ class TextField extends Component {
 
   static defaultProps = {
     hasClearIcon: true,
-    type: "text",
+    type: 'text',
     validationEnabled: true,
-    autoComplete: "off",
-    autoCorrect: "off",
-    autoCapitalize: "off",
+    autoComplete: 'off',
+    autoCorrect: 'off',
+    autoCapitalize: 'off',
     spellCheck: false,
-    value: "",
+    value: '',
   };
 
   constructor(props) {
@@ -197,7 +197,7 @@ class TextField extends Component {
     };
 
     // typecheck for ref callbacks...
-    if (typeof this.props.inputRef === "function") {
+    if (typeof this.props.inputRef === 'function') {
       this.input = (ref) => {
         props.inputRef(ref);
         this.input.current = ref;
@@ -207,10 +207,10 @@ class TextField extends Component {
     }
 
     // if no id has been supplied, generate a unique one
-    if (Object.prototype.hasOwnProperty.call(props, "id")) {
+    if (Object.prototype.hasOwnProperty.call(props, 'id')) {
       this.testId = props.id;
     } else {
-      this.testId = uniqueId("text-input-");
+      this.testId = uniqueId('text-input-');
     }
   }
 
@@ -244,7 +244,7 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
       const tempClasses = this.props.inputStyle.split(/\s+/);
       const csslist = [];
       tempClasses.forEach((classname) => csslist.push(`${css[classname]}`));
-      classStringFromProps = csslist.join(" ");
+      classStringFromProps = csslist.join(' ');
     }
 
     return classNames(
@@ -267,7 +267,7 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
         focused: true,
       });
 
-      if (typeof onFocus === "function") {
+      if (typeof onFocus === 'function') {
         onFocus(event);
       }
     }
@@ -288,7 +288,7 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
         }
       });
 
-      if (typeof onBlur === "function") {
+      if (typeof onBlur === 'function') {
         onBlur(event);
       }
     }
@@ -298,15 +298,15 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
     const { onClearField } = this.props;
 
     // Fire callback
-    if (typeof onClearField === "function") {
+    if (typeof onClearField === 'function') {
       onClearField();
     }
 
     // Clear value on input natively, dispatch an event to be picked up by handleChange, and focus on input again
     if (this.input.current) {
-      nativeChangeField(this.input, true, "");
-      if (this.state.value !== "") {
-        this.setState({ value: "" });
+      nativeChangeField(this.input, true, '');
+      if (this.state.value !== '') {
+        this.setState({ value: '' });
       }
     }
   }
@@ -318,7 +318,7 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
     });
 
     // Fire callback
-    if (typeof onChange === "function") {
+    if (typeof onChange === 'function') {
       onChange(event);
     }
   }
@@ -342,38 +342,38 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
     // know them.
     // this still feels kinda clumsy, but at least it's not broken.
     const inputCustom = omitProps(this.props, [
-      "ariaLabel",
-      "ariaLabelledBy",
-      "clearFieldId",
-      "dirty",
-      "endControl",
-      "focusedClass",
-      "fullWidth",
-      "hasClearIcon",
-      "inputClass",
-      "inputRef",
-      "label",
-      "loading",
-      "marginBottom0",
-      "noBorder",
-      "onClearField",
-      "onFocus",
-      "required",
-      "startControl",
-      "valid",
-      "validationEnabled",
-      "validStylesEnabled",
+      'ariaLabel',
+      'ariaLabelledBy',
+      'clearFieldId',
+      'dirty',
+      'endControl',
+      'focusedClass',
+      'fullWidth',
+      'hasClearIcon',
+      'inputClass',
+      'inputRef',
+      'label',
+      'loading',
+      'marginBottom0',
+      'noBorder',
+      'onClearField',
+      'onFocus',
+      'required',
+      'startControl',
+      'valid',
+      'validationEnabled',
+      'validStylesEnabled',
     ]);
 
     const component = (
       <input
         {...inputCustom}
-        aria-label={inputCustom["aria-label"] || this.props.ariaLabel}
+        aria-label={inputCustom['aria-label'] || this.props.ariaLabel}
         aria-labelledby={
-          inputCustom["aria-labelledby"] || this.props.ariaLabelledBy
+          inputCustom['aria-labelledby'] || this.props.ariaLabelledBy
         }
-        aria-required={inputCustom["aria-required"] || required}
-        aria-invalid={inputCustom["aria-invalid"] || !!this.props.error}
+        aria-required={inputCustom['aria-required'] || required}
+        aria-invalid={inputCustom['aria-invalid'] || !!this.props.error}
         autoComplete={this.props.autoComplete}
         autoFocus={this.props.autoFocus}
         autoCorrect={this.props.autoCorrect}

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -137,8 +137,8 @@ class TextField extends Component {
      */
     required: PropTypes.bool,
     /**
-    * Toggle browser spellchecking
-    */
+     * Toggle browser spellchecking
+     */
     spellCheck: PropTypes.bool,
     /**
      * Control or Icon to display at the start of the textfield.
@@ -163,10 +163,7 @@ class TextField extends Component {
     /**
      * String of text to display after input.
      */
-    value: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-    ]),
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     /**
      * Warning string.
      */
@@ -175,13 +172,13 @@ class TextField extends Component {
 
   static defaultProps = {
     hasClearIcon: true,
-    type: 'text',
+    type: "text",
     validationEnabled: true,
-    autoComplete: 'off',
-    autoCorrect: 'off',
-    autoCapitalize: 'off',
+    autoComplete: "off",
+    autoCorrect: "off",
+    autoCapitalize: "off",
     spellCheck: false,
-    value: ''
+    value: "",
   };
 
   constructor(props) {
@@ -196,11 +193,11 @@ class TextField extends Component {
     this.state = {
       focused: false,
       prevPropsValue: props.value, // eslint-disable-line react/no-unused-state
-      value: props.value
+      value: props.value,
     };
 
     // typecheck for ref callbacks...
-    if (typeof this.props.inputRef === 'function') {
+    if (typeof this.props.inputRef === "function") {
       this.input = (ref) => {
         props.inputRef(ref);
         this.input.current = ref;
@@ -210,10 +207,10 @@ class TextField extends Component {
     }
 
     // if no id has been supplied, generate a unique one
-    if (Object.prototype.hasOwnProperty.call(props, 'id')) {
+    if (Object.prototype.hasOwnProperty.call(props, "id")) {
       this.testId = props.id;
     } else {
-      this.testId = uniqueId('text-input-');
+      this.testId = uniqueId("text-input-");
     }
   }
 
@@ -221,10 +218,18 @@ class TextField extends Component {
     if (props.value !== state.prevPropsValue) {
       return {
         prevPropsValue: props.value,
-        value: props.value
+        value: props.value,
       };
     }
     return null;
+  }
+
+  componentDidMount() {
+    this._isMounted = true;
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
   }
 
   getInput() {
@@ -238,13 +243,13 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
     if (/\s/.test(this.props.inputStyle)) {
       const tempClasses = this.props.inputStyle.split(/\s+/);
       const csslist = [];
-      tempClasses.forEach(classname => csslist.push(`${css[classname]}`));
-      classStringFromProps = csslist.join(' ');
+      tempClasses.forEach((classname) => csslist.push(`${css[classname]}`));
+      classStringFromProps = csslist.join(" ");
     }
 
     return classNames(
       classStringFromProps,
-      sharedInputStylesHelper(this.props),
+      sharedInputStylesHelper(this.props)
     );
   }
 
@@ -254,21 +259,21 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
     this.input.current.focus();
   }
 
-  onFocus = event => {
+  onFocus = (event) => {
     const { onFocus } = this.props;
 
     if (!this.state.focused) {
       this.setState({
-        focused: true
+        focused: true,
       });
 
-      if (typeof onFocus === 'function') {
+      if (typeof onFocus === "function") {
         onFocus(event);
       }
     }
-  }
+  };
 
-  onBlur = event => {
+  onBlur = (event) => {
     const { onBlur } = this.props;
     const { currentTarget, relatedTarget } = event;
 
@@ -276,31 +281,32 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
       // delay focus stay setting for a whole tick. This is intended to keep the clear button around long enough for its
       // click event to fire on iOS devices.
       setTimeout(() => {
-        this.setState({
-          focused: false
-        });
+        if (this._isMounted) {
+          this.setState({
+            focused: false,
+          });
+        }
       });
 
-
-      if (typeof onBlur === 'function') {
+      if (typeof onBlur === "function") {
         onBlur(event);
       }
     }
-  }
+  };
 
   clearField() {
     const { onClearField } = this.props;
 
     // Fire callback
-    if (typeof onClearField === 'function') {
+    if (typeof onClearField === "function") {
       onClearField();
     }
 
     // Clear value on input natively, dispatch an event to be picked up by handleChange, and focus on input again
     if (this.input.current) {
-      nativeChangeField(this.input, true, '');
-      if (this.state.value !== '') {
-        this.setState({ value: '' });
+      nativeChangeField(this.input, true, "");
+      if (this.state.value !== "") {
+        this.setState({ value: "" });
       }
     }
   }
@@ -308,11 +314,11 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
   handleChange(event) {
     const { onChange } = this.props;
     this.setState({
-      value: event.target.value
+      value: event.target.value,
     });
 
     // Fire callback
-    if (typeof onChange === 'function') {
+    if (typeof onChange === "function") {
       onChange(event);
     }
   }
@@ -326,7 +332,7 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
       required,
       readOnly,
       startControl,
-      validationEnabled
+      validationEnabled,
     } = this.props;
 
     // Use omitProps here instead of separateComponentProps because
@@ -335,40 +341,39 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
     // know the names of all the props we want to pass along, but we don't
     // know them.
     // this still feels kinda clumsy, but at least it's not broken.
-    const inputCustom = omitProps(
-      this.props,
-      [
-        'ariaLabel',
-        'ariaLabelledBy',
-        'clearFieldId',
-        'dirty',
-        'endControl',
-        'focusedClass',
-        'fullWidth',
-        'hasClearIcon',
-        'inputClass',
-        'inputRef',
-        'label',
-        'loading',
-        'marginBottom0',
-        'noBorder',
-        'onClearField',
-        'onFocus',
-        'required',
-        'startControl',
-        'valid',
-        'validationEnabled',
-        'validStylesEnabled'
-      ]
-    );
+    const inputCustom = omitProps(this.props, [
+      "ariaLabel",
+      "ariaLabelledBy",
+      "clearFieldId",
+      "dirty",
+      "endControl",
+      "focusedClass",
+      "fullWidth",
+      "hasClearIcon",
+      "inputClass",
+      "inputRef",
+      "label",
+      "loading",
+      "marginBottom0",
+      "noBorder",
+      "onClearField",
+      "onFocus",
+      "required",
+      "startControl",
+      "valid",
+      "validationEnabled",
+      "validStylesEnabled",
+    ]);
 
     const component = (
       <input
         {...inputCustom}
-        aria-label={inputCustom['aria-label'] || this.props.ariaLabel}
-        aria-labelledby={inputCustom['aria-labelledby'] || this.props.ariaLabelledBy}
-        aria-required={inputCustom['aria-required'] || required}
-        aria-invalid={inputCustom['aria-invalid'] || !!(this.props.error)}
+        aria-label={inputCustom["aria-label"] || this.props.ariaLabel}
+        aria-labelledby={
+          inputCustom["aria-labelledby"] || this.props.ariaLabelledBy
+        }
+        aria-required={inputCustom["aria-required"] || required}
+        aria-invalid={inputCustom["aria-invalid"] || !!this.props.error}
         autoComplete={this.props.autoComplete}
         autoFocus={this.props.autoFocus}
         autoCorrect={this.props.autoCorrect}
@@ -389,10 +394,12 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
     let startControlElement;
     let endControlElement;
 
-    if (this.props.hasClearIcon
-      && !this.props.loading
-      && this.state.focused
-      && this.state.value) {
+    if (
+      this.props.hasClearIcon &&
+      !this.props.loading &&
+      this.state.focused &&
+      this.state.value
+    ) {
       clearField = (
         <FormattedMessage id="stripes-components.clearThisField">
           {([ariaLabel]) => (
@@ -411,9 +418,11 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
     // If validStylesEnabled is enabled we add some styling if the field is valid
     // This is disabled by default because it's primarily used when something is
     // getting validated on the server - e.g. checking for an email or similar.
-    if (this.props.validStylesEnabled
-      && validationEnabled
-      && this.props.valid) {
+    if (
+      this.props.validStylesEnabled &&
+      validationEnabled &&
+      this.props.valid
+    ) {
       validation = (
         <FormattedMessage id="stripes-components.fieldIsValid">
           {([ariaLabel]) => (
@@ -490,23 +499,22 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
 
     const wrapperStyles = classNames(
       css.textField,
-      { [this.props.focusedClass]: this.state.focused && this.props.focusedClass },
-      this.props.className,
+      {
+        [this.props.focusedClass]:
+          this.state.focused && this.props.focusedClass,
+      },
+      this.props.className
     );
 
     const inputGroupStyles = classNames(this.getInputStyle(), css.inputGroup, {
       [formStyles.isDisabled]: this.props.disabled,
-      [formStyles.isFocused]: this.state.focused
+      [formStyles.isFocused]: this.state.focused,
     });
 
     return (
       <div className={wrapperStyles}>
         {label && (
-          <Label
-            htmlFor={this.testId}
-            required={required}
-            readOnly={readOnly}
-          >
+          <Label htmlFor={this.testId} required={required} readOnly={readOnly}>
             {label}
           </Label>
         )}


### PR DESCRIPTION
Wrap calls to `setState` in checks to make sure the component is still
mounted.

Refs [STCOM-832](https://issues.folio.org/browse/STCOM-832)