### PR TITLE
Add storybook links

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 
 This is a library of React components and utility functions for use with [the Stripes UI toolkit](https://github.com/folio-org/stripes-core/), part of [the FOLIO project](https://www.folio.org/).
 
+## Storybook
+
+A listing of our components with demonstrations and example usage can be found here:
+https://folio-org.github.io/stripes-components
+
 ## Component categories
 
 These are general descriptive categories that indicate the type of use cases that components serve. A component can have multiple categories associated with it.

--- a/lib/Icon/readme.md
+++ b/lib/Icon/readme.md
@@ -1,6 +1,8 @@
 # Icon
 Component for rendering a variety of FOLIO icons.
 
+To see icons you can use, check out our [available icons list](https://folio-org.github.io/stripes-components/?path=/story/icon--available-icons)
+
 ## Basic Usage
 ```js
 import { Icon } from '@folio/stripes/components';


### PR DESCRIPTION
Adds a link to the storybook icon list to Icon component documentation as well as a link to storybook in our top-level readme.