### PR TITLE
STCOM-1017: Fix 12-hour formatting in getLocalizedTimeFormatInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-components
 
+## 10.2.1 IN PROGRESS
+
+* Fix 12-hour formatting in `dateTimeUtils` `getLocalizedTimeFormatInfo`. Fixes STCOM-1017
+
 ## [10.2.0](https://github.com/folio-org/stripes-components/tree/v10.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.1.0...v10.2.0)
 

--- a/util/dateTimeUtils.js
+++ b/util/dateTimeUtils.js
@@ -18,7 +18,7 @@ export const getLocaleDateFormat = ({ intl }) => {
     const intlFormatter = new Intl.DateTimeFormat(intl.locale, {
       day: '2-digit',
       year: 'numeric',
-      month: '2-digit'
+      month: '2-digit',
     });
 
     const formatted = intlFormatter.formatToParts(tempDate);
@@ -122,9 +122,13 @@ export function getLocalizedTimeFormatInfo(locale) {
     }
   });
 
+  if (timeFormat.includes('A')) {
+    timeFormat = timeFormat.replace('HH', 'hh');
+  }
+
   return {
     ...formatInfo,
     timeFormat,
-    dayPeriods: [...dpOptions]
+    dayPeriods: [...dpOptions],
   };
 }

--- a/util/tests/dateUtils-test.js
+++ b/util/tests/dateUtils-test.js
@@ -68,14 +68,14 @@ describe('Date Utilities', () => {
     });
 
     it('returns the time format according to the passed locale', () => {
-      expect(timeFormat.timeFormat).to.equal('HH:mm A');
+      expect(timeFormat.timeFormat).to.equal('hh:mm A');
     });
 
     it('returns a separator', () => {
       expect(timeFormat.separator).to.equal(':');
     });
 
-    it('returns an array of 2 day perdiods', () => {
+    it('returns an array of 2 day periods', () => {
       expect(timeFormat.dayPeriods.length).to.equal(2);
     });
   });
@@ -87,7 +87,7 @@ describe('Date Utilities', () => {
     });
 
     it('returns the time format according to the passed locale', () => {
-      expect(timeFormat.timeFormat).to.equal('A HH:mm');
+      expect(timeFormat.timeFormat).to.equal('A hh:mm');
     });
   });
 });


### PR DESCRIPTION
# [Jira](https://issues.folio.org/projects/STCOM/issues/STCOM-1017)

The function `getLocalizedTimeFormatInfo` in `dateTimeUtils` always returns a format string with "HH", indicating a format with hours from 00-23, regardless of if it adds AM or PM.

This fixes this, changing `HH` to `hh` (for 1-12 hours) whenever `A` is present in the format string.