### PR TITLE
STCOM-1039 Button: Buton link style has a min-heigt which can offset it from text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Provide ability to disable an Icon Button. Refs STCOM-1028.
 * `MultiSelection` support for `aria-label`. Refs STCOM-977.
 * Fix regex matching of search options in `<AdvancedSearch>`. Fixes STCOM-1031.
+* Button: Button link style has a min-height, which can offset it from text. Fixes STCOM-1039.
 
 ## [10.2.0](https://github.com/folio-org/stripes-components/tree/v10.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.1.0...v10.2.0)

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -205,6 +205,7 @@
     padding: 0;
     width: auto;
     height: auto;
+    min-height: unset;
     border-color: var(--color-link);
     border-style: none;
     box-sizing: content-box;
@@ -213,6 +214,7 @@
     cursor: pointer;
     text-align: start;
     text-decoration: underline;
+    text-underline-offset: 2px;
     appearance: none;
     margin-bottom: 0;
 


### PR DESCRIPTION
## Description
Remove `min-height` from link type button to allow it to have the same height as text around

## Screenshots
![image](https://user-images.githubusercontent.com/19309423/187701189-ae1a8bf5-1d5c-40c9-8bfa-a3639e221c95.png)

## Issues
[STCOM-1039](https://issues.folio.org/browse/STCOM-1039)