### PR TITLE
STCOM-910: pseudo-label of button is not clickable with the mouse.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Interactors should not use dynamic CSS variable names. Refs STCOM-902.
 * Create a Conflict Detection banner. Refs STCOM-889.
 * Scroll MCL to top when a shorter list of content is received. Refs STCOM-907
+* Fix issue with radioButton 'button' not responding to clicks. Fixes STCOM-910.
 
 ## [10.0.0](https://github.com/folio-org/stripes-components/tree/v10.0.0) (2021-09-26)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.2.0...v10.0.0)

--- a/lib/RadioButton/RadioButton.css
+++ b/lib/RadioButton/RadioButton.css
@@ -35,6 +35,8 @@
   font-size: var(--font-size-form-label);
   margin-bottom: 0;
   min-height: var(--control-min-size-desktop);
+  left: -1rem;
+  padding-left: 1rem;
 
   &.error {
     color: var(--error);
@@ -43,6 +45,12 @@
       border-color: var(--error) !important;
     }
   }
+}
+
+[dir=rtl] .radioLabel {
+  right: -1rem;
+  padding-left: 0;
+  padding-right: 1rem;
 }
 
 .labelInputContainer {
@@ -65,7 +73,6 @@
   background: #fff;
   flex-shrink: 0;
   top: 1px;
-  pointer-events: none;
 }
 
 .labelPseudo::after {

--- a/lib/RadioButton/RadioButton.css
+++ b/lib/RadioButton/RadioButton.css
@@ -63,7 +63,7 @@
   composes: isFocused from "../sharedStyles/interactionStyles.css";
 }
 
-.labelPseudo {
+.pseudoButton {
   display: flex;
   position: relative;
   width: var(--radio-button-size);
@@ -75,7 +75,7 @@
   top: 1px;
 }
 
-.labelPseudo::after {
+.pseudoButton::after {
   content: '';
   width: 6px;
   height: 6px;
@@ -95,8 +95,8 @@
     cursor: default;
   }
 
-  & .labelPseudo,
-  & .input:checked + .labelPseudo {
+  & .pseudoButton,
+  & .inputHidden:checked + .pseudoButton {
     background-color: var(--checkable-disabled-fill);
     border-color: var(--checkable-disabled-fill);
 
@@ -116,7 +116,7 @@
     align-items: center;
   }
 
-  & .labelPseudo {
+  & .pseudoButton {
     top: 0;
   }
 
@@ -130,19 +130,19 @@
   margin-left: 0;
 }
 
-.input {
+.inputHidden {
   position: absolute;
   z-index: -1;
   clip: rect(1px, 1px, 1px, 1px);
 }
 
-.input:not(:checked) + .labelPseudo::after {
+.inputHidden:not(:checked) + .pseudoButton::after {
   opacity: 0;
   -webkit-transform: scale(0);
   transform: scale(0);
 }
 
-.input:checked + .labelPseudo {
+.inputHidden:checked + .pseudoButton {
   background-color: #fff;
 
   &::after {
@@ -165,7 +165,7 @@
     color: var(--warn);
   }
 
-  & .labelPseudo {
+  & .pseudoButton {
     border-color: var(--warn);
   }
 }
@@ -175,7 +175,7 @@
     color: var(--error);
   }
 
-  & .labelPseudo {
+  & .pseudoButton {
     border-color: var(--error);
   }
 }

--- a/lib/RadioButton/RadioButton.css
+++ b/lib/RadioButton/RadioButton.css
@@ -57,6 +57,10 @@
   composes: interactionStyles boxOffsetStartSmall boxOffsetEndSmall from "../sharedStyles/interactionStyles.css";
   display: flex;
   align-items: center;
+
+  &.noInteractionLabel {
+    width: 1rem;
+  }
 }
 
 .radioFocused {

--- a/lib/RadioButton/RadioButton.js
+++ b/lib/RadioButton/RadioButton.js
@@ -13,8 +13,6 @@ import css from './RadioButton.css';
 
 class RadioButton extends React.Component {
   static propTypes = {
-    ariaLabeledBy: PropTypes.string,
-    'aria-labelledby': PropTypes.string, // eslint-disable-line
     autoFocus: PropTypes.bool,
     checked: PropTypes.bool,
     className: PropTypes.string,
@@ -57,18 +55,26 @@ class RadioButton extends React.Component {
   }
 
   getContainerStyle() {
+    const { label } = this.props;
+    const { inputInFocus } = this.state;
     return classNames([
       css.labelInputContainer,
-      { [css.radioFocused]: this.state.inputInFocus },
+      { [css.radioFocused]: inputInFocus },
+      { [css.noInteractionLabel]: !label },
     ]);
   }
 
   getLabelStyle() {
+    const {
+      labelClass,
+      labelStyle,
+    } = this.props;
+
     return classNames(
       css.radioLabel,
-      { [`${css[this.props.labelStyle]}`]: !this.props.labelClass && this.props.labelStyle },
       { [css.labelInteractionStyles]: !this.props.disabled },
-      this.props.labelClass,
+      { [css[labelStyle]]: labelStyle },
+      labelClass,
     );
   }
 
@@ -155,7 +161,6 @@ class RadioButton extends React.Component {
   render() {
     const {
       autoFocus,
-      ariaLabeledBy,
       checked,
       disabled,
       label,
@@ -177,7 +182,7 @@ class RadioButton extends React.Component {
             checked={checked}
             {...inputCustom}
             name={name}
-            className={(label || ariaLabeledBy || this.props['aria-labelledby']) ? css.inputHidden : ''}
+            className={css.inputHidden}
             onChange={this.handleChange}
             onFocus={this.handleFocus}
             onBlur={this.handleBlur}
@@ -188,24 +193,18 @@ class RadioButton extends React.Component {
             readOnly={readOnly}
             required={required}
           />
-          {(label || readOnly) &&
-            (
-              <>
-                <span className={css.pseudoButton} />
-                <Label htmlFor={this.id} className={this.getLabelStyle()}>
-                  <span className={css.labelText}>
-                    {label}
-                    {required && <Asterisk />}
-                    {readOnly && (
-                      <span className="sr-only">
-                        <FormattedMessage id="stripes-components.readonly" />
-                      </span>
-                    )}
-                  </span>
-                </Label>
-              </>
-            )
-          }
+          <span className={css.pseudoButton} />
+          <Label htmlFor={this.id} className={this.getLabelStyle()}>
+            <span className={css.labelText}>
+              {label}
+              {required && <Asterisk />}
+              {readOnly && (
+                <span className="sr-only">
+                  <FormattedMessage id="stripes-components.readonly" />
+                </span>
+              )}
+            </span>
+          </Label>
         </div>
         <div role="alert" style={{ display: 'block' }}>
           {this.getFeedbackElement()}

--- a/lib/RadioButton/RadioButton.js
+++ b/lib/RadioButton/RadioButton.js
@@ -13,6 +13,8 @@ import css from './RadioButton.css';
 
 class RadioButton extends React.Component {
   static propTypes = {
+    ariaLabeledBy: PropTypes.string,
+    'aria-labelledby': PropTypes.string, // eslint-disable-line
     autoFocus: PropTypes.bool,
     checked: PropTypes.bool,
     className: PropTypes.string,
@@ -153,6 +155,7 @@ class RadioButton extends React.Component {
   render() {
     const {
       autoFocus,
+      ariaLabeledBy,
       checked,
       disabled,
       label,
@@ -174,7 +177,7 @@ class RadioButton extends React.Component {
             checked={checked}
             {...inputCustom}
             name={name}
-            className={css.input}
+            className={(label || ariaLabeledBy || this.props['aria-labelledby']) ? css.inputHidden : ''}
             onChange={this.handleChange}
             onFocus={this.handleFocus}
             onBlur={this.handleBlur}
@@ -185,20 +188,22 @@ class RadioButton extends React.Component {
             readOnly={readOnly}
             required={required}
           />
-          <span className={css.labelPseudo} />
           {(label || readOnly) &&
             (
-              <Label htmlFor={this.id} className={this.getLabelStyle()}>
-                <span className={css.labelText}>
-                  {label}
-                  {required && <Asterisk />}
-                  {readOnly && (
-                    <span className="sr-only">
-                      <FormattedMessage id="stripes-components.readonly" />
-                    </span>
-                  )}
-                </span>
-              </Label>
+              <>
+                <span className={css.pseudoButton} />
+                <Label htmlFor={this.id} className={this.getLabelStyle()}>
+                  <span className={css.labelText}>
+                    {label}
+                    {required && <Asterisk />}
+                    {readOnly && (
+                      <span className="sr-only">
+                        <FormattedMessage id="stripes-components.readonly" />
+                      </span>
+                    )}
+                  </span>
+                </Label>
+              </>
             )
           }
         </div>


### PR DESCRIPTION
Mark-up for Radio buttons had to be corrected for proper accessibility in #1645 This exclusion from the offending wrapping label edit caused the 'button' to no longer be clickable.

Adding click handlers to the button itself is a can of accessibility worms since it's not, technically, an interactive element (it just responds, visually, to the state of the radio button.)
Expanding the label area allows the component to use native click behavior while keeping the nice, consistent graphic style.

**Approach**: Extend clickable area of radio button label to extend over the 'button' via css, accounting for RTL...