### PR TITLE
STCOM-883 - axe reports nested interactive elements...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add new `textLeft` className to `<Layout>` component. Refs STCOM-897.
 * Check that content inside `<Accordion>` was clicked and set focus flag. Refs STCOM-895.
 * Add an event handler for accordion opening/closing at users' direct request. Refs STCOM-820.
+* Remove default tabIndex from Icon (cause of nested interactive axe errors), treated aria-labelledby appropriately in IconButton. Fixes STCOM-883
 
 ## [10.0.0](https://github.com/folio-org/stripes-components/tree/v10.0.0) (2021-09-26)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.2.0...v10.0.0)

--- a/lib/Accordion/tests/Accordion-test.js
+++ b/lib/Accordion/tests/Accordion-test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { describe, beforeEach, it } from 'mocha';
 import { Accordion as Interactor, Keyboard } from '@folio/stripes-testing';
 import sinon from 'sinon';
-import { mountWithContext } from '../../../tests/helpers';
+import { mountWithContext, runAxeTest } from '../../../tests/helpers';
 
 import Accordion from '../Accordion';
 import AccordionSet from '../AccordionSet';
@@ -19,6 +19,8 @@ describe('Accordion', () => {
       </Accordion>
     );
   });
+
+  it('has no axe errors', runAxeTest);
 
   it('is open by default', () => accordion.is({ open: true }));
 
@@ -62,6 +64,8 @@ describe('Accordion', () => {
         </Accordion>
       );
     });
+
+    it('has no axe errors', runAxeTest);
 
     it('is closed by default', () => accordion.is({ open: false }));
 
@@ -169,6 +173,8 @@ describe('Accordion', () => {
         </AccordionSet>
       );
     });
+
+    it('has no axe errors', runAxeTest);
 
     describe('keyboard navigation: next accordion', () => {
       beforeEach(async () => {

--- a/lib/Accordion/tests/ExpandAllButton-test.js
+++ b/lib/Accordion/tests/ExpandAllButton-test.js
@@ -3,7 +3,7 @@ import {
   describe,
   beforeEach,
   it,
-} from '@bigtest/mocha';
+} from 'mocha';
 import { expect } from 'chai';
 
 import { mount } from '../../../tests/helpers';

--- a/lib/Icon/Icon.js
+++ b/lib/Icon/Icon.js
@@ -39,7 +39,6 @@ const defaultProps = {
   size: 'medium',
   iconPosition: 'start',
   icon: 'default',
-  tabIndex: '-1',
 };
 
 const Icon = React.forwardRef(({
@@ -91,10 +90,10 @@ const Icon = React.forwardRef(({
 
   return (
     <span
-      aria-label={ariaLabel}
       className={getRootClass}
       id={id}
       ref={ref}
+      role="presentation"
       tabIndex={tabIndex}
       {...ariaAttributes}
     >

--- a/lib/Icon/Icon.js
+++ b/lib/Icon/Icon.js
@@ -42,7 +42,6 @@ const defaultProps = {
 };
 
 const Icon = React.forwardRef(({
-  ariaLabel,
   children,
   icon,
   iconClassName,
@@ -86,7 +85,7 @@ const Icon = React.forwardRef(({
     IconElement = icons[icon];
   }
 
-  const ariaAttributes = pickBy(rest, (_, key) => key.startsWith('aria-'));
+  const ariaAttributes = pickBy(rest, (_, key) => key.startsWith('aria'));
 
   return (
     <span

--- a/lib/Icon/tests/Icon-test.js
+++ b/lib/Icon/tests/Icon-test.js
@@ -4,8 +4,10 @@
 
 import React from 'react';
 
-import { beforeEach, it, describe } from '@bigtest/mocha';
+import { beforeEach, it, describe } from 'mocha';
 import { expect } from 'chai';
+import { runAxeTest } from '@folio/stripes-testing';
+
 import { mount } from '../../../tests/helpers';
 import IconInteractor from './interactor';
 
@@ -44,6 +46,7 @@ describe('Icon', () => {
         <Icon
           id="icon-id"
           ariaLabel="icon-title"
+          tabIndex="0"
           icon="bookmark"
           iconClassName={iconClassName}
           iconRootClass={iconRootClass}
@@ -53,10 +56,6 @@ describe('Icon', () => {
 
     it('Renders an <svg> tag', () => {
       expect(icon.iconElement.isPresent).to.be.true;
-    });
-
-    it('Renders supplied title', () => {
-      expect(icon.ariaLabel).to.equal('icon-title');
     });
 
     it('Renders with default size medium', () => {
@@ -74,6 +73,8 @@ describe('Icon', () => {
     it('Renders the supplied classname on the svg element', () => {
       expect(icon.iconElement.className).to.include(iconClassName);
     });
+
+    it('has no axe errors', runAxeTest);
   });
 
   /**
@@ -87,6 +88,8 @@ describe('Icon', () => {
     it('It should render the default icon', () => {
       expect(icon.iconElement.className).to.include('default');
     });
+
+    it('has no axe errors', runAxeTest);
   });
 
   /**
@@ -100,6 +103,8 @@ describe('Icon', () => {
     it('Should include a "iconSpinner" className', () => {
       expect(icon.iconElement.className).to.include(spinnerCss.spinner);
     });
+
+    it('has no axe errors', runAxeTest);
   });
 
   /**
@@ -130,6 +135,8 @@ describe('Icon', () => {
       it('SVG should have a viewBox attribute with the value of "0 0 32 32"', () => {
         expect(icon.iconElement.viewBox).to.equal('0 0 32 32');
       });
+
+      it('has no axe errors', runAxeTest);
     });
   });
 
@@ -170,6 +177,8 @@ describe('Icon', () => {
     it(`Should render with a string of "${label}"`, () => {
       expect(icon.label).to.equal(label);
     });
+
+    it('has no axe errors', runAxeTest);
   });
 
   /**

--- a/lib/IconButton/IconButton.js
+++ b/lib/IconButton/IconButton.js
@@ -85,7 +85,9 @@ const IconButton = React.forwardRef(({
 
 IconButton.propTypes = {
   'aria-label': PropTypes.string,
+  'aria-labelledby': PropTypes.string,
   ariaLabel: PropTypes.string,
+  ariaLabelledby: PropTypes.string,
   autoFocus: PropTypes.bool,
   badgeColor: PropTypes.string,
   badgeCount: PropTypes.oneOfType([

--- a/lib/IconButton/IconButton.js
+++ b/lib/IconButton/IconButton.js
@@ -16,6 +16,8 @@ const IconButton = React.forwardRef(({
   onClick,
   onMouseDown,
   type,
+  ariaLabelledby,
+  'aria-labelledby' : hyphenatedAriaLabelledby,
   ariaLabel,
   'aria-label': hyphenatedAriaLabel,
   id,
@@ -52,6 +54,7 @@ const IconButton = React.forwardRef(({
       className
     ),
     'aria-label': hyphenatedAriaLabel || ariaLabel || icon,
+    'aria-labelledby': hyphenatedAriaLabelledby || ariaLabelledby,
   };
 
   /**

--- a/lib/IconButton/tests/IconButton-test.js
+++ b/lib/IconButton/tests/IconButton-test.js
@@ -9,7 +9,7 @@ import {
 import { expect } from 'chai';
 import { StaticRouter as Router } from 'react-router-dom';
 
-import { IconButton as Interactor, including, converge, Badge as BadgeInteractor } from '@folio/stripes-testing';
+import { IconButton as Interactor, including, converge, Badge as BadgeInteractor, runAxeTest } from '@folio/stripes-testing';
 import { mount } from '../../../tests/helpers';
 
 import IconButton from '../IconButton';
@@ -31,6 +31,8 @@ describe('IconButton', () => {
   });
 
   it('renders passed id prop', () => iconButton.has({ id: 'testId' }));
+
+  it('has no axe errors - IconButton', runAxeTest);
 
   describe('clicking the IconButton', () => {
     ibClicked = false;


### PR DESCRIPTION
## Problem

Axe testing within UI modules will report nested interactive elements in numerous places within the scope of stripes-components. This particularly affects icons, iconButtons and accordions - components that ui-modules use FREQUENTLY.

Interactive elements within eachother create an awkward situation for assistive technology and general user experience. If an inner element is clicked, does that click bubble outward? Does the inner element even register to a screen reader? The outer? Nested interactives can create lots of issues.

For the sake of education, any element with a `tab-index` attribute is considered an interactive element. Even if it's removed from the tab order via `tabindex="-1"`, it's still considered interactive. So despite not being directly focusable, Icons end up rendering as interactable elements. `tabindex="-1"` removes an element from tab order, but sets it up so that **it can be programmatically focused**. The intent of it being focused programmatically is key - that is the only circumstance where `tabindex ="-1"` should be used.

### Approach
- remove default `tabindex=-1` from icon, 
- pass arialabelledby correctly in IconButton