### PR TITLE
STCOM-975 Record detail panes are empty when printed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * Add the ability to pass a className to the rows container in the `<MultiColumnList>`. Refs STCOM-1009.
 * MultiSelection - fix exception when using special characters in search string. Fixes STCOM-1010.
 * Browse contributors > Second pane should not show a horizontal scrollbar. Fixes STCOM-1011.
+* Record detail panes are empty when printed. Refs STCOM-975.
 
 ## [10.1.5](https://github.com/folio-org/stripes-components/tree/v10.1.5) (2022-06-06)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.1.4...v10.1.5)

--- a/lib/Pane/Pane.css
+++ b/lib/Pane/Pane.css
@@ -15,6 +15,10 @@
   overflow: hidden;
   position: absolute;
   will-change: transform;
+
+  @media print {
+    overflow: visible;
+  }
 }
 
 .focusIndicator {
@@ -49,6 +53,10 @@
 
   &.noOverflow {
     overflow: hidden;
+  }
+
+  @media print {
+    overflow: visible;
   }
 }
 

--- a/lib/Paneset/Paneset.css
+++ b/lib/Paneset/Paneset.css
@@ -16,6 +16,10 @@
   &.static {
     position: static;
   }
+
+  @media print {
+    overflow: visible;
+  }
 }
 
 @media (--medium-up) {

--- a/lib/global.css
+++ b/lib/global.css
@@ -81,8 +81,12 @@ html {
 
 /* global "print" styles below was added for solve the problem with extra blank page generating on printing in all modules */
 @media print {
-  body {
-    height: auto !important;
+  html, body {
+    margin: 0 !important;
+  }
+
+  @page {
+    margin: var(--page-margin-default);
   }
 }
 

--- a/lib/variables.css
+++ b/lib/variables.css
@@ -45,6 +45,7 @@
   --input-horizontal-padding: var(--gutter-static-one-third);
   --input-vertical-padding: 0;
   --container-max-width: 80rem;
+  --page-margin-default: 0.4in;
 
   /**
    * Font-size


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/STCOM-975

This bug is the result of an attempt to fix a bug related to an extra blank page ([STCOM-872](https://issues.folio.org/browse/STCOM-872)). Trying to set `height: auto` for the `body` resulted in it collapsing due to absolutely positioned children having no explicit height.

## Approach
Initial issue with extra blank page can be resolved by using `@media print` media query, where margins for `html` and `body` are cleared and page's margins regulated by `@page` at-rule. In this case, the reason for the content collapsing is eliminated and the problem with the empty page is solved.
<details>
  <summary>How it looks locally</summary>
  
 ![image](https://user-images.githubusercontent.com/88109087/174845346-120a31eb-4d75-4566-bce6-7b8e029476a4.png)
![image](https://user-images.githubusercontent.com/88109087/174845852-7d4582f2-0700-486a-9019-f147327c0c25.png)

</details>

---

**NB:** But there is a question about how the pane should be printed. For now it's just one page with visible data - other content is clipped. All because of the visibility settings
<details>
  <summary>How it looks locally</summary>

  ![image](https://user-images.githubusercontent.com/88109087/174846431-3507b07f-ec8f-4df4-ac1c-b824d9adb379.png)

</details>

I think it makes sense to print the entire contents of the pane. So I have added `@media print` for `Pane` and `Paneset` stylesheets to update `overflow` property for print. It also requires to add `@media print` to [`ModuleContainer.css`](https://github.com/folio-org/stripes-core/blob/master/src/components/ModuleContainer/ModuleContainer.css) in stripes-core.

<details>
  <summary>How it looks locally</summary>
  
![chrome_inS0iFgHAW](https://user-images.githubusercontent.com/88109087/174849692-b5be580b-6420-40c2-879c-180f7ec6ab23.gif)

</details>

If this behavior does not meet the requirements - let me know and I will remove the `@media print` queries from `Pane` and `Paneset`. Otherwise, I can create a ticket to add `@media print` to the `ModuleContainer.css` in stripes-core like:
```
 8
 9  @media print {
10    overflow-y: visible;
11  }
12
```
