### PR TITLE
UIIN-2079 - Browse contributors. Placeholder match does not look right in the contributor column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 10.2.1 IN PROGRESS
 * Fix 12-hour formatting in `dateTimeUtils` `getLocalizedTimeFormatInfo`. Fixes STCOM-1017
 * * Add `inputRef` prop to `<Timepicker>`. Refs STCOM-1016
+* Browse contributors. Placeholder match does not look right in the contributor column. Refs UIIN-2079
 
 ## [10.2.0](https://github.com/folio-org/stripes-components/tree/v10.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.1.0...v10.2.0)

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -1404,7 +1404,7 @@ class MCLRenderer extends React.Component {
             role="gridcell"
             key={`${col}-${rowIndex}-${this.keyId}`}
             className={`${css.mclCell} ${showOverflow} ${cellStyleClass}`}
-            style={cellStyle}
+            style={rowData.isAnchor && !!value ? { ...cellStyle, overflow: 'visible' } : cellStyle}
           >
             {value}
           </div>


### PR DESCRIPTION
## Description
This PR adds additional style to the cell rendered in the search result list rendered using MCLRenderer, in order the placeholder text is wrapped across cells in the row.

## Screenshots
![nckt7qBp5E](https://user-images.githubusercontent.com/104053200/175927883-ecd80e9d-0c83-43a5-a0f7-33fe65d37b69.gif)

## Issues
[STCOM-1018](https://issues.folio.org/browse/STCOM-1018)