### PR TITLE
STCOM-1013 Pass 'modifiers' prop to correct component in 'MultiSelection>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 10.2.1 IN PROGRESS
 * Fix 12-hour formatting in `dateTimeUtils` `getLocalizedTimeFormatInfo`. Fixes STCOM-1017
 * Add `inputRef` prop to `<Timepicker>`. Refs STCOM-1016
-* `<MultiDownshift>` - highlight first item when searching for options. Fixes STCOM-1015
+* `<MultiDownshift>` - highlight first item when searching for options. Fixes STCOM-101
+* Pass `modifiers` prop to correct component in `<MultiSelection>`. Fixes STCOM-1013.
 
 ## [10.2.0](https://github.com/folio-org/stripes-components/tree/v10.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.1.0...v10.2.0)

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -85,9 +85,9 @@ class MultiSelection extends React.Component {
     itemToString: option => (option ? option.label : ''),
     maxHeight: 168,
     modifiers: {
-      flip: { boundariesElement: 'viewport', padding: 10 },
-      preventOverflow: { boundariesElement: 'viewport', padding: 10 }
-    }
+      flip: { boundariesElement: 'scrollParent', padding: 5 },
+      preventOverflow: { boundariesElement: 'scrollParent', padding: 5 },
+    },
   };
 
   constructor(props) {
@@ -387,7 +387,6 @@ class MultiSelection extends React.Component {
               onFocus: this.handleFilterFocus,
               onRemove,
               optionsLength: filterResults.renderedItems ? filterResults.renderedItems.length : 0,
-              modifiers,
               placeholder: renderedPlaceholder,
               selectedItems,
               setHighlightedIndex,
@@ -434,6 +433,7 @@ class MultiSelection extends React.Component {
               atSmallMedia,
               downshiftActions: { reset },
               useLegacy,
+              modifiers,
               ...filterResults,
             };
 


### PR DESCRIPTION
## Description
Fix Multiselect options list overlapping input element in eHoldings.
`modifiers` prop was being passed to incorrect component - fixed this. Changed it's default value to `popper.js` default values so that current behaviour stays unchanged.
In eHoldings configured `<MultiSelection>` to render to overlay to prevent overlapping with modal container

## Screenshots
https://user-images.githubusercontent.com/19309423/176142352-8929d628-262d-4f68-b504-279e423c1ee4.mp4

## Issues
[STCOM-1013](https://issues.folio.org/browse/STCOM-1013)

## Related PRs
https://github.com/folio-org/ui-eholdings/pull/1573
