### PR TITLE
STCOM-1041 A11y labeling, focus management for modals.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Export `staticFirstWeekDay` and `staticLangCountryCodes` from `Datepicker`. Refs STCOM-1038.
 * Button: Button link style has a min-height, which can offset it from text. Fixes STCOM-1039.
 * The vertical scroll bar displays at the second pane when it doesn't need. Fixes STCOM-1044.
+* Focus management and accessible labeling of confirmation modals. Confirmation modals announce in a way similart to Javascript alerts. Fixes STCOM-1041.
 
 ## [10.2.0](https://github.com/folio-org/stripes-components/tree/v10.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.1.0...v10.2.0)

--- a/lib/ConfirmationModal/ConfirmationModal.js
+++ b/lib/ConfirmationModal/ConfirmationModal.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import uniqueId from 'lodash/uniqueId';
@@ -8,8 +8,9 @@ import Modal from '../Modal';
 import ModalFooter from '../ModalFooter';
 import css from './ConfirmationModal.css';
 
+const focusFooterPrimary = ref => ref.current.focus();
+
 const propTypes = {
-  ariaLabel: PropTypes.string,
   bodyTag: PropTypes.string,
   buttonStyle: PropTypes.string,
   cancelButtonStyle: PropTypes.string,
@@ -33,13 +34,14 @@ const defaultProps = {
 };
 
 const ConfirmationModal = (props) => {
+  const footerPrimary = useRef(null);
+  const contentId = useRef(uniqueId('modal-content')).current;
   const testId = props.id || uniqueId('confirmation-');
   const cancelLabel = props.cancelLabel || <FormattedMessage id="stripes-components.cancel" />;
   const confirmLabel = props.confirmLabel || <FormattedMessage id="stripes-components.submit" />;
   const {
     bodyTag: Element,
     onCancel,
-    ...rest
   } = props;
 
   const footer = (
@@ -49,6 +51,7 @@ const ConfirmationModal = (props) => {
         buttonStyle={props.buttonStyle}
         id={`clickable-${testId}-confirm`}
         onClick={props.onConfirm}
+        ref={footerPrimary}
       >
         {confirmLabel}
       </Button>
@@ -66,9 +69,10 @@ const ConfirmationModal = (props) => {
   return (
     <Modal
       open={props.open}
+      onOpen={() => { focusFooterPrimary(footerPrimary); }}
       id={testId}
       label={props.heading}
-      aria-label={rest['aria-label'] || props.ariaLabel}
+      aria-labelledby={contentId}
       scope="module"
       size="small"
       footer={footer}
@@ -77,6 +81,7 @@ const ConfirmationModal = (props) => {
       <Element
         data-test-confirmation-modal-message
         className={css.message}
+        id={contentId}
       >
         {props.message}
       </Element>

--- a/lib/ConfirmationModal/ConfirmationModal.js
+++ b/lib/ConfirmationModal/ConfirmationModal.js
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react';
 import { FormattedMessage } from 'react-intl';
+import { deprecated } from 'prop-types-extra';
 import PropTypes from 'prop-types';
 import uniqueId from 'lodash/uniqueId';
 
@@ -11,6 +12,8 @@ import css from './ConfirmationModal.css';
 const focusFooterPrimary = ref => ref.current.focus();
 
 const propTypes = {
+  ariaLabel: deprecated(PropTypes.string,
+    'ariaLabel is deprecated on ConfirmationModal. Please add ariaLabel text to the heading or content.'),
   bodyTag: PropTypes.string,
   buttonStyle: PropTypes.string,
   cancelButtonStyle: PropTypes.string,
@@ -42,6 +45,7 @@ const ConfirmationModal = (props) => {
   const {
     bodyTag: Element,
     onCancel,
+    ariaLabel,
   } = props;
 
   const footer = (
@@ -72,6 +76,7 @@ const ConfirmationModal = (props) => {
       onOpen={() => { focusFooterPrimary(footerPrimary); }}
       id={testId}
       label={props.heading}
+      aria-label={ariaLabel} // keeping for sake of tests that might be testing against this..
       aria-labelledby={contentId}
       scope="module"
       size="small"

--- a/lib/ConfirmationModal/ConfirmationModal.js
+++ b/lib/ConfirmationModal/ConfirmationModal.js
@@ -45,7 +45,7 @@ const ConfirmationModal = (props) => {
   const {
     bodyTag: Element,
     onCancel,
-    ariaLabel,
+    ariaLabel, // deprecated
   } = props;
 
   const footer = (
@@ -76,7 +76,7 @@ const ConfirmationModal = (props) => {
       onOpen={() => { focusFooterPrimary(footerPrimary); }}
       id={testId}
       label={props.heading}
-      aria-label={ariaLabel} // keeping for sake of tests that might be testing against this..
+      aria-label={ariaLabel} // deprecated..
       aria-labelledby={contentId}
       scope="module"
       size="small"

--- a/lib/ConfirmationModal/stories/ConfirmationModalExample.js
+++ b/lib/ConfirmationModal/stories/ConfirmationModalExample.js
@@ -2,20 +2,27 @@
  * Confirmation Modal Example
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 import ConfirmationModal from '..';
+import Button from '../../Button';
 
-export default () => (
-  <ConfirmationModal
-    open
-    id="simple-confirmation-modal"
-    heading="Please confirm this action"
-    message="Here's a detailed message that explains what happens if you confirm this action."
-    bodyTag="div"
-    onConfirm={action('Confirmed')}
-    onCancel={action('Cancelled')}
-    cancelLabel="No, I will not confirm"
-    confirmLabel="Okay, I will confirm this"
-  />
-);
+export default () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open confirmation modal</Button>
+      <ConfirmationModal
+        open={open}
+        id="simple-confirmation-modal"
+        heading="Please confirm this action"
+        message="Here's a detailed message that explains what happens if you confirm this action."
+        bodyTag="div"
+        onConfirm={() => { action('Confirmed'); setOpen(false); }}
+        onCancel={() => { action('Cancelled'); setOpen(false); }}
+        cancelLabel="No, I will not confirm"
+        confirmLabel="Okay, I will confirm this"
+      />
+    </>
+  );
+};

--- a/lib/ConfirmationModal/tests/ConfirmationModal-test.js
+++ b/lib/ConfirmationModal/tests/ConfirmationModal-test.js
@@ -5,12 +5,16 @@
 import React from 'react';
 
 import { describe, beforeEach, it } from 'mocha';
-import { runAxeTest, converge, Bigtest, ConfirmationModal as ConfirmationModalInteractor, Keyboard } from '@folio/stripes-testing';
+import { runAxeTest, converge, Bigtest, ConfirmationModal as ConfirmationModalInteractor, Keyboard, Button } from '@folio/stripes-testing';
 import { mountWithContext } from '../../../tests/helpers';
 
 import ConfirmationModal from '../ConfirmationModal';
 
 const html = Bigtest.HTML;
+const ConfirmButton = Button.extend('confirm button')
+  .filters({
+    focused: el => document.activeElement === el,
+  });
 
 describe('ConfirmationModal', () => {
   const confirmationModal = ConfirmationModalInteractor();
@@ -42,6 +46,8 @@ describe('ConfirmationModal', () => {
   });
 
   it('has no axe errors. - ConfirmationModal', runAxeTest);
+
+  it('focus is on the primary button', () => ConfirmButton(confirmLabel).is({ focused: true }));
 
   describe('When clicking the confirm button', () => {
     beforeEach(async () => {

--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -1,16 +1,28 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Modal as OverlayModal } from 'react-overlays';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { Transition, TransitionGroup } from 'react-transition-group';
+import { uniqueId } from 'lodash';
 
 import IconButton from '../IconButton';
 import Headline from '../Headline';
 import css from './Modal.css';
 
+/**  getA11yLabel will return the appropriate labelling aria-attribute based on the props passed to the component
+* in HTML usage, if both "aria-label" and "aria-labelledby" attributes are used, "aria-labelledby" will be
+* announced, but aria-label will not.
+*/
+function getA11yLabel(props, labelId) {
+  const ariaLabelledBy = props.ariaLabelledBy || props['aria-labelledby'];
+  return ariaLabelledBy ? { 'aria-labelledby': `${labelId} ${ariaLabelledBy}` } :
+    { 'aria-label': props.ariaLabel || props['aria-label'] };
+}
+
 const propTypes = {
   ariaLabel: PropTypes.string,
+  ariaLabelledBy: PropTypes.string,
   children: PropTypes.node.isRequired,
   /** Modal can be dismissed by clicking the background overlay */
   closeOnBackgroundClick: PropTypes.bool,
@@ -94,7 +106,7 @@ const Modal = forwardRef((props, ref) => {
     wrappingElement,
     ...rest
   } = props;
-
+  const modalId = useRef(id || uniqueId('modal')).current;
   const WrappingElement = wrappingElement;
 
   const getModalScope = () => {
@@ -145,8 +157,8 @@ const Modal = forwardRef((props, ref) => {
                 enforceFocus={enforceFocus}
                 restoreFocus={restoreFocus}
                 renderBackdrop={renderBackdrop}
-                aria-label={rest['aria-label'] || props.ariaLabel}
                 onEscapeKeyDown={() => { if (onClose) { onClose(); } }}
+                {...getA11yLabel(props, `${modalId}-label`)}
               >
                 <WrappingElement
                   className={getModalClass()}
@@ -161,7 +173,7 @@ const Modal = forwardRef((props, ref) => {
                         size="small"
                         margin="none"
                         className={css.modalLabel}
-                        id={id && `${id}-label`}
+                        id={`${modalId}-label`}
                       >
                         {props.label}
                       </Headline>

--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -89,6 +89,8 @@ const defaultProps = {
 
 const Modal = forwardRef((props, ref) => {
   const {
+    ariaLabel,
+    ariaLabelledBy,
     children,
     closeOnBackgroundClick,
     contentClass,
@@ -158,6 +160,7 @@ const Modal = forwardRef((props, ref) => {
                 restoreFocus={restoreFocus}
                 renderBackdrop={renderBackdrop}
                 onEscapeKeyDown={() => { if (onClose) { onClose(); } }}
+                aria-label={ariaLabel || rest['aria-label']} // retaining this to fend off test breakage.
                 {...getA11yLabel(props, `${modalId}-label`)}
               >
                 <WrappingElement
@@ -180,12 +183,12 @@ const Modal = forwardRef((props, ref) => {
                       <div className={css.modalControls}>
                         {dismissible &&
                           <FormattedMessage id="stripes-components.dismissModal">
-                            {([ariaLabel]) => (
+                            {([intlLabel]) => (
                               <IconButton
                                 className={css.closeModal}
                                 id={id && `${id}-close-button`}
                                 onClick={onClose}
-                                aria-label={ariaLabel}
+                                aria-label={intlLabel}
                                 icon="times"
                               />
                             )}
@@ -195,6 +198,10 @@ const Modal = forwardRef((props, ref) => {
                     </div>
                   }
                   <div className={getContentClass()} id={id && `${id}-content`}>
+                    {((ariaLabel || rest['aria-label']) && (ariaLabelledBy || rest['aria-labelledby']))
+                    && (
+                      <div className="sr-only">{ariaLabel || rest['aria-label']}</div>
+                    )}
                     {children}
                   </div>
                   {

--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -160,7 +160,7 @@ const Modal = forwardRef((props, ref) => {
                 restoreFocus={restoreFocus}
                 renderBackdrop={renderBackdrop}
                 onEscapeKeyDown={() => { if (onClose) { onClose(); } }}
-                aria-label={ariaLabel || rest['aria-label']} // retaining this to fend off test breakage.
+                aria-label={ariaLabel || rest['aria-label']} // deprecated in ConfirmationModal - will be removed.
                 {...getA11yLabel(props, `${modalId}-label`)}
               >
                 <WrappingElement
@@ -198,6 +198,7 @@ const Modal = forwardRef((props, ref) => {
                     </div>
                   }
                   <div className={getContentClass()} id={id && `${id}-content`}>
+                    {/* so that aria-labels will still announce if aria-labelledby is also provided */}
                     {((ariaLabel || rest['aria-label']) && (ariaLabelledBy || rest['aria-labelledby']))
                     && (
                       <div className="sr-only">{ariaLabel || rest['aria-label']}</div>

--- a/lib/Modal/readme.md
+++ b/lib/Modal/readme.md
@@ -36,3 +36,38 @@ Name | type | description | default | required
 `scope` | string | Parent element for modal. Defaults to 'module' which keeps the main navigation visible. A value of 'root' covers the entire view. | 'module' |
 `size` | string | `small` `medium` or `large` - sets the max-width of the window to `550px`, `750px`, `1100px`, respectively | 'medium' | 
 `wrappingElement` | string | Change the HTML-tag of the wrapping element. Useful if the modal is a form. | |
+
+### Focus management
+By default, the modal will focus its outer element. Internal elements of the modal can be focused using refs and a simple function passed to the `onOpen` prop. For example, the implementation of `<ConfirmationModal>` focuses its primary action using `onOpen`. This code is abridged, but you can [see the full source](../ConfirmationModal/ConfirmationModal.js)
+
+```
+// basic handler function
+const focusFooterPrimary = ref => ref.current.focus();
+
+const ConfirmationModal = () => {
+  // Initialize ref to footer button.
+  const footerPrimary = useRef(null);
+
+  // Set up confirmation footer, applying the ref to the button we want focus to move to.
+  const footer = (
+    <ModalFooter>
+      <Button
+        ...
+        ref={footerPrimary}
+      >
+        {confirmLabel}
+      </Button>
+    </ModalFooter>
+  );
+
+  // Apply the focusFooterPrimary function in the Modal declaration.
+  return(
+    <Modal
+      ...
+      onOpen={() => { focusFooterPrimary(footerPrimary); }}
+      footer={footer}
+    >
+  );
+}
+
+```

--- a/lib/Modal/tests/Modal-test.js
+++ b/lib/Modal/tests/Modal-test.js
@@ -19,6 +19,7 @@ const interactor = ModalInteractor.extend('modal')
     footerPresent: (el) => !!el.querySelector('[class*=modalFooter---]'),
     headerPresent: (el) => !!el.querySelector('[class*=modalHeader---]'),
     ariaLabel: (el) => el.getAttribute('aria-label'),
+    ariaLabelledBy: (el) => el.getAttribute('aria-labelledby')
   });
 
 describe('Modal', () => {
@@ -117,5 +118,23 @@ describe('Modal', () => {
       );
     });
     it('The modal Header should not be present', () => modal.has({ headerPresent: false }));
+  });
+
+  describe('If both aria-label and aria-labelledby props are provided', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <Modal
+          open
+          label={label}
+          showHeader={false}
+          ariaLabel="testAriaLabel"
+          ariaLabelledBy="testAriaLabelledBy"
+        >
+          Test
+        </Modal>
+      );
+    });
+    it('aria-label should not be applied', () => modal.has({ ariaLabel: null }));
+    it('aria-labelledby should be applied', () => modal.has({ ariaLabelledBy: including('testAriaLabelledBy') }));
   });
 });

--- a/lib/Modal/tests/Modal-test.js
+++ b/lib/Modal/tests/Modal-test.js
@@ -5,7 +5,7 @@
 import React from 'react';
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
-import { Modal as ModalInteractor, Button, converge, including, Keyboard } from '@folio/stripes-testing';
+import { HTML, Modal as ModalInteractor, Button, converge, including, Keyboard } from '@folio/stripes-testing';
 
 import { RoledHTML } from '../../../tests/helpers/localInteractors';
 import { mountWithContext } from '../../../tests/helpers';
@@ -134,7 +134,12 @@ describe('Modal', () => {
         </Modal>
       );
     });
-    it('aria-label should not be applied', () => modal.has({ ariaLabel: null }));
+    /* deprecation holdover functionality until ariaLabel is removed from ConfirmationModal */
+    it('aria-label should be applied', () => modal.has({ ariaLabel: including('testAriaLabel') }));
+    it('aria-label should be rendered', () => modal.find(HTML({ text: 'testAriaLabel', visible: false })).exists());
+    /* end deprecation holdover test */
+    /* it('aria-label should not be applied', () => modal.has({ ariaLabel: null })); // for post ariaLabel removal */
+
     it('aria-labelledby should be applied', () => modal.has({ ariaLabelledBy: including('testAriaLabelledBy') }));
   });
 });


### PR DESCRIPTION
[JIRA](https://issues.folio.org/browse/STCOM-1041)

Users requested that focus be automatically placed on the 'confirm' button of `ConfirmationModal`s. This moves focus beyond read-only content that probably contains important information. The solution is to include the message in the labeling of the modal so that it will automatically be announced when focus enters the modal. This will have it behave in a similar way to Javascript alerts.

Other explored approaches: `aria-describedby` - this attribute has varying degrees of functionality between browsers. It would be nice if this just worked in JAWS, but the current `aria-labelledby`-based implementation will have to do for now.

`aria-live` region - this rather-forceful approach always created a double announcement somewhere. Since it's element-based, there's not a straightforward place to actually put it since both the heading of the modal and the content would need announcement.

There is a standard 'dialog' announcement that happens on NVDA, but not in JAWS, so we unfortunately get a double announcement there. A double is flawed, but better than 'none'

This PR includes an example of modal focus-management in documentation as well as functionality to properly set the accessible label attributes of the modal. If both an `aria-label` and `aria-labelledby` prop are applied, `aria-labelledby` is applied in favor since `aria-label` will not be announced (lower priority that `aria-labelledby`)
