### PR TITLE
STCOM-1046: Make MCL row unclickable when a placeholder row is displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Export `staticFirstWeekDay` and `staticLangCountryCodes` from `Datepicker`. Refs STCOM-1038.
 * Button: Button link style has a min-height, which can offset it from text. Fixes STCOM-1039.
 * The vertical scroll bar displays at the second pane when it doesn't need. Fixes STCOM-1044.
+* Make MCL row unclickable when a placeholder row is displayed. Refs STCOM-1046.
 
 ## [10.2.0](https://github.com/folio-org/stripes-components/tree/v10.2.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.1.0...v10.2.0)

--- a/lib/MultiColumnList/defaultRowFormatter.js
+++ b/lib/MultiColumnList/defaultRowFormatter.js
@@ -48,6 +48,10 @@ function defaultRowFormatter(row) {
 
   delete rowProps.labelStrings; // We don't want to spread this onto the DOM element.
 
+  if (!rowData.id) {
+    delete rowProps.onClick;
+  }
+
   return (
     <Element
       key={`row-${rowIndex}`}


### PR DESCRIPTION
## Purpose
Make MCL row unclickable when a placeholder row is displayed.

## Approach
Remove the `onClick` callback if `rowData` doesn't have an `id`.

## Issues
[STCOM-1046](https://issues.folio.org/browse/STCOM-1046)