### PR TITLE
STCOM-844 include exportToCsv enhancements from stripes-util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * `<Selection>` no longer always shows a `props.tether` deprecation warning. Refs STCOM-838.
 * `<Paneset>` should not call `setState` after unmounting. Refs STCOM-833.
 * Add `buttonLabel` to `<ErrorModal>`. Refs STCOM-841.
+* Copy features and bugfixes from the `stripes-util` dupe of `exportToCsv`. Refs STCOM-844.
 
 ## [9.1.0](https://github.com/folio-org/stripes-components/tree/v9.1.0) (2021-04-08)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.0.0...v9.1.0)

--- a/lib/ExportCsv/exportToCsv.js
+++ b/lib/ExportCsv/exportToCsv.js
@@ -79,7 +79,7 @@ export default function exportToCsv(objectArray, opts) {
     return;
   }
   let options = opts;
-  if (opts.isArray) { // backwards-compatiblity
+  if (Array.isArray(opts)) { // backwards-compatiblity
     options = { excludeFields: opts };
   }
 
@@ -87,6 +87,8 @@ export default function exportToCsv(objectArray, opts) {
     excludeFields,           // do not include these fields
     explicitlyIncludeFields, // ensure to include these fields
     onlyFields,              // Only Fields to be included
+    filename,                // Custom filename
+    header = true,           // turn off/on header adding
   } = options;
 
   // The default behavior is to use the keys on the first object as the list of fields
@@ -94,7 +96,7 @@ export default function exportToCsv(objectArray, opts) {
     .omit(excludeFields)
     .ensureToInclude(explicitlyIncludeFields).list;
 
-  const parser = new Parser({ fields, flatten: true });
+  const parser = new Parser({ fields, flatten: true, header });
   const csv = parser.parse(objectArray);
-  triggerDownload(csv);
+  triggerDownload(csv, filename);
 }


### PR DESCRIPTION
`exportToCsv` was copied from `stripes-util` in #780 but the
`stripes-util` version was never labeled as deprecated and it was
enhanced with new features:

* support for custom file names
* toggle header rows

and bug fixes:

* correctly support the legacy second-arg-lists-fields implementation

that were never replicated here. Whoops.

Refs [STCOM-844](https://issues.folio.org/browse/STCOM-844)