### PR TITLE
STCOM-1069: Add 'focusIndex' property to be able to manually control the focus of an element in the list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add 'centered' property to the 'RadioButton' component. Refs STCOM-1065.:
 * Prevent Popover from leaking escape keypress events. Refs STCOM-1061.
 * Enable dependabot. Refs STCOM-1068, FOLIO-3664.
+* Add 'focusIndex' property to be able to manually control the focus of an element in the list. Refs STCOM-1069.
 
 ## [10.3.0](https://github.com/folio-org/stripes-components/tree/v10.3.0) (2022-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.2.0...v10.3.0)

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -188,6 +188,7 @@ class MCLRenderer extends React.Component {
     containerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     contentData: PropTypes.arrayOf(PropTypes.object),
     dataEndReached: PropTypes.bool,
+    focusIndex: PropTypes.string,
     formatter: PropTypes.object,
     getCellClass: PropTypes.func,
     getHeaderCellClass: PropTypes.func,
@@ -260,6 +261,7 @@ class MCLRenderer extends React.Component {
     columnWidths: {},
     contentData: [],
     dataEndReached: false,
+    focusIndex: '',
     formatter: {},
     hasMargin: false,
     hotKeys: { keyMap: {}, handlers: {} },
@@ -496,7 +498,7 @@ class MCLRenderer extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { columnWidths, hasMargin, width, visibleColumns, contentData, pagingType, virtualize } = this.props;
+    const { columnWidths, hasMargin, width, visibleColumns, contentData, pagingType, virtualize, focusIndex } = this.props;
     const { columns, isSparse, columnWidths: stateColumnWidths, hasScrollbar: stateHasScrollbar } = this.state;
 
     let newState = {};
@@ -547,9 +549,9 @@ class MCLRenderer extends React.Component {
       }
     } else if (pagingType === pagingTypes.LOAD_MORE || pagingType === pagingTypes.PREV_NEXT) {
       // this.focusTargetIndex can be 0, so we need to check for undefined
-      if (this.focusTargetIndex !== undefined) {
+      if (focusIndex || this.focusTargetIndex !== undefined) {
         const { current } = this.scrollContainer;
-        const target = current && current.querySelector(`[data-row-index="row-${this.focusTargetIndex}"]`);
+        const target = current && current.querySelector(`[data-row-index="row-${focusIndex || this.focusTargetIndex}"]`);
 
         if (target) {
           const inner = getNextFocusable(target, true, true);

--- a/lib/MultiColumnList/readme.md
+++ b/lib/MultiColumnList/readme.md
@@ -81,6 +81,7 @@ Name | type | description | default | required
 `columnWidths` | object | Set custom column widths, e.g. {email: '150px'}. Component will automatically measure any columns that are unspecified. An object can be provided with `min` and `max` keys to set up a range - MCL will pick as close to the `min` as it can and none over the `max`.| |
 `contentData` | array of object | the list of objects to be displayed. | | required
 `dataEndReached` | bool | Used in conjuction with `pagingType="click"`, `dataEndReached` can be used if a suitable `totalCount` prop cannot be obtained. Setting this to `true` will render the "end-of-list" marker rather than the load button. | `false` |
+`focusIndex`  | string | The index of the list item to be focused on. Use this when pages have different numbers of list items. | |
 `formatter`  | object mapping names to functions | see separate section | |
 `getCellClass` | func | Used to update or completely overwrite the visual styles for each column. The function passed to this prop will receive the current CSS class, row data and the column name as the parameters and the returned value will overwrite the default class – e.g. `(defaultClass, rowData, header) => ${defaultClass} ${myCustomClass}` | `undefined` |
 `getHeaderCellClass` | func | Used to update the visual styles for each column header. The function passed to this prop will receive the column name as the  parameter and the returned value will extend the default class – e.g. `header =>  ${myCustomClass}` | `undefined` |


### PR DESCRIPTION
## Description
The story for which this is being done is [UIPFPAT-47](https://issues.folio.org/browse/UIPFPAT-47).

The focus doesn't go to the first item in the list after clicking the `Previous`/`Next` button. This is because the list can have a different number of items for each page, for example, there are 50 items on page 1, and 100 on the second. 

This was solved by adding the `focusIndex` prop to be able to manually pass the index of the item to be focused.

## Issues
[STCOM-1069](https://issues.folio.org/browse/STCOM-1069)