### PR TITLE
STCOM-902 interactors should not use dynamic css vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add an event handler for accordion opening/closing at users' direct request. Refs STCOM-820.
 * Remove default tabIndex from Icon (cause of nested interactive axe errors), treated aria-labelledby appropriately in IconButton. Fixes STCOM-883
 * Make `useClickOutside` click handler work on `capture` event phase. Refs STCOM-895.
+* Interactors should not use dynamic CSS variable names. Refs STCOM-902.
 
 ## [10.0.0](https://github.com/folio-org/stripes-components/tree/v10.0.0) (2021-09-26)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.2.0...v10.0.0)

--- a/lib/Accordion/tests/interactor.js
+++ b/lib/Accordion/tests/interactor.js
@@ -13,9 +13,8 @@ import {
 } from '@bigtest/interactor';
 
 import css from '../Accordion.css';
-import { selectorFromClassnameString } from '../../../tests/helpers';
 
-const triggerCollapse = selectorFromClassnameString('[class*=defaultCollapseButton---]');
+const triggerCollapse = '[class*=defaultCollapseButton---]';
 
 export const AccordionInteractor = interactor(class AccordionInteractor {
   static defaultScope = '[class*=accordion---]'

--- a/lib/Accordion/tests/interactor.js
+++ b/lib/Accordion/tests/interactor.js
@@ -15,14 +15,14 @@ import {
 import css from '../Accordion.css';
 import { selectorFromClassnameString } from '../../../tests/helpers';
 
-const triggerCollapse = selectorFromClassnameString(`.${css.defaultCollapseButton}`);
+const triggerCollapse = selectorFromClassnameString('[class*=defaultCollapseButton---]');
 
 export const AccordionInteractor = interactor(class AccordionInteractor {
-  static defaultScope = `.${css.accordion}`
+  static defaultScope = '[class*=accordion---]'
 
-  label = text(`.${css.labelArea}`)
+  label = text('[class*=labelArea---]')
   isOpen = hasClass(`.${css.content}`, css.expanded)
-  contentHeight = property(`.${css['content-wrap']}`, 'offsetHeight')
+  contentHeight = property('[class*=content-wrap---]', 'offsetHeight')
   clickHeader = clickable(triggerCollapse)
   id = attribute('[data-test-accordion-wrapper]', 'id')
   accordions = scoped(triggerCollapse, {

--- a/lib/AutoSuggest/tests/interactor.js
+++ b/lib/AutoSuggest/tests/interactor.js
@@ -26,8 +26,8 @@ import TextFieldInteractor from '../../TextField/tests/interactor';
   defaultScope = 'data-test-autosuggest';
   labelDisplayed = isPresent('label');
   renders = isPresent('input');
-  input = scoped(`.${css.textFieldDiv}`, TextFieldInteractor);
-  list = new AutoSuggestListInteractor(`.${css.autoSuggest}`);
+  input = scoped('[class*=textFieldDiv---]', TextFieldInteractor);
+  list = new AutoSuggestListInteractor('[class*=autoSuggest---]');
 }
 
 export default AutoSuggestInteractor;

--- a/lib/Button/tests/interactor.js
+++ b/lib/Button/tests/interactor.js
@@ -12,7 +12,7 @@ import css from '../Button.css';
 import { selectorFromClassnameString } from '../../../tests/helpers';
 
 // necessary due to composing classnames with postcss `composes`
-const btnClassSelector = selectorFromClassnameString(`.${css.button}`);
+const btnClassSelector = selectorFromClassnameString('[class*=button---]');
 
 export default interactor(class ButtonInteractor {
   static defaultScope = btnClassSelector;

--- a/lib/Button/tests/interactor.js
+++ b/lib/Button/tests/interactor.js
@@ -9,10 +9,9 @@ import {
 } from '@bigtest/interactor';
 
 import css from '../Button.css';
-import { selectorFromClassnameString } from '../../../tests/helpers';
 
 // necessary due to composing classnames with postcss `composes`
-const btnClassSelector = selectorFromClassnameString('[class*=button---]');
+const btnClassSelector = '[class*=button---]';
 
 export default interactor(class ButtonInteractor {
   static defaultScope = btnClassSelector;

--- a/lib/ButtonGroup/tests/interactor.js
+++ b/lib/ButtonGroup/tests/interactor.js
@@ -11,6 +11,6 @@ function tagName(selector) {
 }
 
 export default interactor(class ButtonGroupInteractor {
-  static defaultScope = `.${css.buttonGroup}`
+  static defaultScope = '[class*=buttonGroup---]'
   tagName = tagName();
 });

--- a/lib/Callout/tests/interactor.js
+++ b/lib/Callout/tests/interactor.js
@@ -12,9 +12,9 @@ import css from '../Callout.css';
 
 export default interactor(class CalloutInteractor {
   anyCalloutIsPresent = isPresent('[data-test-callout-element]');
-  successCalloutIsPresent = isPresent(`[data-test-callout-element].${css.success}`);
-  errorCalloutIsPresent = isPresent(`[data-test-callout-element].${css.error}`);
-  infoCalloutIsPresent = isPresent(`[data-test-callout-element].${css.info}`);
-  warningCalloutIsPresent = isPresent(`[data-test-callout-element].${css.warning}`);
+  successCalloutIsPresent = isPresent('[data-test-callout-element][class*=success---]');
+  errorCalloutIsPresent = isPresent('[data-test-callout-element][class*=error---]');
+  infoCalloutIsPresent = isPresent('[data-test-callout-element][class*=info---]');
+  warningCalloutIsPresent = isPresent('[data-test-callout-element][class*=warning---]');
   firstCalloutId = attribute('[data-test-callout-element]:first-child', 'id');
 });

--- a/lib/Card/tests/interactor.js
+++ b/lib/Card/tests/interactor.js
@@ -8,7 +8,7 @@ import {
 import css from '../Card.css';
 
 @interactor class CardInteractor {
-  static defaultScope = `.${css.card}`
+  static defaultScope = '[class*=card---]'
   isHeaderPresent = isPresent('[data-test-card-header]');
   header = text('[data-test-card-header]');
   headerStart = text('[data-test-card-header-start]');

--- a/lib/ConfirmationModal/tests/interactor.js
+++ b/lib/ConfirmationModal/tests/interactor.js
@@ -17,7 +17,7 @@ const tagName = selector => computed(function () {
 });
 
 export default interactor(class ConfirmationModalInteractor {
-  heading = new Interactor(`.${css.modalLabel}`);
+  heading = new Interactor('[class*=modalLabel---]');
   body = new Interactor('[data-test-confirmation-modal-message]');
   bodyTagName = tagName('[data-test-confirmation-modal-message]');
   confirmButton = scoped('[data-test-confirmation-modal-confirm-button]', ButtonInteractor);

--- a/lib/Editor/tests/interactor.js
+++ b/lib/Editor/tests/interactor.js
@@ -7,15 +7,14 @@ import {
 } from '@bigtest/interactor';
 
 import formCss from '../../sharedStyles/form.css';
-import { selectorFromClassnameString } from '../../../tests/helpers';
 
 export default interactor(class TextAreaInteractor {
   hasEditor = isPresent('.quill');
   id = attribute('.quill', 'id');
   label = text('label');
   hasLabel = isPresent('label');
-  errorText = text(selectorFromClassnameString(`.${formCss.feedbackError}`));
-  warningText = text(selectorFromClassnameString(`.${formCss.feedbackWarning}`));
+  errorText = text('[class*=feedbackError---]');
+  warningText = text('[class*=feedbackWarning---]');
   hasWarningStyle = hasClass('.quill', formCss.hasWarning);
   hasErrorStyle = hasClass('.quill', formCss.hasError);
   hasValidStyle = hasClass('.quill', formCss.isValid);

--- a/lib/ErrorModal/tests/interactor.js
+++ b/lib/ErrorModal/tests/interactor.js
@@ -13,7 +13,7 @@ const tagName = selector => computed(function () {
 });
 
 export default interactor(class ErrorModalInteractor {
-  label = new Interactor(`.${css.modalLabel}`);
+  label = new Interactor('[class*=modalLabel---]');
   content = new Interactor('[data-test-error-modal-content]');
   bodyTagName = tagName('[data-test-error-modal-content]');
   closeButton = scoped('[data-test-error-modal-close-button]', ButtonInteractor);

--- a/lib/Headline/tests/interactor.js
+++ b/lib/Headline/tests/interactor.js
@@ -3,10 +3,8 @@
  */
 
 import { interactor, text, hasClass, computed, attribute } from '@bigtest/interactor';
-import { selectorFromClassnameString } from '../../../tests/helpers';
 import css from '../Headline.css';
 
-const scopeSelector = selectorFromClassnameString('[data-test-headline]');
 export const sizes = ['small', 'medium', 'large', 'x-large', 'xx-large'];
 
 const tagName = (selector) => computed(function () {
@@ -14,7 +12,7 @@ const tagName = (selector) => computed(function () {
 });
 
 export default interactor(class HeadlineInteractor {
-  static defaultScope = scopeSelector;
+  static defaultScope = '[data-test-headline]';
 
   constructor() {
     sizes.forEach(size => {

--- a/lib/Icon/tests/interactor.js
+++ b/lib/Icon/tests/interactor.js
@@ -6,7 +6,7 @@ import { interactor, attribute, scoped, property, hasClass, isPresent, text } fr
 import { selectorFromClassnameString } from '../../../tests/helpers';
 import css from '../Icon.css';
 
-const iconClassSelector = selectorFromClassnameString(`.${css.icon}`);
+const iconClassSelector = selectorFromClassnameString('[class*=icon---]');
 
 export default interactor(class IconInteractor {
   static defaultScope = iconClassSelector;
@@ -25,7 +25,7 @@ export default interactor(class IconInteractor {
   isSuccess = hasClass(css.success);
 
   isFlippable = hasClass(css.icon.flippable);
-  isSvg = isPresent(`.${css.icon} svg`);
+  isSvg = isPresent('[class*=icon---] svg');
 
   isActionIcon = hasClass(css.action);
 

--- a/lib/Icon/tests/interactor.js
+++ b/lib/Icon/tests/interactor.js
@@ -3,13 +3,10 @@
  */
 
 import { interactor, attribute, scoped, property, hasClass, isPresent, text } from '@bigtest/interactor';
-import { selectorFromClassnameString } from '../../../tests/helpers';
 import css from '../Icon.css';
 
-const iconClassSelector = selectorFromClassnameString('[class*=icon---]');
-
 export default interactor(class IconInteractor {
-  static defaultScope = iconClassSelector;
+  static defaultScope = '[class*=icon---]';
 
   id = attribute('id');
   className = attribute('class');

--- a/lib/IconButton/tests/interactor.js
+++ b/lib/IconButton/tests/interactor.js
@@ -10,7 +10,7 @@ import {
 import css from '../IconButton.css';
 import { selectorFromClassnameString } from '../../../tests/helpers';
 
-const baseClass = selectorFromClassnameString(`.${css.iconButton}`);
+const baseClass = selectorFromClassnameString('[class*=iconButton---]');
 export default interactor(class IconButtonInteractor {
   static defaultScope = baseClass;
   id = attribute('id');

--- a/lib/IconButton/tests/interactor.js
+++ b/lib/IconButton/tests/interactor.js
@@ -7,12 +7,8 @@ import {
   triggerable,
 } from '@bigtest/interactor';
 
-import css from '../IconButton.css';
-import { selectorFromClassnameString } from '../../../tests/helpers';
-
-const baseClass = selectorFromClassnameString('[class*=iconButton---]');
 export default interactor(class IconButtonInteractor {
-  static defaultScope = baseClass;
+  static defaultScope = '[class*=iconButton---]';
   id = attribute('id');
   href = attribute('href');
   className = attribute('class');

--- a/lib/KeyValue/tests/interactor.js
+++ b/lib/KeyValue/tests/interactor.js
@@ -8,12 +8,12 @@ import { selectorFromClassnameString } from '../../../tests/helpers';
 
 import css from '../KeyValue.css';
 
-const iconClassSelector = selectorFromClassnameString(`.${css.kvRoot}`);
+const iconClassSelector = selectorFromClassnameString('[class*=kvRoot---]');
 
 export default interactor(class KeyValueInteractor {
   static defaultScope = iconClassSelector;
 
-  label = scoped(`.${css.kvLabel}`);
+  label = scoped('[class*=kvLabel---]');
   value = scoped('[data-test-kv-value]');
   sub = scoped('[data-test-kv-sub-value]');
 

--- a/lib/KeyValue/tests/interactor.js
+++ b/lib/KeyValue/tests/interactor.js
@@ -4,14 +4,8 @@ import {
   scoped,
 } from '@bigtest/interactor';
 
-import { selectorFromClassnameString } from '../../../tests/helpers';
-
-import css from '../KeyValue.css';
-
-const iconClassSelector = selectorFromClassnameString('[class*=kvRoot---]');
-
 export default interactor(class KeyValueInteractor {
-  static defaultScope = iconClassSelector;
+  static defaultScope = '[class*=kvRoot---]';
 
   label = scoped('[class*=kvLabel---]');
   value = scoped('[data-test-kv-value]');

--- a/lib/Layer/tests/interactor.js
+++ b/lib/Layer/tests/interactor.js
@@ -9,9 +9,9 @@ import {
 import css from '../Layer.css';
 
 export default interactor(class LayerInteractor {
-  rendered = isPresent(`.${css.LayerRoot}`);
-  ariaLabel = attribute(`.${css.LayerRoot}`, 'aria-label');
-  isFocused = is(`.${css.LayerRoot}`, ':focus');
+  rendered = isPresent('[class*=LayerRoot---]');
+  ariaLabel = attribute('[class*=LayerRoot---]', 'aria-label');
+  isFocused = is('[class*=LayerRoot---]', ':focus');
 
   pressTab = triggerable('document.body', 'keydown', { keyCode: 9 }); // tab
 });

--- a/lib/Layout/tests/interactor.js
+++ b/lib/Layout/tests/interactor.js
@@ -8,12 +8,8 @@ import {
   property,
 } from '@bigtest/interactor';
 
-import { selectorFromClassnameString } from '../../../tests/helpers';
-
-const modalClassSelector = selectorFromClassnameString('[data-test-layout]');
-
 export default interactor(class ModalInteractor {
-  static defaultScope = modalClassSelector;
+  static defaultScope = '[data-test-layout]';
   className = attribute('class');
   element = property('tagName');
 });

--- a/lib/List/tests/interactor.js
+++ b/lib/List/tests/interactor.js
@@ -14,10 +14,10 @@ export default interactor(class ListInteractor {
   }
 
   hasUL= isPresent('ul');
-  hasEmptyMessage = isPresent(`.${css.isEmptyMessage}`);
-  emptyMessageText = text(`.${css.isEmptyMessage}`);
-  hasMarginBottom0Class= hasClass('ul', `${css.marginBottom0}`);
-  hasBulletedClass= hasClass('ul', `${css.listStyleBullets}`);
-  hasDefaultClass= hasClass('ul', `${css.listStyleDefault}`);
+  hasEmptyMessage = isPresent('[class*=isEmptyMessage---]');
+  emptyMessageText = text('[class*=isEmptyMessage---]');
+  hasMarginBottom0Class= hasClass('ul', '[class*=marginBottom0---]');
+  hasBulletedClass= hasClass('ul', '[class*=listStyleBullets---]');
+  hasDefaultClass= hasClass('ul', '[class*=listStyleDefault---]');
   itemCount = this.countItems();
 });

--- a/lib/List/tests/interactor.js
+++ b/lib/List/tests/interactor.js
@@ -16,8 +16,8 @@ export default interactor(class ListInteractor {
   hasUL= isPresent('ul');
   hasEmptyMessage = isPresent('[class*=isEmptyMessage---]');
   emptyMessageText = text('[class*=isEmptyMessage---]');
-  hasMarginBottom0Class= hasClass('ul', '[class*=marginBottom0---]');
-  hasBulletedClass= hasClass('ul', '[class*=listStyleBullets---]');
-  hasDefaultClass= hasClass('ul', '[class*=listStyleDefault---]');
+  hasMarginBottom0Class= hasClass('ul', `${css.marginBottom0}`);
+  hasBulletedClass= hasClass('ul', `${css.listStyleBullets}`);
+  hasDefaultClass= hasClass('ul', `${css.listStyleDefault}`);
   itemCount = this.countItems();
 });

--- a/lib/MenuSection/tests/interactor.js
+++ b/lib/MenuSection/tests/interactor.js
@@ -3,12 +3,9 @@
  */
 
 import { interactor, isPresent, attribute, property } from '@bigtest/interactor';
-import { selectorFromClassnameString } from '../../../tests/helpers';
-
-const iconClassSelector = selectorFromClassnameString('[data-test-menu-section]');
 
 export default interactor(class MenuSectionInteractor {
-  static defaultScope = iconClassSelector;
+  static defaultScope = '[data-test-menu-section]';
   hasLabel = isPresent('[data-test-menu-section-label]');
   hasContent = isPresent('*:last-child:not([data-test-menu-section-label])')
   labelTag = property('[data-test-menu-section-label]', 'localName');

--- a/lib/MessageBanner/tests/interactor.js
+++ b/lib/MessageBanner/tests/interactor.js
@@ -17,7 +17,7 @@ import css from '../MessageBanner.module.css';
 export default interactor(class MessageBannerInteractor {
   static defaultScope = '[data-test-message-banner]';
   className = attribute('class');
-  text = text(`.${css.content}`);
+  text = text('[class*=content---]');
   element = property('tagName');
 
   isDefault = hasClass(css['type-default']);

--- a/lib/Modal/tests/interactor.js
+++ b/lib/Modal/tests/interactor.js
@@ -16,15 +16,15 @@ import { selectorFromClassnameString } from '../../../tests/helpers';
 import css from '../Modal.css';
 import IconButtonInteractor from '../../IconButton/tests/interactor';
 
-const modalClassSelector = selectorFromClassnameString(`.${css.modalRoot}`);
+const modalClassSelector = selectorFromClassnameString('[class*=modalRoot---]');
 
 export default interactor(class ModalInteractor {
   static defaultScope = modalClassSelector;
-  closeButton = scoped(`.${css.closeModal}`, IconButtonInteractor);
-  hasHeader = isPresent(`.${css.modalHeader}`);
-  hasFooter = isPresent(`.${css.modalFooter}`);
-  label = text(`.${css.modalLabel}`);
+  closeButton = scoped('[class*=closeModal---]', IconButtonInteractor);
+  hasHeader = isPresent('[class*=modalHeader---]');
+  hasFooter = isPresent('[class*=modalFooter---]');
+  label = text('[class*=modalLabel---]');
   ariaLabel = attribute('aria-label');
-  isForm = is(`.${css.modal}`, 'form');
-  backdrop = new Interactor(`.${css.backdrop}`);
+  isForm = is('[class*=modal---]', 'form');
+  backdrop = new Interactor('[class*=backdrop---]');
 });

--- a/lib/Modal/tests/interactor.js
+++ b/lib/Modal/tests/interactor.js
@@ -12,14 +12,10 @@ import {
   attribute,
 } from '@bigtest/interactor';
 
-import { selectorFromClassnameString } from '../../../tests/helpers';
-import css from '../Modal.css';
 import IconButtonInteractor from '../../IconButton/tests/interactor';
 
-const modalClassSelector = selectorFromClassnameString('[class*=modalRoot---]');
-
 export default interactor(class ModalInteractor {
-  static defaultScope = modalClassSelector;
+  static defaultScope = '[class*=modalRoot---]';
   closeButton = scoped('[class*=closeModal---]', IconButtonInteractor);
   hasHeader = isPresent('[class*=modalHeader---]');
   hasFooter = isPresent('[class*=modalFooter---]');

--- a/lib/MultiColumnList/tests/interactor.js
+++ b/lib/MultiColumnList/tests/interactor.js
@@ -35,8 +35,8 @@ const RowMeasurerInteractor = interactor(class RowMeasurerInteractor {
 
 const RowInteractor = interactor(class RowInteractor {
   isSelected = hasClass(`${css.mclSelected}`);
-  cellCount = count(`.${css.mclCell}`);
-  cells = collection(`.${css.mclCell}`, CellInteractor);
+  cellCount = count('[class*=mclCell---]');
+  cells = collection('[class*=mclCell---]', CellInteractor);
   click = clickable();
   isAnchor = is('a');
   width = property('offsetWidth');
@@ -51,35 +51,35 @@ const HeaderInteractor = interactor(class HeaderInteractor {
 });
 
 export default interactor(class MultiColumnListInteractor {
-  containerPresent = isPresent(`.${css.mclContainer}`);
-  containerVisible = isVisible(`.${css.mclContainer}`);
-  containerWidth = property(`.${css.mclContainer}`, 'offsetWidth');
-  containerHeight = property(`.${css.mclContainer}`, 'offsetHeight');
+  containerPresent = isPresent('[class*=mclContainer---]');
+  containerVisible = isVisible('[class*=mclContainer---]');
+  containerWidth = property('[class*=mclContainer---]', 'offsetWidth');
+  containerHeight = property('[class*=mclContainer---]', 'offsetHeight');
   rowCount = count('[data-row-inner]');
-  columnCount = count(`.${css.mclHeader}`);
+  columnCount = count('[class*=mclHeader---]');
   rows = collection('[data-row-inner]', RowInteractor);
-  rowMeasurers = collection(`.${css.mclRowFormatterContainer}`, RowMeasurerInteractor);
-  loaderPresent = isPresent(`.${css.mclLoaderRow}`);
-  headers = collection(`.${css.mclHeader}`, HeaderInteractor);
-  scrollbodyTop = property(`.${css.mclRowContainer}`, 'offsetTop');
-  scrollBodyHeight = property(`.${css.mclRowContainer}`, 'offsetHeight');
-  displaysEmptyMessage = isPresent(`.${css.mclEmptyMessage}`);
-  displaysLoadingIcon = isPresent(`.${css.mclContentLoading}`);
-  cell = scoped(`.${css.mclCell}`, CellInteractor);
+  rowMeasurers = collection('[class*=mclRowFormatterContainer---]', RowMeasurerInteractor);
+  loaderPresent = isPresent('[class*=mclLoaderRow---]');
+  headers = collection('[class*=mclHeader---]', HeaderInteractor);
+  scrollbodyTop = property('[class*=mclRowContainer---]', 'offsetTop');
+  scrollBodyHeight = property('[class*=mclRowContainer---]', 'offsetHeight');
+  displaysEmptyMessage = isPresent('[class*=mclEmptyMessage---]');
+  displaysLoadingIcon = isPresent('[class*=mclContentLoading---]');
+  cell = scoped('[class*=mclCell---]', CellInteractor);
   pagingButton = scoped('[data-test-paging-button]');
   pagingNext = scoped('[data-test-next-paging-button]');
   pagingPrevious = scoped('[data-test-prev-paging-button]');
 
-  listScrollTop = property(`.${css.mclScrollable}`, 'scrollTop');
+  listScrollTop = property('[class*=mclScrollable---]', 'scrollTop');
 
-  listScrollTop = property(`.${css.mclScrollable}`, 'scrollTop');
+  listScrollTop = property('[class*=mclScrollable---]', 'scrollTop');
 
   columnsMeasured() {
     return this.when(() => (this.cell.style && this.cell.style.width !== ''));
   }
 
   scrollBody(amount) {
-    return this.scroll(`.${css.mclScrollable}`, { top: amount });
+    return this.scroll('[class*=mclScrollable---]', { top: amount });
   }
 
   contains(selector) {

--- a/lib/MultiSelection/tests/interactor.js
+++ b/lib/MultiSelection/tests/interactor.js
@@ -20,16 +20,14 @@ import css from '../MultiSelect.css';
 import formCss from '../../sharedStyles/form.css';
 import iconCss from '../../Icon/DotSpinner.css';
 
-import { selectorFromClassnameString } from '../../../tests/helpers';
-
-const optionClass = selectorFromClassnameString('[class*=multiSelectOption---]');
-const controlClass = selectorFromClassnameString('[class*=multiSelectControl---]');
-const menuClass = selectorFromClassnameString('[class*=multiSelectMenu---]');
-const errorClass = selectorFromClassnameString(`.${formCss.feedbackError}`);
-const warningClass = selectorFromClassnameString(`.${formCss.feedbackWarning}`);
-const filterClass = selectorFromClassnameString('[class*=multiSelectFilterField---]');
-const emptyClass = selectorFromClassnameString('[class*=multiSelectEmptyMessage---]');
-const inputClass = selectorFromClassnameString('[class*=multiSelectValueInput---]');
+const optionClass = '[class*=multiSelectOption---]';
+const controlClass = '[class*=multiSelectControl---]';
+const menuClass = '[class*=multiSelectMenu---]';
+const errorClass = '[class*=feedbackError---]';
+const warningClass = '[class*=feedbackWarning---]';
+const filterClass = '[class*=multiSelectFilterField---]';
+const emptyClass = '[class*=multiSelectEmptyMessage---]';
+const inputClass = '[class*=multiSelectValueInput---]';
 
 const OptionInteractor = interactor(class OptionInteractor {
   defaultScope = optionClass;

--- a/lib/MultiSelection/tests/interactor.js
+++ b/lib/MultiSelection/tests/interactor.js
@@ -22,14 +22,14 @@ import iconCss from '../../Icon/DotSpinner.css';
 
 import { selectorFromClassnameString } from '../../../tests/helpers';
 
-const optionClass = selectorFromClassnameString(`.${css.multiSelectOption}`);
-const controlClass = selectorFromClassnameString(`.${css.multiSelectControl}`);
-const menuClass = selectorFromClassnameString(`.${css.multiSelectMenu}`);
+const optionClass = selectorFromClassnameString('[class*=multiSelectOption---]');
+const controlClass = selectorFromClassnameString('[class*=multiSelectControl---]');
+const menuClass = selectorFromClassnameString('[class*=multiSelectMenu---]');
 const errorClass = selectorFromClassnameString(`.${formCss.feedbackError}`);
 const warningClass = selectorFromClassnameString(`.${formCss.feedbackWarning}`);
-const filterClass = selectorFromClassnameString(`.${css.multiSelectFilterField}`);
-const emptyClass = selectorFromClassnameString(`.${css.multiSelectEmptyMessage}`);
-const inputClass = selectorFromClassnameString(`.${css.multiSelectValueInput}`);
+const filterClass = selectorFromClassnameString('[class*=multiSelectFilterField---]');
+const emptyClass = selectorFromClassnameString('[class*=multiSelectEmptyMessage---]');
+const inputClass = selectorFromClassnameString('[class*=multiSelectValueInput---]');
 
 const OptionInteractor = interactor(class OptionInteractor {
   defaultScope = optionClass;
@@ -41,10 +41,10 @@ const OptionInteractor = interactor(class OptionInteractor {
 });
 
 const ValueChipInteractor = interactor(class ValueChipInteractor {
-  defaultScope = `.${css.valueChipRoot}`;
+  defaultScope = '[class*=valueChipRoot---]';
   clickRemoveButton = clickable('button');
   isFocused = is('button', ':focus');
-  valLabel = text(`.${css.valueChipValue}`);
+  valLabel = text('[class*=valueChipValue---]');
   focusRemoveButton = focusable('button');
   pressHome = triggerable('button', 'keydown', { keyCode: 36, key: 'Home' });
   pressEnd = triggerable('button', 'keydown', { keyCode: 35, key: 'End' });
@@ -52,13 +52,13 @@ const ValueChipInteractor = interactor(class ValueChipInteractor {
 });
 
 export default interactor(class MultiSelectInteractor {
-  defaultScope = `.${css.multiSelectContainer}`
-  controlPresent = isPresent(`.${css.multiSelectContainer}`);
+  defaultScope = '[class*=multiSelectContainer---]'
+  controlPresent = isPresent('[class*=multiSelectContainer---]');
   controlIsFocused = is(controlClass, ':focus');
   filterIsFocused = is(filterClass, ':focus');
-  containerId = attribute(`.${css.multiSelectContainer}`, 'id');
+  containerId = attribute('[class*=multiSelectContainer---]', 'id');
   options = collection(optionClass, OptionInteractor);
-  values = collection(`.${css.valueChipRoot}`, ValueChipInteractor);
+  values = collection('[class*=valueChipRoot---]', ValueChipInteractor);
   emptyMessagePresent = isPresent(emptyClass);
   filterPlaceholder = attribute(filterClass, 'placeholder');
   loaderPresent = isPresent(`.${iconCss.spinner}`);
@@ -67,13 +67,13 @@ export default interactor(class MultiSelectInteractor {
   // aria-attributes
   filterInputAriaLabelledBy = attribute(filterClass, 'aria-labelledby');
   controlAriaLabelledBy = attribute(controlClass, 'aria-labelledby');
-  popupAttribute = attribute(`.${css.multiSelectToggleButton}`, 'aria-haspopup');
+  popupAttribute = attribute('[class*=multiSelectToggleButton---]', 'aria-haspopup');
   filterRole = attribute(filterClass, 'role');
   filterActiveDescendant = attribute(filterClass, 'aria-activedescendant');
-  listPresent = isPresent(`.${css.multiSelectMenu}`);
+  listPresent = isPresent('[class*=multiSelectMenu---]');
   listHiddenAttributeSet = property(menuClass, 'hidden');
-  optionCount = count(`.${css.multiSelectOptionList} li`);
-  valueCount = count(`.${css.valueChipRoot}`);
+  optionCount = count('[class*=multiSelectOptionList---] li');
+  valueCount = count('[class*=valueChipRoot---]');
 
   // label
   label = text('label');
@@ -93,7 +93,7 @@ export default interactor(class MultiSelectInteractor {
 
   // behaviors
   clickControl = clickable(controlClass);
-  clickToggleButton = clickable(`.${css.multiSelectToggleButton}`);
+  clickToggleButton = clickable('[class*=multiSelectToggleButton---]');
   fillFilter = fillable(filterClass);
   focusFilter = focusable(filterClass);
   focusControl = focusable(controlClass);

--- a/lib/Pane/tests/interactor.js
+++ b/lib/Pane/tests/interactor.js
@@ -10,11 +10,11 @@ import { computedStyle } from '../../../tests/helpers';
 import css from '../Pane.css';
 
 export default interactor(class PaneInteractor {
-  static defaultScope = `.${css.pane}`;
+  static defaultScope = '[class*=pane---]';
 
   computedWidth = computedStyle(this.$element, 'width')
   style = attribute('style');
   dismissButton = scoped('[data-test-pane-header-dismiss-button]');
-  content = attribute(`${css.paneContent}`, 'style');
+  content = attribute('[class*=paneContent---]', 'style');
   header = scoped('[data-test-pane-header]', PaneHeaderInteractor);
 });

--- a/lib/PaneBackLink/tests/interactor.js
+++ b/lib/PaneBackLink/tests/interactor.js
@@ -2,5 +2,5 @@ import { interactor } from '@bigtest/interactor';
 import css from '../PaneBackLink.css';
 
 export default interactor(class PaneBackLinkInteractor {
-  static defaultScope = `.${css.paneBackLink}`;
+  static defaultScope = '[class*=paneBackLink---]';
 });

--- a/lib/PaneCloseLink/tests/interactor.js
+++ b/lib/PaneCloseLink/tests/interactor.js
@@ -5,7 +5,7 @@ import {
 import css from '../PaneCloseLink.css';
 
 export default interactor(class PaneCloseLinkInteractor {
-  static defaultScope = `.${css.paneCloseLink}`;
-  displaysX = isPresent(`${css.paneCloseLinkX}`);
-  displaysArrow = isPresent(`${css.paneCloseLinkArrow}`);
+  static defaultScope = '[class*=paneCloseLink---]';
+  displaysX = isPresent('[class*=paneCloseLinkX---]');
+  displaysArrow = isPresent('[class*=paneCloseLinkArrow---]');
 });

--- a/lib/Paneset/tests/interactor.js
+++ b/lib/Paneset/tests/interactor.js
@@ -33,9 +33,9 @@ export const ResizeInteractor = interactor(class ResizeInteractor {
 });
 
 export default interactor(class PaneSetInteractor {
-  static defaultScope = `.${css.paneset}`;
+  static defaultScope = '[class*=paneset---]';
   panes = collection(`.${paneCss.pane}`, paneInteractor);
-  childPanesets = collection(`.${css.paneset}`, {
+  childPanesets = collection('[class*=paneset---]', {
     style: attribute('style')
   });
 

--- a/lib/Select/tests/interactor.js
+++ b/lib/Select/tests/interactor.js
@@ -34,7 +34,7 @@ export default interactor(class SelectInteractor {
   hasErrorStyle = hasClass('select', formCss.hasError);
   hasChangedStyle = hasClass('select', formCss.isChanged);
   hasValidStyle = hasClass('select', formCss.isValid);
-  hasLoadingIcon = isPresent(`.${css.loadingIcon}`);
+  hasLoadingIcon = isPresent('[class*=loadingIcon---]');
 
   selectAndBlur(val) {
     return this

--- a/lib/Select/tests/interactor.js
+++ b/lib/Select/tests/interactor.js
@@ -11,9 +11,7 @@ import {
   value,
 } from '@bigtest/interactor';
 
-import css from '../Select.css';
 import formCss from '../../sharedStyles/form.css';
-import { selectorFromClassnameString } from '../../../tests/helpers';
 
 export default interactor(class SelectInteractor {
   hasSelect = isPresent('select');
@@ -28,8 +26,8 @@ export default interactor(class SelectInteractor {
   hasLabel = isPresent('label');
   labelHidden = hasClass('label', 'sr-only');
   ariaLabelledby = attribute('select', 'aria-labelledby');
-  errorText = text(selectorFromClassnameString(`.${formCss.feedbackError}`));
-  warningText = text(selectorFromClassnameString(`.${formCss.feedbackWarning}`));
+  errorText = text('[class*=feedbackError---]');
+  warningText = text('[class*=feedbackWarning---]');
   hasWarningStyle = hasClass('select', formCss.hasWarning);
   hasErrorStyle = hasClass('select', formCss.hasError);
   hasChangedStyle = hasClass('select', formCss.isChanged);

--- a/lib/Selection/tests/interactor.js
+++ b/lib/Selection/tests/interactor.js
@@ -17,11 +17,10 @@ import {
 import css from '../Selection.css';
 import formCss from '../../sharedStyles/form.css';
 
-import { selectorFromClassnameString } from '../../../tests/helpers';
 
-const errorClass = selectorFromClassnameString(`.${formCss.feedbackError}`);
-const warningClass = selectorFromClassnameString(`.${formCss.feedbackWarning}`);
-const filterClass = selectorFromClassnameString('[class*=selectionFilter---]');
+const errorClass = '[class*=feedbackError---]';
+const warningClass = '[class*=feedbackWarning---]';
+const filterClass = '[class*=selectionFilter---]';
 
 const OptionInteractor = interactor(class OptionInteractor {
   isCursored = hasClass(css.cursor);

--- a/lib/Selection/tests/interactor.js
+++ b/lib/Selection/tests/interactor.js
@@ -21,7 +21,7 @@ import { selectorFromClassnameString } from '../../../tests/helpers';
 
 const errorClass = selectorFromClassnameString(`.${formCss.feedbackError}`);
 const warningClass = selectorFromClassnameString(`.${formCss.feedbackWarning}`);
-const filterClass = selectorFromClassnameString(`.${css.selectionFilter}`);
+const filterClass = selectorFromClassnameString('[class*=selectionFilter---]');
 
 const OptionInteractor = interactor(class OptionInteractor {
   isCursored = hasClass(css.cursor);
@@ -47,13 +47,13 @@ export const OptionSegmentInteractor = interactor(class OptionSegmentInteractor 
 });
 
 export default interactor(class SingleSelectInteractor {
-  controlPresent = isPresent(`.${css.selectionControlContainer}`);
+  controlPresent = isPresent('[class*=selectionControlContainer---]');
   filterFocused = is(filterClass, ':focus');
-  valLabel = text(`.${css.singleValue}`);
+  valLabel = text('[class*=singleValue---]');
   isFocused = is('button', ':focus');
   controlId = attribute('button', 'id');
   options = collection('li', OptionInteractor);
-  alertMessage = scoped(`.${css.selectionAlertMessage}`, {
+  alertMessage = scoped('[class*=selectionAlertMessage---]', {
     messageText: text(),
   });
 
@@ -65,8 +65,8 @@ export default interactor(class SingleSelectInteractor {
   expandedAttribute = attribute('button', 'aria-expanded');
   filterRole = attribute(filterClass, 'role');
   filterActiveDescendant = attribute(filterClass, 'aria-activedescendant');
-  listPresent = isPresent(`.${css.selectionListRoot}`);
-  listHiddenAttributeSet = property(`.${css.selectionListRoot}`, 'hidden');
+  listPresent = isPresent('[class*=selectionListRoot---]');
+  listHiddenAttributeSet = property('[class*=selectionListRoot---]', 'hidden');
   optionCount = count('li');
 
   // label

--- a/lib/TextArea/tests/interactor.js
+++ b/lib/TextArea/tests/interactor.js
@@ -32,7 +32,7 @@ export default interactor(class TextAreaInteractor {
   hasErrorStyle = hasClass('textarea', formCss.hasError);
   hasChangedStyle = hasClass('textarea', formCss.isChanged);
   hasValidStyle = hasClass('textarea', formCss.isValid);
-  hasLoadingIcon = isPresent(`.${css.loadingIcon}`);
+  hasLoadingIcon = isPresent('[class*=loadingIcon---]');
 
   fillAndBlur(val) {
     return this

--- a/lib/TextArea/tests/interactor.js
+++ b/lib/TextArea/tests/interactor.js
@@ -11,9 +11,7 @@ import {
   value,
 } from '@bigtest/interactor';
 
-import css from '../TextArea.css';
 import formCss from '../../sharedStyles/form.css';
-import { selectorFromClassnameString } from '../../../tests/helpers';
 
 export default interactor(class TextAreaInteractor {
   hasTextArea = isPresent('textarea');
@@ -26,8 +24,8 @@ export default interactor(class TextAreaInteractor {
   labelFor = attribute('label', 'for');
   label = text('label');
   hasLabel = isPresent('label');
-  errorText = text(selectorFromClassnameString(`.${formCss.feedbackError}`));
-  warningText = text(selectorFromClassnameString(`.${formCss.feedbackWarning}`));
+  errorText = text('[class*=feedbackError---]');
+  warningText = text('[class*=feedbackWarning---]');
   hasWarningStyle = hasClass('textarea', formCss.hasWarning);
   hasErrorStyle = hasClass('textarea', formCss.hasError);
   hasChangedStyle = hasClass('textarea', formCss.isChanged);

--- a/lib/TextField/tests/interactor.js
+++ b/lib/TextField/tests/interactor.js
@@ -18,9 +18,9 @@ import formCss from '../../sharedStyles/form.css';
 
 import { selectorFromClassnameString } from '../../../tests/helpers';
 
-const rootClass = `.${css.textField}`;
+const rootClass = '[class*=textField---]';
 const errorClass = selectorFromClassnameString(`.${formCss.feedbackError}`);
-const groupClass = `.${css.inputGroup}`;
+const groupClass = '[class*=inputGroup---]';
 
 function computedStyle(selector) {
   return computed(function () {
@@ -39,10 +39,10 @@ export default interactor(class TextFieldInteractor {
   labelFor = attribute('label', 'for');
   label = text('label');
   labelRendered = isPresent('label');
-  endControl = isPresent(`.${css.endControls} span`)
-  endControlsWidth= find(`.${css.endControls}`).offsetWidth;
-  startControl = isPresent(`.${css.startControls} span`);
-  startControlsWidth= find(`.${css.startControls}`).offsetWidth;
+  endControl = isPresent('[class*=endControls---] span')
+  endControlsWidth= find('[class*=endControls---]').offsetWidth;
+  startControl = isPresent('[class*=startControls---] span');
+  startControlsWidth= find('[class*=startControls---]').offsetWidth;
   inputComputed = computedStyle('input');
   inputReadOnly = attribute('input', 'readonly');
   inputError = isPresent(errorClass);
@@ -53,7 +53,7 @@ export default interactor(class TextFieldInteractor {
   hasErrorStyle = hasClass(groupClass, formCss.hasError);
   hasChangedStyle = hasClass(groupClass, formCss.isChanged);
   hasValidStyle = hasClass(groupClass, formCss.isValid);
-  hasLoadingIcon = isPresent(`.${css.loadingIcon}`);
+  hasLoadingIcon = isPresent('[class*=loadingIcon---]');
 
   fillAndBlur(val) {
     return this

--- a/lib/TextField/tests/interactor.js
+++ b/lib/TextField/tests/interactor.js
@@ -16,10 +16,9 @@ import {
 import css from '../TextField.css';
 import formCss from '../../sharedStyles/form.css';
 
-import { selectorFromClassnameString } from '../../../tests/helpers';
 
 const rootClass = '[class*=textField---]';
-const errorClass = selectorFromClassnameString(`.${formCss.feedbackError}`);
+const errorClass = '[class*=feedbackError---]';
 const groupClass = '[class*=inputGroup---]';
 
 function computedStyle(selector) {

--- a/lib/Timepicker/tests/interactor.js
+++ b/lib/Timepicker/tests/interactor.js
@@ -13,7 +13,7 @@ import IconButtonInteractor from '../../IconButton/tests/interactor';
 @interactor class TimepickerDropdownInteractor {
   static defaultScope = '[data-test-timepicker-dropdown]';
 
-  confirmButton = new ButtonInteractor(`.${css.submitButton}`);
+  confirmButton = new ButtonInteractor('[class*=submitButton---]');
 
   hoursInput = new TextFieldInteractor('[data-test-timepicker-dropdown-hours-input]');
   incrementHoursButton = new IconButtonInteractor('[data-test-timepicker-dropdown-increment-hours-button]');


### PR DESCRIPTION
Interactors like
```
.${css.mclHeader}
```
may result in BTOG errors like
```
SyntaxError: ".mclHeader---IgPC+" is not a valid selector
```
because of the `+` appended to the end. I'm not sure exactly where it
comes from, but it ain't right since `+` is meaningful in
CSS-selector-land (as the error tells us). In any case, changing the
selectors to something like
```
[class*=mclHeader---]
```
avoids the problem.

Refs [STCOM-902](https://issues.folio.org/browse/STCOM-902)