### PR TITLE
Add focus-within styling to MCL header

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -121,6 +121,10 @@
   font-size: var(--font-size-medium);
   color: var(--color-text);
 
+  &:focus-within {
+    box-shadow: inner 0 5px 0 0 var(--color-fill-focus);
+  }
+
   &.mclClickable {
     cursor: pointer;
   }


### PR DESCRIPTION
FINALLY... Focus-styling HAS COME BACK to MCL HEADERS!!!


![MCLFocusHeading](https://user-images.githubusercontent.com/20704067/152056790-36aef70f-4dd5-4cdf-bc74-48d16bb35503.gif)

![Finally](https://media.giphy.com/media/11ezOCtJ7Eetri/giphy.gif)
