### PR TITLE
STCOM-956 Lock off postcss-custom-properties to 12.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@
 * Avoid `setState` calls in unmounted components. Refs STCOM-952.
 * Break long words in headings based on zooming 200%. Refs STCOM-835.
 * Improve splitting search query into rows in <AdvancedSearch>. Fixes STCOM-955.
-* Fix cropping of nested panesets. Fixes STCOM-953
+* Fix cropping of nested panesets. Fixes STCOM-953.
+* Lock-off `postcss-custom-properties` to 12.1.4. Fixes STCOM-956.
 
 ## [10.1.0](https://github.com/folio-org/stripes-components/tree/v10.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.0.0...v10.1.0)

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "postcss-calc": "^8.0.0",
     "postcss-color-function": "folio-org/postcss-color-function",
     "postcss-custom-media": "^8.0.0",
-    "postcss-custom-properties": "^12.0.0",
+    "postcss-custom-properties": "12.1.4",
     "postcss-import": "^14.0.2",
     "postcss-loader": "^6.2.0",
     "postcss-media-minmax": "^5.0.0",


### PR DESCRIPTION
This dependency caused a great deal of noise in any test run/build. Will investigate upgrades beyond the 12.1.4 in the future (STCOM-957).

Refs [STCOM-956](https://issues.folio.org/browse/STCOM-956)