### PR TITLE
STCOM-1023: Break long words in Callout message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Long titles do not fit in the confirmation modal window header. Refs STCOM-1020
 * Pass `modifiers` prop to correct component in `<MultiSelection>`. Fixes STCOM-1013.
 * Add `inputRef` prop to `<Selection>`. Refs STCOM-647.
+* Break long words in Callout message. Refs STCOM-1023.
 
 ## [10.2.0](https://github.com/folio-org/stripes-components/tree/v10.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.1.0...v10.2.0)

--- a/lib/Callout/Callout.css
+++ b/lib/Callout/Callout.css
@@ -44,6 +44,7 @@
     flex-grow: 2;
     padding: 0 6px;
     font-size: var(--font-size-medium);
+    word-break: break-word;
   }
 
   &.error {


### PR DESCRIPTION
## Purpose
- Break long words in Callout message
- Refs: https://issues.folio.org/browse/STCOM-1023

## Before
<img src="https://user-images.githubusercontent.com/89512426/177772608-264117cd-376d-490a-9fb5-1d97f9ca2f25.png" width="300" />

## After
<img src="https://user-images.githubusercontent.com/89512426/177773737-39db24e8-e1c7-4cdf-a143-5e56dd0a482f.png" width="300" />



