### PR TITLE
STCOM-1005: Update react-highlight-words library to compatible version with react-17/18

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "prop-types-extra": "^1.1.0",
     "query-string": "^6.1.0",
     "react-flexbox-grid": "1.1.3",
-    "react-highlight-words": "^0.16.0",
+    "react-highlight-words": "^0.18.0",
     "react-overlays": "^4.1.1",
     "react-quill": "^1.3.3",
     "react-svg-loader": "^3.0.3",


### PR DESCRIPTION
## Purpose
- Upgrade is needed in scope of [UIDATIMP-1152](https://issues.folio.org/browse/UIDATIMP-1152). We migrated from `react-highlighter` library to `<Highlighter />` because the library is not maintained since 2018 and giving warnings when installed. `react-highlight-words` which `Highlighter` component uses is also outdated and has `react: "^0.14.0 || ^15.0.0 || ^16.0.0-0"` peerDeps and giving also warnings. This change updates it to the latest `v0.18.0` which is compatible with react-17/18 and has `"react": "^0.14.0 || ^15.0.0 || ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0"` peerDeps.

## Refs
- https://issues.folio.org/browse/STCOM-1005