### PR TITLE
STCOM-909: MultiColumnList - PrevNext buttons return incorrect index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Add a new `valueFormatter` prop to `<MultiSelection>`. Refs STCOM-911.
 * remove `@bigtest/mocha` dependency - using `mocha` instead. Refs STCOM-907.
 * Do not pass `aria-invalid` to any `<button>` elements. Refs STCOM-915.
+* PrevNext buttons return incorrect index. Fixes STCOM-909.
 
 ## [10.0.0](https://github.com/folio-org/stripes-components/tree/v10.0.0) (2021-09-26)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.2.0...v10.0.0)

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -1185,7 +1185,7 @@ class MCLRenderer extends React.Component {
       const canGoPrevious = !contentData[0];
       let canGoNext = !contentData[contentData.length - 1];
       if (totalCount) {
-        canGoNext = !(contentData.length === totalCount) || !contentData[contentData.length - 1];
+        canGoNext = contentData.length !== totalCount || !contentData[contentData.length - 1];
       } else {
         canGoNext = !contentData[contentData.length - 1];
       }

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -1185,7 +1185,7 @@ class MCLRenderer extends React.Component {
       const canGoPrevious = !contentData[0];
       let canGoNext = !contentData[contentData.length - 1];
       if (totalCount) {
-        canGoNext = !(contentData.length === totalCount);
+        canGoNext = !(contentData.length === totalCount) || !contentData[contentData.length - 1];
       } else {
         canGoNext = !contentData[contentData.length - 1];
       }

--- a/lib/MultiColumnList/PrevNextPaginationRow.js
+++ b/lib/MultiColumnList/PrevNextPaginationRow.js
@@ -104,7 +104,13 @@ const PrevNextPaginationRow = ({
                     <PagingButton
                       onClick={() => {
                         // setFocusIndex(rowIndex);
-                        handleLoadMore(pageAmount, rowIndex - (pageAmount * 2));
+                        const remainder = rowIndex % pageAmount;
+
+                        const rowIndexForPrevButton = remainder === 0
+                          ? rowIndex - (pageAmount * 2)
+                          : rowIndex - (pageAmount + remainder);
+
+                        handleLoadMore(pageAmount, rowIndexForPrevButton);
                       }}
                       sendMessage={sendMessage}
                       loadingMessage={message}


### PR DESCRIPTION
## Purpose
Fixes PrevNext buttons return incorrect index.

## Screenshots
![CKYJvji05a](https://user-images.githubusercontent.com/84023879/148855849-a22b9389-570f-464c-94ec-4e92b38ae697.gif)

## Issues
[STCOM-909](https://issues.folio.org/browse/STCOM-909)
