### PR TITLE
STCOM-931 prevent onMount from passing to DOM element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for stripes-components
 
+## In-progress
+* prevent `onMount` from being passed to rendered HTML element in `<Pane>`. fixes STCOM-931
+
 ## [10.1.0](https://github.com/folio-org/stripes-components/tree/v10.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.0.0...v10.1.0)
 

--- a/lib/Pane/Pane.js
+++ b/lib/Pane/Pane.js
@@ -208,6 +208,7 @@ class Pane extends React.Component {
       padContent, // eslint-disable-line no-unused-vars
       paneset, // eslint-disable-line no-unused-vars
       resizer, // eslint-disable-line no-unused-vars
+      onMount, // eslint-disable-line no-unused-vars
       paneSub,
       paneTitle,
       paneTitleRef,


### PR DESCRIPTION
This is showing up in settings:
![image](https://user-images.githubusercontent.com/20704067/154231119-e205b891-044c-44fe-ae36-2bffe9663d29.png)

The `onMount` prop just needs to be filtered out before passing props to internally rendered HTML elements.