### PR TITLE
STCOM-1101 Add `rootClass` and `fitContent` props to `<TextArea>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-components
 
+## [11.1.0](IN PROGRESS)
+
+* Add `rootClass` and `fitContent` props to `<TextArea>`. Refs STCOM-1101.
+
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)
 

--- a/lib/TextArea/TextArea.js
+++ b/lib/TextArea/TextArea.js
@@ -18,7 +18,13 @@ class TextArea extends Component {
     disabled: PropTypes.bool,
     endControl: PropTypes.element,
     error: PropTypes.node,
+    /**
+     * Will resize the textarea to resize to show all it's content
+     */
     fitContent: PropTypes.bool,
+    /**
+     * Will resize the textarea to be 100% of parent element's width
+     */
     fullWidth: PropTypes.bool,
     id: PropTypes.string,
     inputRef: PropTypes.oneOfType([

--- a/lib/TextArea/TextArea.js
+++ b/lib/TextArea/TextArea.js
@@ -18,6 +18,7 @@ class TextArea extends Component {
     disabled: PropTypes.bool,
     endControl: PropTypes.element,
     error: PropTypes.node,
+    fitContent: PropTypes.bool,
     fullWidth: PropTypes.bool,
     id: PropTypes.string,
     inputRef: PropTypes.oneOfType([
@@ -38,6 +39,7 @@ class TextArea extends Component {
     onChange: PropTypes.func,
     readOnly: PropTypes.bool,
     required: PropTypes.bool,
+    rootClass: PropTypes.string,
     startControl: PropTypes.element,
     /**
      * Can be "type" or "number". Standard html attribute.
@@ -70,6 +72,7 @@ class TextArea extends Component {
     return className(
       css.textArea,
       formStyles.inputGroup,
+      this.props.rootClass,
       { [`${css.fullWidth}`]: this.props.fullWidth },
     );
   }
@@ -92,6 +95,7 @@ class TextArea extends Component {
       dirty,
       endControl,
       error,
+      fitContent,
       fullWidth,
       inputRef,
       label,
@@ -117,6 +121,7 @@ class TextArea extends Component {
         id={this.inputId}
         name={name}
         ref={inputRef}
+        cols={fitContent ? this.props.value.length : undefined}
         {...omitProps(inputCustom, ['id', 'validationEnabled'])}
       />
     );

--- a/lib/TextArea/stories/BasicUsage.js
+++ b/lib/TextArea/stories/BasicUsage.js
@@ -17,6 +17,14 @@ const BasicUsage = () => (
       label="Disabled field"
       disabled
     />
+    <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+      <TextArea
+        value="This field has a very very very very very very long value"
+        label="Field with fit content"
+        fitContent
+      />
+      <TextArea label="Empty field" />
+    </div>
     <TextArea
       value="This field is read only"
       label="Read only field"

--- a/lib/TextArea/tests/TextArea-test.js
+++ b/lib/TextArea/tests/TextArea-test.js
@@ -73,4 +73,22 @@ describe('TextArea', () => {
 
     it('with a filled htmlFor attribute', () => textArea.find(LabelInteractor({ for: 'myTestInput' })).exists());
   });
+
+  describe('supplying fitContent', () => {
+    const textArea = Interactor('my test label');
+    const value = 'Test value';
+
+    beforeEach(async () => {
+      await mount(
+        <TextArea
+          label="my test label"
+          id="myTestInput"
+          fitContent
+          value={value}
+        />
+      );
+    });
+
+    it('has \'cols\' property', () => textArea.has({ cols: value.length }));
+  });
 });

--- a/lib/TextArea/tests/TextArea-test.js
+++ b/lib/TextArea/tests/TextArea-test.js
@@ -89,6 +89,6 @@ describe('TextArea', () => {
       );
     });
 
-    it('has \'cols\' property', () => textArea.has({ cols: value.length }));
+    it('has \'cols\' property', () => textArea.has({ cols: `${value.length}` }));
   });
 });

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@bigtest/interactor": "0.7.2",
     "@folio/eslint-config-stripes": "^6",
     "@folio/stripes-cli": "^2.4.0",
-    "@folio/stripes-testing": "^4.3.0",
+    "@folio/stripes-testing": "^4.5.0",
     "@mdx-js/loader": "^1.6.22",
     "@storybook/addon-actions": "^6.3.6",
     "@storybook/addon-essentials": "^6.3.6",


### PR DESCRIPTION
## Description
Add `rootClass` prop to be able to define custom styles for `<TextArea>` wrapper element
Add `fitContent` prop to be able to set initial width of `<TextArea>` to fit content

## Screenshots

https://user-images.githubusercontent.com/19309423/215756427-29c7e504-0572-4010-b9b6-fb439c73b15e.mp4


## Issues
[STCOM-1101](https://issues.folio.org/browse/STCOM-1101)