### PR TITLE
STCOM-1028 - Provide ability to disable an Icon Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * `<MultiSelection>` must handle null filter string. Refs STCOM-1022.
 * Break long words in Callout message. Refs STCOM-1023.
 * Add underline to Button focus indicator. Refs STCOM-1007
+* Provide ability to disable an Icon Button. Refs STCOM-1028
 
 ## [10.2.0](https://github.com/folio-org/stripes-components/tree/v10.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.1.0...v10.2.0)

--- a/lib/IconButton/IconButton.css
+++ b/lib/IconButton/IconButton.css
@@ -21,6 +21,11 @@
   }
 }
 
+.iconButton:disabled,
+.iconButton[disabled]{
+  pointer-events: none;
+}
+
 /* To avoid global :visited color on anchor tags */
 a.iconButton {
   color: var(--color-icon);

--- a/lib/IconButton/IconButton.js
+++ b/lib/IconButton/IconButton.js
@@ -105,6 +105,7 @@ IconButton.propTypes = {
     PropTypes.number,
   ]),
   className: PropTypes.string,
+  disabled: PropTypes.bool,
   href: PropTypes.string,
   icon: PropTypes.string,
   iconClassName: PropTypes.string,
@@ -128,6 +129,7 @@ IconButton.propTypes = {
 
 IconButton.defaultProps = {
   badgeColor: 'default',
+  disabled: false,
   iconSize: 'medium',
   size: 'medium',
   type: 'button',

--- a/lib/IconButton/readme.md
+++ b/lib/IconButton/readme.md
@@ -30,3 +30,4 @@ id | string | Adds an id attribute to the button
 innerClassName | string | Apply a custom class name to the inner element of the component
 aria-label | string | Adds an aria label to the button. Camel-case prop name `ariaLabel` is also supported.
 autoFocus | bool | If this prop is `true`, component will automatically focus on mount | |
+disabled | bool | If this prop is 'true', component will render a disabled button


### PR DESCRIPTION
## Purpose
Provide ability to disable an Icon Button
Issue: [STCOM-1028](https://issues.folio.org/browse/STCOM-1028)

It is possible to accept the disabled props already through the props. 
But, it is still useful to 
1. update the propTypes
2. story book with the disabled prop
3. IconButton Styles