### PR TITLE
STCOM-898: Layout > Add textStart, textEnd properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Add a new `valueFormatter` prop to `<MultiSelection>`. Refs STCOM-911.
 * remove `@bigtest/mocha` dependency - using `mocha` instead. Refs STCOM-907.
 * Do not pass `aria-invalid` to any `<button>` elements. Refs STCOM-915.
+* Add new `text-start`, `text-end` classNames to `<Layout>` component. Refs STCOM-898.
 
 ## [10.0.0](https://github.com/folio-org/stripes-components/tree/v10.0.0) (2021-09-26)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v9.2.0...v10.0.0)

--- a/lib/Layout/stories/classNamePropertiesMapping.js
+++ b/lib/Layout/stories/classNamePropertiesMapping.js
@@ -41,5 +41,7 @@ export default {
   'right': 'float: right;',
   'textLeft': 'text-align: left;',
   'textCentered': 'text-align: center;',
-  'textRight': 'text-align: right;'
+  'textRight': 'text-align: right;',
+  'text-start': 'text-align: start;',
+  'text-end': 'text-align: end;'
 };

--- a/lib/Layout/styles/text.css
+++ b/lib/Layout/styles/text.css
@@ -16,3 +16,11 @@
 .textRight {
   text-align: right;
 }
+
+.text-start {
+  text-align: start;
+}
+
+.text-end {
+  text-align: end;
+}


### PR DESCRIPTION
## Purpose
Adds new `text-start`, `text-end` classNames to `<Layout>` component to support both LTR and RTL languages.

## Issues
[STCOM-898](https://issues.folio.org/browse/STCOM-898)