### PR TITLE
STCOM-1067 purge tether-related tests, props, examples

### DIFF
--- a/lib/AutoSuggest/tests/AutoSuggest-test.js
+++ b/lib/AutoSuggest/tests/AutoSuggest-test.js
@@ -30,21 +30,7 @@ const testItems = [
 
 describe('AutoSuggest', () => {
   const autosuggest = Interactor('autoSuggestTest');
-  // stub test for legacy coverage
-  describe('rendering legacy (tether)', () => {
-    beforeEach(async () => {
-      await mountWithContext(
-        <AutoSuggest label="autoSuggestTest" items={testItems} tether={{}} />
-      );
-    });
 
-    it('has no axe errors', runAxeTest);
-
-    it('renders the component', async () => {
-      await autosuggest.exists();
-    });
-  });
-  // end stub test for legacy.
   describe('rendering', () => {
     beforeEach(async () => {
       await mountWithContext(

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -465,18 +465,6 @@ describe('Datepicker', () => {
     it('adds required attribute to input field', () => datepicker.is({ required: true }));
   });
 
-  describe('legacy tether smoke test', () => {
-    beforeEach(async () => {
-      await mountWithContext(
-        <Datepicker tether={{ attachment: 'top left' }} />
-      );
-
-      await datepicker.openCalendar();
-    });
-
-    it('opens calendar', () => calendar.is({ visible: true }));
-  });
-
   // this test runs successfully in a `describe.only(...)` block
   // but fails when run as part of the full suite.
   // grrrrrrr.

--- a/lib/Dropdown/readme.md
+++ b/lib/Dropdown/readme.md
@@ -79,5 +79,4 @@ Name | type | description | default | required
 `relativePosition` | bool | in [some cases](https://stackoverflow.com/questions/54984952/popper-js-and-flex-end-causing-body-overflow), Popper.js requires relative positioning on the parent element of the anchor to adequately prevent overflow |
 
 ### Migration from past versions.
-- Previously, `<Dropdown>` accepted a `tether` prop that allowed for finer control over the `react-tether` library. Popper.js has its own API for adjusting the positioning behavior.
 - Previously, the API for dropdown used `data-role` attributes on children to identify which element to use as the trigger for the dropdown and which to use as a menu. This worked, but it wasn't great practice to inspect the children and augment their props. Previous `data-role="toggle"` components can be moved out to a `renderTrigger` function, or possibly omitted if the `label` and `buttonProps` props are adequate. The `data-role="menu"` element can be rendered using the `renderMenu` prop.

--- a/lib/MenuSection/stories/DropdownExample.js
+++ b/lib/MenuSection/stories/DropdownExample.js
@@ -22,11 +22,6 @@ class MenuInContext extends Component {
       <Dropdown
         id="AddPermissionDropdown"
         onToggle={() => this.setState(state => ({ open: !state.open }))}
-        tether={{
-          attachment: 'top left',
-          targetAttachment: 'bottom left',
-          targetOffset: '15px 0',
-        }}
         open={this.state.open}
       >
         <Button

--- a/lib/Selection/Selection.js
+++ b/lib/Selection/Selection.js
@@ -12,7 +12,6 @@ const propTypes = {
   labelIsValue: PropTypes.bool,
   listMaxHeight: PropTypes.string,
   name: PropTypes.string,
-  tether: PropTypes.object,
 };
 
 class Selection extends React.Component {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "react-overlays": "^4.1.1",
     "react-quill": "^1.3.3",
     "react-svg-loader": "^3.0.3",
-    "react-tether": "^1.0.1",
     "react-transition-group": "^2.2.1",
     "react-virtualized-auto-sizer": "^1.0.2",
     "tai-password-strength": "^1.1.1"


### PR DESCRIPTION
`tether` was removed in #1926 but we missed a few related tests and examples, as well as the prop on `<Selection>`.

Refs [STCOM-1067](https://issues.folio.org/browse/STCOM-1067)