### PR TITLE
Downgrade webpack to 5.68.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "stylelint": "^9.5.0",
     "stylelint-config-standard": "^18.2.0",
     "stylelint-junit-formatter": "^0.2.1",
-    "webpack": "^5.58.1"
+    "webpack": "~5.68.0
   },
   "dependencies": {
     "@folio/stripes-react-hotkeys": "^3.0.5",


### PR DESCRIPTION
Downgrade due to 5.69, 5.70 causing heavy logs and failing to find karma-webpack.