### PR TITLE
STCOM-963 maintain autoprefixer/postcss compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Lock-off `postcss-custom-properties` to 12.1.4. Fixes STCOM-956.
 * eHoldings app: Package Detail Record> Usage & analysis accordion > Apply pagination to Titles list. Refs STCOM-966.
 * Fix Accessibility problems for "MultiSelection" component. STCOM-967.
+* Update `autoprefixer` to maintain compat with `postcss`. Refs STCOM-963.
 
 ## [10.1.0](https://github.com/folio-org/stripes-components/tree/v10.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.0.0...v10.1.0)

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@storybook/manager-webpack5": "^6.3.12",
     "@storybook/react": "^6.3.6",
     "@svgr/webpack": "^5.5.0",
-    "autoprefixer": "^9.0.0",
+    "autoprefixer": "^10.4.4",
     "babel-loader": "^8.0.0",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-remove-jsx-attributes": "^0.0.2",


### PR DESCRIPTION
When we upgraded postcss in #1680, we missed an update to autoprefixer
that should have been made to maintain compatibility. Whoops.

This should be merged in concert with folio-org/stripes-webpack/pull/57 ([STRWEB-46](https://issues.folio.org/browse/STRWEB-46)).

Refs [STCOM-963](https://issues.folio.org/browse/STCOM-963), [STCOM-892](https://issues.folio.org/browse/STCOM-892)

