### PR TITLE
STCOM-1056 avoid Paneset NPE when evaluating cached layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-components
 
+## 10.4.0 (IN PROGRESS)
+
+* `<Paneset>` evaluates cached layouts more carefully. Refs STCOM-1056.
+
 ## [10.3.0](https://github.com/folio-org/stripes-components/tree/v10.3.0) (2022-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.2.0...v10.3.0)
 

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -222,11 +222,11 @@ class Paneset extends React.Component {
 
     // check for cached layout covers instances where the keys of the object may not be in the same order as
     // the "paneId" array.
-    const matchingCacheIndex = this.state.layoutCache.findIndex((c) => {
+    const matchingCacheIndex = this.state.layoutCache?.findIndex((c) => {
       const cacheIds = Object.keys(c);
       if (cacheIds.length !== paneIds.length) return false;
       return cacheIds.every((id) => paneIds.includes(id));
-    });
+    }) ?? -1;
     if (matchingCacheIndex !== -1) {
       const matchingLCache = this.state.layoutCache[matchingCacheIndex];
       // set array up with defaultWidth and id...pass to calc widths.
@@ -531,7 +531,7 @@ class Paneset extends React.Component {
       let widths;
       const nextLayout = {};
       this.state.panes.forEach(p => { nextLayout[p.id] = 0; });
-      const sizesCached = this.hasCachedLayout(nextLayout);
+      const sizesCached = this.cachedLayoutIndex(nextLayout);
       const toApply = this.props.onLayout({
         changeType,
         nextLayout,
@@ -663,23 +663,29 @@ class Paneset extends React.Component {
   getRef = () => this.container;
   getInstance = () => this;
 
-  hasCachedLayout = (candidate) => {
-    const layoutIndex = this.state.layoutCache.findIndex((cache) => {
+  /**
+   * cachedLayoutIndex
+   * Search state.layoutCache for an object whose keys exactly match those
+   * in the candidate.
+   * @param {object} candidate
+   * @returns int index in state.layoutCache of the matching cache, or -1
+   */
+  cachedLayoutIndex = (candidate) => {
+    return this.state.layoutCache?.findIndex((cache) => {
       const cacheKeys = Object.keys(cache);
       const candidateKeys = Object.keys(candidate);
       if (cacheKeys.length === candidateKeys.length) {
         return cacheKeys.every(ck => candidateKeys.indexOf(ck) !== -1);
       }
       return false;
-    });
-    return layoutIndex;
+    }) ?? -1;
   };
 
   updateLayoutCache = (layoutMap) => {
     if (this.isThisMounted()) {
       this.setState(({ layoutCache }) => {
         // find duplicates with like lengths, id's...
-        const layoutIndex = this.hasCachedLayout(layoutMap);
+        const layoutIndex = this.cachedLayoutIndex(layoutMap);
         if (layoutIndex !== -1) {
           const tempCache = cloneDeep(layoutCache);
           tempCache[layoutIndex] = layoutMap;


### PR DESCRIPTION
In production, we saw that `this.state.layoutCache.findIndex(...)` was sometimes throwing an NPE on `layoutCache`.
```
Uncaught TypeError: Cannot read properties of null (reading 'findIndex')
    at t.hasCachedLayout (Paneset.js:667:48)
    at Paneset.js:534:32
```
It isn't totally clear how this happens since it's initialized from a prop with valid default value. Maybe sometimes the prop is present but `null`? Dunno, but in any case the `...findIndex()` code is now more cautious.

Aside: renamed `hasCachedLayout` to `cachedLayoutIndex` since the previoius name gives the impression it returns a boolean when what it actually returns is an array index, i.e. an int >= -1.

Refs [STCOM-1056](https://issues.folio.org/browse/STCOM-1056)