### PR TITLE
MCL-Sticky Columns

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -85,6 +85,16 @@
 
   &.mclClickableRow:hover {
     cursor: pointer;
+
+    & .mclSticky::after {
+      background-color: var(--color-fill-focus);
+      content: "";
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      top: 0;
+    }
   }
 
   &.mclWrappedCells {
@@ -116,16 +126,14 @@
     }
   }
 
-  &:focus {
-    & .mclSticky::after {
-      background-color: var(--color-fill-focus);
-      content: "";
-      position: absolute;
-      width: 100%;
-      height: 100%;
-      left: 0;
-      top: 0;
-    }
+  &:focus .mclSticky::after {
+    background-color: var(--color-fill-focus);
+    content: "";
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    left: 0;
+    top: 0;
   }
 }
 

--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -49,6 +49,11 @@
   /* Different bg on odd rows */
   &.mclIsOdd:not(.mclSelected) {
     background-color: var(--color-fill-table-row-odd);
+
+    & .mclSticky::before {
+      content: "";
+      background-color: var(--color-fill-table-row-odd);
+    }
   }
 
   &::before {
@@ -72,6 +77,10 @@
     & a:visited {
       color: var(--color-link-visited-current);
     }
+
+    & .mclSticky::before {
+      background-color: var(--color-fill-current);
+    }
   }
 
   &.mclClickableRow:hover {
@@ -80,6 +89,29 @@
 
   &.mclWrappedCells {
     flex-wrap: wrap;
+  }
+
+  & .mclSticky {
+    position: sticky;
+    left: 0;
+    background-color: var(--bg);
+    z-index: 3;
+    box-shadow: 3px 0 4px rgba(0, 0, 0, 0.05);
+
+    &::before {
+      content: "";
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      background-color: var(--color-fill-table-row-even);
+    }
+
+    &.mclStickyEnd {
+      right: 0;
+      left: initial;
+      box-shadow: -3px 0 4px rgba(0, 0, 0, 0.05);
+    }
   }
 }
 
@@ -145,6 +177,31 @@
     &:active,
     &:focus {
       outline: none;
+    }
+  }
+
+  &.mclSticky {
+    position: sticky;
+    left: 0;
+    background-color: var(--bg);
+    z-index: 3;
+    box-shadow: 3px 0 4px rgba(0, 0, 0, 0.05);
+    border-right: 1px solid var(--color-border-p2);
+
+    &::before {
+      content: "";
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      left: 0;
+    }
+
+    &.mclStickyEnd {
+      right: 18px; /* accounts for scrollbar width */
+      left: initial;
+      box-shadow: -3px 0 4px rgba(0, 0, 0, 0.05);
+      border-left: 1px solid var(--color-border-p2);
+      border-right: 0;
     }
   }
 
@@ -336,4 +393,23 @@
   align-items: center;
   justify-content: center;
   align-content: middle;
+}
+
+[dir="rtl"] .mclSticky {
+  left: initial;
+  right: 0;
+  box-shadow: -3px 0 4px rgba(0, 0, 0, 0.05);
+  border-left: 1px solid var(--color-border-p2);
+
+  &.mclStickyEnd {
+    left: 0;
+    right: initial;
+    box-shadow: 3px 0 4px rgba(0, 0, 0, 0.05);
+    border-right: 1px solid var(--color-border-p2);
+    border-left: 0;
+
+    &.mclHeader {
+      left: 18px; /* accounts for scrollbar */
+    }
+  }
 }

--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -94,6 +94,7 @@
   & .mclSticky {
     position: sticky;
     left: 0;
+    top: 0;
     background-color: var(--bg);
     z-index: 3;
     box-shadow: 3px 0 4px rgba(0, 0, 0, 0.05);
@@ -104,6 +105,7 @@
       width: 100%;
       height: 100%;
       left: 0;
+      top: 0;
       background-color: var(--color-fill-table-row-even);
     }
 
@@ -111,6 +113,18 @@
       right: 0;
       left: initial;
       box-shadow: -3px 0 4px rgba(0, 0, 0, 0.05);
+    }
+  }
+
+  &:focus {
+    & .mclSticky::after {
+      background-color: var(--color-fill-focus);
+      content: "";
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      top: 0;
     }
   }
 }

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -240,6 +240,8 @@ class MCLRenderer extends React.Component {
     sortDirection: PropTypes.oneOf(['ascending', 'descending']),
     sortedColumn: PropTypes.string,
     sortOrder: PropTypes.string,
+    stickyFirstColumn: PropTypes.bool,
+    stickyLastColumn: PropTypes.bool,
     striped: PropTypes.bool,
     totalCount: PropTypes.number,
     virtualize: PropTypes.bool,
@@ -1358,7 +1360,16 @@ class MCLRenderer extends React.Component {
   }
 
   renderCells = (rowIndex, rowData) => {
-    const { formatter, contentData, columnOverflow, id, columnWidths: columnWidthsProp, getCellClass } = this.props;
+    const {
+      formatter,
+      contentData,
+      columnOverflow,
+      id,
+      columnWidths: columnWidthsProp,
+      getCellClass,
+      stickyFirstColumn,
+      stickyLastColumn,
+    } = this.props;
     const { columnWidths, columns, modColumns } = this.state;
     const cells = [];
     const labelStrings = [];
@@ -1376,12 +1387,19 @@ class MCLRenderer extends React.Component {
       }
 
       let cellStyle = null;
+      let stickyClasses = '';
       if (columnWidths[col]) {
         cellStyle = { width: this.state.columnWidths[col] };
+
+
         if (colIndex === columns.length - 1 &&
           get(columnWidthsProp, `${col}.max`) === undefined) {
           cellStyle = { minWidth: this.state.columnWidths[col], flex: 'auto' };
         }
+
+        // stick classes... we only apply them after we have column widths
+        if (stickyFirstColumn && colIndex === 0) stickyClasses = css.mclSticky;
+        if (stickyLastColumn && colIndex === columns.length - 1) stickyClasses = `${css.mclSticky} ${css.mclStickyEnd}`;
       }
 
       const showOverflow = (columnOverflow[col]) ? css.mclShowOverflow : '';
@@ -1402,7 +1420,7 @@ class MCLRenderer extends React.Component {
           <div
             role="gridcell"
             key={`${col}-${rowIndex}-${this.keyId}`}
-            className={`${css.mclCell} ${showOverflow} ${cellStyleClass}`}
+            className={classnames(css.mclCell, showOverflow, cellStyleClass, stickyClasses)}
             style={cellStyle}
           >
             {value}
@@ -1501,14 +1519,16 @@ class MCLRenderer extends React.Component {
     const { modColumns, columnWidths, columns } = this.state;
     const {
       columnIdPrefix,
+      columnWidths: columnWidthsProp,
       getHeaderCellClass,
-      onHeaderClick,
+      id,
       nonInteractiveHeaders,
+      onHeaderClick,
       sortDirection,
       sortOrder,
       sortedColumn,
-      id,
-      columnWidths: columnWidthsProp
+      stickyFirstColumn,
+      stickyLastColumn,
     } = this.props;
     const headers = [];
     columns.forEach((header, i) => {
@@ -1545,6 +1565,15 @@ class MCLRenderer extends React.Component {
         headerStyle = { flex: '0 0 auto' };
         headerCellClass = defaultHeaderCellClass;
       }
+
+      let stickyClasses = '';
+      if (columnWidths[header]) {
+        // stick classes... we only apply them after we have column widths
+        if (stickyFirstColumn && i === 0) stickyClasses = css.mclSticky;
+        if (stickyLastColumn && i === columns.length - 1) stickyClasses = `${css.mclSticky} ${css.mclStickyEnd}`;
+      }
+
+      headerCellClass = classnames(headerCellClass, stickyClasses);
 
       let headerInner;
       if (isInteractive) {

--- a/lib/MultiColumnList/readme.md
+++ b/lib/MultiColumnList/readme.md
@@ -15,6 +15,10 @@ const catalogResults = [
 
 You can also specify a formatter object to control exactly how the data is rendered: see below.
 
+### Sticky Columns
+The first and last columns of the grid can be 'pinned' into place. These will keep them visible when they would normally have scrolled out of view.
+To apply this, use the `stickyFirstColumn` or `stickyLastColumns` props.
+
 ### Infinite scroll
 For large lists of data the boolean prop `virtualize` can be turned on to efficiently display only the table rows that are visible to the user within the scrollable body of the list. The `virtualize` prop should be used in conjunction with the `height`, `maxHeight` or `autosize` prop - virtualization will not work otherwise.
 
@@ -109,6 +113,8 @@ Name | type | description | default | required
 `selectedRow` | object | **legacy API** Applies 'selected' class to the table row matching the property in the object, e.g. {id: '1224'}. | |
 `sortedColumn` | string | Used to apply styling to the appropriate column. | |
 `sortOrder` | string | 'ascending' or 'descending' direction. | |
+`stickyFirstColumn` | bool | Pins the first column in place so that it will remain visible when scrolled out of view. | |
+`stickyLastColumn` | bool | Pins the last column in place so that it will remain visible when scrolled out of view | |
 `striped` | bool | Adds striped style to rows | `true` |
 `totalCount` | number | The total number of expected records. It's necessary in various situations: using `virtualize` (so that MCL can anticipate the dimensions of expected rows) and with `prev-next` and `click` paging types ( so that the 'next' or 'load more' button can be adequately disabled when the end of the list is reached.) | 0 |
 `virtualize` | bool | Employs virtualization for performant rendering of large sets of data. | 0 |

--- a/lib/MultiColumnList/stories/MultiColumnList.stories.js
+++ b/lib/MultiColumnList/stories/MultiColumnList.stories.js
@@ -17,6 +17,7 @@ import ClickableRows from './ClickableRows';
 import ColumnWidthHints from './ColumnWidthHints';
 import PrevNextPaging from './PrevNextPaging';
 import ItemToView from './ItemToView';
+import StickyColumns from './StickyColumns';
 
 export default {
   title: 'MultiColumnList',
@@ -88,3 +89,5 @@ export const _ClickableRows = () => <ClickableRows />;
 _ClickableRows.story = {
   name: 'Clickable rows',
 };
+
+export const _StickyColumns = () => <StickyColumns />;

--- a/lib/MultiColumnList/stories/StickyColumns.js
+++ b/lib/MultiColumnList/stories/StickyColumns.js
@@ -1,0 +1,107 @@
+import React from 'react';
+import MultiColumnList from '../MultiColumnList';
+import Checkbox from '../../Checkbox';
+import IconButton from '../../IconButton';
+import { asyncGenerate, syncGenerate } from './service';
+import { Actions } from '../../MultiSelection/stories/MultiSelection.stories';
+
+export default class StickyColumns extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      data: syncGenerate(100, 0),
+      allSelected: false,
+      selected: [],
+    };
+
+    this.formatter = {
+      select: (item) => (
+        <Checkbox
+          value={item.index.toString()}
+          onChange={this.updateSelection}
+          checked={this.state.allSelected ||
+            (this.state.selected.findIndex(s => (s.index === item.index)) !== -1)
+          }
+        />),
+      action: () => (<IconButton icon="edit">Act</IconButton>),
+    };
+  }
+
+  requestMore = async (amount, index) => {
+    const newData = await asyncGenerate(amount, index, 1000);
+    this.setState(curState => ({
+      data: [...curState.data, ...newData]
+    }));
+  }
+
+  updateSelection = (e) => {
+    const value = e.target.value;
+    if (e.target.checked) {
+      this.setState(curState => {
+        return {
+          selected: [...curState.selected, curState.data[value]],
+        };
+      });
+    } else {
+      this.setState(curState => {
+        return {
+          selected: curState.selected.filter(
+            (s) => s.index.toString() !== value
+          ),
+          allSelected: false,
+        };
+      });
+    }
+  }
+
+  toggleSelectAll = (e) => {
+    if (e.target.checked) {
+      this.setState(curState => {
+        return {
+          selected: [...curState.data],
+          allSelected: true,
+        };
+      });
+    } else {
+      this.setState(() => {
+        return {
+          selected: [],
+          allSelected: false
+        };
+      });
+    }
+  }
+
+  isSelected =({ item }) => (
+    this.state.allSelected ||
+    (this.state.selected.findIndex(s => s.index === item.index) !== -1)
+  );
+
+  render() {
+    this.columnMapping = {
+      select: <Checkbox value="selectAll" onChange={this.toggleSelectAll} checked={this.state.allSelected} />,
+      action: 'Action'
+    };
+    return (
+      <>
+        <div style={{ height: '275px', width: '500px'}}>
+          <MultiColumnList
+            contentData={this.state.data}
+            columnMapping={this.columnMapping}
+            formatter={this.formatter}
+            isSelected={this.isSelected}
+            visibleColumns={['select', 'index', 'title', 'email', 'action']}
+            columnWidths={{
+              select: '44px',
+              action: '250px'
+            }}
+            autosize
+            virtualize
+            stickyFirstColumn
+            stickyLastColumn
+          />
+        </div>
+      </>
+    );
+  }
+}

--- a/lib/MultiColumnList/stories/StickyColumns.js
+++ b/lib/MultiColumnList/stories/StickyColumns.js
@@ -84,7 +84,7 @@ export default class StickyColumns extends React.Component {
     };
     return (
       <>
-        <div style={{ height: '275px', width: '500px'}}>
+        <div style={{ height: '245px', width: '500px'}}>
           <MultiColumnList
             contentData={this.state.data}
             columnMapping={this.columnMapping}
@@ -93,7 +93,7 @@ export default class StickyColumns extends React.Component {
             visibleColumns={['select', 'index', 'title', 'email', 'action']}
             columnWidths={{
               select: '44px',
-              action: '250px'
+              action: '64px'
             }}
             autosize
             virtualize

--- a/lib/MultiColumnList/tests/MultiColumnList-test.js
+++ b/lib/MultiColumnList/tests/MultiColumnList-test.js
@@ -820,6 +820,29 @@ describe('MultiColumnList', () => {
     });
   });
 
+  describe('sticky columns', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <MultiColumnList
+          height={300}
+          contentData={data100}
+          visibleColumns={['status', 'id', 'orderer', 'sender']}
+          stickyFirstColumn
+          stickyLastColumn
+        />
+      );
+    });
+
+    it('applies sticky CSS class to first column',
+      () => mcl.find(CellInteractor({ row: 3, columnIndex: 0 })).assert((el) => el.className.includes('mclSticky')));
+
+    it('doesn\'t apply sticky CSS class to second column',
+      () => mcl.find(CellInteractor({ row: 3, columnIndex: 1 })).assert((el) => !el.className.includes('mclSticky')));
+
+    it('applies sticky CSS class to last column',
+      () => mcl.find(CellInteractor({ row: 3, columnIndex: 3 })).assert((el) => el.className.includes('mclSticky')));
+  });
+
   describe('detecting data changes', () => {
     let currentData;
     let nextData;


### PR DESCRIPTION
Added the ability to pin the first and/or last column in place. This can be helpful for wide grids with row-level actions or checkboxes that you would like to remain visible for the user so that they won't have to scroll back to see the checkbox/action.

Approach
Given the props `stickyFirstColumn` and `stickyLastColumn` they will apply appropriate CSS classes that have `position: sticky` applied.

![stickyColumns](https://user-images.githubusercontent.com/20704067/203409779-6186a84a-d55d-4ffe-991f-e6931e5994c4.gif)
