### PR TITLE
STCOM-955: Advanced Search: Updating Advanced Search modal query does not return expected results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Correctly label focus-trap control in `<Timepicker>`. Refs STCOM-945.
 * Avoid `setState` calls in unmounted components. Refs STCOM-952.
 * Break long words in headings based on zooming 200%. Refs STCOM-835.
+* Improve splitting search query into rows in <AdvancedSearch>. Fixes STCOM-955.
 
 ## [10.1.0](https://github.com/folio-org/stripes-components/tree/v10.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.0.0...v10.1.0)

--- a/lib/AdvancedSearch/AdvancedSearch.js
+++ b/lib/AdvancedSearch/AdvancedSearch.js
@@ -43,6 +43,7 @@ const AdvancedSearch = ({
   children,
 }) => {
   const intl = useIntl();
+
   const {
     handleCancel,
     handleSearch,

--- a/lib/AdvancedSearch/tests/AdvancedSearch-test.js
+++ b/lib/AdvancedSearch/tests/AdvancedSearch-test.js
@@ -176,6 +176,29 @@ describe('AdvancedSearch', () => {
     });
   });
 
+  describe('when passing a query string to Advanced Search', () => {
+    beforeEach(async () => {
+      await renderComponent({
+        firstRowInitialSearch: {
+          query: 'keyword==San Martin or Buenos Aires or keyword==Chicago',
+          option: 'advancedSearch',
+        },
+      });
+    });
+
+    it('should split it into several rows correctly', async () => {
+      await advancedSearch.find(RowInteractor({ index: 0 })).perform(el => {
+        expect(el.querySelector('[data-test-advanced-search-query]').value).to.equal('San Martin or Buenos Aires');
+        expect(el.querySelector('[data-test-advanced-search-option]').value).to.equal('keyword');
+      });
+
+      await advancedSearch.find(RowInteractor({ index: 1 })).perform(el => {
+        expect(el.querySelector('[data-test-advanced-search-query]').value).to.equal('Chicago');
+        expect(el.querySelector('[data-test-advanced-search-option]').value).to.equal('keyword');
+      });
+    });
+  });
+
   describe('when clicking cancel', () => {
     beforeEach(async () => {
       await advancedSearch.cancel();

--- a/lib/AdvancedSearch/utilities/splitQueryRows.js
+++ b/lib/AdvancedSearch/utilities/splitQueryRows.js
@@ -7,7 +7,13 @@ import {
 const splitRow = (row) => {
   const queryString = row[FIELD_NAMES.QUERY];
 
-  const splitIntoRowsRegex = /((?:or|and|not)\s+)?([\w]+==[^\s]+)/g;
+  // let's split this regex into smaller parts:
+  // - ((?:or|and|not)\s+)? - this will match boolean operator at the beginning of a row.
+  // - ([\w]+==.+?(?=(or|not|and)\s[\w]+==[^\s]+) - will match a structure like "keyword==Something something"
+  // it will match any character until it finds a string: "or", "and" or "not" with a new search option.
+  // - [\w]+==.+ - this will also match a structure like "keyword==Something something".
+  // this part of regex is OR'd with previous because you can't use lookahead conditionally
+  const splitIntoRowsRegex = /((?:or|and|not)\s+)?([\w]+==.+?(?=(or|not|and)\s[\w]+==[^\s]+)|[\w]+==.+)/g;
 
   const matches = [...queryString.matchAll(splitIntoRowsRegex)];
 


### PR DESCRIPTION
## Description
Fix splitting query string that is passed into `<AdvancedSearch>`.

## Approach
There's a pretty complex RegEx that is used to splita string into rows: `((?:or|and|not)\s+)?([\w]+==.+?(?=(or|not|and)\s[\w]+==[^\s]+)|[\w]+==.+)`
Here's what is does:
- ((?:or|and|not)\s+)? - this will match boolean operator at the beginning of a row. this needs to be at the beginning because a boolean that is related to a row is placed before the `searchOption==query` bit
- ([\w]+==.+?(?=(or|not|and)\s[\w]+==[^\s]+) - this will match a structure like `keyword==Something something`
it will match any character until it finds a string: `or`, `and` or `not` with a next search option.
- [\w]+==.+ - this will also match a structure like `keyword==Something something`.
this part of regex is OR'd with previous because you can't use lookahead conditionally

## Screenshots
Uploading MARC Authority - FOLIO (4).mp4…


## Issues
[STCOM-955](https://issues.folio.org/browse/STCOM-955)