### PR TITLE
Revert "Bump stylelint-config-standard from 18.3.0 to 29.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,8 +95,8 @@
     "storybook-addon-intl": "^2.4.1",
     "storybook-addon-rtl": "^0.3.0",
     "storybook-readme": "^5.0.9",
-    "stylelint": "^14.16.1",
-    "stylelint-config-standard": "^29.0.0",
+    "stylelint": "^9.5.0",
+    "stylelint-config-standard": "^18.2.0",
     "stylelint-junit-formatter": "^0.2.1",
     "webpack": "~5.68.0"
   },


### PR DESCRIPTION
Reverts folio-org/stripes-components#1947

We were not prepared for the numerous warnings our present code generates after applying this update. 