### PR TITLE
STCOM-982 Switch to percentage-based pane resizing.

### DIFF
--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -291,14 +291,6 @@ class Paneset extends React.Component {
     });
   }
 
-  // transitions
-  // set up initial state for transitions...(register)
-  // measurements still in state where new pane isn't there...
-  // apply 'in' state for transitions...
-  // measurements with added pane
-  // Closing...
-  // apply 'out' state with callback to remove pane...
-
   registerPane = (paneObject) => {
     this.setState((oldState) => {
       let newState = Object.assign({}, oldState);
@@ -330,6 +322,8 @@ class Paneset extends React.Component {
     const { layoutCache } = this.state;
     const { paneset } = this.props;
     const layoutObject = layoutCache[layoutIndex];
+    const layoutUnitTypes = {};
+    let newCacheObject = {};
     if (!paneset) {
       // sum the pixels...
       let totalWidth = 0;
@@ -349,10 +343,33 @@ class Paneset extends React.Component {
         }
       }
 
+      // if all panes are non-pixel, resize the last pane
+      // if the percentages don't add up to 100% for panesets of 3 or more panes
+      if (Object.values(layoutUnitTypes).every((v) => (v === 'percent') || (v === 'vw'))) {
+        const widths = Object.keys(layoutObject).length;
+        if (widths.length > 2) {
+          let totalPercentWidth = 0;
+          const newWidth = {};
+          widths.forEach((w, i) => {
+            value = parseInt(layoutObject[widths[w]], 10);
+            if (i === widths.length - 1) {
+              newWidth[w] = `${100 - totalPercentWidth}%`;
+            } else {
+              totalPercentWidth += value;
+            }
+          });
+          newCacheObject = { ...newCacheObject, [newWidth.id]: newWidth.defaultWidth };
+
+          this.previousContainerWidth = window.innerWidth;
+
+          return { ...layoutCache, ...newCacheObject };
+        }
+        return null;
+      }
+
       // if the window size has not changed, the cached pane widths may still need to be validated...
       if (Math.abs(this.previousContainerWidth - window.innerWidth) < 1) {
         if (Math.abs(this.previousContainerWidth - totalWidth) > 1) {
-          let newCacheObject = {};
           const proportion = this.previousContainerWidth / totalWidth;
           for (const p in layoutObject) {
             if (layoutObject[p]) {

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -351,8 +351,9 @@ class Paneset extends React.Component {
         }
       }
 
-      // if all panes are non-pixel, resize the last pane
-      // if the percentages don't add up to exactly 100% for panesets of 3 or more panes
+      // if all panes are non-pixel, resize the last pane in case
+      // the percentages don't add up to 100% for panesets of 3 or more panes.
+      // If a set is 2 or fewer and all percentage-width, we just leave them be.
       if (Object.values(layoutUnitTypes).every((v) => (v === 'percent') || (v === 'vw'))) {
         const widths = Object.keys(layoutObject).length;
         if (widths.length > 2) {

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -15,35 +15,31 @@ const defaultProps = {
   initialLayouts: [],
 };
 
-function getNewPanewidthObject(key, CSSvalue, proportionalChange) {
-  const unit = parseCSSUnit(CSSvalue);
-  let newWidth = CSSvalue;
-  switch (unit) {
+// performs a percentage-based resize of width.
+// This is used when either the window is resized or when 
+// a cached set of widths is loaded in order to match the potentially changed window size.
+
+function resizePaneWidthObject(key, value, CSSunit, previousContainerWidth, newContainerWidth) {
+  let newWidth;
+  switch (CSSunit) {
     case 'percent':
-      newWidth = parseFloat(CSSvalue, 10) * proportionalChange;
-      newWidth = `${newWidth}%`;
+    case 'vw':
+      newWidth = value;
       break;
-    case 'vw': break;
     case 'px':
-      newWidth = Math.ceil(parseInt(CSSvalue, 10) * proportionalChange);
-      newWidth = `${newWidth}px`;
+      newWidth = Math.ceil((value / previousContainerWidth) * newContainerWidth);
       break;
     case 'em':
-      newWidth = Math.ceil(parseInt(CSSvalue, 10) * 14 * proportionalChange);
-      newWidth = `${newWidth / 14}em`;
-      break;
     case 'rem':
-      newWidth = Math.ceil(parseInt(CSSvalue, 10) * 14 * proportionalChange);
-      newWidth = `${newWidth / 14}rem`;
+      newWidth = Math.ceil(((value * 14) / previousContainerWidth) * newContainerWidth);
       break;
     default: break;
   }
   return {
     id: key,
-    defaultWidth: newWidth,
+    defaultWidth: `${newWidth}${CSSunit}`,
   };
 }
-
 
 class Paneset extends React.Component {
   static propTypes = {
@@ -187,10 +183,14 @@ class Paneset extends React.Component {
 
         // check actual width against width of containing element... this prevents continued proportional resizes.
         if (Math.floor(totalWidth) !== currentWidth) {
-          const proportionalChange = currentWidth / totalWidth;
+          // const proportionalChange = currentWidth / totalWidth;
           for (const p in matchingLCache) {
             if (Object.prototype.hasOwnProperty.call(matchingLCache, p)) {
-              const newPO = getNewPanewidthObject(p, matchingLCache[p], proportionalChange);
+              const cssValue = matchingLCache[p];
+              const cssUnit = parseCSSUnit(cssValue);
+              const value = parseInt(cssValue, 10);
+              const newPO = resizePaneWidthObject(p, value, cssUnit, this.previousContainerWidth, currentWidth);
+              // const newPO = getNewPanewidthObject(p, matchingLCache[p], proportionalChange);
               tempPanesList.push(newPO);
             }
           }
@@ -291,6 +291,12 @@ class Paneset extends React.Component {
     });
   }
 
+  // Logic flow for adding a new pane
+  // 1. new pane registered
+  // 2. pane added to pane array (panes sorted left-to-right)
+  // 3. sizes calculated and panes resized accordingly.
+
+  // called by contextual <Pane> children.
   registerPane = (paneObject) => {
     this.setState((oldState) => {
       let newState = Object.assign({}, oldState);
@@ -316,6 +322,7 @@ class Paneset extends React.Component {
     });
   }
 
+
   // sometimes the cached sizes might not match up to the actual container due to different sized window.
   // If that's true, scale the cached sizes accordingly.
   resizeCachedSizesToFit = (layoutIndex) => {
@@ -331,6 +338,7 @@ class Paneset extends React.Component {
       for (const p in layoutObject) {
         if (layoutObject[p]) {
           const unit = parseCSSUnit(layoutObject[p]);
+          layoutUnitTypes[p] = unit;
           if (unit === 'px') {
             value = Math.ceil(parseInt(layoutObject[p], 10));
             totalWidth += value;
@@ -344,7 +352,7 @@ class Paneset extends React.Component {
       }
 
       // if all panes are non-pixel, resize the last pane
-      // if the percentages don't add up to 100% for panesets of 3 or more panes
+      // if the percentages don't add up to exactly 100% for panesets of 3 or more panes
       if (Object.values(layoutUnitTypes).every((v) => (v === 'percent') || (v === 'vw'))) {
         const widths = Object.keys(layoutObject).length;
         if (widths.length > 2) {
@@ -370,15 +378,25 @@ class Paneset extends React.Component {
       // if the window size has not changed, the cached pane widths may still need to be validated...
       if (Math.abs(this.previousContainerWidth - window.innerWidth) < 1) {
         if (Math.abs(this.previousContainerWidth - totalWidth) > 1) {
-          const proportion = this.previousContainerWidth / totalWidth;
+          // const proportion = this.previousContainerWidth / totalWidth;
           for (const p in layoutObject) {
-            if (layoutObject[p]) {
-              const newWidth = getNewPanewidthObject(p, layoutObject[p], proportion);
+            if (layoutObject[p] && layoutUnitTypes[p] === 'px') {
+              // convert width to percentage for better resize.
+              value = parseInt(layoutObject[p], 10);
+              const newWidth = resizePaneWidthObject(
+                p,
+                value,
+                layoutUnitTypes[p],
+                totalWidth,
+                this.previousContainerWidth
+              );
+              // const newWidth = getNewPanewidthObject(p, layoutObject[p], proportion);
               newCacheObject = { ...newCacheObject, [newWidth.id]: newWidth.defaultWidth };
             }
           }
           this.previousContainerWidth = window.innerWidth;
-          return newCacheObject;
+
+          return { ...layoutCache, ...newCacheObject };
         } else {
           return layoutCache[layoutIndex];
         }
@@ -388,6 +406,11 @@ class Paneset extends React.Component {
     }
     return null;
   }
+
+  // called when a new pane is registered or removed
+  // if app has an onLayout callback, the return value of this callback is applied as
+  // the pane widths.
+  // if the pane sizes are cached, the cache is resized to fit the window's width.
 
   calcWidthsAndResize = (changeType) => {
     this.widthsRAF = requestAnimationFrame(() => {
@@ -402,7 +425,7 @@ class Paneset extends React.Component {
         layoutCache: this.state.layoutCache,
         widths: sizesCached !== -1 ? null : this.state.layoutCache[sizesCached],
       });
-      if (toApply && sizesCached === -1) {
+      if (toApply != null && sizesCached === -1) {
         widths = toApply;
       } else if (sizesCached !== -1) {
         widths = this.resizeCachedSizesToFit(sizesCached) || this.state.layoutCache[sizesCached];
@@ -473,7 +496,8 @@ class Paneset extends React.Component {
     const containerWidth = container.offsetWidth;
 
     panes.forEach((pane) => {
-      if (pane.staticWidth) {
+      // if window hasn't been resized, we can use the static cached static width of the pane
+      if (pane.staticWidth && (containerWidth === this.previousContainerWidth)) {
         staticSpace += pane.staticWidth;
       } else {
         const currentPaneWidth = parseInt(pane.defaultWidth, 10);
@@ -560,6 +584,10 @@ class Paneset extends React.Component {
   }
 
   // Accepts the positions of handles, the client rect of the container.
+  // Panes resized here are resized left to right to match the passed positions.
+  // It adjusts the pane sized to match the distance between the positions of the resize
+  // handles.
+
   handlePaneResize = ({ positions, containerRect, ...rest }) => {
     const { panes } = this.state;
     const newWidths = {};


### PR DESCRIPTION
Currently, panes are resized proportionally via a multiplier value applied to all of the pane widths. The numbers don't work out well when percentage-widths are multiplied.
The new logic just passes percentage values through.