### PR TITLE
STCOM-1016: Add Timepicker ref support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-components
 
+## 10.2.1 IN PROGRESS
+
+* Add `inputRef` prop to `<Timepicker>`. Refs STCOM-1016
+
 ## [10.2.0](https://github.com/folio-org/stripes-components/tree/v10.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.1.0...v10.2.0)
 

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -20,6 +20,7 @@ const propTypes = {
   disabled: PropTypes.bool,
   id: PropTypes.string,
   input: PropTypes.object,
+  inputRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
   intl: PropTypes.object,
   label: PropTypes.node,
   locale: PropTypes.string,
@@ -51,7 +52,14 @@ class Timepicker extends React.Component {
   constructor(props) {
     super(props);
 
-    this.textfieldRef = React.createRef();
+    if (typeof props.inputRef === 'function') {
+      this.textfieldRef = (ref) => {
+        props.inputRef(ref);
+        this.textfieldRef.current = ref;
+      };
+    } else {
+      this.textfieldRef = props.inputRef || React.createRef();
+    }
     this.containerRef = React.createRef();
     this.dropdownRef = React.createRef();
     this.picker = null;

--- a/lib/Timepicker/readme.md
+++ b/lib/Timepicker/readme.md
@@ -12,6 +12,7 @@ Name | type | description | default | required
 --- | --- | --- | --- | ---
 `id` | string | Sets the `id` html attribute on the control | |
 `label` | string | If provided, will render a `<label>` tag with an `htmlFor` attribute directed at the provided `id` prop. | |
+`inputRef` | object or func | Obtains a reference to the internal `<input>` where the user can type | | false
 `value` | string | Sets the value for the control. **Not necessary if using redux-form.** | |
 `onChange` | function | Callback function that will receive the control's current value and the onChange event object. `fn(e, value)` **Not necessary if using redux-form**, but it will still work if callback from a change is needed. |  |
 `placement` | string | Determines the position of the date picker overlay. See available options in the <a href="https://github.com/folio-org/stripes-components/tree/master/lib/Popper" target="_blank">Popper documentation</a>. | bottom | false


### PR DESCRIPTION
# [Jira](https://issues.folio.org/projects/STCOM/issues/STCOM-1016)

This adds `inputRef` support to the `<Timepicker>` component.

This supports callback style refs as well as more modern refs produced by `React.createRef`.