### PR TITLE
STCOM-912 restore props spread to avoid console warning

### DIFF
--- a/lib/MultiSelection/MultiSelectOptionsList.js
+++ b/lib/MultiSelection/MultiSelectOptionsList.js
@@ -143,7 +143,6 @@ class MultiSelectOptionsList extends React.Component {
     return (
       <OptionsListWrapper
         className={css.multiSelectMenu}
-        menuPropGetter={getMenuProps}
         style={this.getMenuStyle()}
         modifiers={modifiers}
         isOpen={isOpen}

--- a/lib/MultiSelection/OptionsListWrapper.js
+++ b/lib/MultiSelection/OptionsListWrapper.js
@@ -8,11 +8,12 @@ const OptionsListWrapper = React.forwardRef(({
   controlRef,
   isOpen,
   renderToOverlay,
+  menuPropGetter,
   modifiers,
   ...props
 }, ref) => {
   if (useLegacy) {
-    return <div data-open={props.isOpen} {...props} hidden={!isOpen}>{children}</div>;
+    return <div {...menuPropGetter({ ref })} data-open={props.isOpen} {...props} hidden={!isOpen}>{children}</div>;
   }
 
   let portal;
@@ -41,6 +42,7 @@ OptionsListWrapper.propTypes = {
   children: PropTypes.node,
   controlRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   isOpen: PropTypes.bool,
+  menuPropGetter: PropTypes.func,
   modifiers: PropTypes.object,
   renderToOverlay: PropTypes.bool,
   useLegacy: PropTypes.bool,

--- a/lib/MultiSelection/OptionsListWrapper.js
+++ b/lib/MultiSelection/OptionsListWrapper.js
@@ -8,12 +8,11 @@ const OptionsListWrapper = React.forwardRef(({
   controlRef,
   isOpen,
   renderToOverlay,
-  menuPropGetter,
   modifiers,
   ...props
 }, ref) => {
   if (useLegacy) {
-    return <div {...menuPropGetter({ ref })} data-open={props.isOpen} {...props} hidden={!isOpen}>{children}</div>;
+    return <div data-open={props.isOpen} {...props} hidden={!isOpen}>{children}</div>;
   }
 
   let portal;


### PR DESCRIPTION
Some prop-spreading was removed in an earlier refactor (#1663) that now
causes a console warning because the prop is now applied directly to the
underlying DOM element. Restore the spread.

Refs [STCOM-912](https://issues.folio.org/browse/STCOM-912) and [STCOM-883](https://issues.folio.org/browse/STCOM-883) by extension.