### PR TITLE
STCOM-950 correct Arabic, Japanese CSS typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Correctly apply `aria-haspopup` and `aria-expanded` to IconButton. Refs STCOM 941.
 * Open Loans List: Elements must only use allowed ARIA attributes. Refs STCOM-948.
 * Appropriately apply labels within `<AutoSuggest>` component. Refs STCOM-939.
+* Correct Arabic and Japanese `font-family` typos. Refs STCOM-950.
 
 ## [10.1.0](https://github.com/folio-org/stripes-components/tree/v10.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.0.0...v10.1.0)

--- a/lib/global.css
+++ b/lib/global.css
@@ -33,11 +33,13 @@ html {
     "Segoe UI Emoji",
     "Segoe UI Symbol",
     "Adobe Arabic",
-    "Myriad     abic",
+    "Myriad Arabic",
     "ヒラギノ角ゴ Pro W3",
     "Hiragino Kaku Gothic Pro",
-    メイリオ    Meiryo,
+    メイリオ,
+    Meiryo,
     "ＭＳ Ｐゴシック",
+    "MS PGothic",
     sans-serif;
   color: var(--color-text);
   letter-spacing: 0.04em;
@@ -66,11 +68,13 @@ html {
       "Segoe UI Emoji",
       "Segoe UI Symbol",
       "Adobe Arabic",
-      "Myriad     abic",
+      "Myriad Arabic",
       "ヒラギノ角ゴ Pro W3",
       "Hiragino Kaku Gothic Pro",
-      メイリオ    Meiryo,
+      メイリオ,
+      Meiryo,
       "ＭＳ Ｐゴシック",
+      "MS PGothic",
       sans-serif;
   }
 }


### PR DESCRIPTION
Refactoring ages ago in #93 led to corruption of a few `font-family`
entries, now repaired.

Refs [STCOM-950](https://issues.folio.org/browse/STCOM-950)