### PR TITLE
bump version to keep HEAD at/ahead of latest release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
The modules composing `stripes` must be singletons within the build. This PR addresses a situation that could easily cause multiple copies of `stripes-components` to be included. Given:

* `stripes-components` `9.2.1` was released on a branch while the version on master remained at `9.2.0`.
* `stripes` `6.2.2` was release _on master_, referencing `9.2.1`.

This will cause build problems if `stripes-components` is cloned into a workspace: the `stripes` dep on `~9.2.1` means the git-clone of `stripes-components`, still at `9.2.0`, doesn't satisfy the dependency and it will pull down an additional copy into its `node_modules`. This means there are now multiple copies of `stripes-components` in the bundle, and Bad Things happen when that occurs.

Moral of the story: the version on `#master` _must_ remain ahead of the most recently released version.  Usually, this means bumping the minor version on `#master` immediately after a release. I did not do this after the last `stripes-*` releases, hence this sad tale of woe. At the time, I was expecting that we'd be ready to bump to the next major version _any day now_ to get our React 17 work started, so I thought I'd save the effort of going through the version-bump song and dance twice. Instead, there's this sad tale of woe instead. Will I never learn?