### PR TITLE
lint

### DIFF
--- a/lib/RadioButton/RadioButton.js
+++ b/lib/RadioButton/RadioButton.js
@@ -178,7 +178,6 @@ class RadioButton extends React.Component {
             value={value}
             readOnly={readOnly}
             required={required}
-            aria-invalid={!!(this.props.error)}
           />
           <span className={css.labelPseudo} />
           {(label || readOnly) &&

--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -699,7 +699,6 @@ class SingleSelect extends React.Component {
             className={this.getControlClass()}
             ref={this.control}
             id={this.testId}
-            aria-invalid={this.props.error ? 'true' : 'false'}
             aria-disabled={(this.props.disabled)}
             aria-owns={`sl-${this.props.id}`}
             name={this.props.name}


### PR DESCRIPTION
lint complains about the `aria-invalid` setting here, though it didn't
used to and this part of the component hasn't changed in years. That's
puzzling.
```
/Users/zburke/projects/folio-org/stripes-components/lib/RadioButton/RadioButton.js
  165:11  error  The attribute aria-invalid is not supported by the role radio. This role is implicit on the element input  jsx-a11y/role-supports-aria-props

/Users/zburke/projects/folio-org/stripes-components/lib/Selection/SingleSelect.js
  692:11  error  The attribute aria-invalid is not supported by the role button. This role is implicit on the element button  jsx-a11y/role-supports-aria-props
```