### PR TITLE
STCOM-914 REALLY correct LayoutHeader documentation

### DIFF
--- a/lib/LayoutHeader/LayoutHeader.js
+++ b/lib/LayoutHeader/LayoutHeader.js
@@ -11,7 +11,7 @@ const propTypes = {
     PropTypes.shape({
       handler: PropTypes.func,
       icon: PropTypes.string,
-      name: PropTypes.string,
+      title: PropTypes.string,
     }),
   ),
   level: PropTypes.number,
@@ -30,7 +30,6 @@ const defaultProps = {
 const LayoutHeader = ({ title, level, actions, onDelete, noActions }) => {
   const getHeader = () => React.createElement(`h${level}`, { style: { margin: 0 } }, title);
 
-
   const renderActions = () => {
     const renderedActions = [];
     if (noActions) {
@@ -39,11 +38,11 @@ const LayoutHeader = ({ title, level, actions, onDelete, noActions }) => {
 
     let actionList;
     if (!actions) {
-      actionList = [
-        { title: 'Delete',
-          icon: 'trash',
-          handler: onDelete },
-      ];
+      actionList = [{
+        title: 'Delete',
+        icon: 'trash',
+        handler: onDelete,
+      }];
     } else {
       actionList = actions;
     }
@@ -51,7 +50,7 @@ const LayoutHeader = ({ title, level, actions, onDelete, noActions }) => {
     actionList.forEach((a, i) => {
       renderedActions.push(
         <Button
-          key={`${a.name}-${i}`}
+          key={`${a.title}-${i}`}
           buttonStyle="link slim"
           style={{ margin: 0, padding: 0 }}
           onClick={a.handler}

--- a/lib/LayoutHeader/readme.md
+++ b/lib/LayoutHeader/readme.md
@@ -16,7 +16,7 @@ Name | type | description | default | required
 --- | --- | --- | --- | ---
 title | string | text for the header of the section | |
 level | number | The header level of the rendered `<Hx>` tag. (1-6). | 3 |
-actions | array of `{ name, icon, handler }` | see examples | |
+actions | array of `{ title, icon, handler }` | see examples | |
 onDelete | function | to support delete actions in the simplest use case. | |
 noActions | bool | hides action buttons. Useful for 'read-only' mode. | |
 
@@ -25,7 +25,7 @@ The actions prop can be used to supply a custom set of rendered buttons with ico
 ```
 [
   {
-    name: string,
+    title: string,
     icon: string,
     handler: function
   },
@@ -38,7 +38,7 @@ The simple delete action configuration looks like this:
 ```
 [
   {
-    name: 'Delete',
+    title: 'Delete',
     icon: 'trash',
     handler: props.onDelete,
   },


### PR DESCRIPTION
The prop-types and the code didn't agree, so while the documentation was
changed in #1697 it actually made things worse because following it (as
in https://github.com/folio-org/stripes-smart-components/pull/1164)
would not work.

It appears that `AddressView` is the only case where `actions` is passed
to `LayoutHeader`, but leaving the existing implementation as-is and
changing the doc to match still feels like the safest bet.

Refs [STCOM-914](https://issues.folio.org/browse/STCOM-914)