### PR TITLE
STCOM-937 AccordionSet has incorrect aria attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Prevent `onMount` from being passed to rendered HTML element in `<Pane>`. fixes STCOM-931
 * Include percentage-based layout widths in proportional resizing. fixes STCOM-927.
 * Prevent caching of pane layouts (resizeable widths) when panes do not have a provided stable `id` prop. fixes STCOM-932.
+* AccordionSet has incorrect aria attribute. Refs STCOM-937.
 
 ## [10.1.0](https://github.com/folio-org/stripes-components/tree/v10.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.0.0...v10.1.0)

--- a/lib/Accordion/AccordionSet.js
+++ b/lib/Accordion/AccordionSet.js
@@ -17,7 +17,6 @@ class AccordionSet extends React.Component {
     initialStatus: PropTypes.object,
     onToggle: PropTypes.func,
     setStatus: PropTypes.func,
-    singleOpen: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -138,7 +137,6 @@ class AccordionSet extends React.Component {
       initialStatus,
       accordionStatus,
       onToggle: onToggleProp,
-      singleOpen,
     } = this.props;
 
     let StatusContext = React.Fragment;
@@ -167,7 +165,7 @@ class AccordionSet extends React.Component {
                 }
               }}
             >
-              <div aria-multiselectable={!singleOpen} id={id}>
+              <div id={id}>
                 {children}
               </div>
             </AccProvider>


### PR DESCRIPTION
purpose:
https://issues.folio.org/browse/STCOM-937

based on doc https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiselectable it's used for selects, when accordion is not smth selectable with options, moreover role was removed some time ago