### PR TITLE
STCOM-835: Break long words in MCL headings based on zooming 200%

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -117,6 +117,7 @@
   flex-shrink: 0;
   flex-grow: 0;
   padding: var(--gutter-static-two-thirds) var(--gutter-static-two-thirds) var(--gutter-static-one-third) var(--gutter-static-two-thirds);
+  word-break: break-all;
   font-weight: var(--text-weight-bold);
   font-size: var(--font-size-medium);
   color: var(--color-text);


### PR DESCRIPTION
## Purpose

Fix MCL headings

## Refs
https://issues.folio.org/browse/STCOM-835

## Before
![image](https://user-images.githubusercontent.com/55138456/159115194-fc987a82-ce29-4da4-a7d1-a4b2d9376721.png)

## After
![image](https://user-images.githubusercontent.com/55138456/159115212-3d4b6868-bc9d-4a40-8b00-7b2315ffa2c1.png)
