### PR TITLE
STCOM-848 Set max-height on dropdown menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * `<Datepicker>` must correctly handle RFC-2822 dates. Refs STCOM-861.
 * `<Datepicker>` always provides Arabic numerals (0-9) given `backendDateStandard` to format values. Refs STCOM-860.
 * `<SingleSelect>` add new `loading` and `loadingMessage` props to display while loading options. Refs STCOM-858.
+* Applied maxheight to `<DropdownMenu>`. Fixes STCOM-848
 
 ## [9.2.0](https://github.com/folio-org/stripes-components/tree/v9.2.0) (2021-06-08)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.1.0...v9.2.0)

--- a/lib/Dropdown/Dropdown.stories.js
+++ b/lib/Dropdown/Dropdown.stories.js
@@ -31,6 +31,14 @@ storiesOf('Dropdown', module)
           <ul>
             <li>Example 1</li>
             <li>Example 2</li>
+            <li>Example 1</li>
+            <li>Example 2</li>
+            <li>Example 1</li>
+            <li>Example 2</li>
+            <li>Example 1</li>
+            <li>Example 2</li>
+            <li>Example 1</li>
+            <li>Example 2</li>
           </ul>
         </DropdownMenu>
       )}

--- a/lib/DropdownMenu/DropdownMenu.css
+++ b/lib/DropdownMenu/DropdownMenu.css
@@ -18,6 +18,8 @@
   border-radius: var(--radius);
   box-shadow: var(--shadow);
   pointer-events: all;
+  max-height: 85vh;
+  overflow: auto;
 
   & ul {
     list-style: none;

--- a/lib/DropdownMenu/DropdownMenu.css
+++ b/lib/DropdownMenu/DropdownMenu.css
@@ -18,7 +18,7 @@
   border-radius: var(--radius);
   box-shadow: var(--shadow);
   pointer-events: all;
-  max-height: 85vh;
+  max-height: 80vh;
   overflow: auto;
 
   & ul {


### PR DESCRIPTION
# Problem
Dropdowns with lots of items/options can leave items unreachable since they cannot scroll.

## Approach
Set a maxheight on DropdownMenu so that it won't be pushed beyond the height of the viewport.

![image](https://user-images.githubusercontent.com/20704067/125979033-259976d8-a4aa-4011-ab3a-44dc56f4e12a.png)
