### PR TITLE
STCOM-988 Resize nested paneset container

### DIFF
--- a/lib/Paneset/Paneset.css
+++ b/lib/Paneset/Paneset.css
@@ -8,10 +8,6 @@
   will-change: transform;
   overflow: hidden;
 
-  & .paneset {
-    overflow: visible;
-  }
-
   & .paneset,
   &.nested {
     position: relative;

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -132,6 +132,24 @@ class Paneset extends React.Component {
     this.previousContainerWidth = this.container.current?.getBoundingClientRect().width;
   }
 
+  componentDidUpdate(props, state) {
+    if (state.changeType === 'nested-resize-start') {
+      const containerBounds = this.container.current?.getBoundingClientRect();
+      if (containerBounds.right < window.offsetWidth) {
+        this.setState((curState) => {
+          const {
+            left, right
+          } = containerBounds;
+          const newStyle = { flex: `0 0 ${right - left}px` }
+          return {
+            changeType: 'nested-resize-end',
+            style: { ...curState.style, ...newStyle }
+          }
+        });
+      }
+    }
+  }
+
   componentWillUnmount() {
     this._isMounted = false;
     window.removeEventListener('resize', this.resizeHandler);
@@ -296,14 +314,38 @@ class Paneset extends React.Component {
 
   setStyle = (style) => {
     if (this.isThisMounted()) {
-      this.setState((oldState) => {
-        const newState = oldState;
-        // clone because you can't mutate style....
-        const newStyle = Object.assign({}, newState.style, style);
-        newState.style = newStyle;
-        newState.changeType = 'paneset-resized';
-        return newState;
-      });
+      const {
+        paneset,
+        isRoot
+      } = this.props;
+
+      // for nested, non-root panesets, we resize their element to the edge of the screen.
+      // this resolves a cropping behavior (impetus for STCOM-953) and allows
+      // paneset to accurately resize its children (overflow: hidden)
+      if (paneset && !isRoot) {
+        const containerBounds = this.container.current?.getBoundingClientRect();
+        if (containerBounds.right < window.offsetWidth) {
+          this.setState((curState) => {
+            const {
+              left, right
+            } = containerBounds;
+            const newStyle = { flex: `0 0 ${right - left}px` }
+            return {
+              changeType: 'nested-resize-end',
+              style: { ...curState.style, ...newStyle }
+            }
+          });
+        }
+      } else {
+        this.setState((oldState) => {
+          const newState = oldState;
+          // clone because you can't mutate style....
+          const newStyle = Object.assign({}, newState.style, style);
+          newState.style = newStyle;
+          newState.changeType = 'paneset-resized';
+          return newState;
+        });
+      }
     }
   }
 
@@ -629,11 +671,18 @@ class Paneset extends React.Component {
       panes[panesetIndex].handlePaneResize({ positions, containerRect, ...rest });
     }
 
+
+
     this.resizePanes(panes, newWidths);
 
     // check if the panes all have stable id's before caching their sizes.
     if (this.state.panes.every((p) => p.generatedId === false)) {
       this.updateLayoutCache(newWidths, 'resize');
+    }
+
+    // resize nested panesets to hug the right side of the screen.
+    if (this.props.paneset) {
+      this.setState({ changeType: 'nested-resize-start' });
     }
   }
 


### PR DESCRIPTION
Problem:
CSS changes introduced in STCOM-953 (.paneset .paneset {overflow: visible;}) resolved the issue of cropping, but caused additional strange behavior as percentage-based child panes wouldn't size to the parent paneset element, but to its overflow-hidden parent (100% = 100% of window, not 100% of the element)

Approach
This change resizes nested panesets elements so that their rectangle extends to the end boudary of the window.
This removes the previous CSS-based solution, but also resolves the cropping issue the change fixed.
