### PR TITLE
STCOM-953 Issue with nested panesets cropping panes 

### DIFF
--- a/lib/Paneset/Paneset.css
+++ b/lib/Paneset/Paneset.css
@@ -8,6 +8,10 @@
   will-change: transform;
   overflow: hidden;
 
+  & .paneset {
+    overflow: visible;
+  }
+
   & .paneset,
   &.nested {
     position: relative;

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { pickBy, uniqueId, cloneDeep, debounce, isEqual } from 'lodash';
 import parseCSSUnit from '../../util/parseCSSUnit';
 import insertByClientRect from './insertByClientRect';
@@ -124,7 +125,7 @@ class Paneset extends React.Component {
     this._isMounted = true;
 
     this.resizeHandler = window.addEventListener('resize', debounce(this.handleWindowResize, 50));
-    this.previousContainerWidth = this.container.current.getBoundingClientRect().width;
+    this.previousContainerWidth = this.container.current?.getBoundingClientRect().width;
   }
 
   componentWillUnmount() {
@@ -245,10 +246,12 @@ class Paneset extends React.Component {
   }
 
   getClassName = () => {
-    const nested = this.props.nested ? css.nested : '';
-    const staticClass = this.props.static === true ? css.static : '';
-    const base = css.paneset;
-    return `${base} ${nested} ${staticClass}`;
+    const { nested, static: propsStatic } = this.props;
+    return classNames([
+      { [css.nested]: nested },
+      { [css.static]: propsStatic },
+      css.paneset
+    ]);
   }
 
   setStyle = (style) => {


### PR DESCRIPTION
Approach:
Refactor some ancient pre-classNames code in `<Paneset>`, have the nested Panesets display their overflow content. 

Before fix:
![NestedPaneProblem](https://user-images.githubusercontent.com/20704067/159355376-ca9ae158-861a-42fc-a2dd-1fae1b44391c.gif)

After fix:
![NestedPaneFix](https://user-images.githubusercontent.com/20704067/159355153-fd301c08-7ae2-4731-b551-45969b76b8e6.gif)

