### PR TITLE
STCOM-872: fix issue when staff slips generate an extra blank page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Applied maxheight to `<DropdownMenu>`. Fixes STCOM-848
 * Fix `<Datepicker>` `inputRef` prop not working. Refs STCOM-869
 * Scope the focusable row to the scroll container. Refs STCOM-870
+* Fix issue when staff slips generate an extra blank page. Refs STCOM-872
 
 ## [9.2.0](https://github.com/folio-org/stripes-components/tree/v9.2.0) (2021-06-08)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.1.0...v9.2.0)

--- a/lib/global.css
+++ b/lib/global.css
@@ -75,6 +75,13 @@ html {
   }
 }
 
+/* global "print" styles below was added for solve the problem with extra blank page generating on printing in all modules */
+@media print {
+  body {
+    height: auto !important;
+  }
+}
+
 a {
   color: var(--color-link);
   text-decoration: none;


### PR DESCRIPTION
## Purpose
Fix extra blank page at printing

## Approach
Adding global auto height on printing is solving extra blank page generating in all modules.
This approach was discussed in https://github.com/folio-org/ui-checkin/pull/467#pullrequestreview-737021609

## Refs
https://issues.folio.org/browse/STCOM-872

## Screenshots
![Checkin-empty-page](https://user-images.githubusercontent.com/88130496/130569438-82ed7005-0c7c-4c7a-915f-777213a7984b.png)
![checkin fixed](https://user-images.githubusercontent.com/88130496/130569818-276d3869-14bc-4dcc-bd5e-b38bb99050d5.jpg)
![Circ-emty-page-edit-](https://user-images.githubusercontent.com/88130496/130569934-ed54e3cd-cc07-4043-98be-fc17feac5dbe.png)
![circulation fixed](https://user-images.githubusercontent.com/88130496/130570242-94fb40a7-9d04-40ae-b6ca-9f94fac906e4.jpg)

## TODOS and Open Questions
@JohnC-80, @zburke, could you please clarify do we need to add someone else for review this task?