### PR TITLE
STCOM-996: Adjust _auth path

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -13,7 +13,7 @@
 
 
 name: buildNPM Release
-on: 
+on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
@@ -54,22 +54,22 @@ jobs:
       - name: Get version from package.json
         id: package_version
         uses: notiz-dev/github-action-json-property@release
-        with: 
+        with:
           path: 'package.json'
           prop_path: 'version'
-      
+
       - name: Check matching tag and version in package.json
         if: ${{ env.TAG_VERSION != steps.package_version.outputs.prop }}
         run: |
           echo "Tag version, ${TAG_VERSION}, does not match package.json version, ${PACKAGE_VERSION}."
           exit 1
         env:
-          PACKAGE_VERSION: ${{ steps.package_version.outputs.prop }} 
+          PACKAGE_VERSION: ${{ steps.package_version.outputs.prop }}
 
       - name: Setup kernel for react native, increase watchers
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODEJS_VERSION }}
           check-latest: true
@@ -208,7 +208,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: Set up NPM environment for publishing
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODEJS_VERSION }}
           check-latest: true
@@ -216,13 +216,13 @@ jobs:
 
       - name: Set _auth in .npmrc
         run: |
-          npm config set @folio:registry $FOLIO_NPM_REGISTRY 
-          npm config set _auth $NODE_AUTH_TOKEN 
+          npm config set @folio:registry $FOLIO_NPM_REGISTRY
+          npm config set //repository.folio.org/repository/npm-folio/:_auth $NODE_AUTH_TOKEN
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Exclude some CI-generated artifacts in package
-        run: | 
+        run: |
           echo ".github" >> .npmignore
           echo ".scannerwork" >> .npmignore
           cat .npmignore

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       YARN_TEST_OPTIONS: '--karma.singleRun --karma.browsers ChromeDocker --karma.reporters mocha junit --coverage'
       SQ_ROOT_DIR: './lib'
-      COMPILE_TRANSLATION_FILES: 'false' 
+      COMPILE_TRANSLATION_FILES: 'false'
       PUBLISH_MOD_DESCRIPTOR: 'false'
       FOLIO_NPM_REGISTRY: 'https://repository.folio.org/repository/npm-folioci/'
       FOLIO_MD_REGISTRY: 'https://folio-registry.dev.folio.org'
@@ -41,7 +41,7 @@ jobs:
       - name: Setup kernel for react native, increase watchers
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODEJS_VERSION }}
           check-latest: true
@@ -150,7 +150,7 @@ jobs:
 
       - name: Set up NPM environment for publishing
         if: ${{ github.ref == 'refs/heads/master' || github.ref  == 'refs/heads/main' }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODEJS_VERSION }}
           check-latest: true
@@ -160,13 +160,13 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' || github.ref  == 'refs/heads/main' }}
         run: |
           npm config set @folio:registry $FOLIO_NPM_REGISTRY
-          npm config set _auth $NODE_AUTH_TOKEN
+          npm config set //repository.folio.org/repository/npm-folioci/:_auth $NODE_AUTH_TOKEN
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Exclude some CI-generated artifacts in package
         if: ${{ github.ref == 'refs/heads/master' || github.ref  == 'refs/heads/main' }}
-        run: | 
+        run: |
           echo ".github" >> .npmignore
           echo ".scannerwork" >> .npmignore
           cat .npmignore


### PR DESCRIPTION
The format of `_auth` in `.npmrc` has changed to

`npm config set //repo_path/:_auth TOKEN` instead of `npm config _auth TOKEN`.

This PR updates it to:

`npm config set //repository.folio.org/repository/npm-folio/:_auth $NODE_AUTH_TOKEN`

It also bumps actions/setup-node to a newer version `v3` compatible with node 16.

