### PR TITLE
STCOM-977 Aria-labeling MultiSelection

### DIFF
--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -39,6 +39,7 @@ const filterOptions = (filterText, list) => {
 class MultiSelection extends React.Component {
   static propTypes = {
     actions: PropTypes.arrayOf(PropTypes.object),
+    ariaLabel: PropTypes.string,
     ariaLabelledBy: PropTypes.string,
     asyncFiltering: PropTypes.bool,
     autoFocus: PropTypes.bool,
@@ -278,12 +279,13 @@ class MultiSelection extends React.Component {
   render() {
     const {
       ariaLabelledBy: ariaLabelledByProp,
+      ariaLabel: ariaLabelProp,
       asyncFiltering,
       backspaceDeletes,
       itemToString,
       value,
       formatter,
-      label,
+      label : labelProp,
       placeholder,
       maxHeight,
       renderToOverlay,
@@ -316,6 +318,8 @@ class MultiSelection extends React.Component {
     const valueDescriptionId = `multi-describe-action-${uiId}`;
     const controlDescriptionId = `multi-describe-control-${uiId}`;
     const controlValueStatusId = `multi-value-status-${uiId}`;
+    const ariaLabel = ariaLabelProp || rest['aria-label'];
+    const label = labelProp || ariaLabel || rest['aria-label'];
 
     let filterResults;
     if (!asyncFiltering) {
@@ -456,6 +460,7 @@ class MultiSelection extends React.Component {
                 {label &&
                   <Label // eslint-disable-line
                     {...labelProps}
+                    className={`${ariaLabel ? 'sr-only' : ''}`}
                   >
                     {label}
                   </Label>
@@ -471,6 +476,14 @@ class MultiSelection extends React.Component {
                 <span className="sr-only" id={controlDescriptionId}>
                   <FormattedMessage id="stripes-components.multiSelection.controlDescription" />
                 </span>
+                {/*
+                  Multiselection handles accessible announcement by following the label - value announcement pattern
+                  that's common to standard controls, inputs etc. The announcement includes the label as well as
+                  the number of selected items (if any).
+                  This is assembled via an aria-labelledby pointing at elements that the component fills in.
+                  this means that other props that other props that would be overridden by this (such as aria-label)
+                  are included in these rendered labeling elements.
+                */}
                 <ControlWrapper {...wrapperProps}>
                   <div // eslint-disable-line
                     className={this.getControlClass()}

--- a/lib/MultiSelection/stories/HiddenLabel.js
+++ b/lib/MultiSelection/stories/HiddenLabel.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import MultiSelection from '../MultiSelection';
+import Headline from '../../Headline';
 
 const optionList = [
   { value: 'test0', label: 'Option 0' },
@@ -7,22 +8,24 @@ const optionList = [
   { value: 'test2', label: 'Option 2' },
 ];
 
-const NoAriaLabel = () => {
+const HiddenLabel = () => {
   const [values, setValues] = useState([]);
 
   return (
     <div>
       <Headline size="large">
-        Multiselect with no Aria label
+        Multiselect with no visible label
       </Headline>
+      <p>The "ariaLabel" prop is used to apply a label that isn't visible to the user, but accessible to screenreaders. This is preferable for "required" fields over "ariaLabelledby" since the labeling elements won't need to display an asterisk.</p>
       <MultiSelection
         id="my-multiselect"
         dataOptions={optionList}
         value={values}
         onChange={setValues}
+        ariaLabel="My aria multiselect"
       />
     </div>
   );
 };
 
-export default NoAriaLabel;
+export default HiddenLabel;

--- a/lib/MultiSelection/stories/MultiSelection.stories.js
+++ b/lib/MultiSelection/stories/MultiSelection.stories.js
@@ -8,7 +8,7 @@ import { OptionSegment } from '../../Selection';
 import BasicUsage from './BasicUsage';
 import Required from './Required';
 import CustomAriaLabelledBy from './CustomAriaLabelledBy';
-import NoAriaLabel from './NoAriaLabel';
+import HiddenLabel from './HiddenLabel';
 
 const optionList = [
   { value: 'test0', label: 'Option 0', extra: 'nulla' },
@@ -141,4 +141,4 @@ storiesOf('MultiSelect', module)
   ))
   .add('Required', () => <Required />)
   .add('Custom Aria Label', () => <CustomAriaLabelledBy />)
-  .add('No Aria Label', () => <NoAriaLabel />);
+  .add('Hidden label', () => <HiddenLabel />);

--- a/lib/MultiSelection/stories/MultiSelection.stories.js
+++ b/lib/MultiSelection/stories/MultiSelection.stories.js
@@ -8,6 +8,7 @@ import { OptionSegment } from '../../Selection';
 import BasicUsage from './BasicUsage';
 import Required from './Required';
 import CustomAriaLabelledBy from './CustomAriaLabelledBy';
+import NoAriaLabel from './NoAriaLabel';
 
 const optionList = [
   { value: 'test0', label: 'Option 0', extra: 'nulla' },
@@ -139,4 +140,5 @@ storiesOf('MultiSelect', module)
     </div>
   ))
   .add('Required', () => <Required />)
-  .add('Custom Aria Label', () => <CustomAriaLabelledBy />);
+  .add('Custom Aria Label', () => <CustomAriaLabelledBy />)
+  .add('No Aria Label', () => <NoAriaLabel />);

--- a/lib/MultiSelection/stories/NoAriaLabel.js
+++ b/lib/MultiSelection/stories/NoAriaLabel.js
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import MultiSelection from '../MultiSelection';
+
+const optionList = [
+  { value: 'test0', label: 'Option 0' },
+  { value: 'test1', label: 'Option 1' },
+  { value: 'test2', label: 'Option 2' },
+];
+
+const NoAriaLabel = () => {
+  const [values, setValues] = useState([]);
+
+  return (
+    <div>
+      <Headline size="large">
+        Multiselect with no Aria label
+      </Headline>
+      <MultiSelection
+        id="my-multiselect"
+        dataOptions={optionList}
+        value={values}
+        onChange={setValues}
+      />
+    </div>
+  );
+};
+
+export default NoAriaLabel;

--- a/lib/MultiSelection/tests/MultiSelection-test.js
+++ b/lib/MultiSelection/tests/MultiSelection-test.js
@@ -139,6 +139,8 @@ describe('MultiSelect', () => {
     });
 
     it('renders the label with an sr-only classname', () => Label('test aria selection').has({ className: including('sr-only'), visible: false }));
+
+    it('contains no axe errors - Multiselect: ariaLabel prop', runAxeTest);
   });
 
   describe('clicking the control', () => {

--- a/lib/MultiSelection/tests/MultiSelection-test.js
+++ b/lib/MultiSelection/tests/MultiSelection-test.js
@@ -143,6 +143,30 @@ describe('MultiSelect', () => {
     it('contains no axe errors - Multiselect: ariaLabel prop', runAxeTest);
   });
 
+  describe('supplying an aria-label prop', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <MultiSelectionHarness
+          id={testId}
+          dataOptions={listOptions}
+          aria-label="test aria selection"
+        />
+      );
+    });
+
+    it('renders the label', () => {
+      MultiSelectInteractor('test aria selection').has({ visible: false });
+    });
+
+    it('control\'s aria-labelledBy attribute is set', () => {
+      multiselection.has({ arialabelledBy: `${testId}-label multi-value-status-${testId}` });
+    });
+
+    it('renders the label with an sr-only classname', () => Label('test aria selection').has({ className: including('sr-only'), visible: false }));
+
+    it('contains no axe errors - Multiselect: aria-label prop', runAxeTest);
+  });
+
   describe('clicking the control', () => {
     beforeEach(async () => {
       await multiselection.toggle();

--- a/lib/MultiSelection/tests/MultiSelection-test.js
+++ b/lib/MultiSelection/tests/MultiSelection-test.js
@@ -7,6 +7,7 @@ import {
   MultiSelectOption as OptionInteractor,
   Button,
   TextInput,
+  Label,
   Keyboard,
   converge,
   including,
@@ -116,6 +117,28 @@ describe('MultiSelect', () => {
     it('control\'s aria-labelledBy attribute is set', () => {
       multiselection.has({ arialabelledBy: `${testId}-label multi-value-status-${testId}` });
     });
+  });
+
+  describe('supplying an ariaLabel prop', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <MultiSelectionHarness
+          id={testId}
+          dataOptions={listOptions}
+          ariaLabel="test aria selection"
+        />
+      );
+    });
+
+    it('renders the label', () => {
+      MultiSelectInteractor('test aria selection').has({ visible: false });
+    });
+
+    it('control\'s aria-labelledBy attribute is set', () => {
+      multiselection.has({ arialabelledBy: `${testId}-label multi-value-status-${testId}` });
+    });
+
+    it('renders the label with an sr-only classname', () => Label('test aria selection').has({ className: including('sr-only'), visible: false }));
   });
 
   describe('clicking the control', () => {


### PR DESCRIPTION
This PR adds the `ariaLabel` support to Multiselect. (`aria-label` also works). This will provide an alternative accessible labeling mechanism for when visible labels don't suite requirements.