### PR TITLE
STSCOM-895: Make useClickOutside catch click event on capture phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add new `textLeft` className to `<Layout>` component. Refs STCOM-897.
 * Check that content inside `<Accordion>` was clicked and set focus flag. Refs STCOM-895.
 * Add an event handler for accordion opening/closing at users' direct request. Refs STCOM-820.
+* Make `useClickOutside` click handler work on `capture` event phase. Refs STCOM-895.
 
 ## [10.0.0](https://github.com/folio-org/stripes-components/tree/v10.0.0) (2021-09-26)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.2.0...v10.0.0)

--- a/hooks/tests/useClickOutside-test.js
+++ b/hooks/tests/useClickOutside-test.js
@@ -34,7 +34,13 @@ describe('useClickOutside', () => {
 
     return (
       <div ref={content}>
-        <span id="click-inside-element">Inside element</span>
+        <button
+          id="click-inside-element"
+          type="button"
+          onClick={(e) => e.target.parentNode.removeChild(e.target)}
+        >
+          Inside element
+        </button>
       </div>
     );
   };
@@ -70,6 +76,16 @@ describe('useClickOutside', () => {
     });
 
     it('should not call onClick', () => {
+      expect(onClickSpy.calledOnceWith(false)).to.be.true;
+    });
+  });
+
+  describe('when other click handler removes click target from DOM', () => {
+    beforeEach(async () => {
+      await useClickOutsideInteractor.clickInsideElement();
+    });
+
+    it('should still give correct results', () => {
       expect(onClickSpy.calledOnceWith(false)).to.be.true;
     });
   });

--- a/hooks/useClickOutside/useClickOutside.js
+++ b/hooks/useClickOutside/useClickOutside.js
@@ -7,9 +7,12 @@ const useClickOutside = (ref, onClick) => {
       onClick(e, isOutside);
     };
 
-    document.addEventListener('click', handleClick);
+    // need to catch event in capture phase to process click event before other handlers
+    // this is to fix a case when other click handler might remove e.target from DOM
+    // and when this handler runs - `contains` will return false because e.target is no longer in DOM
+    document.addEventListener('click', handleClick, true);
     return () => {
-      document.removeEventListener('click', handleClick);
+      document.removeEventListener('click', handleClick, true);
     };
   }, [ref, onClick]);
 };


### PR DESCRIPTION
## Description
Previous fix didn't cover all cases https://github.com/folio-org/stripes-components/pull/1646
A breakdown of what is happening when adding a tag to a record:
1. Click on `<MultiSelection>` search field. This opens up a dropdown with a few existing tags.
2. Either search for a tag that exists but is not visible.
3. Click on the tag in dropdown. At this point `onClick` that is added to the `<MultiSelection>` option is executed and the option disappears (removed from DOM)
4. `useClickOutside` click handler is executed. `ref.current.contains(e.target)` returns false because `e.target` is not in DOM even though that element was inside accordion's content.

We can fix this by handling `useClickOutside` click event in it's capture phase by passing `true` as third argument to `addEventListener`. This way this handler will be executed before all other click handlers.

## Screenshots

https://user-images.githubusercontent.com/19309423/142250381-ee40d3b9-d9ba-48df-97c6-8d2b1940406a.mp4



## Issues
[STCOM-895](https://issues.folio.org/browse/STCOM-895)