### PR TITLE
STSMACOM-616 - update navlist tests to use new interactor

### DIFF
--- a/lib/NavList/tests/NavList-test.js
+++ b/lib/NavList/tests/NavList-test.js
@@ -4,15 +4,14 @@
 
 import React from 'react';
 import { describe, beforeEach, it } from 'mocha';
-import { expect } from 'chai';
+import { NavList as Interactor, Bigtest, including } from '@folio/stripes-testing';
 import { mount } from '../../../tests/helpers';
 
-import NavListInteractor from './interactor';
 import NavList from '../NavList';
 import NavListItem from '../../NavListItem';
 
 describe('NavList', () => {
-  const navList = new NavListInteractor();
+  const navList = new Interactor();
   const className = 'my-class';
   const id = 'my-id';
 
@@ -24,15 +23,9 @@ describe('NavList', () => {
     );
   });
 
-  it('Should render any nodes passed as children', () => {
-    expect(navList.hasChildren).to.be.true;
-  });
+  it('Should render any nodes passed as children', () => Bigtest.Button('Test').exists());
 
-  it('Should apply any custom class passed to the className-prop to the root element', () => {
-    expect(navList.class).to.include(className);
-  });
+  it('Should apply any custom class passed to the className-prop to the root element', () => navList.has({ className: including(className) }));
 
-  it('Should apply any ID passed to the ID-prop to the root element', () => {
-    expect(navList.id).to.include(id);
-  });
+  it('Should apply any ID passed to the ID-prop to the root element', () => navList.has({ id }));
 });


### PR DESCRIPTION
Makes use of new Navlist interactor added to `@folio/stripes-testing` 