### PR TITLE
STCOM-1059 Login screen missing scrollbar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * `<Paneset>` initializes state more thoroughly, avoiding nulls. Refs STCOM-1056.
 * After click submit button disable the confirmation button in Confirmation modal component. Refs STCOM-1058
+* FOLIO Login screen missing scrollbar - removed global styling for body overflow. Refs STCOM-1059.
 
 ## [10.3.0](https://github.com/folio-org/stripes-components/tree/v10.3.0) (2022-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.2.0...v10.3.0)

--- a/lib/Layer/Layer.css
+++ b/lib/Layer/Layer.css
@@ -70,7 +70,3 @@
   left: 0;
   background-color: rgba(0, 0, 0, 0.5);
 }
-
-:global body {
-  overflow-y: hidden;
-}


### PR DESCRIPTION
This was happening due to a global style on the body element with `overflow: hidden`

These styles were in use 5 years ago, prior to using flexbox for the outer DOM hierarchy (root, nav, module-container) when there was some risk of introducing a new hierarchical 'layer' causing overflow to occur on the body element and a vertical scrollbar to appear.

Approach: remove the offending global style. The `root` element is rendered as a flex column with its height at `100%` - removing this flex *will make a browser scrollbar appear, but since it's there, the `root` does not become taller than the viewport, which renders the removal of body overflow as unnecessary.