### PR TITLE
Add hideSource prop to MetaSection

### DIFF
--- a/lib/MetaSection/MetaSection.js
+++ b/lib/MetaSection/MetaSection.js
@@ -25,6 +25,7 @@ const propTypes = {
   ]),
   createdDate: PropTypes.string,
   headingLevel: PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
+  hideSource: PropTypes.bool,
   id: PropTypes.string,
   lastUpdatedBy: PropTypes.oneOfType([
     PropTypes.shape({
@@ -42,6 +43,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  hideSource: false,
   showUserLink: false,
   headingLevel: 4
 };
@@ -74,6 +76,7 @@ class MetaSection extends React.Component {
       createdBy,
       createdDate,
       headingLevel,
+      hideSource,
       lastUpdatedBy,
       lastUpdatedDate,
     } = this.props;
@@ -129,16 +132,20 @@ class MetaSection extends React.Component {
           label={lastUpdatedLabel}
         >
           <div className={css.metaSectionContent}>
-            <div className={css.metaSectionContentBlock} data-test-updated-by>
-              {lastUpdatedByLabel}
-            </div>
+            {!hideSource &&
+              <div className={css.metaSectionContentBlock} data-test-updated-by>
+                {lastUpdatedByLabel}
+              </div>
+            }
             <div className={css.metaSectionGroup}>
               <div className={css.metaSectionContentBlock} data-test-created>
                 {createdLabel}
               </div>
-              <div className={css.metaSectionContentBlock} data-test-created-by>
-                {createdByLabel}
-              </div>
+              {!hideSource &&
+                <div className={css.metaSectionContentBlock} data-test-created-by>
+                  {createdByLabel}
+                </div>
+              }
             </div>
           </div>
         </Accordion>

--- a/lib/MetaSection/readme.md
+++ b/lib/MetaSection/readme.md
@@ -19,6 +19,7 @@ contentId | string | HTML id attribute assigned to accordion's content |  |
 createdBy | string/object | Name/record of the user who created the record. |  |
 createdDate | string | Date/time a record was created. |  |
 headingLevel | number | Sets the heading level of the heading inside the accordion header. | 4 |
+hideSource | boolean | Allows for the concealment of the createdBy and updatedBy information on the display
 id | string | HTML id attribute assigned to accordion's root. |  |
 lastUpdatedBy | string/object | Name/record of the last user who modified the record. |  |
 lastUpdatedDate | string | Latest date/time a record was modified. |  |

--- a/lib/MetaSection/tests/MetaSection.test.js
+++ b/lib/MetaSection/tests/MetaSection.test.js
@@ -195,4 +195,33 @@ describe('MetaSection', () => {
       expect(metaSection.createdByText).to.contain('Automated process');
     });
   });
+
+  describe('If hideSource provided', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <MetaSection
+          createdDate="2010-07-08T00:00:00Z"
+          hideSource
+          lastUpdatedDate="2021-07-08T00:00:00Z"
+        />
+      );
+      await metaSection.header.click();
+    });
+
+    it('Should render createdDate field', () => {
+      expect(metaSection.createdTextIsPresent).to.be.true;
+    });
+
+    it('Should not render createdBy field', () => {
+      expect(metaSection.createdByTextIsPresent).to.be.false;
+    });
+
+    it('Should render lastUpdatedDate field', () => {
+      expect(metaSection.updatedTextIsPresent).to.be.true;
+    });
+
+    it('Should not render updatedBy field', () => {
+      expect(metaSection.updatedByTextIsPresent).to.be.false;
+    });
+  });
 });

--- a/lib/MetaSection/tests/interactor.js
+++ b/lib/MetaSection/tests/interactor.js
@@ -10,9 +10,13 @@ export default interactor(class MetaSectionInteractor {
   static defaultScope = '[data-test-meta-section]';
 
   updatedText = text('div[class^=metaHeader] div[class^=metaHeaderLabel]');
+  updatedTextIsPresent = isPresent('div[class^=metaHeader] div[class^=metaHeaderLabel]');
   updatedByText = text('[data-test-updated-by]');
+  updatedByTextIsPresent = isPresent('[data-test-updated-by]');
   createdText = text('[data-test-created]');
+  createdTextIsPresent = isPresent('[data-test-created]');
   createdByText = text('[data-test-created-by]');
+  createdByTextIsPresent = isPresent('[data-test-created-by]');
 
   header = scoped('button', ButtonInteractor);
   accordion = scoped(AccordionInteractor.defaultScope, AccordionInteractor);


### PR DESCRIPTION
Refs ERM-1230, STCOM-859

MetaSection is currently designed so that if user data is provided, it will display that, and if not then it will display "automated process" as a source. For certain applications, such as the mainly German use of ERM apps, user data is not built into the domain model at this level, and so is not attached to lastUpdated/dateCreated.

A lack of user data here implying "AutomatedSource" is not correct, and in ERM at least the desired outcome is to simply be able to hide these lines.

An alternative use case would be the ability to see the user metadata dependent only on permissions.