### PR TITLE
STCOM-838 avoid unnecessary tether deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * `<IconLabel>` Avoid passing `aria-label` to a `<span>`, an a11y violation. Refs STCOM-834.
 * `<CommandList>` should not warn about overriding system key bindings. Refs STCOM-836.
+* `<Selection>` no longer always shows a `props.tether` deprecation warning. Refs STCOM-838.
 
 ## [9.1.0](https://github.com/folio-org/stripes-components/tree/v9.1.0) (2021-04-08)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.0.0...v9.1.0)

--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -68,23 +68,6 @@ const defaultProps = {
   formatter: DefaultOptionFormatter,
   useValidStyle: false,
   multiple: false,
-  tether: {
-    attachment: 'top center',
-    renderElementTo: null,
-    targetAttachment: 'bottom center',
-    optimizations: {
-      gpu: false,
-    },
-    constraints: [{
-      to: 'window',
-      attachment: 'together',
-    },
-    {
-      to: 'scrollParent',
-      pin: true,
-    },
-    ],
-  },
   valid: false,
 };
 
@@ -122,6 +105,24 @@ class SingleSelect extends React.Component {
       'leading': true,
       'trailing': false
     });
+
+    this.tetherDefaults = {
+      attachment: 'top center',
+      renderElementTo: null,
+      targetAttachment: 'bottom center',
+      optimizations: {
+        gpu: false,
+      },
+      constraints: [{
+        to: 'window',
+        attachment: 'together',
+      },
+      {
+        to: 'scrollParent',
+        pin: true,
+      },
+      ],
+    };
 
     const initialCursor = this.initCursor();
 
@@ -772,8 +773,8 @@ class SingleSelect extends React.Component {
       );
     }
 
-    if (!isEqual(tether, SingleSelect.defaultProps.tether)) {
-      const mergedTetherProps = Object.assign({}, SingleSelect.defaultProps.tether, tether);
+    if (!isEqual(tether, this.tetherDefaults)) {
+      const mergedTetherProps = Object.assign({}, this.tetherDefaults, tether);
 
       return (
         <TetherComponent {...mergedTetherProps}>

--- a/lib/Selection/tests/SingleSelection-test.js
+++ b/lib/Selection/tests/SingleSelection-test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { describe, afterEach, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
-const sinon = require('sinon')
+import sinon from 'sinon';
 
 import { mountWithContext } from '../../../tests/helpers';
 import Selection from '../Selection';

--- a/lib/Selection/tests/SingleSelection-test.js
+++ b/lib/Selection/tests/SingleSelection-test.js
@@ -98,7 +98,7 @@ describe('Selection, Single select', () => {
     it('list is hidden by default', expectClosedMenu);
 
     it('renders a deprecation warning', () => {
-      expect(spy.calledOnceWith(text)).to.be.true;
+      expect(spy.calledWith(text)).to.be.true;
     });
   });
   // end stub test for legacy rendering

--- a/lib/Selection/tests/SingleSelection-test.js
+++ b/lib/Selection/tests/SingleSelection-test.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { describe, beforeEach, it } from '@bigtest/mocha';
+import { describe, afterEach, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
+const sinon = require('sinon')
 
 import { mountWithContext } from '../../../tests/helpers';
 import Selection from '../Selection';
@@ -31,6 +32,8 @@ describe('Selection, Single select', () => {
   ];
 
   const testId = 'testingId';
+
+
 
   beforeEach(async () => {
     await mountWithContext(
@@ -69,6 +72,10 @@ describe('Selection, Single select', () => {
 
   // stub test for legacy (tether prop) coverage - remove when tether prop is removed
   describe('legacy rendering (tether prop)', () => {
+    // the spy won't work if called within beforeEach
+    const spy = sinon.spy(console, 'error');
+    const text = 'Warning: The prop `tether` of `SingleSelect` is deprecated. Tether has been replaced by Popper. Use the /"popper/" prop to adjust the underlying Popper component.';
+
     beforeEach(async () => {
       await mountWithContext(
         <Selection
@@ -80,11 +87,19 @@ describe('Selection, Single select', () => {
       );
     });
 
+    afterEach(async () => {
+      spy.restore();
+    });
+
     it('renders the control', () => {
       expect(selection.controlPresent).to.be.true;
     });
 
     it('list is hidden by default', expectClosedMenu);
+
+    it('renders a deprecation warning', () => {
+      expect(spy.calledOnceWith(text)).to.be.true;
+    });
   });
   // end stub test for legacy rendering
 


### PR DESCRIPTION
`tether` props are no longer present in `defaultProps`, which
inadvertently caused a deprecation warning to display, even when such
props were not explicitly passed in.

Refs [STCOM-838](https://issues.folio.org/browse/STCOM-838)