### PR TITLE
STCOM-932 Check for stable id's before caching pane sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change history for stripes-components
 
 ## In-progress
-* prevent `onMount` from being passed to rendered HTML element in `<Pane>`. fixes STCOM-931
+* Prevent `onMount` from being passed to rendered HTML element in `<Pane>`. fixes STCOM-931
+* Prevent caching of pane layouts (resizeable widths) when panes do not have a provided stable `id` prop. fixes STCOM-932
 
 ## [10.1.0](https://github.com/folio-org/stripes-components/tree/v10.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.0.0...v10.1.0)

--- a/lib/Pane/Pane.js
+++ b/lib/Pane/Pane.js
@@ -94,13 +94,16 @@ class Pane extends React.Component {
   }
 
   componentDidMount() {
-    const { transition, defaultWidth, paneset, resizer, paneTitleRef, onMount } = this.props;
+    const { transition, defaultWidth, paneset, resizer, paneTitleRef, onMount, id } = this.props;
     const paneObject = {
       transition,
       setStyle: this.setStyle,
       isThisMounted: this.isThisMounted,
       defaultWidth,
       id: this.id,
+      // whether or not the pane had to generate its id.
+      // This is used to detarmine whether the size of the panes should be cached.
+      generatedId: !id,
       getRef: this.getRef,
     };
     if (paneset) {

--- a/lib/Pane/Pane.js
+++ b/lib/Pane/Pane.js
@@ -102,8 +102,8 @@ class Pane extends React.Component {
       defaultWidth,
       id: this.id,
       // whether or not the pane had to generate its id.
-      // This is used to detarmine whether the size of the panes should be cached.
-      generatedId: !id,
+      // This is used to determine whether the size of the panes should be cached.
+      hasGeneratedId: !id,
       getRef: this.getRef,
     };
     if (paneset) {

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { pickBy, uniqueId, cloneDeep, debounce, isEqual } from 'lodash';
+import { pickBy, uniqueId, cloneDeep, debounce, isEqual, noop } from 'lodash';
 import parseCSSUnit from '../../util/parseCSSUnit';
 import insertByClientRect from './insertByClientRect';
 import css from './Paneset.css';
@@ -371,7 +371,6 @@ class Paneset extends React.Component {
         layoutCache: this.state.layoutCache,
         widths: sizesCached !== -1 ? null : this.state.layoutCache[sizesCached],
       });
-
       if (toApply && sizesCached === -1) {
         widths = toApply;
       } else if (sizesCached !== -1) {
@@ -380,7 +379,11 @@ class Paneset extends React.Component {
         widths = this.calcWidths(this.state.panes);
       }
       this.resizePanes(this.state.panes, widths);
-      this.updateLayoutCache(widths, changeType);
+
+      // check if the panes all have stable id's before caching their sizes.
+      if (this.state.panes.every((p) => p.generatedId === false)) {
+        this.updateLayoutCache(widths, changeType);
+      }
     });
   }
 
@@ -553,7 +556,11 @@ class Paneset extends React.Component {
     }
 
     this.resizePanes(panes, newWidths);
-    this.updateLayoutCache(newWidths, 'resize');
+
+    // check if the panes all have stable id's before caching their sizes.
+    if (this.state.panes.every((p) => p.generatedId === false)) {
+      this.updateLayoutCache(newWidths, 'resize');
+    }
   }
 
   render() {

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -381,7 +381,7 @@ class Paneset extends React.Component {
       this.resizePanes(this.state.panes, widths);
 
       // check if the panes all have stable id's before caching their sizes.
-      if (this.state.panes.every((p) => p.generatedId === false)) {
+      if (this.state.panes.every((p) => p.hasGeneratedId === false)) {
         this.updateLayoutCache(widths, changeType);
       }
     });

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { pickBy, uniqueId, cloneDeep, debounce, isEqual, noop } from 'lodash';
+import { pickBy, uniqueId, cloneDeep, debounce, isEqual } from 'lodash';
 import parseCSSUnit from '../../util/parseCSSUnit';
 import insertByClientRect from './insertByClientRect';
 import css from './Paneset.css';


### PR DESCRIPTION
### Problem

Paneset layout caching is used by panesets to keep track of pane sizes between transitions/changes in the sizes of the panes. This eases the transition between views by retaining the widths that the user had previously set.
the smart component 'PersistedPaneset' pushes the paneset cache up to the browser's local storage, so the user-applied resizing can be applied the next time they log in to FOLIO, or return to an app.

Panes cache their widths based on their id. If an id isn't provided as a prop, one will be generated. A generated id will not be repeated the next time that the pane is rendered, so it will be found as unique and added to the list of caches as-if it were a different paneset.

This can cause the local storage cache to grow every time a Pane is initially rendered.

### Approach
Check to see if current panes have any generated id's before caching widths.
