### PR TITLE
STCOM-1061 Popover leaking escape key presses.

### DIFF
--- a/lib/Popover/Popover.js
+++ b/lib/Popover/Popover.js
@@ -75,7 +75,15 @@ const Popover = forwardRef(({
     }
   }, [open, popoverRef]);
 
+  //
+  const handleKeyDown = (e) => {
+    if (e.key === 'Escape') {
+      e.stopPropagation();
+    }
+  };
+
   const renderPopover = transitionStatus => (
+    // eslint-disable-next-line
     <div
       data-test-popover-overlay
       className={
@@ -89,6 +97,7 @@ const Popover = forwardRef(({
       ref={popoverRef}
       role="dialog"
       tabIndex="-1"
+      onKeyDown={handleKeyDown}
     >
       {typeof children === 'function' ? children(renderProps) : children}
     </div>
@@ -115,7 +124,7 @@ const Popover = forwardRef(({
 });
 
 const legacyNotice = `
-  Note: The presence of this prop indicates 
+  Note: The presence of this prop indicates
   that you are using a legacy implementation of the <Popover>.
   Please see the documentation to learn how to update your implementation.
 `;
@@ -123,9 +132,9 @@ const legacyNotice = `
 const checkForLegacyChildrenProp = (props) => {
   if (isLegacy(props.children)) {
     throw new Error(`
-      You are using a legacy implementation of the <Popover>-component. 
-      See the documentation for this component to learn how to update 
-      your implementation to use the new component API. Docs: 
+      You are using a legacy implementation of the <Popover>-component.
+      See the documentation for this component to learn how to update
+      your implementation to use the new component API. Docs:
       https://github.com/folio-org/stripes-components/blob/master/lib/Popover/readme.md
     `);
   }


### PR DESCRIPTION
This can cause bound keyboard shortcuts outside of of the overlay/popover to be triggered unintentionally - i.e. closing a detail record.

Refs [STCOM-1061](https://issues.folio.org/browse/STCOM-1061)

Approach: add an `onKeyDown` handler to the wrapping element rendered in the `<Popover>` component.