### PR TITLE
STCOM-877: Update react-overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@
 * Fix `<Datepicker>` `inputRef` prop not working. Refs STCOM-869
 * Scope the focusable row to the scroll container. Refs STCOM-870
 * Fix issue when staff slips generate an extra blank page. Refs STCOM-872
-* Use existing Bigtest Interactors from stripes-testing instead of local bigtest interactors. Refs STCOM-862 
+* Use existing Bigtest Interactors from stripes-testing instead of local bigtest interactors. Refs STCOM-862
 * React 17. STCOM-797.
 * Closing `<Popover>`, `<InfoPopover>` should send focus back to the trigger. Fixes STCOM-867.
+* Update `react-overlays` to v4. Refs STCOM-877.
 
 ## [9.2.0](https://github.com/folio-org/stripes-components/tree/v9.2.0) (2021-06-08)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.1.0...v9.2.0)

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "react-flexbox-grid": "1.1.3",
     "react-highlight-words": "^0.16.0",
     "react-hot-loader": "^4.0.0",
-    "react-overlays": "^3.2.0",
+    "react-overlays": "^4.1.1",
     "react-quill": "^1.3.3",
     "react-svg-loader": "^3.0.3",
     "react-tether": "^1.0.1",


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-877

The previous version of `react-overlays` was not working correctly with react 17. Root close would fire right after opening a dialog / modal which would close it.

This was fixed in: 

https://github.com/react-bootstrap/react-overlays/pull/880

More discussion with @aditya-matukumalli here:

https://folio-project.slack.com/archives/C210UCHQ9/p1632347078155500

