### PR TITLE
STCOM-929 NavListSection should accept a tag prop

### DIFF
--- a/lib/NavListSection/NavListSection.js
+++ b/lib/NavListSection/NavListSection.js
@@ -10,6 +10,7 @@ const NavListSection = forwardRef(({
   children,
   className,
   label,
+  tag,
   striped,
   ...rest
 }, ref) => (
@@ -27,7 +28,7 @@ const NavListSection = forwardRef(({
     >
       {label && (
         <div className={css.header} data-test-nav-list-section-header>
-          <Headline className={css.label} tag="h3">
+          <Headline className={css.label} tag={tag}>
             {label}
           </Headline>
         </div>

--- a/lib/NavListSection/NavListSection.js
+++ b/lib/NavListSection/NavListSection.js
@@ -27,7 +27,7 @@ const NavListSection = forwardRef(({
     >
       {label && (
         <div className={css.header} data-test-nav-list-section-header>
-          <Headline className={css.label}>
+          <Headline className={css.label} tag="h3">
             {label}
           </Headline>
         </div>

--- a/lib/NavListSection/NavListSection.js
+++ b/lib/NavListSection/NavListSection.js
@@ -48,8 +48,8 @@ NavListSection.propTypes = {
   ]),
   className: PropTypes.string,
   label: PropTypes.node,
-  tag: PropTypes.string,
   striped: PropTypes.bool,
+  tag: PropTypes.string,
 };
 
 NavListSection.defaultProps = {

--- a/lib/NavListSection/NavListSection.js
+++ b/lib/NavListSection/NavListSection.js
@@ -48,11 +48,13 @@ NavListSection.propTypes = {
   ]),
   className: PropTypes.string,
   label: PropTypes.node,
+  tag: PropTypes.string,
   striped: PropTypes.bool,
 };
 
 NavListSection.defaultProps = {
   activeLink: null,
+  tag: 'div',
 };
 
 NavListSection.displayName = 'NavListSection';

--- a/lib/Select/Select.js
+++ b/lib/Select/Select.js
@@ -142,6 +142,7 @@ class Select extends Component {
         id={this.id}
         required={required}
         ref={inputRef}
+        multiple={multiple}
       >
         {options}
         {


### PR DESCRIPTION
In the scope of fixing some a11y issues in [UIU-2037](https://issues.folio.org/browse/UIU-2037), we need to replace a `<div>` for General, Fee/Fine, Patron blocks with an `<h3>`. So, in NavListSection I added tag prop to Headline component. 

Ref: https://issues.folio.org/browse/UIU-2037
Ref: https://issues.folio.org/browse/STCOM-929

Replaces #1716
