### PR TITLE
STCOM-1010: MultiSelection - exception when using special characters in search string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * Remove paginationBoundaries prop from MCLRenderer and PrevNextPaginationRow components. Refs STCOM-999.
 * Paneset logic handles container widths of 0. Refs STCOM-1004.
 * properly provide popper placements. Fixes STCOM-979.
+* MultiSelection - fix exception when using special characters in search string. Fixes STCOM-1010.
 
 ## [10.1.0](https://github.com/folio-org/stripes-components/tree/v10.1.0) (2022-02-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.0.0...v10.1.0)

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -27,7 +27,7 @@ import css from './MultiSelect.css';
 import formStyles from '../sharedStyles/form.css';
 
 const filterOptions = (filterText, list) => {
-  const filterRegExp = new RegExp(`^${filterText}`, 'i');
+  const filterRegExp = new RegExp(`^${filterText.replace(/[#-.]|[[-^]|[?|{}]/g, '\\$&')}`, 'i');
   const renderedItems = filterText ? list.filter(item => item.label.search(filterRegExp) !== -1) : list;
   const exactMatch = filterText ? (renderedItems.filter(item => item.label === filterText).length === 1) : false;
   return { renderedItems, exactMatch };


### PR DESCRIPTION
## Description
Fix exception when searching in `<MultiSelection>` with special symbols

## Screenshots

https://user-images.githubusercontent.com/19309423/173042816-3d5633eb-fe9d-4d6e-91c8-c49f5680d997.mp4

## Issues
[STCOM-1010](https://issues.folio.org/browse/STCOM-1010)
