### PR TITLE
STCOM-842 re-scale cached sizes to fit...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * Formally export `exportToCsv`. Refs STCOM-843.
 * Copy features and bugfixes from the `stripes-util` dupe of `exportToCsv`. Refs STCOM-844.
 * `<MultiColumnList>` validate container-ref before calling functions on it to avoid NPEs.
-* Fix issue with persistent panesets not adjusting to changed window sizes. Fixes STCOM-842.
+* Fix issue with persisted panesets not adjusting to changed window sizes. Fixes STCOM-842.
 
 ## [9.1.0](https://github.com/folio-org/stripes-components/tree/v9.1.0) (2021-04-08)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.0.0...v9.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Formally export `exportToCsv`. Refs STCOM-843.
 * Copy features and bugfixes from the `stripes-util` dupe of `exportToCsv`. Refs STCOM-844.
 * `<MultiColumnList>` validate container-ref before calling functions on it to avoid NPEs.
+* Fix issue with persistent panesets not adjusting to changed window sizes. Fixes STCOM-842.
 
 ## [9.1.0](https://github.com/folio-org/stripes-components/tree/v9.1.0) (2021-04-08)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.0.0...v9.1.0)

--- a/lib/Paneset/PaneResizeContainer.js
+++ b/lib/Paneset/PaneResizeContainer.js
@@ -7,14 +7,17 @@ import PaneResizeCursor from './PaneResizeCursor';
 import { ResizeProvider } from './ResizeContext';
 import css from './PaneResize.css';
 
-const PaneResizeContainer = ({ isRoot, children, onElementResize, parentElement }) => {
+const PaneResizeContainer = ({ isRoot, children, onElementResize, parentElement, resizeContainerRef }) => {
   const [dragging, setDragging] = useState(false);
   const [cursorX, setCursorX] = useState(0);
   const [handles, setHandles] = useState([]);
   const [activeHandle, setActiveHandle] = useState(null);
   const [update, setUpdate] = useState(0); // eslint-disable-line no-unused-vars
   const [blocking, setBlocking] = useState(null);
-  const container = useRef();
+  let container = useRef();
+  if (resizeContainerRef) {
+    container = resizeContainerRef;
+  }
   const handleData = useRef([]);
   const containerRect = useRef();
   const activeRef = useRef();

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -372,7 +372,6 @@ class Paneset extends React.Component {
         this.updateLayoutCache(widths, changeType);
         this.resizePanes(this.state.panes, widths);
       }
-      // this.resizePanes(this.state.panes, widths);
     });
   }
 

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -354,19 +354,13 @@ class Paneset extends React.Component {
 
       if (toApply && sizesCached === -1) {
         widths = toApply;
-        this.updateLayoutCache(widths, changeType);
-        this.resizePanes(this.state.panes, widths);
       } else if (sizesCached !== -1) {
-        widths = this.state.layoutCache[sizesCached];
-        const adjustedWidths = this.resizeCachedSizesToFit(sizesCached);
-        widths = adjustedWidths || widths;
-        this.updateLayoutCache(widths, changeType);
-        this.resizePanes(this.state.panes, widths);
+        widths = this.resizeCachedSizesToFit(sizesCached) || this.state.layoutCache[sizesCached];
       } else {
         widths = this.calcWidths(this.state.panes);
-        this.updateLayoutCache(widths, changeType);
-        this.resizePanes(this.state.panes, widths);
       }
+      this.updateLayoutCache(widths, changeType);
+      this.resizePanes(this.state.panes, widths);
     });
   }
 

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -314,16 +314,11 @@ class Paneset extends React.Component {
       for (const p in layoutObject) {
         if (layoutObject[p]) {
           const unit = parseCSSUnit(layoutObject[p]);
-          switch (unit) {
-            case 'percent':
-              return null;
-            case 'vw': break;
-            case 'px':
-              value = Math.ceil(parseInt(layoutObject[p], 10));
-              totalWidth += value;
-              break;
-            default:
-              break;
+          if (unit === 'px') {
+            value = Math.ceil(parseInt(layoutObject[p], 10));
+            totalWidth += value;
+          } else {
+            return null;
           }
         }
       }

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -14,6 +14,14 @@ const defaultProps = {
   initialLayouts: [],
 };
 
+function sumWidths(key, objectArray) {
+  let sum = 0;
+  objectArray.forEach(o => {
+    sum += parseInt(o[key], 10);
+  });
+  return sum;
+}
+
 function getNewPanewidthObject(key, CSSvalue, proportionalChange) {
   const unit = parseCSSUnit(CSSvalue);
   let newWidth = CSSvalue;
@@ -163,43 +171,53 @@ class Paneset extends React.Component {
       const tempPanesList = [];
       let currentWidth;
       if (!this.props.paneset) {
-        currentWidth = this.resizeContainer.current?.getBoundingClientRect().width;
+        currentWidth = window.innerWidth;
       } else {
         currentWidth = this.container.current?.getBoundingClientRect().width;
       }
 
       if (currentWidth) {
-        const proportionalChange = currentWidth / this.previousContainerWidth;
-        for (const p in matchingLCache) {
-          if (Object.prototype.hasOwnProperty.call(matchingLCache, p)) {
-            const newPO = getNewPanewidthObject(p, matchingLCache[p], proportionalChange);
-            tempPanesList.push(newPO);
-          }
-        }
+        let totalWidth = 0;
+        // get an actual width of the paneset...
+        this.state.panes.forEach((p) => {
+          const elem = p.getRef();
+          if (elem.current) { totalWidth += elem.current.getBoundingClientRect().width; }
+        });
 
-        // be sure and update the so that we can use this on the next resize...
-        this.previousContainerWidth = currentWidth;
-        this.setState((curr) => {
-          const tempCache = cloneDeep(curr.layoutCache);
-          tempCache.splice(matchingCacheIndex, 1);
-          return {
-            layoutCache: tempCache,
-          };
-        }, () => {
-          // // adjust the layout cache relative to the new client rect size
-          // // size panes accordingly.
-          const newWidths = this.calcWidths(tempPanesList);
-          const changeType = 'windowResize';
-          this.updateLayoutCache(newWidths, changeType);
-          this.resizePanes(this.state.panes, newWidths);
-          this.resizeNestedTO = setTimeout(() => {
-            this.state.panes.forEach((p) => {
-              if (p.isPaneset) {
-                p.getInstance().resizeToContainer();
-              }
+        // check actual width against width of containing element... this prevents continued proportional resizes.
+        if (Math.floor(totalWidth) !== currentWidth) {
+          const proportionalChange = currentWidth / totalWidth;
+          for (const p in matchingLCache) {
+            if (Object.prototype.hasOwnProperty.call(matchingLCache, p)) {
+              const newPO = getNewPanewidthObject(p, matchingLCache[p], proportionalChange);
+              tempPanesList.push(newPO);
+            }
+          }
+
+          // be sure and update the so that we can use this on the next resize...
+          this.previousContainerWidth = currentWidth;
+          this.setState((curr) => {
+            const tempCache = cloneDeep(curr.layoutCache);
+            tempCache.splice(matchingCacheIndex, 1);
+            return {
+              layoutCache: tempCache,
+            };
+          }, () => {
+            // // adjust the layout cache relative to the new client rect size
+            // // size panes accordingly.
+            const newWidths = this.calcWidths(tempPanesList);
+            const changeType = 'windowResize';
+            this.updateLayoutCache(newWidths, changeType);
+            this.resizePanes(this.state.panes, newWidths);
+            this.resizeNestedTO = setTimeout(() => {
+              this.state.panes.forEach((p) => {
+                if (p.isPaneset) {
+                  p.getInstance().resizeToContainer();
+                }
+              });
             });
           });
-        });
+        }
       }
     }
   }
@@ -305,9 +323,9 @@ class Paneset extends React.Component {
   // If that's true, scale the cached sizes accordingly.
   resizeCachedSizesToFit = (layoutIndex) => {
     const { layoutCache } = this.state;
+    const { paneset } = this.props;
     const layoutObject = layoutCache[layoutIndex];
-
-    if (this.resizeContainer.current) {
+    if (!paneset) {
       // sum the pixels...
       let totalWidth = 0;
       let value;
@@ -328,10 +346,11 @@ class Paneset extends React.Component {
         const proportion = totalWidth / this.previousContainerWidth;
         for (const p in layoutObject) {
           if (layoutObject[p]) {
-            const newWidth = this.getNewPanewidthObject(p, layoutObject[p], proportion);
+            const newWidth = getNewPanewidthObject(p, layoutObject[p], proportion);
             newCacheObject = { ...newCacheObject, ...newWidth };
           }
         }
+        this.previousContainerWidth = window.innerWidth;
         return newCacheObject;
       }
     }

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -94,6 +94,7 @@ class Paneset extends React.Component {
     };
 
     this.container = React.createRef();
+    this.resizeContainer = React.createRef();
     this.id = props.id || uniqueId('paneset-');
     this.widths = [];
     this.interval = null;
@@ -160,7 +161,13 @@ class Paneset extends React.Component {
       const matchingLCache = this.state.layoutCache[matchingCacheIndex];
       // set array up with defaultWidth and id...pass to calc widths.
       const tempPanesList = [];
-      const currentWidth = this.container.current?.getBoundingClientRect().width;
+      let currentWidth;
+      if (!this.props.paneset) {
+        currentWidth = this.resizeContainer.current?.getBoundingClientRect().width;
+      } else {
+        currentWidth = this.container.current?.getBoundingClientRect().width;
+      }
+
       if (currentWidth) {
         const proportionalChange = currentWidth / this.previousContainerWidth;
         for (const p in matchingLCache) {
@@ -294,6 +301,48 @@ class Paneset extends React.Component {
     });
   }
 
+  // sometimes the cached sizes might not match up to the actual container due to different sized window.
+  // If that's true, scale the cached sizes accordingly.
+  resizeCachedSizesToFit = (layoutIndex) => {
+    const { layoutCache } = this.state;
+    const layoutObject = layoutCache[layoutIndex];
+
+    if (this.resizeContainer.current) {
+      // sum the pixels...
+      let totalWidth = 0;
+      let value;
+      for (const p in layoutObject) {
+        if (layoutObject[p]) {
+          const unit = parseCSSUnit(layoutObject[p]);
+          switch (unit) {
+            case 'percent':
+              return null;
+            case 'vw': break;
+            case 'px':
+              value = Math.ceil(parseInt(layoutObject[p], 10));
+              totalWidth += value;
+              break;
+            default:
+              break;
+          }
+        }
+      }
+
+      if (totalWidth > 0) {
+        let newCacheObject = {};
+        const proportion = totalWidth / this.previousContainerWidth;
+        for (const p in layoutObject) {
+          if (layoutObject[p]) {
+            const newWidth = this.getNewPanewidthObject(p, layoutObject[p], proportion);
+            newCacheObject = { ...newCacheObject, ...newWidth };
+          }
+        }
+        return newCacheObject;
+      }
+    }
+    return null;
+  }
+
   calcWidthsAndResize = (changeType) => {
     this.widthsRAF = requestAnimationFrame(() => {
       let widths;
@@ -311,13 +360,19 @@ class Paneset extends React.Component {
       if (toApply && sizesCached === -1) {
         widths = toApply;
         this.updateLayoutCache(widths, changeType);
+        this.resizePanes(this.state.panes, widths);
       } else if (sizesCached !== -1) {
         widths = this.state.layoutCache[sizesCached];
+        const adjustedWidths = this.resizeCachedSizesToFit(sizesCached);
+        widths = adjustedWidths || widths;
+        this.updateLayoutCache(widths, changeType);
+        this.resizePanes(this.state.panes, widths);
       } else {
         widths = this.calcWidths(this.state.panes);
         this.updateLayoutCache(widths, changeType);
+        this.resizePanes(this.state.panes, widths);
       }
-      this.resizePanes(this.state.panes, widths);
+      // this.resizePanes(this.state.panes, widths);
     });
   }
 
@@ -510,6 +565,7 @@ class Paneset extends React.Component {
           isRoot={isRoot || !paneset}
           parentElement={this.container?.current}
           onElementResize={this.handlePaneResize}
+          resizeContainerRef={this.resizeContainer}
         >
           <div className={this.getClassName()} id={id} style={this.state.style} ref={this.container} {...dataProps}>
             {children}


### PR DESCRIPTION
## Purpose
This PR resolves issue [STCOM-842](https://issues.folio.org/browse/STCOM-842) where panesets do not fit the window (either they're too small leaving whitespace or the panes are cropped off.) If a user resizes the panes, travels to a different app, resizes the window, then returns to the app where they resized, the old pane dimensions remain which will not match the resized window (*Phew!)

### Approach
a) use the resize container (a full width div) to judge the real width of the window for the top-level paneset.
b) if an initial layout prop is provided, rescale it before applying it to the panes. - sum the widths, compare to the resize container, rescale the values accordingly...

Math. Wooo 🎏 