### PR TITLE
spell check

### DIFF
--- a/lib/MessageBanner/MessageBanner.js
+++ b/lib/MessageBanner/MessageBanner.js
@@ -34,6 +34,7 @@ const MessageBanner = forwardRef(
       className,
       contentClassName,
       dismissable,
+      dismissible,
       dismissButtonAriaLabel,
       dismissButtonProps,
       element: Element,
@@ -108,7 +109,7 @@ const MessageBanner = forwardRef(
           >
             {renderIcon()}
             <div className={classnames(css.content, contentClassName)}>{children}</div>
-            {dismissable && (
+            {(dismissable || dismissible) && (
               <div className={css.dismissButtonWrap}>
                 <FormattedMessage id="stripes-components.MessageBanner.dismissButtonAriaLabel">
                   { ([dismissAriaLabel]) => (
@@ -142,6 +143,7 @@ MessageBanner.propTypes = {
   dismissable: PropTypes.bool,
   dismissButtonAriaLabel: PropTypes.string,
   dismissButtonProps: PropTypes.object,
+  dismissible: PropTypes.bool,
   element: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.func]),
   icon: PropTypes.string,
   onEnter: PropTypes.func,

--- a/lib/MessageBanner/readme.md
+++ b/lib/MessageBanner/readme.md
@@ -36,12 +36,12 @@ If you need the `<MessageBanner>` to enter and exit the UI then you should use t
 
 You can further improve the screen reader experience by adding a more specific dismiss button aria-label. For this purpose you can use the `dismissButtonAriaLabel`-prop to change the message that will be read out load. This label defaults to `"Hide message"`.
 
-## Dismissable
-Setting the `dismissable`-prop enables the option for the user to hide the `<MessageBanner>`. It is also possible to control the visibility externally by using the `show`-prop. See an example below this section.
+## Dismissible
+Setting the `dismissible`-prop enables the option for the user to hide the `<MessageBanner>`. It is also possible to control the visibility externally by using the `show`-prop. See an example below this section.
 
 ```js
-<MessageBanner dismissable>
-  I'm dismissable
+<MessageBanner dismissible>
+  I'm dismissible
 </MessageBanner>
 ```
 

--- a/lib/MessageBanner/readme.md
+++ b/lib/MessageBanner/readme.md
@@ -36,8 +36,8 @@ If you need the `<MessageBanner>` to enter and exit the UI then you should use t
 
 You can further improve the screen reader experience by adding a more specific dismiss button aria-label. For this purpose you can use the `dismissButtonAriaLabel`-prop to change the message that will be read out load. This label defaults to `"Hide message"`.
 
-## Dismissible
-Setting the `dismissble`-prop enables the option for the user to hide the `<MessageBanner>`. It is also possible to control the visibility externally by using the `show`-prop. See an example below this section.
+## Dismissable
+Setting the `dismissable`-prop enables the option for the user to hide the `<MessageBanner>`. It is also possible to control the visibility externally by using the `show`-prop. See an example below this section.
 
 ```js
 <MessageBanner dismissable>


### PR DESCRIPTION
Accept `dismissable` for historical reasons or `dismissible` for correctness reasons. Do not reference `dismissble` for obvious reasons.