### PR TITLE
Pane percent bugfix

### DIFF
--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -405,7 +405,7 @@ class Paneset extends React.Component {
 
           this.previousContainerWidth = window.innerWidth;
 
-          return { ...layoutCache, ...newCacheObject };
+          return { ...layoutObject, ...newCacheObject };
         }
         return null;
       }

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -417,11 +417,11 @@ class Paneset extends React.Component {
           for (const p in layoutObject) {
             if (layoutObject[p] && isUnitPixelBased(layoutUnitTypes[p])) {
               const newWidth = getNewPanewidthObject(p, layoutObject[p], proportion);
-              newCacheObject = { ...layoutObject, [newWidth.id]: newWidth.defaultWidth };
+              newCacheObject = { ...newCacheObject, [newWidth.id]: newWidth.defaultWidth };
             }
           }
           this.previousContainerWidth = window.innerWidth;
-          return newCacheObject;
+          return {...layoutObject, ...newCacheObject };
         } else {
           return layoutCache[layoutIndex];
         }

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -516,7 +516,7 @@ class Paneset extends React.Component {
     const containerWidth = container.offsetWidth;
 
     panes.forEach((pane) => {
-      if (pane.staticWidth) {
+      if (pane.staticWidth && this.previousContainerWidth === containerWidth) {
         staticSpace += pane.staticWidth;
       } else {
         const currentPaneWidth = parseInt(pane.defaultWidth, 10);

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -417,7 +417,7 @@ class Paneset extends React.Component {
           for (const p in layoutObject) {
             if (layoutObject[p] && isUnitPixelBased(layoutUnitTypes[p])) {
               const newWidth = getNewPanewidthObject(p, layoutObject[p], proportion);
-              newCacheObject = { ...newCacheObject, [newWidth.id]: newWidth.defaultWidth };
+              newCacheObject = { ...layoutObject, [newWidth.id]: newWidth.defaultWidth };
             }
           }
           this.previousContainerWidth = window.innerWidth;

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -421,7 +421,7 @@ class Paneset extends React.Component {
             }
           }
           this.previousContainerWidth = window.innerWidth;
-          return {...layoutObject, ...newCacheObject };
+          return { ...layoutObject, ...newCacheObject };
         } else {
           return layoutCache[layoutIndex];
         }


### PR DESCRIPTION
Bug: Panesets are inserting nested objects into the cache rather than values. Only the affected layout object should be returned rather than the whole cache as nested objects.