### PR TITLE
lint. it does a body good.

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -65,7 +65,7 @@
       background-color: #fff;
     }
 
-    & a{
+    & a {
       color: var(--color-link-current);
     }
 

--- a/lib/TextLink/TextLink.css
+++ b/lib/TextLink/TextLink.css
@@ -79,8 +79,7 @@
 }
 
 div[class*="Selected"] {
-
-  & .root {
+  &.root {
     color: var(--link-color-current);
 
     /* Visited */

--- a/lib/TextLink/TextLink.css
+++ b/lib/TextLink/TextLink.css
@@ -79,7 +79,15 @@
 }
 
 div[class*="Selected"] {
-  &.root {
+  /**
+    * :not is the crown prince of pseudo selector specificity.
+    * That's causing stylelint grief here since it's more
+    * specific than the things above it, but if we invert the
+    * hierarchy then we'd have to duplicate most of this code.
+    * <sigh>.
+    */
+  /* stylelint-disable no-descending-specificity */
+  & .root {
     color: var(--link-color-current);
 
     /* Visited */


### PR DESCRIPTION
@JohnC-80 , I'm not confident about changing `& .root` to `&.root` in `TextLink`, but I can't get stylelint to be quiet otherwise. Moving that block above the main `.root` block causes even more complaints 😕 . 