### PR TITLE
STCOM-1020: Long titles do not fit in the confirmation modal window header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fix 12-hour formatting in `dateTimeUtils` `getLocalizedTimeFormatInfo`. Fixes STCOM-1017
 * Add `inputRef` prop to `<Timepicker>`. Refs STCOM-1016
 * `<MultiDownshift>` - highlight first item when searching for options. Fixes STCOM-1015
+* Long titles do not fit in the confirmation modal window header. Refs STCOM-1020
 
 ## [10.2.0](https://github.com/folio-org/stripes-components/tree/v10.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.1.0...v10.2.0)

--- a/lib/Modal/Modal.css
+++ b/lib/Modal/Modal.css
@@ -52,6 +52,9 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  width: 90%;
+  text-align: center;
+  word-break: break-all;
   font-size: var(--font-size-medium);
 }
 


### PR DESCRIPTION
**Refs**: [STCOM-1020](https://issues.folio.org/browse/STCOM-1020)

https://user-images.githubusercontent.com/85172747/176164183-129952d8-b442-4b61-b93e-67e8f18881ba.mp4