### PR TITLE
bump to 10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
New features should land on a new minor version since the last release
so that feature work and bug-fix work can be correctly separated.