### PR TITLE
STCOM-1050 Publish storybook in CI with PR merge

### DIFF
--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -62,5 +62,5 @@ jobs:
         run: |
           git add .
           git commit -am "update storybook"
-          git merge origin/storybook
+          git pull origin/storybook
           git push origin storybook

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -62,4 +62,5 @@ jobs:
         run: |
           git add .
           git commit -am "update storybook"
+          git merge origin/storybook
           git push origin storybook

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -60,9 +60,10 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add -f .out
+          git commit -am "added built storybook"
+          git pull origin storybook --rebase -Xours
           rm -rf docs
           git commit -am "clean hosted storybook"
           git mv .out docs
           git commit -am "update storybook"
-          git pull origin storybook --rebase -Xours
           git push origin storybook

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -20,11 +20,11 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Use Node.js
-              uses: actions/setup-node@v3
-              with:
-                node-version: ${{ env.NODEJS_VERSION }}
-                check-latest: true
-                always-auth: true
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODEJS_VERSION }}
+          check-latest: true
+          always-auth: true
 
       - name: Set yarn config
         run: yarn config set @folio:registry $FOLIO_NPM_REGISTRY

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -59,7 +59,6 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add .
+          git add -f .out
           git commit -am "update storybook"
-          git pull --rebase origin/storybook -Xours
           git push origin storybook

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -42,7 +42,6 @@ jobs:
       - name: checkout storybook branch
         uses: actions/checkout@v3
         with:
-          ref: storybook,
           fetch-depth: 0,
 
       - name: Run yarn install
@@ -52,6 +51,8 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
+          git fetch
+          git checkout storybook
           git merge master
           npm run storybook-build
 

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -48,7 +48,7 @@ jobs:
         run: npm run storybook-build
 
       # commit the build to history, clean the previous build, promote the new build (rename .out to docs)"
-      - name: Update records storybook
+      - name: Promote new storybook build to published build
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -3,6 +3,8 @@
 name: Build and Publish Storybook
 
 on:
+  pull_request:
+    branches: [ "master" ]
   push:
     branches: [ "master" ]
 
@@ -26,32 +28,35 @@ jobs:
       - name: Set yarn config
         run: yarn config set @folio:registry $FOLIO_NPM_REGISTRY
 
-      - name: Checkout
-        uses: actions/checkout@v3
+      # - name: Checkout
+      #   uses: actions/checkout@v3
 
-      - name: Sync storybook branch
-        uses: devmasx/merge-branch@master
-        with:
-          type: now
-          from_branch: master
-          target_branch: storybook
-          github_token: ${{ github.token }}
+      # - name: Sync storybook branch
+      #   uses: devmasx/merge-branch@master
+      #   with:
+      #     type: now
+      #     from_branch: master
+      #     target_branch: storybook
+      #     github_token: ${{ github.token }}
 
       - name: checkout storybook branch
         uses: actions/checkout@v3
         with:
-          ref: storybook
+          ref: storybook,
+          fetch-depth: 0,
 
       - name: Run yarn install
         run: yarn install --ignore-scripts
 
-      - name: Build storybook
-        run: npm run storybook-build
-
-      - name: Publish storybook
+      - name: Sync and Build storybook
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
+          git merge master
+          npm run storybook-build
+
+      - name: Publish storybook
+        run: |
           git add .
           git commit -am "update storybook"
           git push origin storybook

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -61,5 +61,5 @@ jobs:
           git config user.email github-actions@github.com
           git add .
           git commit -am "update storybook"
-          git pull origin storybook -Xours
+          git pull --rebase origin/storybook -Xours
           git push origin storybook

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -5,6 +5,8 @@ name: Build and Publish Storybook
 # Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the "master" branch
+  pull_request:
+    branches: [ "master" ]
   push:
     branches: [ "master" ]
 

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -62,5 +62,5 @@ jobs:
         run: |
           git add .
           git commit -am "update storybook"
-          git pull origin/storybook
+          git merge -Xtheirs origin/storybook
           git push origin storybook

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -51,9 +51,9 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git fetch
+          git fetch origin
           git checkout storybook
-          git merge origin/master
+          git reset --hard origin/master
 
       - name: Build storybook
         run: npm run storybook-build

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -13,8 +13,12 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
+  # This workflow contains a single job called "build-storybook"
+  build-storybook:
+    env:
+      FOLIO_NPM_REGISTRY: 'https://repository.folio.org/repository/npm-folioci/'
+      NODEJS_VERSION: '16'
+
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -23,7 +27,19 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
 
-      # Runs a set of commands using the runners shell
+      - name: Use Node.js
+              uses: actions/setup-node@v3
+              with:
+                node-version: ${{ env.NODEJS_VERSION }}
+                check-latest: true
+                always-auth: true
+
+      - name: Set yarn config
+        run: yarn config set @folio:registry $FOLIO_NPM_REGISTRY
+
+      - name: Run yarn install
+        run: yarn install --ignore-scripts
+
       - name: Build and push storybook
         run: |
           echo git checkout storybook
@@ -32,4 +48,3 @@ jobs:
           echo git add .
           echo git commit -am "update storybook"
           echo git push origin storybook
-

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -62,5 +62,5 @@ jobs:
         run: |
           git add .
           git commit -am "update storybook"
-          git merge -Xtheirs origin/storybook
+          git merge -Xours origin/storybook
           git push origin storybook

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -59,9 +59,10 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
+          git add -f .out
           rm -rf docs
-          mv .out docs
-          git add .
+          git commit -am "clean hosted storybook"
+          git mv .out docs
           git commit -am "update storybook"
           git pull origin storybook --rebase -Xours
           git push origin storybook

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -28,6 +28,17 @@ jobs:
       - name: Set yarn config
         run: yarn config set @folio:registry $FOLIO_NPM_REGISTRY
 
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Sync storybook branch
+        uses: devmasx/merge-branch@master
+        with:
+          type: now
+          from_branch: master
+          target_branch: storybook
+          github_token: ${{ github.token }}
+
       - name: checkout storybook branch
         uses: actions/checkout@v3
         with:
@@ -36,18 +47,13 @@ jobs:
       - name: Run yarn install
         run: yarn install --ignore-scripts
 
-      - name: update from master
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-
       - name: Build storybook
-        run: |
-          git merge master
-          npm run storybook-build
+        run: npm run storybook-build
 
       - name: Publish storybook
         run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
           git add .
           git commit -am "update storybook"
           git push origin storybook

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -39,7 +39,7 @@ jobs:
       #     target_branch: storybook
       #     github_token: ${{ github.token }}
 
-      - name: checkout storybook branch
+      - name: checkout master
         uses: actions/checkout@v3
         with:
           fetch-depth: 0,
@@ -47,14 +47,16 @@ jobs:
       - name: Run yarn install
         run: yarn install --ignore-scripts
 
-      - name: Sync and Build storybook
+      - name: Sync storybook branch
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
           git fetch
           git checkout storybook
-          git merge master
-          npm run storybook-build
+          git merge origin/master
+
+      - name: Build storybook
+        run: npm run storybook-build
 
       - name: Publish storybook
         run: |

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build storybook
         run: |
-          git merge origin/master
+          git merge master
           npm run storybook-build
 
       - name: Publish storybook

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -1,32 +1,22 @@
-# This is a basic workflow to help you get started with Actions
+# This is a basic workflow to build and publish stripes-components storybook
 
 name: Build and Publish Storybook
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "master" branch
   pull_request:
     branches: [ "master" ]
   push:
     branches: [ "master" ]
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build-storybook"
   build-storybook:
     env:
       FOLIO_NPM_REGISTRY: 'https://repository.folio.org/repository/npm-folioci/'
       NODEJS_VERSION: '16'
 
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
 
       - name: Use Node.js
@@ -44,9 +34,9 @@ jobs:
 
       - name: Build and push storybook
         run: |
-          echo git checkout storybook
-          echo git merge master
-          echo npm run storybook-build
-          echo git add .
-          echo git commit -am "update storybook"
-          echo git push origin storybook
+          git checkout storybook
+          git merge master
+          npm run storybook-build
+          git add .
+          git commit -am "update storybook"
+          git push origin storybook

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -63,5 +63,5 @@ jobs:
           mv .out docs
           git add .
           git commit -am "update storybook"
-          git pull origin storybook -Xours
+          git pull origin storybook --rebase -Xours
           git push origin storybook

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -60,6 +60,7 @@ jobs:
 
       - name: Publish storybook
         run: |
+          git status
           git add .
           git commit -am "update storybook"
           git merge -Xours origin/storybook

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
 
       - name: Use Node.js
         uses: actions/setup-node@v3
@@ -29,14 +28,26 @@ jobs:
       - name: Set yarn config
         run: yarn config set @folio:registry $FOLIO_NPM_REGISTRY
 
+      - name: checkout storybook branch
+        uses: actions/checkout@v3
+        with:
+          ref: storybook
+
       - name: Run yarn install
         run: yarn install --ignore-scripts
 
-      - name: Build and push storybook
+      - name: update from master
         run: |
-          git checkout storybook
-          git merge master
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+      - name: Build storybook
+        run: |
+          git merge origin/master
           npm run storybook-build
+
+      - name: Publish storybook
+        run: |
           git add .
           git commit -am "update storybook"
           git push origin storybook

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -28,40 +28,32 @@ jobs:
       - name: Set yarn config
         run: yarn config set @folio:registry $FOLIO_NPM_REGISTRY
 
-      # - name: Checkout
-      #   uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-      # - name: Sync storybook branch
-      #   uses: devmasx/merge-branch@master
-      #   with:
-      #     type: now
-      #     from_branch: master
-      #     target_branch: storybook
-      #     github_token: ${{ github.token }}
+      - name: Sync storybook branch
+        uses: devmasx/merge-branch@master
+        with:
+          type: now
+          from_branch: master
+          target_branch: storybook
+          github_token: ${{ github.token }}
 
-      - name: checkout master
+      - name: checkout storybook branch
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0,
+          ref: storybook,
 
       - name: Run yarn install
         run: yarn install --ignore-scripts
-
-      - name: Sync storybook branch
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git fetch origin
-          git checkout storybook
-          git reset --hard origin/master
 
       - name: Build storybook
         run: npm run storybook-build
 
       - name: Publish storybook
         run: |
-          git status
+          git config user.name github-actions
+          git config user.email github-actions@github.com
           git add .
           git commit -am "update storybook"
-          git merge -Xours origin/storybook
           git push origin storybook

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -31,14 +31,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # - name: Sync storybook branch
-      #   uses: devmasx/merge-branch@master
-      #   with:
-      #     type: now
-      #     from_branch: master
-      #     target_branch: storybook
-      #     github_token: ${{ github.token }}
-
       - name: checkout storybook branch
         uses: actions/checkout@v3
         with:
@@ -55,7 +47,8 @@ jobs:
       - name: Build storybook
         run: npm run storybook-build
 
-      - name: Publish storybook
+      # commit the build to history, clean the previous build, promote the new build (rename .out to docs)"
+      - name: Update records storybook
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
@@ -66,4 +59,6 @@ jobs:
           git commit -am "clean hosted storybook"
           git mv .out docs
           git commit -am "update storybook"
-          git push origin storybook
+
+      - name: Publish storybook
+        run: git push origin storybook

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -60,7 +60,7 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           rm -rf docs
-          git mv .out docs
+          mv .out docs
           git add .
           git commit -am "update storybook"
           git pull origin storybook -Xours

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -42,7 +42,7 @@ jobs:
       - name: checkout storybook branch
         uses: actions/checkout@v3
         with:
-          ref: storybook,
+          ref: storybook
 
       - name: Run yarn install
         run: yarn install --ignore-scripts

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -3,8 +3,6 @@
 name: Build and Publish Storybook
 
 on:
-  pull_request:
-    branches: [ "master" ]
   push:
     branches: [ "master" ]
 

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -31,18 +31,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Sync storybook branch
-        uses: devmasx/merge-branch@master
-        with:
-          type: now
-          from_branch: master
-          target_branch: storybook
-          github_token: ${{ github.token }}
+      # - name: Sync storybook branch
+      #   uses: devmasx/merge-branch@master
+      #   with:
+      #     type: now
+      #     from_branch: master
+      #     target_branch: storybook
+      #     github_token: ${{ github.token }}
 
       - name: checkout storybook branch
         uses: actions/checkout@v3
         with:
-          ref: storybook
+          fetch-depth: 0
+
+      - name: sync storybook branch
+        run: |
+          git checkout storybook
+          git reset --hard origin/master
 
       - name: Run yarn install
         run: yarn install --ignore-scripts
@@ -56,4 +61,5 @@ jobs:
           git config user.email github-actions@github.com
           git add .
           git commit -am "update storybook"
+          git pull origin storybook -Xours
           git push origin storybook

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -59,6 +59,9 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add -f .out
+          rm -rf docs
+          git mv .out docs
+          git add .
           git commit -am "update storybook"
+          git pull origin storybook -Xours
           git push origin storybook

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,35 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Build and Publish Storybook
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "master" branch
+  push:
+    branches: [ "master" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      # Runs a set of commands using the runners shell
+      - name: Build and push storybook
+        run: |
+          echo git checkout storybook
+          echo git merge master
+          echo npm run storybook-build
+          echo git add .
+          echo git commit -am "update storybook"
+          echo git push origin storybook
+


### PR DESCRIPTION
This PR addes a github action to automate storybook updates. 
Stripes-components' storybook is hosted through github.io pages from its own `storybook` branch.
The action, upon a merge to master, will checkout the storybook branch, merge master into it, run the storybook build command, commit and push the changes back to the storybook branch.

This does sync up the branches better as the storybook branch had a slightly different build setup (building to the `.out` directory rather than the `docs` folder) and pushes the docs folder specifically to the ci action with a slightly more granular approach to the history management of it.