### PR TITLE
STCOM-841: Add buttonLabel to ErrorModal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@
 * `<CommandList>` should not warn about overriding system key bindings. Refs STCOM-836.
 * `<Selection>` no longer always shows a `props.tether` deprecation warning. Refs STCOM-838.
 * `<Paneset>` should not call `setState` after unmounting. Refs STCOM-833.
+* Add `buttonLabel` to `<ErrorModal>`. Refs STCOM-841.
 
 ## [9.1.0](https://github.com/folio-org/stripes-components/tree/v9.1.0) (2021-04-08)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.0.0...v9.1.0)
 
-* Fix Accordion content is displayed below other accordions when using scrollbar. Fixes STCOM-812. 
+* Fix Accordion content is displayed below other accordions when using scrollbar. Fixes STCOM-812.
 * Add languageOptionsES for the laguage facet. Refs UISEES-29.
 * Fix Pane behavior on window resize/3rd pane/nested paneset resize. Fixes STCOM-808.
 * Add the `<ErrorModal>` component. Refs STCOM-794.

--- a/lib/ErrorModal/ErrorModal.js
+++ b/lib/ErrorModal/ErrorModal.js
@@ -12,6 +12,7 @@ const ErrorModal = ({
   open,
   content,
   label,
+  buttonLabel,
   onClose,
   ...rest
 }) => {
@@ -21,7 +22,7 @@ const ErrorModal = ({
         data-test-error-modal-close-button
         onClick={onClose}
       >
-        <FormattedMessage id="stripes-components.close" />
+        {buttonLabel || <FormattedMessage id="stripes-components.close" />}
       </Button>
     </ModalFooter>
   );
@@ -45,6 +46,10 @@ const ErrorModal = ({
 ErrorModal.propTypes = {
   ariaLabel: PropTypes.string,
   bodyTag: PropTypes.string,
+  buttonLabel: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+  ]),
   content: PropTypes.node.isRequired,
   label: PropTypes.node.isRequired,
   onClose: PropTypes.func.isRequired,

--- a/lib/ErrorModal/tests/ErrorModal-test.js
+++ b/lib/ErrorModal/tests/ErrorModal-test.js
@@ -39,7 +39,7 @@ describe('ErrorModal', () => {
     expect(errorModal.bodyTagName).to.equal('div');
   });
 
-  it('the button label should be present', () => {
+  it('shows correct button label', () => {
     expect(errorModal.closeButton.text).to.equal(buttonLabel);
   });
 

--- a/lib/ErrorModal/tests/ErrorModal-test.js
+++ b/lib/ErrorModal/tests/ErrorModal-test.js
@@ -14,6 +14,7 @@ describe('ErrorModal', () => {
 
   const label = 'Something went wrong';
   const content = 'Here is a detailed message that explains why the error occurred.';
+  const buttonLabel = 'Close';
 
   beforeEach(async () => {
     await mountWithContext(
@@ -36,6 +37,10 @@ describe('ErrorModal', () => {
 
   it('the content tagName should be div', () => {
     expect(errorModal.bodyTagName).to.equal('div');
+  });
+
+  it('the button label should be present', () => {
+    expect(errorModal.closeButton.text).to.equal(buttonLabel);
   });
 
   describe('when clicking the close button', () => {


### PR DESCRIPTION
There are some cases where it would be nice to customize the button on the `<ErrorModal>`.
This PR introduces a new prop called `buttonLabel` to allow for that. 

https://issues.folio.org/browse/STCOM-841
