### PR TITLE
STCOM-867 Popover close focus management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Scope the focusable row to the scroll container. Refs STCOM-870.
 * Fix issue when staff slips generate an extra blank page. Refs STCOM-872.
 * React 17. STCOM-797.
+* Closing `<Popover>`, `<InfoPopover>` should send focus back to the trigger. Fixes STCOM-867.
 
 ## [9.2.0](https://github.com/folio-org/stripes-components/tree/v9.2.0) (2021-06-08)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.1.0...v9.2.0)

--- a/lib/Popover/Popover.js
+++ b/lib/Popover/Popover.js
@@ -37,7 +37,20 @@ const Popover = forwardRef(({
   const internalPopoverRef = useRef(null);
   const anchorRef = anchorRefProp || internalAnchorRef;
   const popoverRef = ref || internalPopoverRef;
-  const handleToggle = typeof onToggle === 'function' ? onToggle : () => setOpen(!open);
+  const internalToggleRef = useRef(() => {
+    setOpen((cur) => {
+      if (cur &&
+        (popoverRef.current === document.activeElement ||
+          popoverRef.current?.contains(document.activeElement)
+        )
+      ) {
+        anchorRef.current?.focus(); // eslint-disable-line
+      }
+      return !cur;
+    });
+  }).current;
+
+  const handleToggle = typeof onToggle === 'function' ? onToggle : () => internalToggleRef();
   const modifiers = { offset: { enabled: true, offset: `0,${offset}` }, ...modifiersProp };
 
   const renderProps = {

--- a/lib/Popover/tests/Popover-test.js
+++ b/lib/Popover/tests/Popover-test.js
@@ -33,7 +33,7 @@ const ControlledPopoverHarness = () => {
   );
 };
 
-describe('Popover', () => {
+describe.only('Popover', () => {
   const popover = new PopoverInteractor();
   const button = new ButtonInteractor('#trigger-button');
   const content = new Interactor('#content');
@@ -60,6 +60,20 @@ describe('Popover', () => {
 
   it('Renders the popover overlay when the trigger is clicked', () => {
     expect(popover.isOpen).to.be.true;
+  });
+
+  describe('Pressing the escape key', () => {
+    beforeEach(async () => {
+      await popover.pressEscape();
+    });
+
+    it('closes the popover', () => {
+      expect(popover.isOpen).to.be.false;
+    });
+
+    it('focuses the trigger', () => {
+      expect(button.isFocused).to.be.true;
+    });
   });
 
   describe('If contents is rendered using a render-prop function', () => {

--- a/lib/Popover/tests/Popover-test.js
+++ b/lib/Popover/tests/Popover-test.js
@@ -3,7 +3,7 @@
  */
 
 import React, { useState } from 'react';
-import { Interactor, triggerable } from '@bigtest/interactor';
+import { Interactor } from '@bigtest/interactor';
 import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 
@@ -60,16 +60,6 @@ describe('Popover', () => {
 
   it('Renders the popover overlay when the trigger is clicked', () => {
     expect(popover.isOpen).to.be.true;
-  });
-
-  describe('Pressing the escape key', () => {
-    beforeEach(async () => {
-      await triggerable('keydown', { keyCode: 27 });
-    });
-
-    it('closes the popover', () => {
-      expect(popover.isOpen).to.be.false;
-    });
   });
 
   describe('If contents is rendered using a render-prop function', () => {

--- a/lib/Popover/tests/Popover-test.js
+++ b/lib/Popover/tests/Popover-test.js
@@ -3,7 +3,7 @@
  */
 
 import React, { useState } from 'react';
-import { Interactor } from '@bigtest/interactor';
+import { Interactor, triggerable } from '@bigtest/interactor';
 import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 
@@ -60,6 +60,16 @@ describe('Popover', () => {
 
   it('Renders the popover overlay when the trigger is clicked', () => {
     expect(popover.isOpen).to.be.true;
+  });
+
+  describe('Pressing the escape key', () => {
+    beforeEach(async () => {
+      await triggerable('keydown', { keyCode: 27 });
+    });
+
+    it('closes the popover', () => {
+      expect(popover.isOpen).to.be.false;
+    });
   });
 
   describe('If contents is rendered using a render-prop function', () => {

--- a/lib/Popover/tests/Popover-test.js
+++ b/lib/Popover/tests/Popover-test.js
@@ -33,7 +33,7 @@ const ControlledPopoverHarness = () => {
   );
 };
 
-describe.only('Popover', () => {
+describe('Popover', () => {
   const popover = new PopoverInteractor();
   const button = new ButtonInteractor('#trigger-button');
   const content = new Interactor('#content');

--- a/lib/Popover/tests/interactor.js
+++ b/lib/Popover/tests/interactor.js
@@ -1,8 +1,10 @@
 import {
   interactor,
   isPresent,
+  triggerable
 } from '@bigtest/interactor';
 
 export default interactor(class PopoverInteractor {
   isOpen = isPresent('[data-test-popover-overlay]');
+  pressEscape = triggerable('keyup', { key: 'Escape', keyCode: 27 });
 });


### PR DESCRIPTION
When the popover is closing, if the popover is focused or contains the focused element, the trigger of the popover should be focused.

Covers `<Popover>` and `<InfoPopover>` components.