### PR TITLE
STCOM-952 avoid setState in unmounted components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Provide `<NoValue>` interactor. Refs STCOM-949.
 * Export to CSV not handling diacritics. Fixes STCOM-951.
 * Correctly label focus-trap control in `<Timepicker>`. Refs STCOM-945.
+* Avoid `setState` calls in unmounted components. Refs STCOM-952.
 
 ## [10.1.0](https://github.com/folio-org/stripes-components/tree/v10.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.0.0...v10.1.0)

--- a/lib/Callout/Callout.js
+++ b/lib/Callout/Callout.js
@@ -20,10 +20,12 @@ class Callout extends React.Component {
   }
 
   componentDidMount() {
+    this._isMounted = true;
     this.updateCalloutContainer();
   }
 
   componentWillUnmount() {
+    this._isMounted = false;
     this.timeouts.forEach(t => {
       window.clearTimeout(t);
     });
@@ -39,14 +41,16 @@ class Callout extends React.Component {
       { type, message, timeout }
     );
 
-    this.setState((curState) => {
-      const newState = cloneDeep(curState);
-      newState.callouts.push(newCallout);
-      if (timeout !== 0) {
-        this.timeouts.push(window.setTimeout(() => { this.removeCallout(newCallout.id); }, timeout));
-      }
-      return newState;
-    });
+    if (this._isMounted) {
+      this.setState((curState) => {
+        const newState = cloneDeep(curState);
+        newState.callouts.push(newCallout);
+        if (timeout !== 0) {
+          this.timeouts.push(window.setTimeout(() => { this.removeCallout(newCallout.id); }, timeout));
+        }
+        return newState;
+      });
+    }
 
     return newCallout.id;
   }
@@ -54,11 +58,13 @@ class Callout extends React.Component {
   removeCallout(id) {
     const toHide = findIndex(this.state.callouts, c => c.id === id);
     if (toHide === -1) { return; }
-    this.setState((curState) => {
-      const newState = cloneDeep(curState);
-      newState.callouts.splice(toHide, 1);
-      return newState;
-    });
+    if (this._isMounted) {
+      this.setState((curState) => {
+        const newState = cloneDeep(curState);
+        newState.callouts.splice(toHide, 1);
+        return newState;
+      });
+    }
   }
 
   render() {

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -156,6 +156,11 @@ class Paneset extends React.Component {
   }
 
   resizeToContainer = () => {
+    // no sense doing all this math if the component has already unmounted
+    if (!this._isMounted) {
+      return;
+    }
+
     // pick the active layout cache entry - will contain matching id's and number of id's...
     const paneIds = [];
     this.state.panes.forEach((p) => paneIds.push(p.id));


### PR DESCRIPTION
React throws errors if `setState` is called after a component has
unmounted.

Refs [STCOM-952](https://issues.folio.org/browse/STCOM-952)