### PR TITLE
STCOM-926 Settings : Move focus to second pane

### DIFF
--- a/lib/Pane/Pane.js
+++ b/lib/Pane/Pane.js
@@ -6,6 +6,7 @@ import css from './Pane.css';
 import PaneHeader from '../PaneHeader';
 import { withPaneset } from '../Paneset/PanesetContext';
 import { withResize } from '../Paneset/ResizeContext';
+import { getFirstFocusable } from '../../util/getFocusableElements';
 
 const propTypes = {
   actionMenu: PropTypes.func,
@@ -94,6 +95,10 @@ class Pane extends React.Component {
 
   componentDidMount() {
     const { transition, defaultWidth, paneset, resizer } = this.props;
+
+    const el = getFirstFocusable(this.el.current);
+    el.focus();
+
     const paneObject = {
       transition,
       setStyle: this.setStyle,

--- a/lib/Pane/Pane.js
+++ b/lib/Pane/Pane.js
@@ -95,9 +95,7 @@ class Pane extends React.Component {
 
   componentDidMount() {
     const { transition, defaultWidth, paneset, resizer } = this.props;
-
     const el = getFirstFocusable(this.el.current);
-    el.focus();
 
     const paneObject = {
       transition,
@@ -121,6 +119,8 @@ class Pane extends React.Component {
       this.setState({ contentMinWidth: this.getContentWidth() }); // eslint-disable-line react/no-unused-state
     });
     this._isMounted = true;
+
+    if (el) el.focus();
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
https://issues.folio.org/browse/STSMACOM-617

## Problem
In the current implementation, when you click on the link in the "settings" panel, the focus does not switch to the newly opened one. 

![current](https://issues.folio.org/secure/attachment/43487/fixed.gif)

## Solution
- Add an focus to first focusable element in Pane

![fixed](https://issues.folio.org/secure/attachment/43487/fixed.gif)