### PR TITLE
Headline: Update description of props

### DIFF
--- a/lib/Headline/readme.md
+++ b/lib/Headline/readme.md
@@ -13,9 +13,12 @@ Renders headlines in different sizes and with different tags, margins and styles
 ### Props
 Name | Type | Description | Options | Default
 --- | --- | --- | --- | ---
-children | node | Alternative way to set the label of the headline | | |
+children | node | The label of the headline | | |
 size | string | The size of the headline | xx-small, x-small, small, medium, large, x-large, xx-large | medium
 margin | string | The bottom margin of the component. Automatically matches the size-prop. | xx-small, x-small, small, medium, large, x-large, xx-large, none | medium
 tag | string | The tag of the headline | h1, h2, h3, h4, h5, h6, p, div, legend | div
 faded | boolean | Adds faded style to headline (gray color) | true/false | false
 weight | string | Changes the font-weight of the `<Headline>` | regular, medium, bold, black | bold
+block | boolean | If the headline should have `display: block` applied | true/false | false
+flex | boolean | If the headline should have `display: flex` applied | true/false | false
+className | string | Any custom class(es) which should be added to the Headline | | `""`


### PR DESCRIPTION
It seems like the `label` prop was removed a few years ago, however, the documentation for `<Headline>` still refers to the `children` prop as an "alternative": https://github.com/folio-org/stripes-components/commit/990df3318062db963fb15aac4e516c785236ba81

Additionally, this PR adds descriptions for props that were previously not described: `block`, `flex`, and `className`.