### PR TITLE
STCOM-1068 enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-
+    ignore:
+      - dependency-name: "react-router-dom""

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,8 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-      - dependency-name: "react-router-dom""
+      - dependency-name: "faker"
+      - dependency-name: "react"
+      - dependency-name: "react-dom"
+      - dependency-name: "react-router"
+      - dependency-name: "react-router-dom"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Correctly configure SonarCloud to find coverage reports. Refs STCOM-1064.
 * Add 'centered' property to the 'RadioButton' component. Refs STCOM-1065.:
 * Prevent Popover from leaking escape keypress events. Refs STCOM-1061.
+* Enable dependabot. Refs STCOM-1068, FOLIO-3664.
 
 ## [10.3.0](https://github.com/folio-org/stripes-components/tree/v10.3.0) (2022-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.2.0...v10.3.0)


### PR DESCRIPTION
Enable dependabot. This is a POC. This is only a POC. If this turns out to be overwhelming, we'll turn it off.

See https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates for configuration options, including ignoring certain libraries and automatically tagging certain contributors for review, among many other options.

Refs [STCOM-1068](https://issues.folio.org/browse/STCOM-1068), [FOLIO-3664](https://issues.folio.org/browse/FOLIO-3664)