### PR TITLE
STCOM-1076 loosen prop-types for TextLink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * BREAKING: Remove properties and components labeled as "deprecated". Refs STCOM-1067.
 * Enable dependabot. Refs STCOM-1068, FOLIO-3664.
 * Fix link in focused MCL row not working. Fixes STCOM-1066.
+* Loosen prop-types for `<TextLink>`. Refs STCOM-1076.
 
 ## [10.3.0](https://github.com/folio-org/stripes-components/tree/v10.3.0) (2022-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.2.0...v10.3.0)

--- a/lib/TextLink/TextLink.js
+++ b/lib/TextLink/TextLink.js
@@ -30,7 +30,7 @@ TextLink.propTypes = {
   className: PropTypes.string,
   element: PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.func]),
   href: PropTypes.string,
-  to: PropTypes.string,
+  to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
 };
 
 TextLink.displayName = 'TextLink';


### PR DESCRIPTION
`<TextLink>` may spread its props onto `<Link>`, which also accepts an object for `to`, hence the PropType here must also be less restrictive.

Refs [STCOM-1076](https://issues.folio.org/browse/STCOM-1076)