### PR TITLE
STCOM-1066 User can't click on the link if focus (highlighting) is on the row with link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add 'centered' property to the 'RadioButton' component. Refs STCOM-1065.:
 * Prevent Popover from leaking escape keypress events. Refs STCOM-1061.
 * Enable dependabot. Refs STCOM-1068, FOLIO-3664.
+* Fix link in focused MCL row not working. Fixes STCOM-1066.
 
 ## [10.3.0](https://github.com/folio-org/stripes-components/tree/v10.3.0) (2022-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.2.0...v10.3.0)

--- a/lib/sharedStyles/interactionStyles.css
+++ b/lib/sharedStyles/interactionStyles.css
@@ -54,6 +54,7 @@
   background: transparent;
   border-radius: var(--radius);
   z-index: -1;
+  pointer-events: none;
 }
 
 /**


### PR DESCRIPTION
## Description
Prevent row-level css from capturing pointer-events

`before` pseudo-elements on MCL row elements are covering the whole row and catching click events.

## Screenshots

https://user-images.githubusercontent.com/19309423/211005916-42c0c9da-448e-4758-a252-5b725a60c1e7.mp4

## Issues
[STCOM-1066](https://issues.folio.org/browse/STCOM-1066)