### PR TITLE
STCOM-860 always use Arabic numerals given backendDateStandard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Change history for stripes-components
 
-## [9.3.0](IN PROGRESS)
+## [9.3.0] (IN PROGRESS)
 
 * Add link icon. Refs STCOM-852.
 * `<MultiColumnList>` add ability to focus component if content data is empty. Refs STCOM-851.
 * Expose getLocaleDateFormat Datepicker util. Refs STCOM-854.
 * Fix issue with misaligned dates/weekdays in Datepicker Calendar. Refs STCOM-849
+* `<Datepicker>` always provides Arabic numerals (0-9) given `backendDateStandard` to format values. Refs STCOM-860.
 
 ## [9.2.0](https://github.com/folio-org/stripes-components/tree/v9.2.0) (2021-06-08)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.1.0...v9.2.0)

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -122,7 +122,7 @@ export const defaultOutputFormatter = ({ backendDateStandard, value, uiFormat, o
 
   // for support of the RFC2822 format (rare thus far and support may soon be deprecated.)
   if (/2822/.test(backendDateStandard)) {
-    const DATE_RFC2822 = 'ddd, MM MMM YYYY HH:mm:ss ZZ';
+    const DATE_RFC2822 = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
     return parsed.locale('en').format(DATE_RFC2822);
   }
 

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -101,7 +101,7 @@ const defaultParser = (value, timeZone, uiFormat, outputFormats) => {
  *
  * @returns {string} 7-bit ASCII
  */
-const defaultOutputFormatter = ({ backendDateStandard, value, uiFormat, outputFormats, timeZone }) => {
+export const defaultOutputFormatter = ({ backendDateStandard, value, uiFormat, outputFormats, timeZone }) => {
   if (!value || value === '') { return value; }
   const parsed = new moment.tz(value, [uiFormat, ...outputFormats], timeZone); // eslint-disable-line
 

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -82,7 +82,25 @@ const defaultParser = (value, timeZone, uiFormat, outputFormats) => {
   return inputValue;
 };
 
-// Controls the formatting from the value prop/input to what is relayed in the onChange event.
+/**
+ * defaultOutputFormatter
+ * Controls the formatting from the value prop/input to what is relayed in the onChange event.
+ * This function has two responsibilities:
+ *   1. use `backendDateStandard` to format `value`
+ *   2. convert value to Arabic/Latn digits (0-9)
+ *
+ * The first responsibility is pretty obvious, but the second one is subtle,
+ * implied but never clearly stated in API documentation. Dates are passed
+ * as strings in API requests and are then interpreted by the backend as Dates.
+ * To be so interpretable, they must conform to the expected formatted AND use
+ * the expected numeral system.
+ *
+ * This function allows the format to be changed with `backendDateStandard`.
+ * To change the numeral system, pass a function as `outputFormatter`, which
+ * gives you control over both the format and the numeral system.
+ *
+ * @returns {string} 7-bit ASCII
+ */
 const defaultOutputFormatter = ({ backendDateStandard, value, uiFormat, outputFormats, timeZone }) => {
   if (!value || value === '') { return value; }
   const parsed = new moment.tz(value, [uiFormat, ...outputFormats], timeZone); // eslint-disable-line
@@ -91,18 +109,28 @@ const defaultOutputFormatter = ({ backendDateStandard, value, uiFormat, outputFo
     return parsed.toISOString();
   }
 
+  // Use `.locale('en')` before `.format(...)` to get Arabic/"Latn" numerals.
+  // otherwise, a locale like ar-SA or any locale with a "-u-nu-..." subtag
+  // can give us non-Arabic (non-"Latn") numerals, and in such a locale the
+  // formatter "YYYY-MM-DD" can give us output like this: ١٦‏/٠٧‏/٢٠٢١
+  // i.e. we get year-month-day but in non-Arabic numerals.
+  //
+  // Additional details about numbering systems at
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem
+  // and about how the locale string may be parsed at
+  // https://www.rfc-editor.org/rfc/rfc5646.html
+
   // for support of the RFC2822 format (rare thus far and support may soon be deprecated.)
   if (/2822/.test(backendDateStandard)) {
     const DATE_RFC2822 = 'ddd, MM MMM YYYY HH:mm:ss ZZ';
-    return parsed.format(DATE_RFC2822);
+    return parsed.locale('en').format(DATE_RFC2822);
   }
 
   // if a localized string dateformat has been passed, normalize the date first...
   // otherwise, localized strings could be submitted to the backend.
-
   const normalizedDate = moment.utc(value, [uiFormat, ...outputFormats]);
 
-  return new moment(normalizedDate, 'YYYY-MM-DD').format(backendDateStandard); // eslint-disable-line new-cap
+  return new moment(normalizedDate, 'YYYY-MM-DD').locale('en').format(backendDateStandard); // eslint-disable-line
 };
 
 const propTypes = {
@@ -139,7 +167,6 @@ const propTypes = {
   usePortal: PropTypes.bool,
   value: PropTypes.string,
 };
-
 
 const getBackendDateStandard = (standard, use) => {
   if (!use) return undefined;

--- a/lib/Datepicker/readme.md
+++ b/lib/Datepicker/readme.md
@@ -16,15 +16,15 @@ outputBackendValue: PropTypes.bool,
 Name | type | description | default | required
 --- | --- | --- | --- | ---
 `autoFocus` | bool | If this prop is `true`, component will automatically focus on mount | |
-`backendDateStandard` | string | parses to/from ISO 8601 standard by default before committing value. | "ISO 8601" | false
+`backendDateStandard` | string | parses to/from ISO 8601 standard, with Arabic (0-9) digits, by default before committing value. | "ISO 8601" | false
 `disabled` | bool | if true, field will be disabled for focus or entry. | false | false
 `id` | string | id for date field - used in the "id" attribute of the text input | | false
 `label` | string | visible field label | | false
 `locale` | string | Overrides the locale provided by context. | "en" | false
 `onChange` | func | Event handler to handle updates to the datefield text. | | false
 `outputBackendValue` | bool | If False - Outputs the value as it is displayed in the input. | true |
-`outputFormatter` | func | Function to format the date value for submission to the backend. | `defaultOutputFormatter` | 
-`parser` | func | Function to format the date from the `value` prop to the value ui's presentation within the input. | `defaultParser` | 
+`outputFormatter` | func | Function to format the date value for submission to the backend. | `defaultOutputFormatter` |
+`parser` | func | Function to format the date from the `value` prop to the value ui's presentation within the input. | `defaultParser` |
 `placement` | string | Determines the position of the date picker overlay. See available options in the <a href="https://github.com/folio-org/stripes-components/tree/master/lib/Popper" target="_blank">Popper documentation</a>. | bottom | false
 `modifiers` | object | Passes modifiers for the internal <a href="https://github.com/folio-org/stripes-components/tree/master/lib/Popper" target="_blank">Popper</a>-component which handles the positioning of the date picker overlay. | | false
 `readOnly` | bool | if true, field will be readonly. 'Calendar' and 'clear' buttons will be omitted. | false | false
@@ -100,7 +100,7 @@ The value flow happens in 3 stages
 - uiFormat - the localized format or `dateFormat` prop.
 - outputFormat - the ISO-string literal format derived from the `backendDateStandard` prop
 3. output formatting - when the input is changed by the user, its value is formatted again to work with the backend using the `outputFormatter` function. This function is provided with **a parameter object** holding the following values:
-- backendDateStandard - the prop of the same name. 
+- backendDateStandard - the prop of the same name.
 - value - the value prop.
 - uiFormat - the localized format or `dateFormat` prop for displaying in the textfield.
 - outputFormat - the ISO-string literal format derived from the `backendDateStandard` prop.
@@ -117,7 +117,7 @@ The value flow happens in 3 stages
 
 ## Custom Circumstances with RFF
 
-If the provided defaults and base behaviors don't quite cover your requirements, you may need write an additional function in order to wrap the datepicker and modify props from `<Field>`. Simply supplying a function that accepts the input, and meta props that components usually receive from RFF. In this example, we want validation errors to 
+If the provided defaults and base behaviors don't quite cover your requirements, you may need write an additional function in order to wrap the datepicker and modify props from `<Field>`. Simply supplying a function that accepts the input, and meta props that components usually receive from RFF. In this example, we want validation errors to
 to show only if there are no warnings. Note the passing of a `useInput` prop to Datepicker. This is typically and internal prop for Datepicker to know when it's being used within a `<Field>` and act accordingly - otherwise, you may see date output coming through in the incorrect format.
 
 ```

--- a/lib/Datepicker/tests/Datepicker-ReduxForm-test.js
+++ b/lib/Datepicker/tests/Datepicker-ReduxForm-test.js
@@ -445,7 +445,7 @@ describe('Datepicker with Redux Form integration', () => {
       });
 
       it('returns an RFC2822 datetime string for specific time zone', () => {
-        expect(onChange.mock.calls[0][1]).to.equal('Sun, 04 Apr 2018 00:00:00 -0700');
+        expect(onChange.mock.calls[0][1]).to.equal('Sun, 01 Apr 2018 00:00:00 -0700');
       });
     });
 

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -548,7 +548,7 @@ describe('Datepicker', () => {
     });
   });
 
-  describe('defaultOutputFormatter converts to RFC2822 output', () => {
+  describe('defaultOutputFormatter provides RFC-2822 output', () => {
     const frm = moment().locale('en');
 
     let output;
@@ -568,4 +568,44 @@ describe('Datepicker', () => {
       expect(output).to.equal('Mon, 12 Jul 2021 14:15:16 +0000');
     });
   });
+
+  describe('defaultOutputFormatter provides ISO-8601 output', () => {
+    const frm = moment().locale('en');
+
+    let output;
+    const value = frm.format('2021-07-12T14:15:16+00:00');
+
+    beforeEach(async () => {
+      output = defaultOutputFormatter({
+        backendDateStandard: 'ISO-8601',
+        value,
+        uiFormat: 'YYYY-MM-DD HH:mm:ss',
+        outputFormats: [],
+        timeZone: 'UTC',
+      });
+    });
+
+    it('returns a ISO-8601 string', () => {
+      expect(output).to.equal('2021-07-12T14:15:16.000Z');
+    });
+  });
+
+  describe('defaultOutputFormatter leaves empty string alone', () => {
+    let output;
+
+    beforeEach(async () => {
+      output = defaultOutputFormatter({
+        backendDateStandard: 'RFC2822',
+        value: '',
+        uiFormat: 'YYYY-MM-DD HH:mm:ss',
+        outputFormats: [],
+        timeZone: 'UTC',
+      });
+    });
+
+    it('returns empty string', () => {
+      expect(output).to.equal('');
+    });
+  });
+
 });

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import mock from 'jest-mock';
 import moment from 'moment';
 import 'moment/locale/ar';
+import 'moment/locale/fr';
 
 
 import { Interactor } from '@bigtest/interactor';
@@ -501,7 +502,12 @@ describe('Datepicker', () => {
     });
   });
 
-  describe('defaultOutputFormatter converts non-Latn input to Latn-output', () => {
+  // this test runs successfully in a `describe.only(...)` block
+  // but fails when run as part of the full suite.
+  // grrrrrrr.
+  // the same test is below with a Latn locale (fr) instead of
+  // an Arab one (ar) since that seems to be the deciding factor.
+  describe.skip('defaultOutputFormatter converts non-Latn input to Latn-output', () => {
     const arm = moment().locale('ar');
 
     let output;
@@ -518,6 +524,48 @@ describe('Datepicker', () => {
 
     it('returns a Latn (Arabic, 0-9) string', () => {
       expect(output).to.equal('2021-07-11');
+    });
+  });
+
+  // see above; this doesn't really convert non-Latn to Latn
+  describe('defaultOutputFormatter converts non-en input to Latn-output', () => {
+    const frm = moment().locale('fr');
+
+    let output;
+    const value = frm.format('2021/07/11');
+    beforeEach(async () => {
+      output = defaultOutputFormatter({
+        backendDateStandard: 'YYYY-MM-DD',
+        value,
+        uiFormat: 'YYYY/MM/DD',
+        outputFormats: [],
+        timeZone: 'UTC',
+      });
+    });
+
+    it('returns a Latn (Arabic, 0-9) string', () => {
+      expect(output).to.equal('2021-07-11');
+    });
+  });
+
+  describe('defaultOutputFormatter converts to RFC2822 output', () => {
+    const frm = moment().locale('en');
+
+    let output;
+    const value = frm.format('2021-07-12 14:15:16');
+
+    beforeEach(async () => {
+      output = defaultOutputFormatter({
+        backendDateStandard: 'RFC2822',
+        value,
+        uiFormat: 'YYYY-MM-DD HH:mm:ss',
+        outputFormats: [],
+        timeZone: 'UTC',
+      });
+    });
+
+    it('returns a RFC-2822 string', () => {
+      expect(output).to.equal('Mon, 12 Jul 2021 14:15:16 +0000');
     });
   });
 });

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -607,5 +607,4 @@ describe('Datepicker', () => {
       expect(output).to.equal('');
     });
   });
-
 });

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -2,11 +2,15 @@ import React from 'react';
 import { describe, beforeEach, afterEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 import mock from 'jest-mock';
+import moment from "moment";
+import "moment/locale/ar";
+
+
 import { Interactor } from '@bigtest/interactor';
 
 import { mountWithContext, focusPrevious, focusNext } from '../../../tests/helpers';
 
-import Datepicker, { getMomentLocalizedFormat } from '../Datepicker';
+import Datepicker, { defaultOutputFormatter, getMomentLocalizedFormat } from '../Datepicker';
 import DatepickerAppHarness from './DatepickerAppHarness';
 import DatepickerInteractor, { Calendar } from './interactor';
 
@@ -494,6 +498,26 @@ describe('Datepicker', () => {
 
     it('returns the long date format according to the passed locale', () => {
       expect(format).to.equal('DD.MM.YYYY');
+    });
+  });
+
+  describe('defaultOutputFormatter converts non-Latn input to Latn-output', () => {
+    const arm = moment().locale('ar');
+
+    let output;
+    const value = arm.format('2021-07-21');
+    beforeEach(async () => {
+      output = defaultOutputFormatter({
+        backendDateStandard: 'YYYY-MM-DD',
+        value,
+        uiFormat: 'MM/DD/YYYY',
+        outputFormats: [],
+        timeZone: 'UTC',
+      });
+    });
+
+    it('returns a Latn (Arabic, 0-9) string', () => {
+      expect(output).to.equal('2021-07-12');
     });
   });
 });

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { describe, beforeEach, afterEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 import mock from 'jest-mock';
-import moment from "moment";
-import "moment/locale/ar";
+import moment from 'moment';
+import 'moment/locale/ar';
 
 
 import { Interactor } from '@bigtest/interactor';
@@ -505,19 +505,19 @@ describe('Datepicker', () => {
     const arm = moment().locale('ar');
 
     let output;
-    const value = arm.format('2021-07-21');
+    const value = arm.format('2021/07/11');
     beforeEach(async () => {
       output = defaultOutputFormatter({
         backendDateStandard: 'YYYY-MM-DD',
         value,
-        uiFormat: 'MM/DD/YYYY',
+        uiFormat: 'YYYY/MM/DD',
         outputFormats: [],
         timeZone: 'UTC',
       });
     });
 
     it('returns a Latn (Arabic, 0-9) string', () => {
-      expect(output).to.equal('2021-07-12');
+      expect(output).to.equal('2021-07-11');
     });
   });
 });


### PR DESCRIPTION
The implied promise of `outputFormatter`, given `backendDateStandard` is
that it will format dates using Arabic numerals (0-9) as this is what
the backend expects. Previously, it handled only for formatting but not
the conversion to Arabic ("Latn") numerals if the current locale used
non-Arabic numerals, which is the case for manu Arabic locales that use
Arabic-Hindi numerals.

Now, `<Datepicker>` delivers on both its promises:

1. it formats the date as expected for the backend
2. it provieds dates in Arabic numerals as expected for the backend

Refs [STCOM-860](https://issues.folio.org/browse/STCOM-860), [FOLIO-3208](https://issues.folio.org/browse/FOLIO-3208)