### PR TITLE
STCOM-994 Extend proptypes for avoiding errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Button: 'Link' style should behave as expected. Fixes STCOM-938.
 * Resized nested paneset containing elements. Fixes STCOM-989.
 * Hours format on Timepicker consistent to locale. Fixes STCOM-947.
+* Extend proptypes for avoiding console errors. Fixes STCOM-994.
 
 ## [10.1.0](https://github.com/folio-org/stripes-components/tree/v10.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.0.0...v10.1.0)

--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -17,6 +17,7 @@ const propTypes = {
   accordionSet: PropTypes.object,
   children: PropTypes.oneOfType([
     PropTypes.node,
+    PropTypes.func,
   ]).isRequired,
   className: PropTypes.string,
   closedByDefault: PropTypes.bool,
@@ -121,7 +122,7 @@ const Accordion = (props) => {
     }
   }, [open]);
 
-  useEffect(() => { // eslint-disable-line 
+  useEffect(() => { // eslint-disable-line
     if (accordionSet) {
       accordionSet.registerAccordion(getRef, trackingId, closedByDefault);
       return () => {

--- a/lib/LayoutHeader/LayoutHeader.js
+++ b/lib/LayoutHeader/LayoutHeader.js
@@ -11,7 +11,10 @@ const propTypes = {
     PropTypes.shape({
       handler: PropTypes.func,
       icon: PropTypes.string,
-      title: PropTypes.string,
+      title: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.node,
+      ]),
     }),
   ),
   level: PropTypes.number,

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -164,6 +164,7 @@ function computeRowWidth(columnWidths, columns) {
 
 export const pagingTypes = {
   LOAD_MORE: 'click',
+  NONE: 'none',
   PREV_NEXT: 'prev-next',
   SCROLL: 'scroll'
 };

--- a/lib/MultiColumnList/readme.md
+++ b/lib/MultiColumnList/readme.md
@@ -72,7 +72,7 @@ Check out our [hosted storybook](https://ux.folio.org/storybook/) for examples o
 Name | type | description | default | required
 --- | --- | --- | --- | ---
 `autosize` | bool | if true, list will size itself to fit its containing element. Use this to have a list occupy the full width and height of a `<Pane>`s content area. | false |
-`columnIdPrefix` | string | Appends a prefix to the id's for column headers and clickable headers for buttons. Useful in case multiple grids with the same shape of data appear in the same view.| | 
+`columnIdPrefix` | string | Appends a prefix to the id's for column headers and clickable headers for buttons. Useful in case multiple grids with the same shape of data appear in the same view.| |
 `columnMapping` | object | Maps rendered column labels to the data fields for the onHeaderClick prop. | `{}` |
 `columnWidths` | object | Set custom column widths, e.g. {email: '150px'}. Component will automatically measure any columns that are unspecified. An object can be provided with `min` and `max` keys to set up a range - MCL will pick as close to the `min` as it can and none over the `max`.| |
 `contentData` | array of object | the list of objects to be displayed. | | required
@@ -98,7 +98,7 @@ Name | type | description | default | required
 `onRowClick` | function(`event`, `item`) | callback function invoked when one of the lines in the table is clicked (typically to select a record for more detailed display). | |
 `onScroll` | func | Callback for scrolling of list body. | `noop` |
 `pageAmount` | number | The base amount of data to pass as the `askAmount` parameter for the `onNeedMoreData` prop | `30` |
-`pagingType` | string | Controls the interaction type when loading more data in the MCL. `"scroll"` is used for infinite scroll/loading scenarios, `"click"` renders a paging button below the results if the loaded count is less than the `totalCount` prop. `prev-next` will render pagination with 'previous' and 'next' buttons with a display of the current page's item numbers. | `"scroll"` |
+`pagingType` | string | Controls the interaction type when loading more data in the MCL. `"scroll"` is used for infinite scroll/loading scenarios, `"click"` renders a paging button below the results if the loaded count is less than the `totalCount` prop. `prev-next` will render pagination with 'previous' and 'next' buttons with a display of the current page's item numbers.`"none"` is used for custom pagination | `"scroll"` |
 `rowFormatter`  | func | function of shape `<name>({rowIndex, rowClass, rowData, cells, rowProps}){return <reactElement>}` that can be used to supply custom row layout. Forking [defaultRowFormatter](defaultRowFormatter.js) is a good place to start if you need to use this. | `defaultRowFormatter` |
 `rowMetadata` | array | a list of keys in `contentData` that should not be rendered.  This is useful if you wish to add arbitrary data outside of the realm of the rendered MCL, such as for the `onRowClick` handler. | `[]` |
 `rowUpdater` | func(`rowData`, `rowIndex`) | This function should return a shallow data structure (flattened object) or primitive (string, number) that will indicate that exterior data for a row has changed. It will receive two parameters of the `rowData` and the `rowIndex` that can be used to base return values. This result is fed directly to the data rows via props, keeping them pure. You should rarely have to use this prop, as most changes will be relayed directly in the `contentData` array itself. | `noop` |

--- a/lib/Select/Select.js
+++ b/lib/Select/Select.js
@@ -37,7 +37,7 @@ class Select extends Component {
     'valid': PropTypes.bool,
     'validationEnabled': PropTypes.bool,
     'validStylesEnabled': PropTypes.bool,
-    'value': PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    'value': PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.bool]),
     'warning': PropTypes.node,
   };
 


### PR DESCRIPTION
Purpose:
- add `PropTypes.func` for accordion children for `Open` render-prop usage
- add `PropTypes.node` for `LayoutHeader` actions title to use `<FormattedMessage>` as prop ([AddressView](https://github.com/folio-org/stripes-smart-components/blob/master/lib/AddressFieldGroup/AddressView/AddressView.js#L82))
- introduce new MCL `pagingType` `none` for custom pagination
- add `PropTypes.bool` as one of value type for `Select` option