### PR TITLE
STCOM-830 add 'scroll-to-item' logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * `<Selection>` no longer always shows a `props.tether` deprecation warning. Refs STCOM-838.
 * `<Paneset>` should not call `setState` after unmounting. Refs STCOM-833.
 * Add `buttonLabel` to `<ErrorModal>`. Refs STCOM-841.
+* Add `prev-next` pagination option to MCL. Refs STCOM-829
+* Add support for sparse arrays to MCL. Refs STCOM-829
+* Add `ItenToView` functionality so that item-based scroll positions can be marked by modules. Resolves STCOM-830.
 
 ## [9.1.0](https://github.com/folio-org/stripes-components/tree/v9.1.0) (2021-04-08)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.0.0...v9.1.0)

--- a/index.js
+++ b/index.js
@@ -143,3 +143,5 @@ export {
 export { default as useCurrencyOptions } from './hooks/useCurrencyOptions';
 export { default as useDateFormatter } from './hooks/useFormatDate';
 export { default as useTimeFormatter } from './hooks/useFormatTime';
+
+export { pagingTypes as MCLPagingTypes } from './lib/MultiColumnList';

--- a/lib/MultiColumnList/CenteredContainer.js
+++ b/lib/MultiColumnList/CenteredContainer.js
@@ -4,7 +4,7 @@ import { isFinite } from 'lodash';
 import Layout from '../Layout';
 import css from './MCLRenderer.css';
 
-const CenteredContainer = ({ innerRef, visible, width, children }) => {
+const CenteredContainer = ({ innerRef, visible, width, children, style: styleProp }) => {
   // subtracting the margins to prevent horizontal scroll
   const endOfListWidth = isFinite(width) ? `${Math.max(width - 20, 200)}px` : '100%';
 
@@ -16,7 +16,8 @@ const CenteredContainer = ({ innerRef, visible, width, children }) => {
         { width: endOfListWidth,
           visibility: `${visible ? 'visible' : 'hidden'}`,
           height: `${visible ? null : 0}`,
-          padding: `${visible ? null : 0}` }
+          padding: `${visible ? null : 0}`,
+          ...styleProp }
         }
     >
       <Layout className="textCentered">
@@ -29,6 +30,7 @@ const CenteredContainer = ({ innerRef, visible, width, children }) => {
 CenteredContainer.propTypes = {
   children: PropTypes.node,
   innerRef: PropTypes.object,
+  style: PropTypes.object,
   visible: PropTypes.bool,
   width: PropTypes.number,
 };

--- a/lib/MultiColumnList/LoadMorePaginationRow.js
+++ b/lib/MultiColumnList/LoadMorePaginationRow.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import PagingButton from './PagingButton';
+import RowPositioner from './RowPositioner';
+import CenteredContainer from './CenteredContainer';
+
+const propTypes = {
+  dataEndReached: PropTypes.bool,
+  handleLoadMore: PropTypes.func,
+  id: PropTypes.string,
+  keyId: PropTypes.string,
+  loading: PropTypes.bool,
+  pageAmount: PropTypes.number,
+  pagingButtonLabel: PropTypes.node,
+  pagingButtonRef: PropTypes.object,
+  positionCache: PropTypes.object,
+  prevWidth: PropTypes.number,
+  rowHeightCache: PropTypes.object,
+  rowIndex: PropTypes.number,
+  sendMessage: PropTypes.func,
+  setFocusIndex: PropTypes.func,
+  staticBody: PropTypes.bool,
+  virtualize: PropTypes.bool,
+  width: PropTypes.number
+};
+
+const LoadMorePaginationRow = ({
+  dataEndReached,
+  handleLoadMore,
+  id,
+  keyId,
+  loading,
+  pageAmount,
+  pagingButtonLabel,
+  pagingButtonRef,
+  positionCache,
+  prevWidth,
+  rowHeightCache,
+  rowIndex,
+  sendMessage,
+  setFocusIndex,
+  staticBody,
+  virtualize,
+  width,
+}) => {
+  if (dataEndReached) { return null; }
+
+  return (
+    <RowPositioner
+      key={`load-button-positioner-${rowIndex}-${keyId}`}
+      gridId={id}
+      heightCache={rowHeightCache}
+      positionCache={positionCache}
+      shouldPosition={!staticBody}
+      rowIndex={rowIndex}
+    >
+      {({ localRowIndex, position }) => (
+        <div
+          key={`${localRowIndex}-load-button`}
+          style={{ position: virtualize ? 'absolute' : 'relative', top: `${position}px`, marginTop: '1rem' }}
+        >
+          <CenteredContainer
+            width={width || prevWidth || undefined}
+            innerRef={pagingButtonRef}
+            visible
+          >
+            <FormattedMessage id="stripes-components.mcl.itemsRequestedMessage">
+              { ([message]) => (
+                <PagingButton
+                  onClick={() => {
+                    setFocusIndex(rowIndex);
+                    handleLoadMore(pageAmount, rowIndex);
+                  }}
+                  sendMessage={sendMessage}
+                  loadingMessage={message}
+                  disabled={loading}
+                  pagingButtonLabel={pagingButtonLabel}
+                  id={`${id || keyId}-clickable-paging-button`}
+                  style={{ width: '75%' }}
+                />
+              )}
+            </FormattedMessage>
+          </CenteredContainer>
+        </div>
+      )}
+    </RowPositioner>
+  );
+};
+
+LoadMorePaginationRow.propTypes = propTypes;
+
+export default LoadMorePaginationRow;

--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -277,3 +277,45 @@
     margin: 0 var(--gutter-static);
   }
 }
+
+/**
+* Styles for previous/next pagination
+*/
+.mclPrevNextButtonContainer {
+  display: flex;
+  margin-bottom: 1rem;
+  width: 100%;
+  max-width: 500px;
+  justify-content: space-around;
+
+  & button[disabled] {
+    background-color: transparent;
+    color: var(--color-text-p2, rgba(0, 0, 0, 0.62));
+
+    &:hover {
+      background-color: var(--color-fill-disabled, rgba(0, 0, 0, 0.15));
+    }
+  }
+}
+
+.mclPrevNextStickyContainer {
+  position: sticky;
+  left: 0;
+}
+
+.mclPaginationCenterContainer {
+  display: flex;
+  justify-content: center;
+  position: relative;
+}
+
+.mclPrevNextPageInfoContainer {
+  font-weight: bold;
+  display: flex;
+  flex-grow: 3;
+  flex-shrink: 0;
+  flex-basis: 45%;
+  align-items: center;
+  justify-content: center;
+  align-content: middle;
+}

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -44,17 +44,21 @@ import { calculateColumnWidth3q } from './calculateWidth';
 import convertToPixels from './convertToPixels';
 import RowPositioner from './RowPositioner';
 import CenteredContainer from './CenteredContainer';
-import PagingButton from './PagingButton';
+import LoadMorePaginationRow from './LoadMorePaginationRow';
+import PrevNextPaginationRow from './PrevNextPaginationRow';
 
 // used in all margin calculations... static based on CSS value of 15px (gutter-static). (15px * 2 = 30px)
 const ROWMARGIN = 30;
+const CHANGE_NEWDATA = 'new data';
+const CHANGE_LESSDATA = 'less';
+const CHANGE_DIFFERENCE = 'difference';
 
 /* some item fields will have arrays... those don't always come back in the same
 *  order, despite the item being the same. This function checks for equality with that in mind.
 */
 function comparison(obj, oth) {
   if (obj === oth) return true;
-  if (obj === undefined || oth === undefined) return true;
+  // if (obj === undefined || oth === undefined) return true;
   const objType = typeof obj;
   const othType = typeof oth;
   if (objType !== othType) return false;
@@ -63,10 +67,14 @@ function comparison(obj, oth) {
   if (objIsArray && othIsArray) {
     if (obj.length !== oth.length) return false;
     if (obj.length > 0) {
-      obj.forEach(obji => { // eslint-disable-line consistent-return
+      for (let obji = 0; obji < obj.length; obji++) {
         const itemIndex = oth.findIndex(i => isEqual(i, obj[obji]));
         if (itemIndex === -1) return false;
-      });
+      }
+      // obj.forEach(obji => { // eslint-disable-line consistent-return
+      //   const itemIndex = oth.findIndex(i => isEqual(i, obj[obji]));
+      //   if (itemIndex === -1) return false;
+      // });
     }
     return true;
   }
@@ -74,20 +82,42 @@ function comparison(obj, oth) {
 }
 
 export function dataChangedOrLess(previous, current) {
-  // Filtering... smaller data always a change
-  if (current.length < previous.length) return true;
+  // compare Object.keys for sparse array structures.
+  const currentKeys = Object.keys(current);
+  const previousKeys = Object.keys(previous);
+
+  if (currentKeys.length < previousKeys.length) {
+    return { changed: true, changeType: CHANGE_LESSDATA, populatedLength: current.length };
+  }
 
   /* greater data length could be paging... so check to see the data is the same,
   * keeping in mind those array order changes that can happen using the comparison function.
   */
-  for (let i = 0; i < previous.length - 1; i += 4) {
-    const notEqual = !isEqualWith(previous[i] || {}, current[i], comparison);
-    if (notEqual) return true;
+  // find a suitable interval...
+  const interval = Math.min(4, Math.ceil(previous.length / 6));
+  for (let i = parseInt(previousKeys[0], 10); i <
+    parseInt(previousKeys[previousKeys.length - 1], 10);
+    i += interval) {
+    const notEqual = !isEqualWith(previous[i] || {}, current[i] || {}, comparison);
+    if (notEqual) {
+      return {
+        changed: true,
+        changeType: !previous[i] ? CHANGE_NEWDATA : CHANGE_DIFFERENCE,
+        datalength: currentKeys.length,
+      };
+    }
   }
+
   // finally, compare the last item...
   const prevLast = previous.length - 1;
-  if (!isEqualWith(current[prevLast], previous[prevLast], comparison)) return true;
-  return false;
+  if (!isEqualWith(current[prevLast], previous[prevLast], comparison)) {
+    return {
+      changed: true,
+      changeType: previous[prevLast] === null ? CHANGE_NEWDATA : CHANGE_DIFFERENCE,
+      datalength: currentKeys.length,
+    };
+  }
+  return { changed: false, changeType: null, datalength: currentKeys.length };
 }
 
 // if no visibleColumns prop is provided, this function is used to generate a columns array for state.
@@ -132,6 +162,12 @@ function computeRowWidth(columnWidths, columns) {
     }, 0);
 }
 
+export const pagingTypes = {
+  LOAD_MORE: 'click',
+  PREV_NEXT: 'prev-next',
+  SCROLL: 'scroll',
+};
+
 class MCLRenderer extends React.Component {
   static propTypes = {
     autosize: PropTypes.bool,
@@ -151,6 +187,7 @@ class MCLRenderer extends React.Component {
     height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     hotKeys: PropTypes.object,
     id: PropTypes.string,
+    initialScrollTop: PropTypes.number,
     instanceRef: PropTypes.func,
     interactive: PropTypes.bool,
     intl: PropTypes.shape({
@@ -173,7 +210,7 @@ class MCLRenderer extends React.Component {
     onScroll: PropTypes.func,
     pageAmount: PropTypes.number,
     pagingButtonLabel: PropTypes.node,
-    pagingType: PropTypes.oneOf(['scroll', 'click']),
+    pagingType: PropTypes.oneOf(['scroll', 'click', 'prev-next']),
     rowFormatter: PropTypes.func,
     rowMetadata: PropTypes.arrayOf(PropTypes.string),
     rowProps: PropTypes.object,
@@ -201,6 +238,7 @@ class MCLRenderer extends React.Component {
     formatter: {},
     hasMargin: false,
     hotKeys: { keyMap: {}, handlers: {} },
+    initialScrollTop: 0,
     interactive: true,
     isSelected: ({ item, criteria }) => {
       return isEqual(item, criteria);
@@ -223,8 +261,6 @@ class MCLRenderer extends React.Component {
 
   constructor(props) {
     super(props);
-
-    const { scrollToIndex } = this.props;
 
     this.rowContainer = React.createRef();
     this.headerRow = React.createRef();
@@ -256,7 +292,7 @@ class MCLRenderer extends React.Component {
     this.state = {
       columns: null,
       receivedRows: 0,
-      firstIndex: scrollToIndex,
+      firstIndex: 0,
       scrollTop: 0,
       loading: false,
       columnWidths: {},
@@ -266,7 +302,9 @@ class MCLRenderer extends React.Component {
       maxScrollDelta: 0,
       rowWidth: null,
       staticBody: !props.virtualize,
+      prevDataLength: 0,
       modColumns: [],
+      isSparse: false,
     };
 
     this.handlers = Object.assign({
@@ -346,11 +384,26 @@ class MCLRenderer extends React.Component {
     }
 
     // data prop has changed
-    if (receivedRows !== contentData.length) {
-      newState.receivedRows = contentData.length;
+    if (contentData && contentData.length !== 0) {
+      const dataKeys = Object.keys(contentData);
+      newState.dataStartIndex = parseInt(dataKeys[0], 10);
+      newState.dataEndIndex = parseInt(dataKeys[dataKeys.length - 1], 10);
+      newState.isSparse = true;
+    }
+
+    const checkValue = parseInt(Object.keys(contentData).length, 10);
+
+    if (receivedRows !== checkValue) {
+      newState.receivedRows = checkValue;
       newState.loading = false;
 
-      if (contentData.length < receivedRows) {
+      // for paging via slice-at-a-time sparse arrays (and prev/next pagination);
+      if (!virtualize) {
+        const contentDataIndices = Object.keys(contentData);
+        newState.firstIndex = parseInt(contentDataIndices[0], 10) || 0;
+        newState.lastIndex = parseInt(contentDataIndices[contentDataIndices.length - 1], 10) || 0;
+        newState.receivedRows = 0;
+      } else if (checkValue < receivedRows) {
         newState.receivedRows = 0;
         newState.firstIndex = 0;
       }
@@ -374,6 +427,8 @@ class MCLRenderer extends React.Component {
     const {
       contentData,
       width,
+      scrollToIndex,
+      initialScrollTop,
     } = this.props;
 
     window.addEventListener('resize', this.debouncedHandleResize);
@@ -392,6 +447,14 @@ class MCLRenderer extends React.Component {
         newState = this.getWidthsFromContainer();
       }
 
+      if (scrollToIndex !== 0) {
+        newState.scrollTop = this.rowHeightCache.requestAccumulated(scrollToIndex);
+        this.scrollContainer.current.scrollTop = newState.scrollTop;
+      } else if (initialScrollTop !== 0) {
+        newState.scrollTop = initialScrollTop;
+        this.scrollContainer.current.scrollTop = newState.scrollTop;
+      }
+
       if (this.rowHeightCache.length > 0 && this.state.averageHeight === 0) {
         const avg = this.updateAverageHeight();
         if (avg > 0) {
@@ -401,7 +464,8 @@ class MCLRenderer extends React.Component {
 
       if (Object.keys(newState).length > 0) {
         this.setState(curState => {
-          if (Object.keys(newState.columnWidths).length !== Object.keys(curState.columnWidths).length) {
+          if (newState.columnWidths &&
+            Object.keys(newState.columnWidths).length !== Object.keys(curState.columnWidths).length) {
             newState.columnWidths = Object.assign({}, curState.columnWidths, newState.columnWidths);
           }
           return newState;
@@ -412,7 +476,7 @@ class MCLRenderer extends React.Component {
 
   componentDidUpdate(prevProps) {
     const { columnWidths, hasMargin, width, visibleColumns, contentData, pagingType } = this.props;
-    const { columns } = this.state;
+    const { columns, isSparse } = this.state;
 
     let newState = {};
 
@@ -427,14 +491,22 @@ class MCLRenderer extends React.Component {
       newState = Object.assign(newState, this.getWidthsFromContainer());
     }
 
-    // data is different, but the length is the same, so reset scroll...(sorting causes this)
-    if (dataChangedOrLess(prevProps.contentData, contentData)) {
+    // detect if data has changed...
+    // dChOL returns an object in the shape of {changed: bool, changeType: string | null}
+    // the changeType could be "difference", "length", "new data", "none".
+    const shouldUpdate = dataChangedOrLess(prevProps.contentData, contentData);
+    if (shouldUpdate.changed && shouldUpdate.changeType !== CHANGE_NEWDATA) {
       this.resetCaches(!!this.props.virtualize);
       this.maximumRowHeight = this.props.minimumRowHeight;
-      if (this.scrollContainer.current) {
-        this.scrollContainer.current.scrollTop = 0;
+      // newState.loadedEstimate = shouldUpdate.datalength;
+
+      // only scroll to top for sorting (all current data is non-null and the length is the same)
+      if (shouldUpdate.changeType === CHANGE_DIFFERENCE) {
+        if (this.scrollContainer.current) {
+          this.scrollContainer.current.scrollTop = 0;
+        }
+        newState.scrollTop = 0;
       }
-      newState.scrollTop = 0;
       newState.columnWidths = {};
       if (columnWidths) {
         const propColumnWidths = getPixelColumnWidths(columnWidths, this.state.prevWidth, hasMargin);
@@ -443,9 +515,14 @@ class MCLRenderer extends React.Component {
           newState.rowWidth = computeRowWidth(newState.columnWidths, columns ?? visibleColumns);
         }
       }
+
       newState.averageRowHeight = 0;
-      newState.firstIndex = 0;
-    } else if (pagingType === 'click') {
+      if (!isSparse) {
+        newState.firstIndex = 0;
+      } else {
+        newState.firstIndex = parseInt(Object.keys(contentData)[0], 10) || 0;
+      }
+    } else if (pagingType === 'click' || pagingType === 'prev-next') {
       if (this.focusTargetIndex) {
         const target = document.querySelector(`[data-row-index="row-${this.focusTargetIndex}"]`);
         if (target) {
@@ -455,6 +532,8 @@ class MCLRenderer extends React.Component {
           this.focusTargetIndex = null;
         }
       }
+    } else if (prevProps.contentData.length < contentData.length) {
+      newState.prevDataLength = prevProps.contentData.length;
     }
 
     if (!isEqual(visibleColumns, prevProps.visibleColumns)) {
@@ -639,7 +718,7 @@ class MCLRenderer extends React.Component {
       }
     });
 
-    this.props.onScroll(e);
+    this.props.onScroll(e, e.scrollTop, e.scrollLeft);
   }
 
   handleInfiniteScroll = (currentScroll, currentScrollLeft, index) => {
@@ -897,6 +976,7 @@ class MCLRenderer extends React.Component {
       firstIndex,
       rowWidth,
       staticBody,
+      prevDataLength,
     } = this.state;
 
     const loaderClassname = `${css.mclRow} ${rowIndex % 2 !== 0 ? '' : css.mclIsOdd}`;
@@ -932,24 +1012,31 @@ class MCLRenderer extends React.Component {
         columnCount={columns.length}
         columnWidths={Object.keys(columnWidths).length}
         averageHeight={heightIncrement}
+        shiftAfter={prevDataLength}
         rowIndex={rowIndex}
       >
         { /*  rowIndex passed through to children as localRowIndex since
               the outer scope rowIndex changes */
-          ({ localRowIndex, position }) => (
-            <LoaderRow
-              key={`loader-row-${localRowIndex}-${this.keyId}`}
-              askAmount={Math.min(pageAmount, totalCount - contentData.length)}
-              height={heightIncrement}
-              minWidth={rowWidth}
-              rowIndex={localRowIndex}
-              loadMore={this.handleLoadMore}
-              className={loaderClassname}
-              columns={columns}
-              styleTop={position}
-              columnWidths={columnWidths}
-            />
-          )
+          ({ localRowIndex, position }) => {
+            let askAmount = Math.min(pageAmount, totalCount - contentData.length);
+            if (askAmount < 0 || totalCount === contentData.length) {
+              askAmount = pageAmount > totalCount ? totalCount : pageAmount;
+            }
+            return (
+              <LoaderRow
+                key={`loader-row-${localRowIndex}-${this.keyId}`}
+                askAmount={askAmount}
+                height={heightIncrement}
+                minWidth={rowWidth}
+                rowIndex={localRowIndex}
+                loadMore={this.handleLoadMore}
+                className={loaderClassname}
+                columns={columns}
+                styleTop={position}
+                columnWidths={columnWidths}
+              />
+            );
+          }
         }
       </RowPositioner>
     );
@@ -966,7 +1053,7 @@ class MCLRenderer extends React.Component {
 
     const {
       prevWidth,
-      staticBody
+      staticBody,
     } = this.state;
 
     return (
@@ -996,64 +1083,92 @@ class MCLRenderer extends React.Component {
     );
   }
 
-  renderPagingButton = (rowIndex) => {
+  renderPagingRow = (rowIndex) => {
     const {
       dataEndReached,
       id,
       width,
       pageAmount,
       pagingButtonLabel,
-      virtualize
+      virtualize,
+      pagingType,
+      contentData,
+      totalCount,
     } = this.props;
 
     const {
       prevWidth,
       loading,
       staticBody,
+      rowWidth,
+      dataStartIndex,
+      dataEndIndex,
     } = this.state;
 
-    if (dataEndReached) { return null; }
+    if (pagingType === 'click') {
+      return (
+        <LoadMorePaginationRow
+          dataEndReached={dataEndReached}
+          handleLoadMore={this.handleLoadMore}
+          key="mcl-load-more-pagination-row"
+          id={id}
+          keyId={this.keyId}
+          loading={loading}
+          pageAmount={pageAmount}
+          pagingButtonLabel={pagingButtonLabel}
+          pagingButtonRef={this.pageButton}
+          positionCache={this.positionCache}
+          prevWidth={prevWidth}
+          rowHeightCache={this.rowHeightCache}
+          rowIndex={rowIndex}
+          sendMessage={this.sendMessage}
+          setFocusIndex={this.setFocusIndex}
+          staticBody={staticBody}
+          virtualize={virtualize}
+          width={width}
+        />
+      );
+    } else if (pagingType === 'prev-next') {
+      const canGoPrevious = !contentData[0];
+      let canGoNext = !contentData[contentData.length - 1];
+      if (totalCount) {
+        canGoNext = !(contentData.length === totalCount);
+      } else {
+        canGoNext = !contentData[contentData.length - 1];
+      }
 
-    return (
-      <RowPositioner
-        key={`load-button-positioner-${rowIndex}-${this.keyId}`}
-        gridId={id}
-        heightCache={this.rowHeightCache}
-        positionCache={this.positionCache}
-        shouldPosition={!staticBody}
-        rowIndex={rowIndex}
-      >
-        {({ localRowIndex, position }) => (
-          <div
-            key={`${localRowIndex}-load-button`}
-            style={{ position: virtualize ? 'absolute' : 'relative', top: `${position}px`, marginTop: '1rem' }}
-          >
-            <CenteredContainer
-              width={width || prevWidth || undefined}
-              innerRef={this.pageButton}
-              visible
-            >
-              <FormattedMessage id="stripes-components.mcl.itemsRequestedMessage">
-                { ([message]) => (
-                  <PagingButton
-                    rowIndex={rowIndex}
-                    onClick={() => {
-                      this.setFocusIndex(rowIndex);
-                      this.handleLoadMore(pageAmount, rowIndex);
-                    }}
-                    sendMessage={this.sendMessage}
-                    loadingMessage={message}
-                    loading={loading}
-                    pagingButtonLabel={pagingButtonLabel}
-                    gridId={id || this.keyId}
-                  />
-                )}
-              </FormattedMessage>
-            </CenteredContainer>
-          </div>
-        )}
-      </RowPositioner>
-    );
+      return (
+        <PrevNextPaginationRow
+          activeNext={canGoNext}
+          activePrevious={canGoPrevious}
+          dataEndReached={dataEndReached}
+          handleLoadMore={this.handleLoadMore}
+          id={id}
+          key="mcl-prev-next-pagination-row"
+          keyId={this.keyId}
+          loading={loading}
+          pageAmount={pageAmount}
+          pagingButtonLabel={pagingButtonLabel}
+          pagingButtonRef={this.pageButton}
+          positionCache={this.positionCache}
+          prevWidth={prevWidth}
+          rowHeightCache={this.rowHeightCache}
+          rowIndex={rowIndex}
+          sendMessage={this.sendMessage}
+          setFocusIndex={this.setFocusIndex}
+          staticBody={staticBody}
+          virtualize={virtualize}
+          width={width}
+          rowWidth={rowWidth}
+          previousActive={canGoPrevious}
+          nextActive={canGoNext}
+          dataStartIndex={dataStartIndex + 1}
+          dataEndIndex={dataEndIndex + 1}
+        />
+      );
+    } else {
+      return null;
+    }
   }
 
   renderRows = () => {
@@ -1074,11 +1189,13 @@ class MCLRenderer extends React.Component {
       maxScrollDelta,
       scrollDirection,
       prevHeight,
+      dataStartIndex,
     } = this.state;
 
     this.framePositions = {};
     const rows = [];
 
+    // beginning of sparse array...
     const scrollRange = scrollDirection === 'down' ? maxScrollDelta : 0;
 
     let bodyExtent;
@@ -1087,14 +1204,15 @@ class MCLRenderer extends React.Component {
     if (virtualize && bodyHeight) {
       bodyExtent = bodyHeight * 2 + scrollTop;
     } else {
-      bodyExtent = contentData.length * heightIncrement;
+      // bodyExtent = contentData.length * heightIncrement;
+      bodyExtent = Object.keys(contentData).length * heightIncrement;
     }
 
     /* look-ahead of a minimumRow + a maximumRow.
       This improves UX in scrolling (reducing white gaps at the top/bottom of the visible rows)
     */
     bodyExtent += (minimumRowHeight + this.maximumRowHeight + scrollRange * 2);
-    let currentTop = firstIndex > 0 ? scrollTop : 0;
+    let currentTop = firstIndex > dataStartIndex ? scrollTop : 0;
     const loaderSettings = {
       load: true,
       visible: true,
@@ -1126,10 +1244,13 @@ class MCLRenderer extends React.Component {
         }
         if (pagingType === 'scroll') {
           rows.push(this.renderLoaderRow(rowIndex, dataRowsRendered, heightIncrement));
-        } else if (pagingType === 'click') {
+        } else if (pagingType === 'click' || pagingType === 'prev-next') {
           currentTop = bodyExtent;
-          rows.push(this.renderPagingButton(rowIndex));
+          rows.push(this.renderPagingRow(rowIndex));
         }
+      } else if (pagingType === 'prev-next') {
+        currentTop = bodyExtent;
+        rows.push(this.renderPagingRow(rowIndex));
       }
     }
 
@@ -1406,14 +1527,19 @@ class MCLRenderer extends React.Component {
 
   _loadMore(askAmount, index) {
     const { onNeedMoreData } = this.props;
-    if (!this.state.loading && onNeedMoreData) {
-      onNeedMoreData(askAmount, index);
+    const { loading, firstIndex } = this.state;
+    if (!loading && onNeedMoreData) {
+      onNeedMoreData(askAmount, index, firstIndex);
       this.setState({ loading: true });
     }
   }
 
   handleLoadMore = (askAmount, index) => {
-    this.debouncedLoadMore(askAmount, index);
+    if (index === 0 || index === this.state.firstindex || index % this.props.pageAmount !== 0) {
+      this.debouncedLoadMore(askAmount, index);
+    } else {
+      this._loadMore(askAmount, index);
+    }
   }
 
   handleMoreResultsLoaded = () => {
@@ -1455,7 +1581,7 @@ class MCLRenderer extends React.Component {
   }
 
   getRowContainerStyle = () => {
-    const { totalCount, wrapCells, height, minimumRowHeight, virtualize, pagingType } = this.props;
+    const { totalCount, wrapCells, height, minimumRowHeight, virtualize, pagingType, scrollToIndex } = this.props;
     const { receivedRows, rowWidth, averageRowHeight } = this.state;
 
     let position = 'static';
@@ -1467,6 +1593,11 @@ class MCLRenderer extends React.Component {
     if (wrapCells) width = '100%';
 
     let newHeight;
+    let newMinHeight = 0;
+
+    if (scrollToIndex !== 0) {
+      newMinHeight = scrollToIndex * minimumRowHeight;
+    }
 
     /* if the height prop is not defined, the size of the physical container is ever-growing
     *  with the size of the contentData.
@@ -1475,13 +1606,13 @@ class MCLRenderer extends React.Component {
       // if we have a totalCount, we can set size based on that... if not, the receivedRows count.
       const scrollBarHeight = 20;
       newHeight = Math.max(
-        ((pagingType === 'click' ? receivedRows : totalCount || receivedRows) * minimumRowHeight),
+        ((pagingType !== 'scroll' ? receivedRows : totalCount || receivedRows) * minimumRowHeight),
         (height - this.headerHeight - scrollBarHeight)
       );
-      return { height: `${newHeight}px`, width, position };
+      return { height: `${newHeight}px`, minHeight: `${newMinHeight + height}px`, width, position };
     } else if (virtualize) {
       newHeight = receivedRows * averageRowHeight;
-      return { height: `${newHeight}px`, width, position };
+      return { height: `${newHeight}px`, minHeight: `${newMinHeight + window.innerHeight}px`, width, position };
     }
     return { position };
   }
@@ -1547,7 +1678,7 @@ class MCLRenderer extends React.Component {
       return amount + 1;
     }
     return amount;
-  }
+  };
 
   render() {
     const {
@@ -1631,5 +1762,4 @@ class MCLRenderer extends React.Component {
     );
   }
 }
-
 export default injectIntl(MCLRenderer);

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -583,6 +583,10 @@ class MCLRenderer extends React.Component {
           newState = Object.assign(newState, { averageRowHeight: avg });
         }
       }
+
+      if (!virtualize && columns.length === Object.keys(stateColumnWidths).length) {
+        this.scrollToItemToView();
+      }
     }
 
     // if props.columnWidths changes...

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -432,8 +432,6 @@ class MCLRenderer extends React.Component {
       width,
     } = this.props;
 
-
-
     window.addEventListener('resize', this.debouncedHandleResize);
 
     if (contentData.length > 0) {

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -187,7 +187,6 @@ class MCLRenderer extends React.Component {
     height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     hotKeys: PropTypes.object,
     id: PropTypes.string,
-    initialScrollTop: PropTypes.number,
     instanceRef: PropTypes.func,
     interactive: PropTypes.bool,
     intl: PropTypes.shape({
@@ -200,11 +199,16 @@ class MCLRenderer extends React.Component {
       PropTypes.arrayOf([PropTypes.node]),
     ]),
     isSelected: PropTypes.func,
+    itemToView: PropTypes.shape({
+      localClientTop: PropTypes.number,
+      selector: PropTypes.string,
+    }),
     loading: PropTypes.bool,
     maxHeight: PropTypes.number,
     minimumRowHeight: PropTypes.number,
     nonInteractiveHeaders: PropTypes.arrayOf(PropTypes.string),
     onHeaderClick: PropTypes.func,
+    onMarkPosition: PropTypes.func,
     onNeedMoreData: PropTypes.func,
     onRowClick: PropTypes.func,
     onScroll: PropTypes.func,
@@ -238,7 +242,6 @@ class MCLRenderer extends React.Component {
     formatter: {},
     hasMargin: false,
     hotKeys: { keyMap: {}, handlers: {} },
-    initialScrollTop: 0,
     interactive: true,
     isSelected: ({ item, criteria }) => {
       return isEqual(item, criteria);
@@ -427,9 +430,9 @@ class MCLRenderer extends React.Component {
     const {
       contentData,
       width,
-      scrollToIndex,
-      initialScrollTop,
     } = this.props;
+
+
 
     window.addEventListener('resize', this.debouncedHandleResize);
 
@@ -447,20 +450,14 @@ class MCLRenderer extends React.Component {
         newState = this.getWidthsFromContainer();
       }
 
-      if (scrollToIndex !== 0) {
-        newState.scrollTop = this.rowHeightCache.requestAccumulated(scrollToIndex);
-        this.scrollContainer.current.scrollTop = newState.scrollTop;
-      } else if (initialScrollTop !== 0) {
-        newState.scrollTop = initialScrollTop;
-        this.scrollContainer.current.scrollTop = newState.scrollTop;
-      }
-
       if (this.rowHeightCache.length > 0 && this.state.averageHeight === 0) {
         const avg = this.updateAverageHeight();
         if (avg > 0) {
           newState = Object.assign(newState, { averageRowHeight: avg });
         }
       }
+
+      this.scrollToItemToView();
 
       if (Object.keys(newState).length > 0) {
         this.setState(curState => {
@@ -475,8 +472,8 @@ class MCLRenderer extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { columnWidths, hasMargin, width, visibleColumns, contentData, pagingType } = this.props;
-    const { columns, isSparse } = this.state;
+    const { columnWidths, hasMargin, width, visibleColumns, contentData, pagingType, virtualize } = this.props;
+    const { columns, isSparse, columnWidths: stateColumnWidths } = this.state;
 
     let newState = {};
 
@@ -568,6 +565,11 @@ class MCLRenderer extends React.Component {
           this.keyId = uniqueId('mcl');
         }
       }
+
+      if (contentData.length !== 0 &&
+         !virtualize) {
+        this.scrollToItemToView();
+      }
     }
 
     if (contentData.length > 0) {
@@ -629,6 +631,27 @@ class MCLRenderer extends React.Component {
     window.removeEventListener('resize', this.debouncedHandleResize);
     this.throttledHandleScroll.cancel();
     this.resetCaches();
+  }
+
+  scrollToItemToView = () => {
+    const {
+      columns,
+      columnWidths,
+    } = this.state;
+
+    const {
+      itemToView
+    } = this.props;
+
+    const item = itemToView || this.itemToView;
+
+    if (item && columns.length === Object.keys(columnWidths).length) {
+      const itemElem = this.container.current.querySelector(item.selector);
+      if (itemElem) {
+        const offset = itemElem.offsetTop;
+        this.scrollContainer.current.scrollTop = offset - (item.localClientTop);
+      }
+    }
   }
 
   getWidthsFromContainer = () => {
@@ -799,8 +822,17 @@ class MCLRenderer extends React.Component {
     }
   }
 
-  handleRowFocus = (rowIndex) => {
+  handleRowFocus = (e, rowIndex) => {
     this.focusedRowIndex = rowIndex;
+    const mclRect = this.container.current.getBoundingClientRect();
+    const rowRect = e.target.getBoundingClientRect();
+    this.itemToView = {
+      selector: `[aria-rowindex="${rowIndex}"]`,
+      localClientTop: rowRect.top - mclRect.top,
+    };
+    if (this.props.onMarkPosition) {
+      this.props.onMarkPosition(this.itemToView);
+    }
   }
 
   handleRowBlur = () => {
@@ -949,7 +981,7 @@ class MCLRenderer extends React.Component {
                 className={css.mclRowFormatterContainer}
                 aria-rowindex={localRowIndex + 2}
                 onClick={onRowClick ? this.handleRowClick : undefined}
-                onFocus={this.handleRowFocus}
+                onFocus={(e) => this.handleRowFocus(e, localRowIndex + 2)}
                 onBlur={this.handleRowBlur}
                 style={positionedRowStyle}
                 role="row"

--- a/lib/MultiColumnList/PagingButton.js
+++ b/lib/MultiColumnList/PagingButton.js
@@ -4,7 +4,7 @@ import { Loading } from '../Loading';
 
 import Button from '../Button';
 
-const PagingButton = ({ loading, onClick, loadingMessage, pagingButtonLabel, sendMessage, gridId }) => {
+const PagingButton = ({ loading, onClick, loadingMessage, pagingButtonLabel, sendMessage, ...props }) => {
   const handleClick = () => {
     sendMessage(loadingMessage);
     onClick();
@@ -13,11 +13,9 @@ const PagingButton = ({ loading, onClick, loadingMessage, pagingButtonLabel, sen
   return (
     <>
       <Button
-        disabled={loading}
         onClick={handleClick}
-        style={{ width: '75%' }}
         data-test-paging-button
-        id={`${gridId}-clickable-paging-button`}
+        {... props}
       >
         {!loading && pagingButtonLabel}
         {loading && <Loading size="medium" useCurrentColor />}
@@ -27,12 +25,11 @@ const PagingButton = ({ loading, onClick, loadingMessage, pagingButtonLabel, sen
 };
 
 PagingButton.propTypes = {
-  gridId: PropTypes.string,
   loading: PropTypes.bool,
   loadingMessage: PropTypes.string,
   onClick: PropTypes.func,
   pagingButtonLabel: PropTypes.node,
-  sendMessage: PropTypes.func
+  sendMessage: PropTypes.func,
 };
 
 export default PagingButton;

--- a/lib/MultiColumnList/PrevNextPaginationRow.js
+++ b/lib/MultiColumnList/PrevNextPaginationRow.js
@@ -1,0 +1,148 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import Icon from '../Icon';
+import PagingButton from './PagingButton';
+import RowPositioner from './RowPositioner';
+import css from './MCLRenderer.css';
+
+const propTypes = {
+  activeNext: PropTypes.bool,
+  activePrevious: PropTypes.bool,
+  dataEndIndex: PropTypes.number,
+  dataEndReached: PropTypes.bool,
+  dataStartIndex: PropTypes.number,
+  handleLoadMore: PropTypes.func,
+  id: PropTypes.string,
+  keyId: PropTypes.string,
+  loading: PropTypes.bool,
+  pageAmount: PropTypes.number,
+  positionCache: PropTypes.object,
+  prevWidth: PropTypes.number,
+  rowHeightCache: PropTypes.object,
+  rowIndex: PropTypes.number,
+  rowWidth: PropTypes.number,
+  sendMessage: PropTypes.func,
+  staticBody: PropTypes.bool,
+  virtualize: PropTypes.bool,
+  width: PropTypes.number
+};
+
+const PrevNextPaginationRow = ({
+  activeNext,
+  activePrevious,
+  dataEndReached,
+  handleLoadMore,
+  id,
+  keyId,
+  loading,
+  pageAmount,
+  positionCache,
+  prevWidth,
+  rowHeightCache,
+  rowIndex,
+  rowWidth,
+  sendMessage,
+  staticBody,
+  virtualize,
+  width,
+  dataStartIndex,
+  dataEndIndex,
+}) => {
+  if (dataEndReached) { return null; }
+
+  const widthVar = width || prevWidth;
+  const scrollBarWidth = widthVar < rowWidth ? 17 : 0;
+
+  const previousLabel = (
+    <div data-test-pagination-previous>
+      <Icon size="small" icon="caret-left">
+        <FormattedMessage id="stripes-components.previous">
+          { (text) => <span>{text}</span>}
+        </FormattedMessage>
+      </Icon>
+    </div>
+  );
+
+  const nextLabel = (
+    <div data-test-pagination-next>
+      <Icon size="small" icon="caret-right" iconPosition="end">
+        <FormattedMessage id="stripes-components.next">
+          { (text) => <span>{text}</span>}
+        </FormattedMessage>
+      </Icon>
+    </div>
+  );
+
+  return (
+    <RowPositioner
+      key={`load-button-positioner-${rowIndex}-${keyId}`}
+      gridId={id}
+      heightCache={rowHeightCache}
+      positionCache={positionCache}
+      shouldPosition={!staticBody}
+      rowIndex={rowIndex}
+    >
+      {({ localRowIndex, position }) => (
+        <div
+          key={`${localRowIndex}-pagination-row`}
+          style={{
+            width: '100%',
+            position: virtualize ? 'absolute' : 'relative',
+            top: `${position}px`,
+            marginTop: '1rem'
+          }}
+        >
+          <FormattedMessage id="stripes-components.mcl.itemsRequestedMessage">
+            { ([message]) => (
+              <div
+                style={{ width: `${(width || prevWidth) - scrollBarWidth}px` }}
+                className={css.mclPrevNextStickyContainer}
+              >
+                <div className={css.mclPaginationCenterContainer}>
+                  <div className={css.mclPrevNextButtonContainer}>
+                    <PagingButton
+                      onClick={() => {
+                        // setFocusIndex(rowIndex);
+                        handleLoadMore(pageAmount, rowIndex - (pageAmount * 2));
+                      }}
+                      sendMessage={sendMessage}
+                      loadingMessage={message}
+                      disabled={loading || !activePrevious}
+                      pagingButtonLabel={previousLabel}
+                      buttonStyle="none"
+                      bottomMargin0
+                      data-test-prev-paging-button
+                      id={`${id || keyId}-prev-paging-button`}
+                    />
+                    <div className={css.mclPrevNextPageInfoContainer}>
+                      <div>{dataStartIndex}</div>&nbsp;-&nbsp;<div>{dataEndIndex}</div>
+                    </div>
+                    <PagingButton
+                      onClick={() => {
+                        // setFocusIndex(rowIndex);
+                        handleLoadMore(pageAmount, rowIndex);
+                      }}
+                      sendMessage={sendMessage}
+                      loadingMessage={message}
+                      disabled={loading || !activeNext}
+                      pagingButtonLabel={nextLabel}
+                      buttonStyle="none"
+                      bottomMargin0
+                      data-test-next-paging-button
+                      id={`${id || keyId}-next-paging-button`}
+                    />
+                  </div>
+                </div>
+              </div>
+            )}
+          </FormattedMessage>
+        </div>
+      )}
+    </RowPositioner>
+  );
+};
+
+PrevNextPaginationRow.propTypes = propTypes;
+
+export default PrevNextPaginationRow;

--- a/lib/MultiColumnList/index.js
+++ b/lib/MultiColumnList/index.js
@@ -1,1 +1,2 @@
 export { default } from './MultiColumnList';
+export { pagingTypes } from './MCLRenderer';

--- a/lib/MultiColumnList/readme.md
+++ b/lib/MultiColumnList/readme.md
@@ -86,12 +86,14 @@ Name | type | description | default | required
 `height` | string or number | the height of the table. **Necessary if `virtualize` is active you aren't using `autosize` already.** |  |
 `interactive` | bool | Applies a "pointer" cursor when the mouse hovers over a row | `true` |
 `isEmptyMessage` | string, object, node, arrayOf(node) | Message to display when the supplied contentData array is empty. | <FormattedMessage id="stripes-components.tableEmpty" /> |
+`itemToView` | positionObject | This object has keys for a 'selector' (string) and a client offset (number, pixels). This object is used to scroll the MCL list to the item that matches the selector, visually positioning it at the client offset from the top of the MCL. This is currently only working for **non-virtualized** lists. | `null` |
 `isSelected` | func({`item`}) | Should return `true` or `false` on whether or not to apply the `selectedClass` to the row. Useful for multiple selections. Preferred over `selectedRow` | |
 `loading` | bool | If true, will display an animated loading icon. | |
 `maxHeight` | number | the maximum height that the list should grow to before scrolling its list body in pixels. | |
 `nonInteractiveHeaders` | array of strings | Pass an array of column names to make their column headers non-interactive. This is only relevant if you have supplied an `onHeaderClick`-callback and you only want some of the header columns to be interactable. | [] |
 `onHeaderClick` | func[event, headerMetadata] | callback function invoked when one of the cells in the header is clicked (typically to choose a sort-order). By default, headerMetadata includes the column's data name as well as its alias, in case a object is supplied to the columnMapping prop. | |
 `onNeedMoreData` | func(`askAmount`, `index`) | Callback for fetching more data. If this prop is provided and a `totalCount` prop is provided, but un-reached by the count of loaded data items, `askAmount` will ask for the remainder of items or the `pageAmount` prop, whichever is less. This can be used to fulfill `limit` query parameters. `rowIndex` can be used to fulfill an `offset` query parameter. | |
+`onMarkPosition` | func(positionObject) | Called when an item is focused within the list. The position object consists of a 'selector' string and a client-space offset in pixels. This can be fed back to the `itemToView` prop and, upon rendering the list, MCL will scroll to the item, maintaining the same visual position. `itemToView` is currently only working for **non-virtualized** lists.| |
 `onRowClick` | function(`event`, `item`) | callback function invoked when one of the lines in the table is clicked (typically to select a record for more detailed display). | |
 `onScroll` | func | Callback for scrolling of list body. | `noop` |
 `pageAmount` | number | The base amount of data to pass as the `askAmount` parameter for the `onNeedMoreData` prop | `30` |

--- a/lib/MultiColumnList/readme.md
+++ b/lib/MultiColumnList/readme.md
@@ -18,6 +18,9 @@ You can also specify a formatter object to control exactly how the data is rende
 ### Infinite scroll
 For large lists of data the boolean prop `virtualize` can be turned on to efficiently display only the table rows that are visible to the user within the scrollable body of the list. The `virtualize` prop should be used in conjunction with the `height`, `maxHeight` or `autosize` prop - virtualization will not work otherwise.
 
+### Sparse Array Support
+Currently for non-virtualized (non-infinite scroll) lists, MCL can render sparse array structures. Sparse arrays are simply arrays that don't have their entire `length`'s worth of data items.
+
 ### Height and `autosize` props
 For efficiency, virtualization of list items requires a static `height` value (not percentage-based). If you're unsure how large the list's containing element will be, you can set the `autosize` prop to true - this will make the grid dynamically fill the space that it has, automatically using the resulting static width and height. This is ideal for the content of results panes.
 
@@ -92,7 +95,7 @@ Name | type | description | default | required
 `onRowClick` | function(`event`, `item`) | callback function invoked when one of the lines in the table is clicked (typically to select a record for more detailed display). | |
 `onScroll` | func | Callback for scrolling of list body. | `noop` |
 `pageAmount` | number | The base amount of data to pass as the `askAmount` parameter for the `onNeedMoreData` prop | `30` |
-`pagingType` | string | Controls the interaction type when loading more data in the MCL. `"scroll"` is used for infinite scroll/loading scenarios, `"click"` renders a paging button below the results if the loaded count is less than the `totalCount` prop. | `"scroll"` |
+`pagingType` | string | Controls the interaction type when loading more data in the MCL. `"scroll"` is used for infinite scroll/loading scenarios, `"click"` renders a paging button below the results if the loaded count is less than the `totalCount` prop. `prev-next` will render pagination with 'previous' and 'next' buttons with a display of the current page's item numbers. | `"scroll"` |
 `rowFormatter`  | func | function of shape `<name>({rowIndex, rowClass, rowData, cells, rowProps}){return <reactElement>}` that can be used to supply custom row layout. Forking [defaultRowFormatter](defaultRowFormatter.js) is a good place to start if you need to use this. | `defaultRowFormatter` |
 `rowMetadata` | object | arbitrary data that is passed as a metadata object to the `onRowClick` handler - useful for passing in data that may exist outside of the realm of the rendered MCL. | |
 `rowUpdater` | func(`rowData`, `rowIndex`) | This function should return a shallow data structure (flattened object) or primitive (string, number) that will indicate that exterior data for a row has changed. It will receive two parameters of the `rowData` and the `rowIndex` that can be used to base return values. This result is fed directly to the data rows via props, keeping them pure. You should rarely have to use this prop, as most changes will be relayed directly in the `contentData` array itself. | `noop` |

--- a/lib/MultiColumnList/stories/ItemToView.js
+++ b/lib/MultiColumnList/stories/ItemToView.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+import MultiColumnList from '../MultiColumnList';
+import { syncGenerate } from './service';
+
+export default class ItemToView extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      selected: null,
+      sorted: 'patronGroup',
+      data: syncGenerate(100, 0),
+      viewWidth: '800px',
+      viewItem: null,
+    };
+
+    this.columnWidths = {
+      active: '25%',
+      email: '50%',
+      index: '25%'
+    };
+  }
+
+  onRowClick = (e, row) => {
+    action('button-click');
+    this.setState(cur => ({
+      viewWidth: cur.viewWidth === '800px' ? '400px' : '800px',
+      selected: row
+    }));
+  }
+
+  markItem = (item) => {
+    this.setState({ viewItem: item })
+  }
+
+  onHeaderClick = (e, { name }) => {
+    this.setState({
+      sorted: name,
+    });
+  }
+
+  render() {
+    const {
+      viewWidth,
+      viewItem
+    } = this.state;
+
+    return (
+      <div style={{ height: '300px', width: viewWidth }}>
+        <MultiColumnList
+          striped
+          onMarkPosition={this.markItem}
+          contentData={this.state.data}
+          sortedColumn={this.state.sorted}
+          sortDirection="ascending"
+          selectedRow={this.state.selected}
+          onRowClick={this.onRowClick}
+          onHeaderClick={this.onHeaderClick}
+          columnWidths={this.columnWidths}
+          itemToView={viewItem}
+          columnMapping={{
+            active: 'Active',
+            email: 'Email',
+            index: 'Index'
+          }}
+          visibleColumns={[
+            'active', 'email', 'index'
+          ]}
+          autosize
+        />
+      </div>
+    );
+  }
+}

--- a/lib/MultiColumnList/stories/ItemToView.js
+++ b/lib/MultiColumnList/stories/ItemToView.js
@@ -30,7 +30,7 @@ export default class ItemToView extends React.Component {
   }
 
   markItem = (item) => {
-    this.setState({ viewItem: item })
+    this.setState({ viewItem: item });
   }
 
   onHeaderClick = (e, { name }) => {

--- a/lib/MultiColumnList/stories/MultiColumnList.stories.js
+++ b/lib/MultiColumnList/stories/MultiColumnList.stories.js
@@ -17,6 +17,7 @@ import PagingType from './PagingType';
 import Resizing from './Resizing';
 import ClickableRows from './ClickableRows';
 import ColumnWidthHints from './ColumnWidthHints';
+import PrevNextPaging from './PrevNextPaging';
 
 storiesOf('MultiColumnList', module)
   .addDecorator(withReadme(readme))
@@ -32,6 +33,7 @@ storiesOf('MultiColumnList', module)
   .add('Add Items', () => <AddItem />)
   .add('CheckboxSelect', () => <CheckboxSelect />)
   .add('Column chooser', () => <ColumnChooser />)
-  .add('Paging type', () => <PagingType />)
+  .add('Load More Paging', () => <PagingType />)
+  .add('Prev/Next Paging', () => <PrevNextPaging />)
   .add('Resizing', () => <Resizing />)
   .add('Clickable rows', () => <ClickableRows />);

--- a/lib/MultiColumnList/stories/MultiColumnList.stories.js
+++ b/lib/MultiColumnList/stories/MultiColumnList.stories.js
@@ -18,6 +18,7 @@ import Resizing from './Resizing';
 import ClickableRows from './ClickableRows';
 import ColumnWidthHints from './ColumnWidthHints';
 import PrevNextPaging from './PrevNextPaging';
+import ItemToView from './ItemToView';
 
 storiesOf('MultiColumnList', module)
   .addDecorator(withReadme(readme))
@@ -25,6 +26,7 @@ storiesOf('MultiColumnList', module)
   .add('Basic Usage', () => <BasicMCL />)
   .add('Autosize', () => <Autosize />)
   .add('Formatter', () => <Formatter />)
+  .add('Item-To-View', () => <ItemToView />)
   .add('Max height, virtualized', () => <MaxHeightVirtualized />)
   .add('End of list marker', () => <EndOfListMarker />)
   .add('Column widths', () => <ColumnWidths />)

--- a/lib/MultiColumnList/stories/PrevNextPaging.js
+++ b/lib/MultiColumnList/stories/PrevNextPaging.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import MultiColumnList from '../MultiColumnList';
+import { asyncGenerateSparse } from './service';
+
+export default class PrevNextPaging extends React.Component {
+  constructor() {
+    super();
+    this.endReached = false;
+    this.state = {
+      dataA: [],
+      dataB: [],
+      widths: {
+        index: '100px',
+        title: '150px',
+        date: '200px',
+        email: '50%',
+      },
+    };
+    this.requestMoreA(100, 0);
+    this.requestMoreB(100, 0);
+  }
+
+  requestMoreA = async (amount, index) => {
+    const newData = await asyncGenerateSparse(amount, index, 10000, 1000);
+    this.setState(() => ({
+      dataA: newData
+    }));
+  }
+
+  requestMoreB = async (amount, index) => {
+    const newData = await asyncGenerateSparse(amount, index, 10000, 1000);
+    this.setState(() => ({
+      dataB: newData
+    }));
+  }
+
+  render() {
+    const { dataB, dataA, widths } = this.state;
+    this.endReached = dataB.length > 500;
+    return (
+      <>
+        <div style={{ display: 'flex' }}>
+          <div style={{ width: '480px', height:'400px' }}>
+            <h2>Using totalCount prop</h2>
+            <MultiColumnList
+              contentData={dataA}
+              columnWidths={widths}
+              onNeedMoreData={this.requestMoreA}
+              visibleColumns={['index', 'title', 'date', 'email']}
+              interactive={false}
+              maxHeight={500}
+              pageAmount={100}
+              totalCount={10000}
+              pagingType="prev-next"
+            />
+          </div>
+          {/* <div style={{ width: '480px', height:'400px' }}>
+            <h2>Using dataEndReached prop</h2>
+            <MultiColumnList
+              contentData={dataB}
+              columnWidths={widths}
+              dataEndReached={this.endReached}
+              onNeedMoreData={this.requestMoreB}
+              visibleColumns={['index', 'title', 'date', 'email']}
+              interactive={false}
+              maxHeight={500}
+              pageAmount={100}
+              pagingType="prev-next"
+            />
+          </div> */}
+        </div>
+      </>
+    );
+  }
+}

--- a/lib/MultiColumnList/stories/service.js
+++ b/lib/MultiColumnList/stories/service.js
@@ -1,21 +1,21 @@
 import faker from 'faker';
 
-export function syncGenerate(n, start, generator) {
+export function syncGenerate(n, start = 0, generator) {
   const res = [];
-  let i = n;
-  while (i) {
+  let i = start;
+  while (i < n) {
     if (generator) {
       res.push(generator());
     } else {
       res.push({
         active: faker.random.boolean(),
         title: faker.random.words(),
-        index: start + res.length,
+        index: (start || 0) + res.length,
         date: faker.date.past().toString(),
         email: faker.internet.email(),
       });
     }
-    i--;
+    i++;
   }
   return res;
 }

--- a/lib/MultiColumnList/stories/service.js
+++ b/lib/MultiColumnList/stories/service.js
@@ -28,3 +28,32 @@ export function asyncGenerate(n, start, timeout = 0) {
     }, timeout);
   });
 }
+
+export function syncGenerateSparse(n, start, length, generator) {
+  const res = new Array(start);
+  let i = 0;
+  while (i < n) {
+    if (generator) {
+      res.push(generator());
+    } else {
+      res.push({
+        active: faker.random.boolean(),
+        title: faker.random.words(),
+        index: start + i + 1,
+        date: faker.date.past().toString(),
+        email: faker.internet.email(),
+      });
+    }
+    i++;
+  }
+  return res;
+}
+
+export function asyncGenerateSparse(n, start, length, timeout = 0) {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      const res = syncGenerateSparse(n, start, length);
+      resolve(res);
+    }, timeout);
+  });
+}

--- a/lib/MultiColumnList/tests/MCLHarness.js
+++ b/lib/MultiColumnList/tests/MCLHarness.js
@@ -3,7 +3,7 @@ import cloneDeep from 'lodash/cloneDeep';
 
 import MultiColumnList from '../MultiColumnList';
 import Button from '../../Button';
-import generate from './generate';
+import { generate } from './generate';
 
 
 class MCLHarness extends React.Component {

--- a/lib/MultiColumnList/tests/MCLHarness.js
+++ b/lib/MultiColumnList/tests/MCLHarness.js
@@ -19,7 +19,8 @@ class MCLHarness extends React.Component {
       height: 400,
       selected: {},
       displayGrid: props.displayGrid,
-      columns: this.props.columns || ['name', 'email', 'phone']
+      columns: this.props.columns || ['name', 'email', 'phone'],
+      placeMarker: null,
     };
 
     this.onNeedMore = this.onNeedMore.bind(this);
@@ -28,6 +29,7 @@ class MCLHarness extends React.Component {
     this.loadData = this.loadData.bind(this);
     this.filterData = this.filterData.bind(this);
     this.handleRowClick = this.handleRowClick.bind(this);
+    this.markPosition = this.markPosition.bind(this);
   }
 
   loadData() {
@@ -85,8 +87,14 @@ class MCLHarness extends React.Component {
     }));
   }
 
+  markPosition(marker) {
+    this.setState({
+      placeMarker: marker,
+    });
+  }
+
   render() {
-    const { displayGrid } = this.state;
+    const { displayGrid, placeMarker } = this.state;
     const { initialData, ...rest } = this.props; // eslint-disable-line no-unused-vars
     return (
       <div>
@@ -110,6 +118,8 @@ class MCLHarness extends React.Component {
             selectedRow={this.state.selected}
             onRowClick={this.handleRowClick}
             onHeaderClick={this.fakeSort}
+            onMarkPosition={this.markPosition}
+            itemToView={placeMarker}
             {...rest}
           />
         </div>

--- a/lib/MultiColumnList/tests/MultiColumnList-test.js
+++ b/lib/MultiColumnList/tests/MultiColumnList-test.js
@@ -31,12 +31,9 @@ const data = generate(10);
 const data3 = generate(3);
 const data100 = generate(100);
 const bigWidthData = generate(30, generator);
-<<<<<<< HEAD
 const sparseData = sparseGenerate(30, 30, generator);
-=======
 const bigWidthLongData = generate(100, generator);
 
->>>>>>> ae80fac1 (add tests for ItemToView)
 let headerClicked = false;
 
 describe('MultiColumnList', () => {

--- a/lib/MultiColumnList/tests/MultiColumnList-test.js
+++ b/lib/MultiColumnList/tests/MultiColumnList-test.js
@@ -732,7 +732,6 @@ describe('MultiColumnList', () => {
     });
   });
 
-<<<<<<< HEAD
   describe('prev-next paging', () => {
     const needMoreHandler = sinon.spy();
     beforeEach(async () => {
@@ -765,9 +764,7 @@ describe('MultiColumnList', () => {
       });
     });
   });
-  
-=======
->>>>>>> 92bf445fffcc3ae06eda7b67a5e7ce48d5e890b3
+
   describe('mark position functionality', () => {
     const markPositionInspector = sinon.spy();
     beforeEach(async () => {

--- a/lib/MultiColumnList/tests/MultiColumnList-test.js
+++ b/lib/MultiColumnList/tests/MultiColumnList-test.js
@@ -16,7 +16,7 @@ import MultiColumnListInteractor from './interactor';
 import * as handlers from '../defaultHandlers';
 import convertToPixels from '../convertToPixels';
 
-import generate from './generate';
+import { generate, sparseGenerate } from './generate';
 
 const generator = () => (
   {
@@ -31,7 +31,7 @@ const data = generate(10);
 const data3 = generate(3);
 const data100 = generate(100);
 const bigWidthData = generate(30, generator);
-
+const sparseData = sparseGenerate(30, 30, generator);
 let headerClicked = false;
 
 describe('MultiColumnList', () => {
@@ -730,6 +730,39 @@ describe('MultiColumnList', () => {
     });
   });
 
+  describe('prev-next paging', () => {
+    const needMoreHandler = sinon.spy();
+    beforeEach(async () => {
+      needMoreHandler.resetHistory();
+      mountWithContext(
+        <MultiColumnList
+          contentData={sparseData}
+          pagingType="prev-next"
+          onNeedMoreData={needMoreHandler}
+          pageLength={30}
+          totalCount={90}
+          height={300}
+        />
+      );
+
+      await mcl.pagingNext.click();
+    });
+
+    it('calls handler with appropriate parameters', () => {
+      expect(needMoreHandler.calledWith(30, 60, 30)).to.be.true;
+    });
+
+    describe('paging previous', () => {
+      beforeEach(async () => {
+        await mcl.pagingPrevious.click();
+      });
+
+      it('calls previous paging handler with appropriae parameters', () => {
+        expect(needMoreHandler.calledWith(30, 60, 30)).to.be.true;
+      });
+    });
+  });
+
   describe('detecting data changes', () => {
     let currentData;
     let nextData;
@@ -743,7 +776,7 @@ describe('MultiColumnList', () => {
       it('data change detected', () => {
         currentData = generate(4);
         nextData = generate(4);
-        expect(dataChangedOrLess(currentData, nextData)).to.be.true;
+        expect(dataChangedOrLess(currentData, nextData).changed).to.be.true;
       });
     });
 
@@ -751,7 +784,7 @@ describe('MultiColumnList', () => {
       it('data items did not change', () => {
         currentData = generate(5);
         nextData = [...currentData, ...generate(5)];
-        expect(dataChangedOrLess(currentData, nextData)).to.be.false;
+        expect(dataChangedOrLess(currentData, nextData).changed).to.be.false;
       });
     });
 
@@ -765,7 +798,7 @@ describe('MultiColumnList', () => {
           { name: 'james', servicePoints: ['south', 'north', 'west', 'east'] },
           { name: 'phil', servicePoints: ['north'] },
         ];
-        expect(dataChangedOrLess(currentData, nextData)).to.be.false;
+        expect(dataChangedOrLess(currentData, nextData).changed).to.be.false;
       });
     });
 
@@ -779,7 +812,7 @@ describe('MultiColumnList', () => {
           { name: 'james', servicePoints: ['south', 'north', 'east'] },
           { name: 'phil', servicePoints: ['north'] },
         ];
-        expect(dataChangedOrLess(currentData, nextData)).to.be.true;
+        expect(dataChangedOrLess(currentData, nextData).changed).to.be.true;
       });
     });
 
@@ -793,7 +826,7 @@ describe('MultiColumnList', () => {
           { name: 'james', servicePoints: ['north', 'south', 'east', 'west'] },
           { name: 'randy', servicePoints: ['east'] },
         ];
-        expect(dataChangedOrLess(currentData, nextData)).to.be.true;
+        expect(dataChangedOrLess(currentData, nextData).changed).to.be.true;
       });
     });
 
@@ -807,7 +840,7 @@ describe('MultiColumnList', () => {
           { name: 'james', servicePoints: ['north', 'south', 'east', 'west'] },
           { name: 'phil', servicePoints: [] },
         ];
-        expect(dataChangedOrLess(currentData, nextData)).to.be.false;
+        expect(dataChangedOrLess(currentData, nextData).changed).to.be.false;
       });
     });
 
@@ -821,7 +854,7 @@ describe('MultiColumnList', () => {
           'phil',
           'james'
         ];
-        expect(dataChangedOrLess(currentData, nextData)).to.be.true;
+        expect(dataChangedOrLess(currentData, nextData).changed).to.be.true;
       });
     });
 
@@ -836,7 +869,7 @@ describe('MultiColumnList', () => {
           { name: 'james', servicePoints: ['north', 'south', 'east', 'west'] },
           { name: 'phil', servicePoints: [] },
         ];
-        expect(dataChangedOrLess(currentData, nextData)).to.be.true;
+        expect(dataChangedOrLess(currentData, nextData).changed).to.be.true;
       });
     });
   });

--- a/lib/MultiColumnList/tests/MultiColumnList-test.js
+++ b/lib/MultiColumnList/tests/MultiColumnList-test.js
@@ -31,7 +31,12 @@ const data = generate(10);
 const data3 = generate(3);
 const data100 = generate(100);
 const bigWidthData = generate(30, generator);
+<<<<<<< HEAD
 const sparseData = sparseGenerate(30, 30, generator);
+=======
+const bigWidthLongData = generate(100, generator);
+
+>>>>>>> ae80fac1 (add tests for ItemToView)
 let headerClicked = false;
 
 describe('MultiColumnList', () => {
@@ -760,6 +765,65 @@ describe('MultiColumnList', () => {
       it('calls previous paging handler with appropriae parameters', () => {
         expect(needMoreHandler.calledWith(30, 60, 30)).to.be.true;
       });
+    });
+  });
+  
+  describe('mark position functionality', () => {
+    const markPositionInspector = sinon.spy();
+    beforeEach(async () => {
+      await mountWithContext(<MCLHarness virtualize={false} onMarkPosition={markPositionInspector} initialData={data100} onNeedMoreData={null} />);
+      await mcl.rows(6).click();
+    });
+
+    it('calls the markPosition handler, supplying proper arguments', () => {
+      expect(markPositionInspector.calledOnceWith()).to.not.equal(null);
+    });
+  });
+
+  describe('itemToView, width change', () => {
+    let position;
+    beforeEach(async () => {
+      position = 0;
+      await mountWithContext(
+        <MCLHarness
+          virtualize={false}
+          initialData={bigWidthLongData}
+          columns={['status', 'id', 'orderer', 'sender']}
+          columnWidths={{
+            status: '50px',
+            id: '20%',
+            orderer: '35%',
+            sender: '25%'
+          }}
+          onNeedMoreData={null}
+        />
+      );
+      await mcl.rows(50).focus().click();
+      position = mcl.rows(50).clientTop;
+    });
+
+    it('applies the ', () => {
+      expect(mcl.rows(50).clientTop).to.equal(position);
+    });
+  });
+
+  describe('item-to-view functionality', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <MultiColumnList
+          height={300}
+          contentData={data100}
+          itemToView={{
+            selector: '[aria-rowindex="50"]',
+            localClientTop: 30
+          }}
+          visibleColumns={['id']}
+        />
+      );
+    });
+
+    it('scrolls list to view offset', () => {
+      expect(mcl.listScrollTop).to.be.gt(0);
     });
   });
 

--- a/lib/MultiColumnList/tests/generate.js
+++ b/lib/MultiColumnList/tests/generate.js
@@ -1,6 +1,6 @@
 import faker from 'faker';
 
-export default function generate(num, generator) {
+export function generate(num, generator) {
   const arr = [];
   let cur = num;
   while (cur) {
@@ -20,4 +20,25 @@ export default function generate(num, generator) {
     cur--;
   }
   return arr;
+}
+
+export function sparseGenerate(num, start, generator) {
+  const res = new Array(start);
+  let i = 0;
+  while (i < num) {
+    if (generator) {
+      res.push(generator());
+    } else {
+      res.push({
+        id: faker.random.uuid(),
+        name: faker.name.findName(),
+        email: faker.internet.email(),
+        phone: faker.phone.phoneNumber(),
+        userName: faker.random.word(),
+        joinDate: faker.date.past().toString(),
+      });
+    }
+    i++;
+  }
+  return res;
 }

--- a/lib/MultiColumnList/tests/interactor.js
+++ b/lib/MultiColumnList/tests/interactor.js
@@ -58,6 +58,8 @@ export default interactor(class MultiColumnListInteractor {
   displaysLoadingIcon = isPresent(`.${css.mclContentLoading}`);
   cell = scoped(`.${css.mclCell}`, CellInteractor);
   pagingButton = scoped('[data-test-paging-button]');
+  pagingNext = scoped('[data-test-next-paging-button]');
+  pagingPrevious = scoped('[data-test-prev-paging-button]');
 
   columnsMeasured() {
     return this.when(() => (this.cell.style && this.cell.style.width !== ''));

--- a/lib/MultiColumnList/tests/interactor.js
+++ b/lib/MultiColumnList/tests/interactor.js
@@ -10,10 +10,18 @@ import {
   property,
   isVisible,
   scoped,
+  computed,
 } from '@bigtest/interactor';
 
 import { computedStyle } from '../../../tests/helpers';
 import css from '../MCLRenderer.css';
+
+
+function clientTop(selector) {
+  return computed(function () {
+    return this.$(selector).getBoundingClientRect().top;
+  });
+}
 
 const CellInteractor = interactor(class CellInteractor {
   content = text();
@@ -33,6 +41,7 @@ const RowInteractor = interactor(class RowInteractor {
   isAnchor = is('a');
   width = property('offsetWidth');
   minWidth = computedStyle(undefined, 'minWidth');
+  clientTop = clientTop(this.$selector);
 });
 
 const HeaderInteractor = interactor(class HeaderInteractor {
@@ -60,6 +69,8 @@ export default interactor(class MultiColumnListInteractor {
   pagingButton = scoped('[data-test-paging-button]');
   pagingNext = scoped('[data-test-next-paging-button]');
   pagingPrevious = scoped('[data-test-prev-paging-button]');
+
+  listScrollTop = property(`.${css.mclScrollable}`, 'scrollTop');
 
   columnsMeasured() {
     return this.when(() => (this.cell.style && this.cell.style.width !== ''));

--- a/lib/MultiSelection/stories/MultiSelection.stories.js
+++ b/lib/MultiSelection/stories/MultiSelection.stories.js
@@ -131,6 +131,7 @@ storiesOf('MultiSelect', module)
   .add('Disabled state', () => (
     <div>
       <MultiSelection
+        value={optionList}
         label="My Disabled MultiSelect"
         id="my-disabled-multiselect"
         dataOptions={optionList}

--- a/translations/stripes-components/en.json
+++ b/translations/stripes-components/en.json
@@ -5,6 +5,8 @@
   "goToPreviousMonth": "Go to previous month",
   "goToNextYear": "Go to next year",
   "goToNextMonth": "Go to next month",
+  "previous": "Previous",
+  "next": "Next",
   "selectDay": "Choose {dayOfWeek}, {date}",
   "dateSelected": "{date} selected",
   "Datepicker.monthControl": "month",


### PR DESCRIPTION
This PR aims to give modules a way to restore their scroll position of a current MCL given an 'itemToView' prop, as well as an 'onMarkPosition' handler. In the example image, it retains the item's vertical position across switches in the MCL's width.

![scrollItemToView](https://user-images.githubusercontent.com/20704067/119202190-e280a400-ba55-11eb-9198-15217bf4ccbf.gif)

at first, this will only be compatible with non-virtualized lists, but we'll hopefully expand that soon.