### PR TITLE
STCOM-999 Remove paginationBoundaries prop from MCLRenderer and PrevNextPaginationRow components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Extend proptypes for avoiding console errors. Fixes STCOM-994.
 * Added `pagingCanGoNext` and `pagingCanGoPrevious` props to `<MultiColumnList>`. Refs STCOM-995.
 * Break long words in (checkbox) labels. Fixes STCOM-990.
+* Remove paginationBoundaries prop from MCLRenderer and PrevNextPaginationRow components. Refs STCOM-999.
 
 ## [10.1.0](https://github.com/folio-org/stripes-components/tree/v10.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.0.0...v10.1.0)

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -218,7 +218,8 @@ class MCLRenderer extends React.Component {
     onRowClick: PropTypes.func,
     onScroll: PropTypes.func,
     pageAmount: PropTypes.number,
-    paginationBoundaries: deprecated(PropTypes.bool), // will be removed in next major release. Use pagingCanGoPrevious and pagingCanGoNext instead.
+    // Use pagingCanGoPrevious and pagingCanGoNext instead.
+    paginationBoundaries: deprecated(PropTypes.bool),
     pagingButtonLabel: PropTypes.node,
     pagingCanGoNext: PropTypes.bool,
     pagingCanGoPrevious: PropTypes.bool,

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -1191,7 +1191,6 @@ class MCLRenderer extends React.Component {
       virtualize,
       pagingType,
       hidePageIndices,
-      paginationBoundaries,
     } = this.props;
 
     const {
@@ -1253,7 +1252,6 @@ class MCLRenderer extends React.Component {
           dataStartIndex={dataStartIndex + 1}
           dataEndIndex={dataEndIndex + 1}
           hidePageIndices={hidePageIndices}
-          paginationBoundaries={paginationBoundaries}
         />
       );
     } else {

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -12,6 +12,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { deprecated } from 'prop-types-extra';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import classnames from 'classnames';
 import {
@@ -217,7 +218,7 @@ class MCLRenderer extends React.Component {
     onRowClick: PropTypes.func,
     onScroll: PropTypes.func,
     pageAmount: PropTypes.number,
-    paginationBoundaries: PropTypes.bool,
+    paginationBoundaries: deprecated(PropTypes.bool), // will be removed in next major release. Use pagingCanGoPrevious and pagingCanGoNext instead.
     pagingButtonLabel: PropTypes.node,
     pagingCanGoNext: PropTypes.bool,
     pagingCanGoPrevious: PropTypes.bool,

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -217,6 +217,7 @@ class MCLRenderer extends React.Component {
     onRowClick: PropTypes.func,
     onScroll: PropTypes.func,
     pageAmount: PropTypes.number,
+    paginationBoundaries: PropTypes.bool,
     pagingButtonLabel: PropTypes.node,
     pagingCanGoNext: PropTypes.bool,
     pagingCanGoPrevious: PropTypes.bool,
@@ -268,6 +269,7 @@ class MCLRenderer extends React.Component {
     striped: true,
     totalCount: 0,
     minimumRowHeight: 30.8,
+    paginationBoundaries: true,
   }
 
   constructor(props) {

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -217,7 +217,6 @@ class MCLRenderer extends React.Component {
     onRowClick: PropTypes.func,
     onScroll: PropTypes.func,
     pageAmount: PropTypes.number,
-    paginationBoundaries: PropTypes.bool,
     pagingButtonLabel: PropTypes.node,
     pagingCanGoNext: PropTypes.bool,
     pagingCanGoPrevious: PropTypes.bool,
@@ -269,7 +268,6 @@ class MCLRenderer extends React.Component {
     striped: true,
     totalCount: 0,
     minimumRowHeight: 30.8,
-    paginationBoundaries: true,
   }
 
   constructor(props) {

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -1191,6 +1191,7 @@ class MCLRenderer extends React.Component {
       virtualize,
       pagingType,
       hidePageIndices,
+      paginationBoundaries,
     } = this.props;
 
     const {
@@ -1252,6 +1253,7 @@ class MCLRenderer extends React.Component {
           dataStartIndex={dataStartIndex + 1}
           dataEndIndex={dataEndIndex + 1}
           hidePageIndices={hidePageIndices}
+          paginationBoundaries={paginationBoundaries}
         />
       );
     } else {

--- a/lib/MultiColumnList/PrevNextPaginationRow.js
+++ b/lib/MultiColumnList/PrevNextPaginationRow.js
@@ -18,7 +18,6 @@ const propTypes = {
   keyId: PropTypes.string,
   loading: PropTypes.bool,
   pageAmount: PropTypes.number,
-  paginationBoundaries: PropTypes.bool,
   positionCache: PropTypes.object,
   prevWidth: PropTypes.number,
   rowHeightCache: PropTypes.object,
@@ -51,7 +50,6 @@ const PrevNextPaginationRow = ({
   width,
   dataStartIndex,
   dataEndIndex,
-  paginationBoundaries,
   hidePageIndices,
   setFocusIndex,
 }) => {
@@ -59,8 +57,8 @@ const PrevNextPaginationRow = ({
 
   const widthVar = width || prevWidth;
   const scrollBarWidth = widthVar < rowWidth ? 17 : 0;
-  const isNextButtonDisabled = paginationBoundaries && (loading || !activeNext);
-  const isPrevButtonDisabled = paginationBoundaries && (loading || !activePrevious);
+  const isNextButtonDisabled = !activeNext || loading;
+  const isPrevButtonDisabled = !activePrevious || loading;
 
   const previousLabel = (
     <div data-test-pagination-previous>

--- a/lib/MultiColumnList/PrevNextPaginationRow.js
+++ b/lib/MultiColumnList/PrevNextPaginationRow.js
@@ -19,7 +19,6 @@ const propTypes = {
   keyId: PropTypes.string,
   loading: PropTypes.bool,
   pageAmount: PropTypes.number,
-  // eslint-disable-next-line react/no-unused-prop-types
   paginationBoundaries: deprecated(PropTypes.bool), // will be removed in next major release. Please use activeNext and activePrevious instead
   positionCache: PropTypes.object,
   prevWidth: PropTypes.number,
@@ -53,6 +52,7 @@ const PrevNextPaginationRow = ({
   width,
   dataStartIndex,
   dataEndIndex,
+  paginationBoundaries,
   hidePageIndices,
   setFocusIndex,
 }) => {
@@ -60,8 +60,8 @@ const PrevNextPaginationRow = ({
 
   const widthVar = width || prevWidth;
   const scrollBarWidth = widthVar < rowWidth ? 17 : 0;
-  const isNextButtonDisabled = !activeNext || loading;
-  const isPrevButtonDisabled = !activePrevious || loading;
+  const isNextButtonDisabled = paginationBoundaries && (loading || !activeNext);
+  const isPrevButtonDisabled = paginationBoundaries && (loading || !activePrevious);
 
   const previousLabel = (
     <div data-test-pagination-previous>

--- a/lib/MultiColumnList/PrevNextPaginationRow.js
+++ b/lib/MultiColumnList/PrevNextPaginationRow.js
@@ -19,7 +19,8 @@ const propTypes = {
   keyId: PropTypes.string,
   loading: PropTypes.bool,
   pageAmount: PropTypes.number,
-  paginationBoundaries: deprecated(PropTypes.bool), // will be removed in next major release. Please use activeNext and activePrevious instead
+  // Use activeNext and activePrevious instead
+  paginationBoundaries: deprecated(PropTypes.bool),
   positionCache: PropTypes.object,
   prevWidth: PropTypes.number,
   rowHeightCache: PropTypes.object,

--- a/lib/MultiColumnList/PrevNextPaginationRow.js
+++ b/lib/MultiColumnList/PrevNextPaginationRow.js
@@ -18,6 +18,7 @@ const propTypes = {
   keyId: PropTypes.string,
   loading: PropTypes.bool,
   pageAmount: PropTypes.number,
+  paginationBoundaries: PropTypes.bool,
   positionCache: PropTypes.object,
   prevWidth: PropTypes.number,
   rowHeightCache: PropTypes.object,
@@ -50,6 +51,7 @@ const PrevNextPaginationRow = ({
   width,
   dataStartIndex,
   dataEndIndex,
+  paginationBoundaries,
   hidePageIndices,
   setFocusIndex,
 }) => {
@@ -57,8 +59,8 @@ const PrevNextPaginationRow = ({
 
   const widthVar = width || prevWidth;
   const scrollBarWidth = widthVar < rowWidth ? 17 : 0;
-  const isNextButtonDisabled = !activeNext || loading;
-  const isPrevButtonDisabled = !activePrevious || loading;
+  const isNextButtonDisabled = paginationBoundaries && (loading || !activeNext);
+  const isPrevButtonDisabled = paginationBoundaries && (loading || !activePrevious);
 
   const previousLabel = (
     <div data-test-pagination-previous>

--- a/lib/MultiColumnList/PrevNextPaginationRow.js
+++ b/lib/MultiColumnList/PrevNextPaginationRow.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { deprecated } from 'prop-types-extra';
 import { FormattedMessage } from 'react-intl';
 import Icon from '../Icon';
 import PagingButton from './PagingButton';
@@ -18,7 +19,8 @@ const propTypes = {
   keyId: PropTypes.string,
   loading: PropTypes.bool,
   pageAmount: PropTypes.number,
-  paginationBoundaries: PropTypes.bool,
+  // eslint-disable-next-line react/no-unused-prop-types
+  paginationBoundaries: deprecated(PropTypes.bool), // will be removed in next major release. Please use activeNext and activePrevious instead
   positionCache: PropTypes.object,
   prevWidth: PropTypes.number,
   rowHeightCache: PropTypes.object,
@@ -51,7 +53,6 @@ const PrevNextPaginationRow = ({
   width,
   dataStartIndex,
   dataEndIndex,
-  paginationBoundaries,
   hidePageIndices,
   setFocusIndex,
 }) => {
@@ -59,8 +60,8 @@ const PrevNextPaginationRow = ({
 
   const widthVar = width || prevWidth;
   const scrollBarWidth = widthVar < rowWidth ? 17 : 0;
-  const isNextButtonDisabled = paginationBoundaries && (loading || !activeNext);
-  const isPrevButtonDisabled = paginationBoundaries && (loading || !activePrevious);
+  const isNextButtonDisabled = !activeNext || loading;
+  const isPrevButtonDisabled = !activePrevious || loading;
 
   const previousLabel = (
     <div data-test-pagination-previous>


### PR DESCRIPTION
paginationBoundaries - this property is no longer needed, since by using activeNext and activePrevious we can achieve the same goals and disable the next and prev buttons.