### PR TITLE
STCOM-1008: panesets vs suspense - call componentDidMount code in a ref callback

### DIFF
--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -143,30 +143,6 @@ class Paneset extends React.Component {
     this._isMounted = false;
   }
 
-  componentDidMount() {
-    if (!this.props.isRoot) {
-      if (this.props.paneset) { // register with parent paneset if it exists
-        this.props.paneset.registerPane({
-          id: this.id,
-          setStyle: this.setStyle,
-          getChildInfo: this.getChildInfo,
-          isThisMounted: this.isThisMounted,
-          isPaneset: true,
-          transition: 'none',
-          doTransition: false,
-          getRef: this.getRef,
-          getInstance: this.getInstance,
-          handlePaneResize: this.handlePaneResize,
-          getChildPanesTotalWidth: this.getChildPanesTotalWidth
-        });
-      }
-    }
-    this._isMounted = true;
-
-    this.resizeHandler = window.addEventListener('resize', debounce(this.handleWindowResize, 50));
-    this.previousContainerWidth = this.container.current?.getBoundingClientRect().width;
-  }
-
   componentWillUnmount() {
     this._isMounted = false;
     window.removeEventListener('resize', this.resizeHandler);
@@ -192,6 +168,32 @@ class Paneset extends React.Component {
 
     if (!this.props.isRoot && this.props.paneset) {
       this.props.paneset.removePane(false);
+    }
+  }
+
+  mountedRef = (ref) => {
+    if (!this._isMounted && ref !== null) {
+      if (!this.props.isRoot) {
+        if (this.props.paneset) { // register with parent paneset if it exists
+          this.props.paneset.registerPane({
+            id: this.id,
+            setStyle: this.setStyle,
+            getChildInfo: this.getChildInfo,
+            isThisMounted: this.isThisMounted,
+            isPaneset: true,
+            transition: 'none',
+            doTransition: false,
+            getRef: this.getRef,
+            getInstance: this.getInstance,
+            handlePaneResize: this.handlePaneResize,
+            getChildPanesTotalWidth: this.getChildPanesTotalWidth
+          });
+        }
+      }
+      this._isMounted = true;
+
+      this.resizeHandler = window.addEventListener('resize', debounce(this.handleWindowResize, 50));
+      this.previousContainerWidth = ref?.getBoundingClientRect().width;
     }
   }
 
@@ -721,6 +723,11 @@ class Paneset extends React.Component {
     this.updateLayoutCache(newWidths, 'resize');
   }
 
+  handleRef = (ref) => {
+    this.container.current = ref;
+    this.mountedRef(ref);
+  }
+
   render() {
     const {
       id,
@@ -740,7 +747,7 @@ class Paneset extends React.Component {
           onElementResize={this.handlePaneResize}
           resizeContainerRef={this.resizeContainer}
         >
-          <div className={this.getClassName()} id={id} style={this.state.style} ref={this.container} {...dataProps}>
+          <div className={this.getClassName()} id={id} style={this.state.style} ref={this.handleRef} {...dataProps}>
             {children}
           </div>
         </PaneResizeContainer>

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -171,6 +171,9 @@ class Paneset extends React.Component {
     }
   }
 
+  // this function is called during a ref callback since it depends on the DOM elements being full ready.
+  // With React's Suspense feature in use, the ComponentDidMount
+  // lifecycle may fire before the component has rendered/loaded.
   mountedRef = (ref) => {
     if (!this._isMounted && ref !== null) {
       if (!this.props.isRoot) {


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-1008

Moving `componentDidMount` logic to a ref callback on the container, as per suggestion from this thread: https://github.com/facebook/react/issues/18139