### PR TITLE
limit stripes-testing to ~4.3.0 <4.3.1000004620

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@bigtest/interactor": "0.7.2",
     "@folio/eslint-config-stripes": "^6",
     "@folio/stripes-cli": "^2.4.0",
-    "@folio/stripes-testing": "^4.2.0",
+    "@folio/stripes-testing": "~4.3.0 <4.3.1000004620",
     "@mdx-js/loader": "^1.6.22",
     "@storybook/addon-actions": "^6.3.6",
     "@storybook/addons": "^6.3.6",


### PR DESCRIPTION
Breaking changes in `stripes-testing` were committed under the auspices of a bug fix (PR #572, though only noted as breaking in the PR it replaced, PR #439) on master after the previous release (`4.3.0`) but before the minor was bumped for the next release to `4.4.0`. The effect of this is that a typical version constraint like `~4.3.0` will not work for npm-folioci builds where that commit exists in build/release `4.3.1000004620`.

This illustrates why it is important to bump the minor version at the time a new feature is added, or the major version at the time a breaking change is added, rather than waiting until publishing the release: waiting makes it impossible to publish a patch release that relies on those changes _not_ being included in the previous version.

CC: @JohnC-80 , @NikitaSedyx 