### PR TITLE
STCOM-1015 Fix Multiselect element lose focus when user typing name of option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 10.2.1 IN PROGRESS
 * Fix 12-hour formatting in `dateTimeUtils` `getLocalizedTimeFormatInfo`. Fixes STCOM-1017
-* * Add `inputRef` prop to `<Timepicker>`. Refs STCOM-1016
+* Add `inputRef` prop to `<Timepicker>`. Refs STCOM-1016
+* `<MultiDownshift>` - highlight first item when searching for options. Fixes STCOM-1015
 
 ## [10.2.0](https://github.com/folio-org/stripes-components/tree/v10.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.1.0...v10.2.0)

--- a/lib/MultiSelection/MultiDownshift.js
+++ b/lib/MultiSelection/MultiDownshift.js
@@ -28,6 +28,11 @@ class MultiDownshift extends React.Component {
           };
         }
         return {};
+      case Downshift.stateChangeTypes.changeInput:
+        return {
+          ...changes,
+          highlightedIndex: 0,
+        };
       case Downshift.stateChangeTypes.keyDownEnter:
       case Downshift.stateChangeTypes.clickItem:
         if (Object.prototype.hasOwnProperty.call(changes.selectedItem, 'onSelect')) {


### PR DESCRIPTION
## Description
Fix an issue in `<Multiselection>` when searching for options - first option wasn't being highlighted
Issue was in `<MultiDownshift>` component. If you hover over an option - then index of that option is saved in state `highlightedIndex` and doesn't change until user clicks on an option, or arrow keys to navigate the list.
This causes a behaviour when a user hovers over a 3rd item, then searches for something that gives only result - this result is not highlighted because `highlightedIndex` is still 2.
Fixed by handling `changeInput` event and setting `highlightedIndex` to 0

## Screenshots

https://user-images.githubusercontent.com/19309423/174973507-863dd166-6092-415c-9824-d8889fbc73d4.mp4



## Issues
[STCOM-1015](https://issues.folio.org/browse/STCOM-1015)