### PR TITLE
STCOM-833 avoid calling setState after unmounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * `<IconLabel>` Avoid passing `aria-label` to a `<span>`, an a11y violation. Refs STCOM-834.
 * `<CommandList>` should not warn about overriding system key bindings. Refs STCOM-836.
 * `<Selection>` no longer always shows a `props.tether` deprecation warning. Refs STCOM-838.
+* `<Paneset>` should not call `setState` after unmounting. Refs STCOM-833.
 
 ## [9.1.0](https://github.com/folio-org/stripes-components/tree/v9.1.0) (2021-04-08)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.0.0...v9.1.0)

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -439,25 +439,27 @@ class Paneset extends React.Component {
   };
 
   updateLayoutCache = (layoutMap) => {
-    this.setState(({ layoutCache }) => {
-      // find duplicates with like lengths, id's...
-      const layoutIndex = this.hasCachedLayout(layoutMap);
-      if (layoutIndex !== -1) {
-        const tempCache = cloneDeep(layoutCache);
-        tempCache[layoutIndex] = layoutMap;
-        return {
-          layoutCache: tempCache
-        };
-      }
-      return { layoutCache: [...layoutCache, layoutMap], changeType: 'resize' };
-    }, () => {
-      if (this.props.onResize) {
-        this.props.onResize({
-          currentLayout: layoutMap,
-          layoutCache: this.state.layoutCache
-        });
-      }
-    });
+    if (this.isThisMounted()) {
+      this.setState(({ layoutCache }) => {
+        // find duplicates with like lengths, id's...
+        const layoutIndex = this.hasCachedLayout(layoutMap);
+        if (layoutIndex !== -1) {
+          const tempCache = cloneDeep(layoutCache);
+          tempCache[layoutIndex] = layoutMap;
+          return {
+            layoutCache: tempCache
+          };
+        }
+        return { layoutCache: [...layoutCache, layoutMap], changeType: 'resize' };
+      }, () => {
+        if (this.props.onResize) {
+          this.props.onResize({
+            currentLayout: layoutMap,
+            layoutCache: this.state.layoutCache
+          });
+        }
+      });
+    }
   }
 
   // Accepts the positions of handles, the client rect of the container.


### PR DESCRIPTION
`<Paneset>` could call `setState()` after unmount, causing a memory
leak.

Refs [STCOM-833](https://issues.folio.org/browse/STCOM-833)