### PR TITLE
STCOM-902 exclude unused CSS imports in interactors

### DIFF
--- a/lib/AutoSuggest/tests/interactor.js
+++ b/lib/AutoSuggest/tests/interactor.js
@@ -8,7 +8,6 @@ import {
   isVisible
 } from '@bigtest/interactor';
 
-import css from '../AutoSuggest.css';
 import TextFieldInteractor from '../../TextField/tests/interactor';
 
 @interactor class listItemInteractor {

--- a/lib/ButtonGroup/tests/interactor.js
+++ b/lib/ButtonGroup/tests/interactor.js
@@ -2,7 +2,6 @@ import {
   interactor,
   computed,
 } from '@bigtest/interactor';
-import css from '../ButtonGroup.css';
 
 function tagName(selector) {
   return computed(function () {

--- a/lib/Callout/tests/interactor.js
+++ b/lib/Callout/tests/interactor.js
@@ -8,8 +8,6 @@ import {
   isPresent,
 } from '@bigtest/interactor';
 
-import css from '../Callout.css';
-
 export default interactor(class CalloutInteractor {
   anyCalloutIsPresent = isPresent('[data-test-callout-element]');
   successCalloutIsPresent = isPresent('[data-test-callout-element][class*=success---]');

--- a/lib/ConfirmationModal/tests/interactor.js
+++ b/lib/ConfirmationModal/tests/interactor.js
@@ -10,8 +10,6 @@ import {
 } from '@bigtest/interactor';
 import ButtonInteractor from '../../Button/tests/interactor';
 
-import css from '../../Modal/Modal.css';
-
 const tagName = selector => computed(function () {
   return this.$(selector).tagName.toLowerCase();
 });

--- a/lib/ErrorModal/tests/interactor.js
+++ b/lib/ErrorModal/tests/interactor.js
@@ -6,8 +6,6 @@ import {
 } from '@bigtest/interactor';
 import ButtonInteractor from '../../Button/tests/interactor';
 
-import css from '../../Modal/Modal.css';
-
 const tagName = selector => computed(function () {
   return this.$(selector).tagName.toLowerCase();
 });

--- a/lib/Layer/tests/interactor.js
+++ b/lib/Layer/tests/interactor.js
@@ -6,8 +6,6 @@ import {
   triggerable,
 } from '@bigtest/interactor';
 
-import css from '../Layer.css';
-
 export default interactor(class LayerInteractor {
   rendered = isPresent('[class*=LayerRoot---]');
   ariaLabel = attribute('[class*=LayerRoot---]', 'aria-label');

--- a/lib/Pane/tests/interactor.js
+++ b/lib/Pane/tests/interactor.js
@@ -7,8 +7,6 @@ import {
 import PaneHeaderInteractor from '../../PaneHeader/tests/interactor';
 import { computedStyle } from '../../../tests/helpers';
 
-import css from '../Pane.css';
-
 export default interactor(class PaneInteractor {
   static defaultScope = '[class*=pane---]';
 

--- a/lib/PaneBackLink/tests/interactor.js
+++ b/lib/PaneBackLink/tests/interactor.js
@@ -1,5 +1,4 @@
 import { interactor } from '@bigtest/interactor';
-import css from '../PaneBackLink.css';
 
 export default interactor(class PaneBackLinkInteractor {
   static defaultScope = '[class*=paneBackLink---]';

--- a/lib/PaneCloseLink/tests/interactor.js
+++ b/lib/PaneCloseLink/tests/interactor.js
@@ -2,7 +2,6 @@ import {
   interactor,
   isPresent,
 } from '@bigtest/interactor';
-import css from '../PaneCloseLink.css';
 
 export default interactor(class PaneCloseLinkInteractor {
   static defaultScope = '[class*=paneCloseLink---]';

--- a/lib/Paneset/tests/interactor.js
+++ b/lib/Paneset/tests/interactor.js
@@ -7,7 +7,6 @@ import {
 } from '@bigtest/interactor';
 
 import paneInteractor from '../../Pane/tests/interactor';
-import css from '../Paneset.css';
 import paneCss from '../../Pane/Pane.css';
 import resizeCss from '../PaneResize.css';
 import { computedStyle } from '../../../tests/helpers';

--- a/lib/Timepicker/tests/interactor.js
+++ b/lib/Timepicker/tests/interactor.js
@@ -5,7 +5,6 @@ import {
   value,
 } from '@bigtest/interactor';
 
-import css from '../TimeDropdown.css';
 import TextFieldInteractor from '../../TextField/tests/interactor';
 import ButtonInteractor from '../../Button/tests/interactor';
 import IconButtonInteractor from '../../IconButton/tests/interactor';


### PR DESCRIPTION
Clean up imports that I missed in previous PRs (#1671, #1668) because I
am a bad, bad person. The CSS values have been factored out of the
selectors so we no longer need to import the CSS files into the
interactors.

Refs [STCOM-902](https://issues.folio.org/browse/STCOM-902)