### PR TITLE
STCOM-1031: Selected search option changes to query search when user reopened advanced search modal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fix TextField bug where "focused" state is retained if component is disabled while it's in focus. fixes STCOM-818.
 * Provide ability to disable an Icon Button. Refs STCOM-1028.
 * `MultiSelection` support for `aria-label`. Refs STCOM-977.
+* Fix regex matching of search options in `<AdvancedSearch>`. Fixes STCOM-1031.
 
 ## [10.2.0](https://github.com/folio-org/stripes-components/tree/v10.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.1.0...v10.2.0)

--- a/lib/AdvancedSearch/tests/AdvancedSearch-test.js
+++ b/lib/AdvancedSearch/tests/AdvancedSearch-test.js
@@ -37,6 +37,9 @@ describe('AdvancedSearch', () => {
     label: 'keyword',
     value: 'keyword',
   }, {
+    label: 'identifiers',
+    value: 'identifiers.all',
+  }, {
     label: 'name',
     value: 'name',
   }, {
@@ -195,6 +198,30 @@ describe('AdvancedSearch', () => {
       await advancedSearch.find(RowInteractor({ index: 1 })).perform(el => {
         expect(el.querySelector('[data-test-advanced-search-query]').value).to.equal('Chicago');
         expect(el.querySelector('[data-test-advanced-search-option]').value).to.equal('keyword');
+      });
+    });
+  });
+
+  describe('when search options has a dot in name and opening advanced search again', () => {
+    beforeEach(async () => {
+      await RowInteractor({ index: 0 }).selectSearchOption(0, 'identifiers');
+      await RowInteractor({ index: 0 }).fillQuery('id0001');
+      await RowInteractor({ index: 1 }).selectBoolean(1, 'OR');
+      await RowInteractor({ index: 1 }).selectSearchOption(1, 'identifiers');
+      await RowInteractor({ index: 1 }).fillQuery('id0002');
+
+      await advancedSearch.search();
+    });
+
+    it('should split it into several rows correctly', async () => {
+      await advancedSearch.find(RowInteractor({ index: 0 })).perform(el => {
+        expect(el.querySelector('[data-test-advanced-search-query]').value).to.equal('id0001');
+        expect(el.querySelector('[data-test-advanced-search-option]').value).to.equal('identifiers.all');
+      });
+
+      await advancedSearch.find(RowInteractor({ index: 1 })).perform(el => {
+        expect(el.querySelector('[data-test-advanced-search-query]').value).to.equal('id0002');
+        expect(el.querySelector('[data-test-advanced-search-option]').value).to.equal('identifiers.all');
       });
     });
   });

--- a/lib/AdvancedSearch/utilities/splitQueryRows.js
+++ b/lib/AdvancedSearch/utilities/splitQueryRows.js
@@ -9,11 +9,11 @@ const splitRow = (row) => {
 
   // let's split this regex into smaller parts:
   // - ((?:or|and|not)\s+)? - this will match boolean operator at the beginning of a row.
-  // - ([\w]+==.+?(?=(or|not|and)\s[\w]+==[^\s]+) - will match a structure like "keyword==Something something"
+  // - ([\w.]+==.+?(?=(or|not|and)\s[\w.]+==[^\s]+) - will match a structure like "keyword==Something something"
   // it will match any character until it finds a string: "or", "and" or "not" with a new search option.
-  // - [\w]+==.+ - this will also match a structure like "keyword==Something something".
+  // - [\w.]+==.+ - this will also match a structure like "keyword==Something something".
   // this part of regex is OR'd with previous because you can't use lookahead conditionally
-  const splitIntoRowsRegex = /((?:or|and|not)\s+)?([\w]+==.+?(?=(or|not|and)\s[\w]+==[^\s]+)|[\w]+==.+)/g;
+  const splitIntoRowsRegex = /((?:or|and|not)\s+)?([\w.]+==.+?(?=(or|not|and)\s[\w.]+==[^\s]+)|[\w.]+==.+)/g;
 
   const matches = [...queryString.matchAll(splitIntoRowsRegex)];
 


### PR DESCRIPTION
## Description
Fix incorrect splitting of rows in `<AdvancedSearch>` when using `Identifiers (all)` option

Issue was caused by a `.` inside `identifiers.all` option value. Fixed it by including `.` alongside `\w` inside regex segment `[\w.]+==.+`

## Screenshots

https://user-images.githubusercontent.com/19309423/181472066-0faaf8d8-78ea-4b69-aa8a-10178a26c761.mp4


## Issues
[STCOM-1031](https://issues.folio.org/browse/STCOM-1031)