### PR TITLE
STCOM-833 Paneset: don't call setState on unmounted components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-components
 
+## 9.2.0 (IN PROGRESS)
+
+* `Paneset`: Don't call `setState` on unmounted components. Refs STCOM-833.
+
 ## [9.1.0](https://github.com/folio-org/stripes-components/tree/v9.1.0) (2021-04-08)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.0.0...v9.1.0)
 

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -157,27 +157,29 @@ class Paneset extends React.Component {
 
         // be sure and update the so that we can use this on the next resize...
         this.previousContainerWidth = currentWidth;
-        this.setState((curr) => {
-          const tempCache = cloneDeep(curr.layoutCache);
-          tempCache.splice(matchingCacheIndex, 1);
-          return {
-            layoutCache: tempCache,
-          };
-        }, () => {
-          // // adjust the layout cache relative to the new client rect size
-          // // size panes accordingly.
-          const newWidths = this.calcWidths(tempPanesList);
-          const changeType = 'windowResize';
-          this.updateLayoutCache(newWidths, changeType);
-          this.resizePanes(this.state.panes, newWidths);
-          setTimeout(() => {
-            this.state.panes.forEach((p) => {
-              if (p.isPaneset) {
-                p.getInstance().resizeToContainer();
-              }
+        if (this.isThisMounted()) {
+          this.setState((curr) => {
+            const tempCache = cloneDeep(curr.layoutCache);
+            tempCache.splice(matchingCacheIndex, 1);
+            return {
+              layoutCache: tempCache,
+            };
+          }, () => {
+            // // adjust the layout cache relative to the new client rect size
+            // // size panes accordingly.
+            const newWidths = this.calcWidths(tempPanesList);
+            const changeType = 'windowResize';
+            this.updateLayoutCache(newWidths, changeType);
+            this.resizePanes(this.state.panes, newWidths);
+            setTimeout(() => {
+              this.state.panes.forEach((p) => {
+                if (p.isPaneset) {
+                  p.getInstance().resizeToContainer();
+                }
+              });
             });
           });
-        });
+        }
       }
     }
   }
@@ -235,15 +237,17 @@ class Paneset extends React.Component {
   }
 
   removePane = () => {
-    this.setState((oldState) => {
-      // accounts for odd situations where multiple Panes are dismissed/dismounted at once...
-      // simply filters out any that have dismounted.
-      const newPanes = oldState.panes.filter(p => p.isThisMounted());
-      const newState = Object.assign({}, oldState);
-      newState.panes = newPanes;
-      newState.changeType = 'removed';
-      return newState;
-    }, this.calcWidthsAndResize('removed'));
+    if (this.isThisMounted()) {
+      this.setState((oldState) => {
+        // accounts for odd situations where multiple Panes are dismissed/dismounted at once...
+        // simply filters out any that have dismounted.
+        const newPanes = oldState.panes.filter(p => p.isThisMounted());
+        const newState = Object.assign({}, oldState);
+        newState.panes = newPanes;
+        newState.changeType = 'removed';
+        return newState;
+      }, this.calcWidthsAndResize('removed'));
+    }
   }
 
   // transitions
@@ -255,28 +259,30 @@ class Paneset extends React.Component {
   // apply 'out' state with callback to remove pane...
 
   registerPane = (paneObject) => {
-    this.setState((oldState) => {
-      let newState = Object.assign({}, oldState);
-      // if the new pane has a transition just set its starting appearance...
-      // otherwise resize all the panes...
-      if (paneObject.transition !== 'none') {
-        this.transitionStart(paneObject);
-        this.resizePanes(newState.panes, this.widths); // pass cached widths
-        newState.panes.push(paneObject);
-        this.interval = setTimeout(() => {
-          this.transitionEnd(paneObject);
-          this.interval = null;
-        });
-      } else {
-        // insert sorted by left coordinate of clientrect...
-        const newPanes = insertByClientRect(newState.panes, paneObject);
-        newState = Object.assign(newState, { panes: newPanes, changeType: 'added' });
-        // newState = this.insertPaneObject(newState, paneObject);
-      }
-      return newState;
-    }, () => {
-      this.calcWidthsAndResize();
-    });
+    if (this.isThisMounted()) {
+      this.setState((oldState) => {
+        let newState = Object.assign({}, oldState);
+        // if the new pane has a transition just set its starting appearance...
+        // otherwise resize all the panes...
+        if (paneObject.transition !== 'none') {
+          this.transitionStart(paneObject);
+          this.resizePanes(newState.panes, this.widths); // pass cached widths
+          newState.panes.push(paneObject);
+          this.interval = setTimeout(() => {
+            this.transitionEnd(paneObject);
+            this.interval = null;
+          });
+        } else {
+          // insert sorted by left coordinate of clientrect...
+          const newPanes = insertByClientRect(newState.panes, paneObject);
+          newState = Object.assign(newState, { panes: newPanes, changeType: 'added' });
+          // newState = this.insertPaneObject(newState, paneObject);
+        }
+        return newState;
+      }, () => {
+        this.calcWidthsAndResize();
+      });
+    }
   }
 
   calcWidthsAndResize = (changeType) => {
@@ -424,25 +430,27 @@ class Paneset extends React.Component {
   };
 
   updateLayoutCache = (layoutMap) => {
-    this.setState(({ layoutCache }) => {
-      // find duplicates with like lengths, id's...
-      const layoutIndex = this.hasCachedLayout(layoutMap);
-      if (layoutIndex !== -1) {
-        const tempCache = cloneDeep(layoutCache);
-        tempCache[layoutIndex] = layoutMap;
-        return {
-          layoutCache: tempCache
-        };
-      }
-      return { layoutCache: [...layoutCache, layoutMap], changeType: 'resize' };
-    }, () => {
-      if (this.props.onResize) {
-        this.props.onResize({
-          currentLayout: layoutMap,
-          layoutCache: this.state.layoutCache
-        });
-      }
-    });
+    if (this.isThisMounted()) {
+      this.setState(({ layoutCache }) => {
+        // find duplicates with like lengths, id's...
+        const layoutIndex = this.hasCachedLayout(layoutMap);
+        if (layoutIndex !== -1) {
+          const tempCache = cloneDeep(layoutCache);
+          tempCache[layoutIndex] = layoutMap;
+          return {
+            layoutCache: tempCache
+          };
+        }
+        return { layoutCache: [...layoutCache, layoutMap], changeType: 'resize' };
+      }, () => {
+        if (this.props.onResize) {
+          this.props.onResize({
+            currentLayout: layoutMap,
+            layoutCache: this.state.layoutCache
+          });
+        }
+      });
+    }
   }
 
   // Accepts the positions of handles, the client rect of the container.


### PR DESCRIPTION
Wrap calls to `setState` in checks to make sure the components is still
mounted.

Refs [STCOM-833](https://issues.folio.org/browse/STCOM-833)