### PR TITLE
STCOM-985 correctly set first-day-of-week for es-419

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Export `<Calendar>` component as standalone. Refs STCOM-850
 * Export all exports from `<FilterGroups>`. Refs STCOM-980.
 * Add background-color to <Select> options for FF UA styles. Fixes STCOM-974.
+* Set Monday as first day of the week for `es-419`. Refs STCOM-985.
 
 ## [10.1.0](https://github.com/folio-org/stripes-components/tree/v10.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.0.0...v10.1.0)

--- a/lib/Datepicker/staticFirstWeekDay.js
+++ b/lib/Datepicker/staticFirstWeekDay.js
@@ -65,6 +65,7 @@ export default {
   ],
   mon: [
     '001',
+    '419',
     'AD',
     'AI',
     'AL',


### PR DESCRIPTION
The `es-419` locale expects the first day of the week to be Monday. Make
it so.

Refs [STCOM-985](https://issues.folio.org/browse/STCOM-985)