### PR TITLE
STCOM-954 reimplement childrenOf without react-hot-loader

### DIFF
--- a/util/childrenOf.js
+++ b/util/childrenOf.js
@@ -7,8 +7,6 @@
 * string or a `<FormattedMessage>` and the range allowed by `PropTypes.node`
 * is too wide.
 */
-import { areComponentsEqual } from 'react-hot-loader';
-
 function getDisplayName(WrappedComponent) {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component';
 }
@@ -39,7 +37,7 @@ export default function childrenOf(...types) {
   return requirable((props, propName, componentName, location = 'prop', propFullName = propName) => {
     const component = props[propName];
 
-    const check = c => types.some(type => areComponentsEqual(type, c.type));
+    const check = c => types.some(type => type === c.type);
     const valid = Array.isArray(component) ? component.every(check) : check(component);
     if (!valid) {
       return new Error(


### PR DESCRIPTION
`react-hot-loader` was removed in #1758 so we need to implement
`childrenOf` without relying on its exports. There are different [dev](https://github.com/gaearon/react-hot-loader/blob/ed8b31080e766ae07c0dd2dc27b639df45cbc0c9/src/utils.dev.js)
and [prod](https://github.com/gaearon/react-hot-loader/blob/ed8b31080e766ae07c0dd2dc27b639df45cbc0c9/src/utils.prod.js) implementations, but since the prod version is, um, pretty simple, we're
just gonna implement that locally.

Refs [STCOM-954](https://issues.folio.org/browse/STCOM-954)