### PR TITLE
Update getLocalizedTimeFormatInfo docs

### DIFF
--- a/util/dateTimeUtils.js
+++ b/util/dateTimeUtils.js
@@ -68,7 +68,7 @@ export const getLocaleDateFormat = ({ intl }) => {
 // getLocalizedTimeFormatInfo('en-US') returns:
 //   {
 //     separator: ':',
-//     timeFormat: 'HH:mm A',
+//     timeFormat: 'hh:mm A',
 //     dayPeriods: ['am', 'pm'], // day periods: 12 hour time format.
 //   }
 


### PR DESCRIPTION
For consistency with #1832/#1837.  This reflects that the format code `hh` should be used for 12-hour time, rather than `HH`, whenever `A` is present.