### PR TITLE
correctly test RadioButton focus under React 17

### DIFF
--- a/lib/RadioButton/tests/RadioButton-ReduxForm-test.js
+++ b/lib/RadioButton/tests/RadioButton-ReduxForm-test.js
@@ -3,7 +3,7 @@ import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
 
 import { Field } from 'redux-form';
-import { RadioButton as Interactor } from '@folio/stripes-testing';
+import { RadioButton as Interactor, converge } from '@folio/stripes-testing';
 import { mountWithContext } from '../../../tests/helpers';
 import TestForm from '../../../tests/TestForm';
 
@@ -25,8 +25,10 @@ describe('RadioButton with Redux Form', () => {
             onChange={(event) => {
               output = event.target.checked;
             }}
+            validate={value => (value === 'green' ? 'Not ready to eat' : undefined)}
             type="radio"
             value="green"
+            warn={value => (value === 'ripe' ? 'Warning: may be mushy' : undefined)}
           />
         </div>
         <div id="radio-button-2">
@@ -48,15 +50,17 @@ describe('RadioButton with Redux Form', () => {
 
   describe('clicking the label', () => {
     beforeEach(async () => {
+      await radioButton1.focus();
       await radioButton1.click();
       await radioButton1.blur();
+      await radioButton2.focus();
     });
 
     it('toggles the value', () => expect(output).to.be.true);
 
     it('displays the input as checked', () => radioButton1.is({ checked: true }));
 
-    it('displays the error text', () => radioButton1.has({ feedbackText: 'Not ready to eat' }));
+    it('displays the error text', () => converge(() => radioButton1.has({ feedbackText: 'Not ready to eat' })));
 
     it('applies an error class', () => radioButton1.has({ hasError: true }));
 


### PR DESCRIPTION
Focus handling changed under react 17. This was patched on master in #1630 in a commit that introduced a dependency on some additional `@folio/stripes-testing` components that have not yet been released. Thus, when that commit was picked to this release branch in e34c1bcc6569f20112b347305e488e7f12e0e03b, the release process failed. So: this PR reverts the portion of that commit that introduced new dependencies and keeps others parts that fixed the tests. Whew.
