### PR TITLE
STCOM-974: Add <Select> option background-color for FF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Add Cancel icon. Refs STCOM-976.
 * Export `<Calendar>` component as standalone. Refs STCOM-850
 * Export all exports from `<FilterGroups>`. Refs STCOM-980.
+* Add background-color to <Select> options for FF UA styles. Fixes STCOM-974.
 
 ## [10.1.0](https://github.com/folio-org/stripes-components/tree/v10.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.0.0...v10.1.0)

--- a/lib/Select/Select.css
+++ b/lib/Select/Select.css
@@ -25,7 +25,7 @@
   }
 
   & option {
-    background-color: white;
+    background-color: var(--bg);
   }
 }
 

--- a/lib/Select/Select.css
+++ b/lib/Select/Select.css
@@ -23,6 +23,10 @@
       color: #444;
     }
   }
+
+  & option {
+    background-color: white;
+  }
 }
 
 [dir="rtl"] .selectControl {


### PR DESCRIPTION
# [Jira](https://issues.folio.org/browse/STCOM-974)

Currently, in Firefox, `<Select>` dropdowns are styled with `color: black;`.  However, Firefox's default UA stylesheet uses a dark background and light text color, therefore, when `color: black` is added, the dropdown is nearly unreadable:
![image](https://user-images.githubusercontent.com/8005215/164957699-05d36154-74d6-4ce6-8e9a-d7b61a7e175f.png)

This behavior is only present in Windows versions of Firefox -- on macOS, iOS, etc., a system dropdown is used, overriding any custom styling.  On Windows, Chrome and Edge similarly fully override dropdown colors.

This PR adds an explicit rule stating that `<option>` background colors should be white, which aligns with the way Chrome, etc. display dropdowns themselves, providing a more consistent experience and fixing this bug.

Here it is with the fix:
![image](https://user-images.githubusercontent.com/8005215/164957753-7e5073bc-150c-42e9-9e8e-e6cb34cb5fc1.png)

_(The solid-grey option is controlled by Firefox, and reflects whichever option currently has hover.  Other browsers have similar systems (usually in blue), so this default behavior is fine.)_

I've tested this across Edge, Chrome, and Firefox on Windows; Chrome, Safari, and Firefox and macOS; as well as in Safari on an iPad, and all select boxes render as expected.  I'm aware that Firefox is not officially supported by FOLIO, however, adding this in has no negative drawbacks (and may be beneficial in the future if any other browsers add additional styling support to select options, like Firefox did).