### PR TITLE
STCOM-1056 prevent null in state.layoutCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 10.4.0 (IN PROGRESS)
 
-* `<Paneset>` evaluates cached layouts more carefully. Refs STCOM-1056.
+* `<Paneset>` initializes state more thoroughly, avoiding nulls. Refs STCOM-1056.
 
 ## [10.3.0](https://github.com/folio-org/stripes-components/tree/v10.3.0) (2022-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.2.0...v10.3.0)

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -131,7 +131,7 @@ class Paneset extends React.Component {
       },
       panes: [],
       // layoutCache must not be null, but initialLayouts may come in that way,
-      // e.g. if the calling component looks for a cached value but doesn't 
+      // e.g. if the calling component looks for a cached value but doesn't
       // find one then initialLayouts will be present but null.
       layoutCache: props.initialLayouts ?? [],
       style: initStyle,

--- a/lib/Paneset/Paneset.js
+++ b/lib/Paneset/Paneset.js
@@ -130,7 +130,10 @@ class Paneset extends React.Component {
         getTopmostContainer: this.getTopmostContainer,
       },
       panes: [],
-      layoutCache: props.initialLayouts,
+      // layoutCache must not be null, but initialLayouts may come in that way,
+      // e.g. if the calling component looks for a cached value but doesn't 
+      // find one then initialLayouts will be present but null.
+      layoutCache: props.initialLayouts ?? [],
       style: initStyle,
       changeType: 'init', // eslint-disable-line react/no-unused-state
     };


### PR DESCRIPTION
Yeah it's pretty clear, can't have no nulls, fool! 
So I can index, index, like I'm supposed to do
Can't have no boom boom when changing column spaces 
I need all the right punc in all the right places

I see the state init, it reads initial props
But it don't check for null, so reading dot-paths stops 
If you got braces braces, just post 'em up
So you can index an array and you don't ever have to stop

Yeah John Coburn, he told me, "You got to initialize!" 
Be like, "If props come in null then defaults will not override." 
And so when props come in empty we add our own brand new stash 
So traversing the state doesn't blow up on null layoutCache

Because you know it's all about that brace

Supercedes #1095, which was insufficient.

Refs [STCOM-1056](https://issues.folio.org/browse/STCOM-1056), again