### PR TITLE
STCOM-869 Fix Datepicker inputRef prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * `<Datepicker>` always provides Arabic numerals (0-9) given `backendDateStandard` to format values. Refs STCOM-860.
 * `<SingleSelect>` add new `loading` and `loadingMessage` props to display while loading options. Refs STCOM-858.
 * Applied maxheight to `<DropdownMenu>`. Fixes STCOM-848
+* Fix `<Datepicker>` `inputRef` prop not working. Refs STCOM-869
 
 ## [9.2.0](https://github.com/folio-org/stripes-components/tree/v9.2.0) (2021-06-08)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.1.0...v9.2.0)

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -186,6 +186,7 @@ const defaultProps = {
   placement: 'bottom',
   screenReaderMessage: '',
   useFocus: true,
+  inputRef: React.createRef(),
 };
 
 const Datepicker = (
@@ -213,6 +214,7 @@ const Datepicker = (
     useInput,
     usePortal,
     value: valueProp,
+    inputRef,
     ...props }
 ) => {
   const format = useRef(
@@ -239,7 +241,6 @@ const Datepicker = (
   const [displayedValue, updateDisplayed] = useState(datePair.dateString);
   const [showCalendar, setShowCalendar] = useState(showCalendarProp);
 
-  const input = useRef(null);
   const pickerRef = useRef(null);
   const blurTimeout = useRef(null);
   const hiddenInput = useRef(null);
@@ -254,7 +255,7 @@ const Datepicker = (
   useEffect(() => {
     if (typeof valueProp !== 'undefined' && valueProp !== datePair.dateString && valueProp !== datePair.formatted) {
       payload.current = Object.assign(payload.current, maybeUpdateValue(valueProp));
-      nativeChangeField(input, false, payload.current.dateString);
+      nativeChangeField(inputRef, false, payload.current.dateString);
     }
   }, [valueProp, maybeUpdateValue, datePair.dateString, datePair.formatted]);
 
@@ -320,7 +321,7 @@ const Datepicker = (
   };
 
   const setFromCalendar = (value) => {
-    nativeChangeField(input, hideOnChoose, value);
+    nativeChangeField(inputRef, hideOnChoose, value);
     if (hideOnChoose) {
       setShowCalendar(false);
     }
@@ -358,7 +359,7 @@ const Datepicker = (
 
   const internalClearDate = () => {
     updateDatePair({ dateString: '', formatted: '' });
-    nativeChangeField(input, true, '');
+    nativeChangeField(inputRef, true, '');
   };
 
   const toggleCalendar = () => {
@@ -371,7 +372,7 @@ const Datepicker = (
       if (onBlur) {
         if (useInput) {
           onBlur({
-            target: outputBackendValue ? hiddenInput.current : input.current,
+            target: outputBackendValue ? hiddenInput.current : inputRef.current,
             stopPropagation: () => {},
             preventDefault: () => {},
             defaultPrevented: true,
@@ -408,7 +409,7 @@ const Datepicker = (
   };
 
   const handleRequestClose = () => {
-    input.current?.focus(); // eslint-disable-line no-unused-expressions
+    inputRef.current?.focus(); // eslint-disable-line no-unused-expressions
     setShowCalendar(false);
   };
 
@@ -486,7 +487,7 @@ const Datepicker = (
         onChange={internalHandleChange}
         endControl={renderEndElement()}
         hasClearIcon={false}
-        inputRef={input}
+        inputRef={inputRef}
         placeholder={format}
       />
       <input

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -143,7 +143,7 @@ const propTypes = {
   hideOnChoose: PropTypes.bool,
   id: PropTypes.string,
   input: PropTypes.object,
-  inputRef: PropTypes.object,
+  inputRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
   intl: PropTypes.object,
   label: PropTypes.node,
   locale: PropTypes.string,
@@ -186,7 +186,6 @@ const defaultProps = {
   placement: 'bottom',
   screenReaderMessage: '',
   useFocus: true,
-  inputRef: React.createRef(),
 };
 
 const Datepicker = (
@@ -241,6 +240,7 @@ const Datepicker = (
   const [displayedValue, updateDisplayed] = useState(datePair.dateString);
   const [showCalendar, setShowCalendar] = useState(showCalendarProp);
 
+  const input = useRef(null);
   const pickerRef = useRef(null);
   const blurTimeout = useRef(null);
   const hiddenInput = useRef(null);
@@ -255,7 +255,7 @@ const Datepicker = (
   useEffect(() => {
     if (typeof valueProp !== 'undefined' && valueProp !== datePair.dateString && valueProp !== datePair.formatted) {
       payload.current = Object.assign(payload.current, maybeUpdateValue(valueProp));
-      nativeChangeField(inputRef, false, payload.current.dateString);
+      nativeChangeField(input, false, payload.current.dateString);
     }
   }, [valueProp, maybeUpdateValue, datePair.dateString, datePair.formatted]);
 
@@ -321,7 +321,7 @@ const Datepicker = (
   };
 
   const setFromCalendar = (value) => {
-    nativeChangeField(inputRef, hideOnChoose, value);
+    nativeChangeField(input, hideOnChoose, value);
     if (hideOnChoose) {
       setShowCalendar(false);
     }
@@ -359,7 +359,7 @@ const Datepicker = (
 
   const internalClearDate = () => {
     updateDatePair({ dateString: '', formatted: '' });
-    nativeChangeField(inputRef, true, '');
+    nativeChangeField(input, true, '');
   };
 
   const toggleCalendar = () => {
@@ -372,7 +372,7 @@ const Datepicker = (
       if (onBlur) {
         if (useInput) {
           onBlur({
-            target: outputBackendValue ? hiddenInput.current : inputRef.current,
+            target: outputBackendValue ? hiddenInput.current : input.current,
             stopPropagation: () => {},
             preventDefault: () => {},
             defaultPrevented: true,
@@ -409,7 +409,7 @@ const Datepicker = (
   };
 
   const handleRequestClose = () => {
-    inputRef.current?.focus(); // eslint-disable-line no-unused-expressions
+    input.current?.focus(); // eslint-disable-line no-unused-expressions
     setShowCalendar(false);
   };
 
@@ -487,7 +487,11 @@ const Datepicker = (
         onChange={internalHandleChange}
         endControl={renderEndElement()}
         hasClearIcon={false}
-        inputRef={inputRef}
+        inputRef={element => {
+          input.current = element;
+          if (typeof inputRef === 'object') inputRef.current = element;
+          if (typeof inputRef === 'function') inputRef(element);
+        }}
         placeholder={format}
       />
       <input

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -153,6 +153,23 @@ describe('Datepicker', () => {
     });
   });
 
+  describe('focusing inputRef', () => {
+    beforeEach(async () => {
+      const inputRef = React.createRef();
+
+      await mountWithContext(
+        <Datepicker inputRef={inputRef} />
+      );
+
+      await datepicker.input.blurInput();
+      await inputRef.current.focus();
+    });
+
+    it('focuses the input', () => {
+      expect(datepicker.input.isFocused).to.be.true;
+    });
+  });
+
   describe('value set after initial render', () => {
     const datepickerAppInteractor = new Interactor();
     beforeEach(async () => {


### PR DESCRIPTION
The Datepicker's  `inputRef` prop was ignored - it did not reference the input element for real