### PR TITLE
STCOM-983 Selectively resize percentage-width panesets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,11 @@
 * Add Cancel icon. Refs STCOM-976.
 * Export `<Calendar>` component as standalone. Refs STCOM-850
 * Export all exports from `<FilterGroups>`. Refs STCOM-980.
-* Add background-color to <Select> options for FF UA styles. Fixes STCOM-974.
+* Add background-color to `<Select>` options for FF UA styles. Fixes STCOM-974.
 * Set Monday as first day of the week for `es-419`. Refs STCOM-985.
 * The schedule time does not accept PM value. Fixes STCOM-986.
-
+* Handle panesets containing only percentage-based panes differently. Fixes STCOM-983
+  
 ## [10.1.0](https://github.com/folio-org/stripes-components/tree/v10.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.0.0...v10.1.0)
 

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -291,14 +291,6 @@ class Paneset extends React.Component {
     });
   }
 
-  // transitions
-  // set up initial state for transitions...(register)
-  // measurements still in state where new pane isn't there...
-  // apply 'in' state for transitions...
-  // measurements with added pane
-  // Closing...
-  // apply 'out' state with callback to remove pane...
-
   registerPane = (paneObject) => {
     this.setState((oldState) => {
       let newState = Object.assign({}, oldState);
@@ -330,6 +322,8 @@ class Paneset extends React.Component {
     const { layoutCache } = this.state;
     const { paneset } = this.props;
     const layoutObject = layoutCache[layoutIndex];
+    const layoutUnitTypes = {};
+    let newCacheObject = {};
     if (!paneset) {
       // sum the pixels...
       let totalWidth = 0;
@@ -349,10 +343,33 @@ class Paneset extends React.Component {
         }
       }
 
+      // if all panes are non-pixel, resize the last pane
+      // if the percentages don't add up to 100% for panesets of 3 or more panes
+      if (Object.values(layoutUnitTypes).every((v) => (v === 'percent') || (v === 'vw'))) {
+        const widths = Object.keys(layoutObject).length;
+        if (widths.length > 2) {
+          let totalPercentWidth = 0;
+          const newWidth = {};
+          widths.forEach((w, i) => {
+            value = parseInt(layoutObject[widths[w]], 10);
+            if (i === widths.length - 1) {
+              newWidth[w] = `${100 - totalPercentWidth}%`;
+            } else {
+              totalPercentWidth += value;
+            }
+          });
+          newCacheObject = { ...newCacheObject, [newWidth.id]: newWidth.defaultWidth };
+
+          this.previousContainerWidth = window.innerWidth;
+
+          return { ...layoutCache, ...newCacheObject };
+        }
+        return null;
+      }
+
       // if the window size has not changed, the cached pane widths may still need to be validated...
       if (Math.abs(this.previousContainerWidth - window.innerWidth) < 1) {
         if (Math.abs(this.previousContainerWidth - totalWidth) > 1) {
-          let newCacheObject = {};
           const proportion = this.previousContainerWidth / totalWidth;
           for (const p in layoutObject) {
             if (layoutObject[p]) {

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -331,6 +331,7 @@ class Paneset extends React.Component {
       for (const p in layoutObject) {
         if (layoutObject[p]) {
           const unit = parseCSSUnit(layoutObject[p]);
+          layoutUnitTypes[p] = unit;
           if (unit === 'px') {
             value = Math.ceil(parseInt(layoutObject[p], 10));
             totalWidth += value;
@@ -346,14 +347,15 @@ class Paneset extends React.Component {
       // if all panes are non-pixel, resize the last pane
       // if the percentages don't add up to 100% for panesets of 3 or more panes
       if (Object.values(layoutUnitTypes).every((v) => (v === 'percent') || (v === 'vw'))) {
-        const widths = Object.keys(layoutObject).length;
+        const widths = Object.keys(layoutObject);
         if (widths.length > 2) {
           let totalPercentWidth = 0;
           const newWidth = {};
           widths.forEach((w, i) => {
-            value = parseInt(layoutObject[widths[w]], 10);
+            value = parseInt(layoutObject[w], 10);
             if (i === widths.length - 1) {
-              newWidth[w] = `${100 - totalPercentWidth}%`;
+              newWidth.id = w;
+              newWidth.defaultWidth = `${100 - totalPercentWidth}%`;
             } else {
               totalPercentWidth += value;
             }

--- a/lib/Paneset/tests/Paneset-test.js
+++ b/lib/Paneset/tests/Paneset-test.js
@@ -225,8 +225,55 @@ describe('Paneset', () => {
       );
     });
 
-    it.only('sizes remain at their set percentages - filter pane 20%', async () => {
+    it('sizes remain at their set percentages - filter pane 20%', async () => {
       await PaneStyleInteractor('Filter pane').has({ style: including('20%') });
+    });
+  });
+
+  describe('paneset does not affect percentage-based panes on resize', () => {
+    const filterPane = paneInteractor('Filter pane');
+
+    beforeEach(async () => {
+      const layouts = [
+        {
+          'filter-pane': '20%',
+          'results-pane': '80%',
+        },
+        {
+          'filter-pane': '20%',
+          'results-pane': '30%',
+          'detail-pane': '40%',
+        }
+      ];
+      await mountWithContext(
+        <Paneset initialLayout={layouts}>
+          <Pane
+            paneTitle="Filter pane"
+            defaultWidth="20%"
+            id="filter-pane" 
+          >
+            <p>Filter Pane content.</p>
+          </Pane>
+          <Pane
+            paneTitle="Results pane"
+            defaultWidth="30%"
+            id="results-pane" 
+          >
+            <p>Results Pane content.</p>
+          </Pane>
+          <Pane
+            paneTitle="Detail pane"
+            defaultWidth="40%"
+            id="detail-pane" 
+          >
+            <p>Results Pane content.</p>
+          </Pane>
+        </Paneset>
+      );
+    });
+
+    it('sizes remain at their set percentages - filter pane 20%', async () => {
+      await PaneStyleInteractor('Detail pane').has({ style: including('50%') });
     });
   });
 });

--- a/lib/Paneset/tests/Paneset-test.js
+++ b/lib/Paneset/tests/Paneset-test.js
@@ -272,7 +272,7 @@ describe('Paneset', () => {
       );
     });
 
-    it('sizes remain at their set percentages - filter pane 20%', async () => {
+    it('sizes remain at their set percentages - detail pane 50%', async () => {
       await PaneStyleInteractor('Detail pane').has({ style: including('50%') });
     });
   });

--- a/lib/Paneset/tests/Paneset-test.js
+++ b/lib/Paneset/tests/Paneset-test.js
@@ -21,7 +21,7 @@ const PaneStyleInteractor = HTML.extend('Pane')
     widthStyle: (el) => el.style.flex
   });
 
-describe.only('Paneset', () => {
+describe('Paneset', () => {
   const paneset = new PanesetInteractor();
   const childPaneset = new PanesetInteractor('#childPaneset');
   const harness = new HarnessInteractor();

--- a/lib/Paneset/tests/Paneset-test.js
+++ b/lib/Paneset/tests/Paneset-test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { describe, beforeEach, it, context } from 'mocha';
 import { expect } from 'chai';
-
+import { HTML, including } from '@folio/stripes-testing';
 import { mountWithContext } from '../../../tests/helpers';
 
 import Paneset from '../Paneset';
@@ -10,19 +10,18 @@ import PanesetHarness from './PanesetHarness';
 import PanesetInteractor from './interactor';
 import HarnessInteractor from './harnessInteractor';
 import parseCSSUnit from '../../../util/parseCSSUnit';
-import { Pane as PaneInteractor } from '@folio/stripes-testing';
-import { HTML, including } from '@folio/stripes-testing';
+
 
 function title(el) { return el.querySelector('[class^=paneTitle]').textContent; }
 
 const PaneStyleInteractor = HTML.extend('Pane')
-  .selector('section')
+  .selector('section[class^=pane]')
   .locator(title)
-  .filter({
-    style: (el) => el.style
+  .filters({
+    widthStyle: (el) => el.style.flex
   });
 
-describe('Paneset', () => {
+describe.only('Paneset', () => {
   const paneset = new PanesetInteractor();
   const childPaneset = new PanesetInteractor('#childPaneset');
   const harness = new HarnessInteractor();
@@ -196,8 +195,6 @@ describe('Paneset', () => {
   });
 
   describe('paneset does not affect percentage-based panes on resize', () => {
-    const filterPane = paneInteractor('Filter pane');
-
     beforeEach(async () => {
       const layouts = [
         {
@@ -210,14 +207,14 @@ describe('Paneset', () => {
           <Pane
             paneTitle="Filter pane"
             defaultWidth="20%"
-            id="filter-pane" 
+            id="filter-pane"
           >
             <p>Filter Pane content.</p>
           </Pane>
           <Pane
             paneTitle="Results pane"
             defaultWidth="80%"
-            id="results-pane" 
+            id="results-pane"
           >
             <p>Results Pane content.</p>
           </Pane>
@@ -226,13 +223,11 @@ describe('Paneset', () => {
     });
 
     it('sizes remain at their set percentages - filter pane 20%', async () => {
-      await PaneStyleInteractor('Filter pane').has({ style: including('20%') });
+      await PaneStyleInteractor('Filter pane').has({ widthStyle: including('20%') });
     });
   });
 
   describe('paneset does not affect percentage-based panes on resize', () => {
-    const filterPane = paneInteractor('Filter pane');
-
     beforeEach(async () => {
       const layouts = [
         {
@@ -250,21 +245,21 @@ describe('Paneset', () => {
           <Pane
             paneTitle="Filter pane"
             defaultWidth="20%"
-            id="filter-pane" 
+            id="filter-pane"
           >
             <p>Filter Pane content.</p>
           </Pane>
           <Pane
             paneTitle="Results pane"
             defaultWidth="30%"
-            id="results-pane" 
+            id="results-pane"
           >
             <p>Results Pane content.</p>
           </Pane>
           <Pane
             paneTitle="Detail pane"
             defaultWidth="40%"
-            id="detail-pane" 
+            id="detail-pane"
           >
             <p>Results Pane content.</p>
           </Pane>
@@ -273,7 +268,7 @@ describe('Paneset', () => {
     });
 
     it('sizes remain at their set percentages - detail pane 50%', async () => {
-      await PaneStyleInteractor('Detail pane').has({ style: including('50%') });
+      await PaneStyleInteractor('Detail pane').has({ widthStyle: including('50%') });
     });
   });
 });

--- a/lib/Paneset/tests/Paneset-test.js
+++ b/lib/Paneset/tests/Paneset-test.js
@@ -10,6 +10,17 @@ import PanesetHarness from './PanesetHarness';
 import PanesetInteractor from './interactor';
 import HarnessInteractor from './harnessInteractor';
 import parseCSSUnit from '../../../util/parseCSSUnit';
+import { Pane as PaneInteractor } from '@folio/stripes-testing';
+import { HTML, including } from '@folio/stripes-testing';
+
+function title(el) { return el.querySelector('[class^=paneTitle]').textContent; }
+
+const PaneStyleInteractor = HTML.extend('Pane')
+  .selector('section')
+  .locator(title)
+  .filter({
+    style: (el) => el.style
+  });
 
 describe('Paneset', () => {
   const paneset = new PanesetInteractor();
@@ -181,6 +192,41 @@ describe('Paneset', () => {
           expect(harness.paneset.childPanesets(0).$root.style).to.not.be.null;
         });
       });
+    });
+  });
+
+  describe('paneset does not affect percentage-based panes on resize', () => {
+    const filterPane = paneInteractor('Filter pane');
+
+    beforeEach(async () => {
+      const layouts = [
+        {
+          'filter-pane': '20%',
+          'results-pane': '80%',
+        },
+      ];
+      await mountWithContext(
+        <Paneset initialLayout={layouts}>
+          <Pane
+            paneTitle="Filter pane"
+            defaultWidth="20%"
+            id="filter-pane" 
+          >
+            <p>Filter Pane content.</p>
+          </Pane>
+          <Pane
+            paneTitle="Results pane"
+            defaultWidth="80%"
+            id="results-pane" 
+          >
+            <p>Results Pane content.</p>
+          </Pane>
+        </Paneset>
+      );
+    });
+
+    it.only('sizes remain at their set percentages - filter pane 20%', async () => {
+      await PaneStyleInteractor('Filter pane').has({ style: including('20%') });
     });
   });
 });


### PR DESCRIPTION
Currently, the percentage-based panes are always resized to full screen width. This can be strange in cases where there are only 2 panes (like settings) that are not full width. 

The logic in this PR modifies this so that 
- panesets where ALL of the panes are percentage -based are only resized by adjusting the last pane (percentages, for the most part can be left alone, but this takes care of some oddness when the window is resized)
- only panesets with 3 or more panes are held to this percentage resizing.