### PR TITLE
this one goes to 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for stripes-components
 
-## 10.4.0 (IN PROGRESS)
+## 11.0.0 (IN PROGRESS)
 
 * `<Paneset>` initializes state more thoroughly, avoiding nulls. Refs STCOM-1056.
 * After click submit button disable the confirmation button in Confirmation modal component. Refs STCOM-1058

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "10.4.0",
+  "version": "11.0.0",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
Bump the major version to accommodate breaking changes, i.e. the removal of many long-deprecated props across several components.