### PR TITLE
STCOM-927 Perform proportional resize on panes with percentage-based widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## In-progress
 * prevent `onMount` from being passed to rendered HTML element in `<Pane>`. fixes STCOM-931.
-* resize panes that use percentage-based layout widths. fixes STCOM-927.
+* include percentage-based layout widths in proportional resizing. fixes STCOM-927.
 
 ## [10.1.0](https://github.com/folio-org/stripes-components/tree/v10.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.0.0...v10.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change history for stripes-components
 
 ## In-progress
-* prevent `onMount` from being passed to rendered HTML element in `<Pane>`. fixes STCOM-931
+* prevent `onMount` from being passed to rendered HTML element in `<Pane>`. fixes STCOM-931.
+* resize panes that use percentage-based layout widths. fixes STCOM-927.
 
 ## [10.1.0](https://github.com/folio-org/stripes-components/tree/v10.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.0.0...v10.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change history for stripes-components
 
 ## In-progress
-* prevent `onMount` from being passed to rendered HTML element in `<Pane>`. fixes STCOM-931.
-* include percentage-based layout widths in proportional resizing. fixes STCOM-927.
+* Prevent `onMount` from being passed to rendered HTML element in `<Pane>`. fixes STCOM-931.
+* Include percentage-based layout widths in proportional resizing. fixes STCOM-927.
 
 ## [10.1.0](https://github.com/folio-org/stripes-components/tree/v10.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.0.0...v10.1.0)

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -19,6 +19,9 @@ function getNewPanewidthObject(key, CSSvalue, proportionalChange) {
   let newWidth = CSSvalue;
   switch (unit) {
     case 'percent':
+      newWidth = parseFloat(CSSvalue, 10) * proportionalChange;
+      newWidth = `${newWidth}%`;
+      break;
     case 'vw': break;
     case 'px':
       newWidth = Math.ceil(parseInt(CSSvalue, 10) * proportionalChange);
@@ -328,6 +331,9 @@ class Paneset extends React.Component {
           const unit = parseCSSUnit(layoutObject[p]);
           if (unit === 'px') {
             value = Math.ceil(parseInt(layoutObject[p], 10));
+            totalWidth += value;
+          } else if (unit === 'percent') {
+            value = (parseFloat(layoutObject[p], 10) / 100) * (this.containerWidth || window.innerWidth);
             totalWidth += value;
           } else {
             return null;


### PR DESCRIPTION
### Problem
Pane widths using a percentage were not proportionally resized, which would leave them mis-matched if they were in a set with a pixel-based value. Ending panes would end up cut off or falling short (leaving a white space between the pane and the edge of the window)
See https://issues.folio.org/browse/STCOM-927 for the previous case...

### Approach
If the layout cache uses a percentage-based width, parse the value and perform calculations to increase or decrease the number based on the relative size of the container.