### PR TITLE
STCOM-834 prevent aria-label from applying on a span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 9.2.0 (IN PROGRESS)
 
+* `<IconLabel>` Avoid passing `aria-label` to a `<span>`, an a11y violation. Refs STCOM-834.
+
 ## [9.1.0](https://github.com/folio-org/stripes-components/tree/v9.1.0) (2021-04-08)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.0.0...v9.1.0)
 

--- a/lib/IconButton/IconButton.js
+++ b/lib/IconButton/IconButton.js
@@ -17,6 +17,7 @@ const IconButton = React.forwardRef(({
   onMouseDown,
   type,
   ariaLabel,
+  'aria-label': hyphenatedAriaLabel,
   id,
   style,
   className,
@@ -50,7 +51,7 @@ const IconButton = React.forwardRef(({
       css[size],
       className
     ),
-    'aria-label': rest['aria-label'] || ariaLabel || icon,
+    'aria-label': hyphenatedAriaLabel || ariaLabel || icon,
   };
 
   /**
@@ -80,6 +81,7 @@ const IconButton = React.forwardRef(({
 });
 
 IconButton.propTypes = {
+  'aria-label': PropTypes.string,
   ariaLabel: PropTypes.string,
   autoFocus: PropTypes.bool,
   badgeColor: PropTypes.string,


### PR DESCRIPTION
`props.aria-label` would inadvertently be copied into a `<span>`
element, an a11y violation, while the companion `props.ariaLabel` would
be siphoned off. Now, both props are siphoned off.

Maybe a replacement for #1546? 

Refs [STCOM-834](https://issues.folio.org/browse/STCOM-834)