### PR TITLE
Add Datepicker dateFormat prop for tests.

### DIFF
--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -607,7 +607,7 @@ describe('Datepicker', () => {
   describe('weekday alignment (en-SE locale)', () => {
     beforeEach(async () => {
       await (mountWithContext(
-        <Datepicker label="Pick a date" value={'2021-20-10'} />,
+        <Datepicker label="Pick a date" dateFormat="YYYY-DD-MM" value={'2021-20-10'} />,
         [],
         'en-SE'
       ));
@@ -626,7 +626,7 @@ describe('Datepicker', () => {
   describe('weekday alignment (SV locale)', () => {
     beforeEach(async () => {
       await (mountWithContext(
-        <Datepicker label="Pick a date" value={'2021-20-10'} />,
+        <Datepicker label="Pick a date" dateFormat="YYYY-DD-MM" value={'2021-20-10'} />,
         [],
         'sv'
       ));
@@ -645,7 +645,7 @@ describe('Datepicker', () => {
   describe('weekday alignment (RU locale)', () => {
     beforeEach(async () => {
       await (mountWithContext(
-        <Datepicker label="Pick a date" value={'2021-20-10'} />,
+        <Datepicker label="Pick a date" dateFormat="YYYY-DD-MM" value={'2021-20-10'} />,
         [],
         'ru'
       ));
@@ -665,7 +665,7 @@ describe('Datepicker', () => {
   describe('weekday alignment (en locale)', () => {
     beforeEach(async () => {
       await (mountWithContext(
-        <Datepicker label="Pick a date" value={'2021-20-10'} />
+        <Datepicker label="Pick a date" dateFormat="YYYY-DD-MM" value={'2021-20-10'} />
       ));
 
       await datepicker.openCalendar();


### PR DESCRIPTION
Adding a dateFormat for tests so that they'll interpret the value correctly rather than defaulting the calendar to 'this month' since we test calendar/weekday alignment with a particular day.