### PR TITLE
STSMACOM-611/STCOM-901 receiving fewer results will have MCL scroll to top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Make `useClickOutside` click handler work on `capture` event phase. Refs STCOM-895.
 * Interactors should not use dynamic CSS variable names. Refs STCOM-902.
 * Create a Conflict Detection banner. Refs STCOM-889.
+* Scroll MCL to top when a shorter list of content is received. Refs STCOM-907
 
 ## [10.0.0](https://github.com/folio-org/stripes-components/tree/v10.0.0) (2021-09-26)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.2.0...v10.0.0)

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -498,7 +498,7 @@ class MCLRenderer extends React.Component {
       // newState.loadedEstimate = shouldUpdate.datalength;
 
       // only scroll to top for sorting (all current data is non-null and the length is the same)
-      if (shouldUpdate.changeType === CHANGE_DIFFERENCE) {
+      if (shouldUpdate.changeType === CHANGE_DIFFERENCE || shouldUpdate.changeType === CHANGE_LESSDATA) {
         if (this.scrollContainer.current) {
           this.scrollContainer.current.scrollTop = 0;
         }


### PR DESCRIPTION
## Problem
MCL doesn't scroll to the top-most item when result count is decreased. 
Reproducable on folio-testing in ui-users:
Go to ui-uerss https://folio-snapshot.dev.folio.org/users?sort=name
Check the filter for 'Active'
Scroll all the way to the bottom of the results....
Enter 'System' in the search field...
The list will have few results than can fill the frame, but it will not be scrolled completely to the top so that all are visible.

### Approach
Simple change in the update cycle of MCL - less data should also mean scrolling to top (as does sorting the list)