### PR TITLE
STCOM-818 Textfield retains focused 'state' when disabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Break long words in Callout message. Refs STCOM-1023.
 * Add underline to Button focus indicator. Refs STCOM-1007
 * Fix selection bug where pressing the enter key while no options are available will clear the selected value. fixes STCOM-1024.
+* Fix TextField bug where "focused" state is retained if component is disabled while it's in focus. fixes STCOM-818.
 
 ## [10.2.0](https://github.com/folio-org/stripes-components/tree/v10.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.1.0...v10.2.0)

--- a/lib/TextField/TextField.js
+++ b/lib/TextField/TextField.js
@@ -218,11 +218,19 @@ class TextField extends Component {
   }
 
   static getDerivedStateFromProps(props, state) {
+    const newState = {};
+
+    if (props.disabled && state.focused) {
+      newState.focused = false;
+    }
+
     if (props.value !== state.prevPropsValue) {
-      return {
-        prevPropsValue: props.value,
-        value: props.value
-      };
+      newState.prevPropsValue = props.value;
+      newState.value = props.value;
+    }
+
+    if (Object.keys(newState).length > 0) {
+      return newState;
     }
     return null;
   }

--- a/lib/TextField/tests/TextField-test.js
+++ b/lib/TextField/tests/TextField-test.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
 
-import { TextField as Interactor, Label as LabelInteractor, runAxeTest } from '@folio/stripes-testing';
+import { TextField as Interactor, Label as LabelInteractor, IconButton as IconButtonInteractor, runAxeTest, converge } from '@folio/stripes-testing';
 import { mountWithContext } from '../../../tests/helpers';
 import { label } from '../../../tests/helpers/localInteractors';
 import TextField from '../TextField';
@@ -168,5 +168,34 @@ describe('TextField', () => {
 
       it('focuses the input', () => textField.is({ focused: true }));
     });
+  });
+
+  const FocusHarness = ({ onFocus }) => {
+    const [disabled, setDisabled] = useState(false);
+
+    const handleFocus = () => {
+      onFocus();
+      setTimeout(setDisabled(true), 1000);
+    };
+
+    return (
+      <TextField autoFocus value="test value" disabled={disabled} onFocus={handleFocus} />
+    );
+  };
+
+  describe.only('disabling a focused textfield', () => {
+    let fieldFocused = false;
+    beforeEach(async () => {
+      fieldFocused = false;
+      await mountWithContext(
+        <FocusHarness onFocus={() => { fieldFocused = true; }} />
+      );
+    });
+
+    it('called focus handler', () => converge(() => fieldFocused));
+
+    it('is disabled', () => textField.is({ disabled: true }));
+
+    it('hides things that would be present when focused', () => IconButtonInteractor({ icon: 'times-circle-solid' }).absent());
   });
 });

--- a/lib/TextField/tests/TextField-test.js
+++ b/lib/TextField/tests/TextField-test.js
@@ -183,7 +183,7 @@ describe('TextField', () => {
     );
   };
 
-  describe.only('disabling a focused textfield', () => {
+  describe('disabling a focused textfield', () => {
     let fieldFocused = false;
     beforeEach(async () => {
       fieldFocused = false;


### PR DESCRIPTION
Textfield still displays clear icon/focus state when 'disabled' is set.

See https://issues.folio.org/browse/STCOM-818

Approach - caught the disabled prop in gDSFP and set the focused state to false.