### PR TITLE
STCOM-861 correctly format RFC-2822 dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * `<MultiColumnList>` add ability to focus component if content data is empty. Refs STCOM-851.
 * Expose getLocaleDateFormat Datepicker util. Refs STCOM-854.
 * Fix issue with misaligned dates/weekdays in Datepicker Calendar. Refs STCOM-849
+* `<Datepicker>` must correctly handle RFC-2822 dates. Refs STCOM-861.
 
 ## [9.2.0](https://github.com/folio-org/stripes-components/tree/v9.2.0) (2021-06-08)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.1.0...v9.2.0)

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -93,7 +93,7 @@ const defaultOutputFormatter = ({ backendDateStandard, value, uiFormat, outputFo
 
   // for support of the RFC2822 format (rare thus far and support may soon be deprecated.)
   if (/2822/.test(backendDateStandard)) {
-    const DATE_RFC2822 = 'ddd, MM MMM YYYY HH:mm:ss ZZ';
+    const DATE_RFC2822 = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
     return parsed.format(DATE_RFC2822);
   }
 
@@ -144,8 +144,8 @@ const propTypes = {
 const getBackendDateStandard = (standard, use) => {
   if (!use) return undefined;
   if (standard === 'ISO8601') return ['YYYY-MM-DDTHH:mm:ss.sssZ', 'YYYY-MM-DDTHH:mm:ssZ'];
-  if (standard === 'RFC2822') return ['ddd, MM MMM YYYY HH:mm:ss ZZ'];
-  return [standard, 'YYYY-MM-DDTHH:mm:ss.sssZ', 'ddd, MM MMM YYYY HH:mm:ss ZZ'];
+  if (standard === 'RFC2822') return ['ddd, DD MMM YYYY HH:mm:ss ZZ'];
+  return [standard, 'YYYY-MM-DDTHH:mm:ss.sssZ', 'ddd, DD MMM YYYY HH:mm:ss ZZ'];
 };
 
 const defaultProps = {

--- a/lib/Datepicker/tests/Datepicker-ReduxForm-test.js
+++ b/lib/Datepicker/tests/Datepicker-ReduxForm-test.js
@@ -445,7 +445,7 @@ describe('Datepicker with Redux Form integration', () => {
       });
 
       it('returns an RFC2822 datetime string for specific time zone', () => {
-        expect(onChange.mock.calls[0][1]).to.equal('Sun, 04 Apr 2018 00:00:00 -0700');
+        expect(onChange.mock.calls[0][1]).to.equal('Sun, 01 Apr 2018 00:00:00 -0700');
       });
     });
 


### PR DESCRIPTION
Correctly format RFC-2822 dates; the format is `ddd, DD MMM...` not
`ddd, MM MMM` (which includes the month in two different formats but
never the day-of-month).

Refs [STCOM-861](https://issues.folio.org/browse/STCOM-861)