### PR TITLE
STCOM-915 do not set aria-invalid on button elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Upgrade `postcss` to v8. Refs STCOM-892.
 * Add a new `valueFormatter` prop to `<MultiSelection>`. Refs STCOM-911.
 * remove `@bigtest/mocha` dependency - using `mocha` instead. Refs STCOM-907.
+* Do not pass `aria-invalid` to any `<button>` elements. Refs STCOM-915.
 
 ## [10.0.0](https://github.com/folio-org/stripes-components/tree/v10.0.0) (2021-09-26)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.2.0...v10.0.0)

--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -699,7 +699,6 @@ class SingleSelect extends React.Component {
             className={this.getControlClass()}
             ref={this.control}
             id={this.testId}
-            aria-invalid={this.props.error ? 'true' : 'false'}
             aria-disabled={(this.props.disabled)}
             aria-owns={`sl-${this.props.id}`}
             name={this.props.name}


### PR DESCRIPTION
The nature of `<button>` elements is that they cannot be invalid. They
are interactive by being clickable but there is no way for their input
to be invalid. This change resolves the following lint error:

> The attribute aria-invalid is not supported by the role button. This
> role is implicit on the element button [jsx-a11y/role-supports-aria-props](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/30deacbf240f8cea7b88a977a72ed54b499c134e/docs/rules/role-supports-aria-props.md)

Refs [STCOM-915](https://issues.folio.org/browse/STCOM-915)