### PR TITLE
STCOM-949 leverage stripes-testing NoValue interactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Correctly apply `aria-haspopup` and `aria-expanded` to IconButton. Refs STCOM 941.
 * Open Loans List: Elements must only use allowed ARIA attributes. Refs STCOM-948.
 * Appropriately apply labels within `<AutoSuggest>` component. Refs STCOM-939.
+* Provide `<NoValue>` interactor. Refs STCOM-949.
 
 ## [10.1.0](https://github.com/folio-org/stripes-components/tree/v10.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.0.0...v10.1.0)

--- a/lib/KeyValue/tests/KeyValue-test.js
+++ b/lib/KeyValue/tests/KeyValue-test.js
@@ -6,9 +6,12 @@ import {
   it
 } from 'mocha';
 
-import { KeyValue as Interactor } from '@folio/stripes-testing';
-import KeyValue from '../KeyValue';
+import {
+  KeyValue as Interactor,
+  NoValue as NoValueInteractor,
+} from '@folio/stripes-testing';
 
+import KeyValue from '../KeyValue';
 import { mount, mountWithContext } from '../../../tests/helpers';
 
 describe('KeyValue', () => {
@@ -55,6 +58,8 @@ describe('KeyValue', () => {
   });
 
   describe('with undefined value', () => {
+    const noValue = NoValueInteractor();
+
     beforeEach(async () => {
       await mountWithContext(
         <KeyValue label="Label" value={undefined} />
@@ -62,11 +67,13 @@ describe('KeyValue', () => {
     });
 
     it('should display correct value', async () => {
-      await keyValue.has({ value: 'No value set-' });
+      await noValue.exists();
     });
   });
 
   describe('with empty string value', () => {
+    const noValue = NoValueInteractor();
+
     beforeEach(async () => {
       await mountWithContext(
         <KeyValue label="Label" value={''} />
@@ -74,7 +81,7 @@ describe('KeyValue', () => {
     });
 
     it('should display correct value', async () => {
-      await keyValue.has({ value: 'No value set-' });
+      await noValue.exists();
     });
   });
 

--- a/lib/NoValue/readme.md
+++ b/lib/NoValue/readme.md
@@ -1,7 +1,7 @@
 # NoValue
 
-Render a dash, `-`, to indicate "no value set", including the appropriate
-`aria-label` so screen readers will also read "no value set".
+Render a visual dash (`-`) to visually indicate "no value set", and a
+screen-reader-only element so screen readers will also read "no value set".
 
 ## Basic Usage
 

--- a/lib/NoValue/tests/NoValue-test.js
+++ b/lib/NoValue/tests/NoValue-test.js
@@ -1,52 +1,66 @@
 import React from 'react';
-import { expect } from 'chai';
 
 import {
   beforeEach,
   describe,
-  it,
+  it
 } from 'mocha';
 
+import { NoValue as Interactor } from '@folio/stripes-testing';
 import NoValue from '../NoValue';
+import translations from '../../../translations/stripes-components/en';
 
 import { mountWithContext } from '../../../tests/helpers';
-import NoValueInteractor from './interactor';
 
 describe('NoValue', () => {
-  const noValue = new NoValueInteractor();
+  const noValue = Interactor();
 
-  beforeEach(async () => {
-    await mountWithContext(<NoValue />);
-  });
-
-  // Dummy test: make sure the component is present. I mean, duh.
-  it('should display label', () => {
-    expect(noValue.isPresent).to.be.true;
-  });
-
-  describe('when aria-label is not passed from parent', () => {
+  describe('without aria-label', () => {
     beforeEach(async () => {
-      await mountWithContext(<NoValue />);
+      await mountWithContext(
+        <NoValue />
+      );
     });
 
-    // Check to make sure an aria-label attribute, which is what will be read
-    // by screenreaders in lieu of the text-value of the span.
-    it('should have a default screen reader text', () => {
-      expect(noValue.ariaLabel).to.equal('No value set');
+    it('should display default screen value', async () => {
+      await noValue.has({ emptyScreenValue: true });
+    });
+
+    it('should display default sr-only value', async () => {
+      await noValue.has({ ariaValue: translations['noValue.noValueSet'] });
     });
   });
 
-  describe('when aria-label was passed from parent', () => {
-    const ariaLabel = 'No custom value set';
-
+  describe('with empty aria-label', () => {
     beforeEach(async () => {
-      await mountWithContext(<NoValue ariaLabel={ariaLabel} />);
+      await mountWithContext(
+        <NoValue ariaLabel="" />
+      );
     });
 
-    // Check to make sure that aria-label attribute has value passed down
-    // from parent component
-    it('should have a custom screen reader', () => {
-      expect(noValue.ariaLabel).to.equal(ariaLabel);
+    it('should display default screen value', async () => {
+      await noValue.has({ emptyScreenValue: true });
+    });
+
+    it('should display default sr-only value', async () => {
+      await noValue.has({ ariaValue: translations['noValue.noValueSet'] });
+    });
+  });
+
+  describe('with non-empty aria-label', () => {
+    const s = 'this is not the value you\'re looking for';
+    beforeEach(async () => {
+      await mountWithContext(
+        <NoValue ariaLabel={s} />
+      );
+    });
+
+    it('should display default screen value', async () => {
+      await noValue.has({ emptyScreenValue: true });
+    });
+
+    it('should display custom sr-only value', async () => {
+      await noValue.has({ ariaValue: s });
     });
   });
 });


### PR DESCRIPTION
Leverage the `NoValue` interactor from `@folio/stripes-testing` to
consistently handle no-value elements.

Refs [STCOM-949](https://issues.folio.org/browse/STCOM-949), [STCOM-936](https://issues.folio.org/browse/STCOM-936)