### PR TITLE
STCOM-880 correctly test disabled dropdown

### DIFF
--- a/lib/Dropdown/tests/dropdown-test.js
+++ b/lib/Dropdown/tests/dropdown-test.js
@@ -5,7 +5,6 @@ import {
   Dropdown as Interactor,
   HTML as HtmlInteractor,
   Keyboard as keyboard,
-  isVisible
 } from '@folio/stripes-testing';
 
 import { expect } from 'chai';
@@ -458,11 +457,7 @@ describe('Dropdown', () => {
       );
     });
 
-    describe('clicking the disabled trigger', () => {
-      beforeEach(() => dropdown.toggle());
-
-      it('does not open the menu', () => dropdown.is({ open: false }));
-    });
+    it('disables the trigger', () => ButtonInteractor('testDropdown').has({ disabled: true }));
   });
 
   describe('controlled functionality', () => {


### PR DESCRIPTION
Instead of attempting to interact with a disabled element, check for the
element's disabled attribute.

Copied from #1635

Refs [STCOM-880](https://issues.folio.org/browse/STCOM-880)