### PR TITLE
STCOM-987 Check for window resize in calcWidths

### DIFF
--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -516,7 +516,7 @@ class Paneset extends React.Component {
     const containerWidth = container.offsetWidth;
 
     panes.forEach((pane) => {
-      if (pane.staticWidth) {
+      if (pane.staticWidth && this.previousContainerWidth === containerWidth) {
         staticSpace += pane.staticWidth;
       } else {
         const currentPaneWidth = parseInt(pane.defaultWidth, 10);


### PR DESCRIPTION
See https://issues.folio.org/browse/STCOM-987

Currently, after their 'calcWidths' process, panes will store their width for re-use in future recalculations. 

If the window has been resized, then this static width no longer applies and the pane should be re-measured.

