### PR TITLE
STCOM-834: Pass aria-label to button element of IconButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 9.2.0 (IN PROGRESS)
 
+* TextFieldIcon - Pass aria-label to button instead of span to IconButton. Refs STSMACOM-498.
+
 ## [9.1.0](https://github.com/folio-org/stripes-components/tree/v9.1.0) (2021-04-08)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.0.0...v9.1.0)
 

--- a/lib/TextField/TextFieldIcon.js
+++ b/lib/TextField/TextFieldIcon.js
@@ -11,7 +11,7 @@ const TextFieldIcon = ({ onClick, ariaLabel, icon, iconClassName, onMouseDown, t
   <div className={css.textFieldIcon}>
     { (typeof onClick === 'function' || typeof onMouseDown === 'function') ? (
       <IconButton
-        aria-label={rest['aria-label'] || ariaLabel}
+        ariaLabel={rest['aria-label'] || ariaLabel}
         onClick={onClick}
         onMouseDown={onMouseDown}
         tabIndex={tabIndex}


### PR DESCRIPTION
## Description
Fixes failing tests in `stripes-smart-components` - passing `aria-label` to `span` elements is considered an accessibility issue
https://dequeuniversity.com/rules/axe/4.2/aria-allowed-attr?application=axeAPI

## Related PRs
https://github.com/folio-org/stripes-smart-components/pull/1050

## Issues
[STSMACOM-498](https://issues.folio.org/browse/STSMACOM-498)