### PR TITLE
STCOM-843 formally export exportToCsv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * `<Selection>` no longer always shows a `props.tether` deprecation warning. Refs STCOM-838.
 * `<Paneset>` should not call `setState` after unmounting. Refs STCOM-833.
 * Add `buttonLabel` to `<ErrorModal>`. Refs STCOM-841.
+* Formally export `exportToCsv`. Refs STCOM-843.
 
 ## [9.1.0](https://github.com/folio-org/stripes-components/tree/v9.1.0) (2021-04-08)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.0.0...v9.1.0)

--- a/index.js
+++ b/index.js
@@ -114,6 +114,7 @@ export {
 export { default as FilterControlGroup } from './lib/FilterControlGroup';
 export { default as FilterPaneSearch } from './lib/FilterPaneSearch';
 export { default as ExportCsv } from './lib/ExportCsv';
+export { default as exportToCsv } from './lib/ExportCsv/exportToCsv';
 
 /* utilities */
 export { default as RootCloseWrapper } from './util/RootCloseWrapper';


### PR DESCRIPTION
When we copied `exportToCsv` from `stripes-util` in #780, we forgot to
(or declined to) add it to the list of formal exports here. While this
is primarily a component library, we export plenty of functions in
addition to components.

Refs [STCOM-843](https://issues.folio.org/browse/STCOM-843)