### PR TITLE
STCOM-1007 - improve focus indicator for buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add `inputRef` prop to `<Selection>`. Refs STCOM-647.
 * `<MultiSelection>` must handle null filter string. Refs STCOM-1022.
 * Break long words in Callout message. Refs STCOM-1023.
+* Add underline to Button focus indicator. Refs STCOM-1007
 
 ## [10.2.0](https://github.com/folio-org/stripes-components/tree/v10.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.1.0...v10.2.0)

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -62,6 +62,11 @@
     margin-left: 0;
   }
 
+  &:focus {
+    text-decoration: underline;
+    text-decoration-skip: objects;
+    text-decoration-thickness: 2px;
+  }
   /**
   * Colors
   */


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-1007

This PR adds `text-decoration: underline` to focused buttons as well as applying a thickness of 2px to the underline.

Standard buttons
![focus_styles_underline](https://user-images.githubusercontent.com/20704067/178520002-f7bf2d98-c951-4d7b-8dd8-03d716e52e47.gif)

With buttongroups
![focus_buttongroup_underline](https://user-images.githubusercontent.com/20704067/178519871-ee851b23-30ed-403d-be33-1dd5e0f04003.gif)

