### PR TITLE
STCOM-1040  Expose id prop in List component

### DIFF
--- a/lib/List/List.js
+++ b/lib/List/List.js
@@ -5,6 +5,7 @@ import { camelCase } from 'lodash';
 import css from './List.css';
 
 const propTypes = {
+  id: PropTypes.string,
   isEmptyMessage: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.node,
@@ -26,28 +27,36 @@ const defaultProps = {
   itemFormatter: (item, i) => (<li key={i}>{item}</li>),
 };
 
-const List = (props) => {
+const List = ({
+  id,
+  itemFormatter,
+  listClass,
+  marginBottom0,
+  listStyle,
+  items,
+  isEmptyMessage
+}) => {
   /**
    * Get list classes
    */
   const getListClass = () => classNames(
     css.list,
-    props.listClass,
-    { [css.marginBottom0]: props.marginBottom0 },
-    { [css[camelCase(`list style ${props.listStyle}`)]]: props.listStyle }
+    listClass,
+    { [css.marginBottom0]: marginBottom0 },
+    { [css[camelCase(`list style ${listStyle}`)]]: listStyle }
   );
 
   /**
    * Return empty message if we have one
    * and there is no visible items
    */
-  if (!props.items.length && props.isEmptyMessage) {
-    return (<p className={css.isEmptyMessage}>{props.isEmptyMessage}</p>);
+  if (!items.length && isEmptyMessage) {
+    return (<p className={css.isEmptyMessage}>{isEmptyMessage}</p>);
   }
 
   return (
-    <ul className={getListClass()}>
-      {props.items.map(props.itemFormatter, this)}
+    <ul className={getListClass()} id={id}>
+      {items.map(itemFormatter, this)}
     </ul>
   );
 };

--- a/lib/List/tests/list-test.js
+++ b/lib/List/tests/list-test.js
@@ -4,23 +4,21 @@
 
 import React from 'react';
 import { describe, beforeEach, it } from 'mocha';
-import { runAxeTest, converge, HTML, including } from '@folio/stripes-testing';
+import { runAxeTest, converge, HTML, including, List as ListInteractor } from '@folio/stripes-testing';
 
 import { mount } from '../../../tests/helpers';
 
 import List from '../List';
 
-const ListInteractor = HTML.extend('list')
-  .selector('ul')
+const LocalListInteractor = ListInteractor.extend('list')
   .filters({
-    itemCount: (el) => el.querySelectorAll('li').length,
+    className: (el) => [...el.classList].join(' '),
   });
-
 
 const items = ['Apples', 'Bananas', 'Strawberries', 'Oranges'];
 
 describe('List', () => {
-  const list = new ListInteractor();
+  const list = new LocalListInteractor();
   beforeEach(async () => {
     await mount(
       <List items={items} />
@@ -29,7 +27,7 @@ describe('List', () => {
 
   it('renders a UL', () => ListInteractor().exists());
 
-  it('renders the correct count of items', () => list.has({ itemCount: items.length }));
+  it('renders the correct count of items', () => list.has({ count: items.length }));
 
   it('should have no axe errors - List', runAxeTest);
 
@@ -78,5 +76,18 @@ describe('List', () => {
     });
 
     it('displays the empty message element', () => HTML('No items to show').exists());
+  });
+
+  describe('supplying an id prop', () => {
+    beforeEach(async () => {
+      await mount(
+        <List
+          items={['one', 'two', 'three']}
+          id="testId"
+        />
+      );
+    });
+
+    it('displays the provided id attribute', () => ListInteractor('testId').exists());
   });
 });


### PR DESCRIPTION
This PR based from the way that the stripes-testing interactor is setup to work (locating via an id.) This component has been around a while, and could fairly be accomplished directly in app code with a simple `map` call, but nevertheless, we want to add this slight degree of versatility/ambiguity to this component's rendered instance... 