### PR TITLE
WIP: Clear timeouts on unmount

### DIFF
--- a/lib/MultiSelection/SelectedValuesList.js
+++ b/lib/MultiSelection/SelectedValuesList.js
@@ -21,6 +21,12 @@ class SelectedValuesList extends React.Component {
     valueLabelId: PropTypes.string,
   }
 
+  componentWillUnmount() {
+    if (this.focusTO) {
+      clearTimeout(this.focusTO);
+      this.focusTO = null;
+    }
+  }
   // componentDidUpdate(prevProps) {
   //   if (prevProps.removeButtonUsed === -1 && this.props.removeButtonUsed !== -1) {
   //     this.handleFocusAfterRemoval(this.props.removeButtonUsed);
@@ -47,7 +53,7 @@ class SelectedValuesList extends React.Component {
         this.props.inputRef.current.focus();
       }
     } else {
-      setTimeout(() => {
+      this.focusTO = setTimeout(() => {
         let neighbor = index;
         if (index === 0) {
           neighbor = 1;

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -131,6 +131,21 @@ class Paneset extends React.Component {
       this.widthsRAF = null;
     }
 
+    if (this.resizeNestedTO) {
+      clearTimeout(this.resizeNestedTO);
+      this.resizeNestedTO = null;
+    }
+
+    if (this.transitionCallbackTO) {
+      clearTimeout(this.transitionCallbackTO);
+      this.transitionCallbackTO = null;
+    }
+
+    if (this.interval) {
+      clearTimeout(this.interval);
+      this.interval = null;
+    }
+
     if (!this.props.isRoot && this.props.paneset) {
       this.props.paneset.removePane();
     }
@@ -170,7 +185,7 @@ class Paneset extends React.Component {
           const changeType = 'windowResize';
           this.updateLayoutCache(newWidths, changeType);
           this.resizePanes(this.state.panes, newWidths);
-          setTimeout(() => {
+          this.resizeNestedTO = setTimeout(() => {
             this.state.panes.forEach((p) => {
               if (p.isPaneset) {
                 p.getInstance().resizeToContainer();
@@ -336,7 +351,7 @@ class Paneset extends React.Component {
       this.removePane();
       this.transitionEnd(pane);
       if (callback) {
-        setTimeout(() => {
+        this.transitionCallbackTO = setTimeout(() => {
           callback();
         }, 300);
       }

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -227,6 +227,13 @@ class TextField extends Component {
     return null;
   }
 
+  componentWillUnmount() {
+    if (this.resetFocusTO) {
+      clearTimeout(this.resetFocusTO);
+      this.resetFocusTO = null;
+    }
+  }
+
   getInput() {
     console.warn(`[DEPRECATION] - the "getInput()" method for TextField is deprecated.
 Use the "inputRef" prop instead to obtain a ref to the input.`);
@@ -275,7 +282,7 @@ Use the "inputRef" prop instead to obtain a ref to the input.`);
     if (!(relatedTarget && currentTarget.contains(relatedTarget))) {
       // delay focus stay setting for a whole tick. This is intended to keep the clear button around long enough for its
       // click event to fire on iOS devices.
-      setTimeout(() => {
+      this.resetFocusTO = setTimeout(() => {
         this.setState({
           focused: false
         });

--- a/lib/Timepicker/TimeDropdown.js
+++ b/lib/Timepicker/TimeDropdown.js
@@ -100,6 +100,15 @@ class TimeDropdown extends React.Component {
   componentWillUnmount() {
     // Re-focus the timepicker input when the dropdown closes
     this.props.mainControl.focus();
+    if (this.blurTO) {
+      clearTimeout(this.blurTO);
+      this.blurTO = null;
+    }
+
+    if (this.hoursBlurTO) {
+      clearTimeout(this.hoursBlurTO);
+      this.hoursBlurTO = null;
+    }
   }
 
   buildState(props) {
@@ -207,7 +216,7 @@ class TimeDropdown extends React.Component {
     if (e.keyCode === 9 && !e.shiftKey) { // tab
       // refocus the datepicker textfield if it's tabbed out...
       this.props.onBlur(() => {
-        setTimeout(() => {
+        this.blurTO = setTimeout(() => {
           this.props.mainControl.focus();
         }, 20);
       });
@@ -218,7 +227,7 @@ class TimeDropdown extends React.Component {
     if (e.keyCode === 9 && e.shiftKey) { // tab
       // refocus the datepicker textfield if the users shift-tabs out...
       this.props.onBlur(() => {
-        setTimeout(() => {
+        this.hoursBlurTO = setTimeout(() => {
           this.props.mainControl.focus();
         }, 20);
       });


### PR DESCRIPTION
ref to #1541 and #1542 
Addresses timeouts in Paneset, Timepicker, Textfield, and MultiSelection

The change ends up a bit lighter as code isn't being wrapped in conditionals... in class-based components, it ends up being simple - set an instance variable, clear it out on unmount...
```
 this.someTO = setTimeout(...
 
 componentWillUnmount() {
  if(this.someTO) {
    clearTimeout(this.someTO);
    this.someTO = null;
  }
 }
```

in functional components, it's a bit weirder - but yeah, functional be like that... (no functional in this PR, but for future ref)

```
// store a ref to hold it (functional version of instance variables)
let someTO = useRef(null).current;

// useEffect with empty dependency array is equiv of didMount -> willUnmount
useEffect(() => {
  return () => {
    if (someTO) {
      clearTimeout(someTO);
      someTO = null;
    }
  }
}, [])

someTO = setTimeout(...
```