### PR TITLE
STCOM-902 use correct expanded-accordion selector

### DIFF
--- a/lib/Accordion/tests/interactor.js
+++ b/lib/Accordion/tests/interactor.js
@@ -20,7 +20,7 @@ export const AccordionInteractor = interactor(class AccordionInteractor {
   static defaultScope = '[class*=accordion---]'
 
   label = text('[class*=labelArea---]')
-  isOpen = hasClass(`.${css.content}`, css.expanded)
+  isOpen = hasClass(`.${css['content-wrap']}`, css.expanded)
   contentHeight = property('[class*=content-wrap---]', 'offsetHeight')
   clickHeader = clickable(triggerCollapse)
   id = attribute('[data-test-accordion-wrapper]', 'id')


### PR DESCRIPTION
How did this ever work? There is no `content` class in the imported CSS,
only `content-wrap` and `content-region`. What the ...?

Refs [STCOM-902](https://issues.folio.org/browse/STCOM-902)