### PR TITLE
STCOM-935 Add aria label for `<MultiSelectFilterField>` component

### DIFF
--- a/lib/MultiSelection/MultiSelectFilterField.js
+++ b/lib/MultiSelection/MultiSelectFilterField.js
@@ -65,6 +65,7 @@ class MultiSelectFilterField extends React.Component {
       <input
         {...getInputProps({
           'aria-labelledby': rest['aria-labelledby'] || ariaLabelledBy,
+          'aria-label': `input-${ariaLabelledBy}`,
           'type': 'text',
           'ref': inputRef,
           'onKeyDown': this.handleInputKeyDown,


### PR DESCRIPTION
In scope of UIU-1686 it is necessary to add `aria-label` for `<MultiSelectFilterField>` component.
* multiselect-5-input (in tags multiselect)
* owner-service-point-input (in settings > fee/fine > owners > new)

Refs: https://issues.folio.org/browse/UIU-1686