### PR TITLE
STCOM-1104 Timedropdown spinners not respecting ranges.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 * Add `rootClass` and `fitContent` props to `<TextArea>`. Refs STCOM-1101.
 * Fix bug with Timepicker formatting user input too quickly/aggressively. Refs STCOM-1103.
-
+* Fix big with Timepicker timedropdown spinners not respecting their appropriate ranges. Refs STCOM-1104.
+ 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)
 

--- a/lib/Timepicker/TimeDropdown.js
+++ b/lib/Timepicker/TimeDropdown.js
@@ -16,7 +16,7 @@ import TextField from '../TextField';
 import css from './TimeDropdown.css';
 import FocusLink from '../FocusLink';
 
-const keepInRange = (value, min, max, loop) => {
+const keepInRange = (value, min, max, loop = false) => {
   if (value > max) {
     return loop ? min : max;
   } else if (value < min) {
@@ -25,14 +25,14 @@ const keepInRange = (value, min, max, loop) => {
   return value;
 };
 
-const rangedIncrement = (value, amount, min, max, add) => {
+const rangedIncrement = (value, amount, min, max, add, loop) => {
   let local = value;
   if (add) {
     local += amount;
-    keepInRange(local, min, max);
+    local = keepInRange(local, min, max, loop);
   } else {
     local -= amount;
-    keepInRange(local, min, max);
+    local = keepInRange(local, min, max, loop);
   }
   return local;
 };
@@ -127,7 +127,7 @@ const TimeDropdown = ({
         let adjustedHour = curHour;
         if (!curHour) adjustedHour = '12';
         let newHour = parseInt(adjustedHour, 10);
-        newHour = rangedIncrement(newHour, amount, hourMax, hourMin, add);
+        newHour = rangedIncrement(newHour, amount, hourMin, hourMax, add, true);
         newHour = padZero(newHour);
         return newHour;
       });
@@ -136,7 +136,7 @@ const TimeDropdown = ({
         let adjustedMinute = curMinute;
         if (!curMinute) adjustedMinute = '0';
         let newMinute = parseInt(adjustedMinute, 10);
-        newMinute = rangedIncrement(newMinute, amount, 0, 59, add);
+        newMinute = rangedIncrement(newMinute, amount, 0, 59, add, true);
         newMinute = padZero(newMinute);
         return newMinute;
       });

--- a/lib/Timepicker/TimeDropdown.js
+++ b/lib/Timepicker/TimeDropdown.js
@@ -62,7 +62,7 @@ const rangedIncrement = (value, amount, min, max, add, loop) => {
 /**
 * @description padZero - utility function use to obtain two-character values,
 * adding a leading '0' to single number values.
-* @param {number} value - the value to pad.
+* @param {number} value - the value to possibly prefix with leading 0's.
 * @returns {string}
 */
 const padZero = (value) => {
@@ -75,7 +75,7 @@ const padZero = (value) => {
 /**
 * @description getListofDayPeriods - given a locale, returns the list of possible
 *   day periods as part of the locale's date format.
-* @param {string} locale the 4 character locale code.
+* @param {string} locale the 4 character locale code e.g. 'en-SE'.
 * @returns {string[]}
 */
 const getListofDayPeriods = (locale) => {

--- a/lib/Timepicker/TimeDropdown.js
+++ b/lib/Timepicker/TimeDropdown.js
@@ -16,6 +16,16 @@ import TextField from '../TextField';
 import css from './TimeDropdown.css';
 import FocusLink from '../FocusLink';
 
+/**
+* @description keepInRange - utility function for adjusting a supplied value to
+* fit within a supplied range of numbers.
+* @param {number} value - the current numerical value.
+* @param {number} min - the minimum value allowed in the range.
+* @param {number} max - the maximum value allowed in the range.
+* @param {bool} [loop = false] controls the behavior of the function when reaching the ends of the range -
+*   e.g. with loop set to 'true', once the value is greater than the max value, the min value will be returned.
+* @returns {number}
+*/
 const keepInRange = (value, min, max, loop = false) => {
   if (value > max) {
     return loop ? min : max;
@@ -25,6 +35,18 @@ const keepInRange = (value, min, max, loop = false) => {
   return value;
 };
 
+/**
+* @description rangedIncrement - utility function for incrementing/decrementing a
+* numeric value within a min/max range.
+* @param {number} value - the current numerical value.
+  @param {number} amount - the amount to increment the value by.
+  @param {number} min - the minimum value allowed in the range.
+  @param {number} max - the maximum value allowed in the range.
+* @param {bool} add controls if the call adds (true) or subtracts (false) from the value.
+* @param {bool} loop controls the behavior of the function when reaching the ends of the range -
+*   e.g. with loop set to 'true', once the value is greater than the max value, the min value will be returned.
+* @returns {number}
+*/
 const rangedIncrement = (value, amount, min, max, add, loop) => {
   let local = value;
   if (add) {
@@ -37,6 +59,12 @@ const rangedIncrement = (value, amount, min, max, add, loop) => {
   return local;
 };
 
+/**
+* @description padZero - utility function use to obtain two-character values,
+* adding a leading '0' to single number values.
+* @param {number} value - the value to pad.
+* @returns {string}
+*/
 const padZero = (value) => {
   if (typeof value === 'undefined') return undefined;
   return parseInt(value, 10) < 10 ?
@@ -44,6 +72,12 @@ const padZero = (value) => {
     value.toString();
 };
 
+/**
+* @description getListofDayPeriods - given a locale, returns the list of possible
+*   day periods as part of the locale's date format.
+* @param {string} locale the 4 character locale code.
+* @returns {string[]}
+*/
 const getListofDayPeriods = (locale) => {
   // Build array of time stamps for convenience.
   const dateArray = [];
@@ -70,6 +104,15 @@ const getListofDayPeriods = (locale) => {
   return [...dpOptions] || null;
 };
 
+/**
+* @description deriveDefaultTimePeriod - given the parameters, provides a possible time period used
+* to set the value of the timedropdown's period <Select>.
+* @param {string} value - a time string matching the timeFormat.
+* @param {string} hoursFormat - '12' or '24' matches the locale-based time format.
+* @param {string[]} timeFormat - array of possible time formats, ex: ['h:mm', 'h:', 'h']
+* @param {string[]} dayPeriods - array of possible day periods - am, pm, etc...
+* @returns {string}
+*/
 const deriveDefaultTimePeriod = (value, hoursFormat, timeFormat, dayPeriods) => {
   if (hoursFormat === '24') return null;
   if (value) return moment(value, timeFormat).format('A');

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -419,7 +419,7 @@ describe('Timepicker', () => {
     });
   });
 
-  describe('Timedropdown with 24 hour mode', () => {
+  describe.only('Timedropdown with 24 hour mode', () => {
     beforeEach(async () => {
       await mountWithContext((
         <div>
@@ -437,14 +437,23 @@ describe('Timepicker', () => {
       await timepicker.clickDropdownToggle();
     });
 
-    it('should set the hour time to zero', () => timeDropdown.has({ hour: 0 }));
+    it('should open the time dropdown', () => timeDropdown.exists());
 
-    describe('decrementing below the minimum', () => {
+    describe('entering a 0 into the hour field', () => {
       beforeEach(async () => {
-        await timeDropdown.clickDecrementHour();
-      });
+        await timeDropdown.fillHour('00');
+        await timeDropdown.fillMinute('00');
+      })
 
-      it('should loop to the maximum hour value', () => timeDropdown.has({ hour: 23 }));
+      it('zeros out the time', () => timeDropdown.has({ hour: 0 }));
+
+      describe('decrementing below the minimum', () => {
+        beforeEach(async () => {
+          await timeDropdown.clickDecrementHour();
+        });
+
+        it('should loop to the maximum hour value', () => timeDropdown.has({ hour: 23 }));
+      });
     });
   });
 });

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -426,7 +426,6 @@ describe('Timepicker', () => {
           <TimepickerHarness
             initialValue={'6:00:00.000Z'}
             id="timepicker-dropdown-test"
-            locale="de"
             autoFocus
           />
           <div id="anywhere-else" />
@@ -434,6 +433,7 @@ describe('Timepicker', () => {
       [{ prefix: 'stripes-components', translations: translationsDE }],
       'de');
 
+      await timepicker.fillIn('0:00');
       await timepicker.clickDropdownToggle();
     });
 

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -419,7 +419,7 @@ describe('Timepicker', () => {
     });
   });
 
-  describe.only('Timedropdown with 24 hour mode', () => {
+  describe('Timedropdown with 24 hour mode', () => {
     beforeEach(async () => {
       await mountWithContext((
         <div>

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -314,12 +314,48 @@ describe('Timepicker', () => {
 
       describe('when filling out the hour/minute inputs and clicking the confirm button', () => {
         const initialHours = 11;
-        const initialMinutes = 30;
+        const initialMinutes = 58;
 
         beforeEach(async () => {
           // Manually filling out the hours and minutes inputs
           await timeDropdown.fillHour(initialHours);
           await timeDropdown.fillMinute(initialMinutes);
+        });
+
+        describe('clicking the add hours button', () => {
+          beforeEach(async () => {
+            await timeDropdown.clickAddHour();
+            await timeDropdown.clickAddHour();
+          });
+
+          it('should loop the value to the minimum hour value', () => timeDropdown.has({ hour: 1 }));
+        });
+
+        describe('clicking the add minute button', () => {
+          beforeEach(async () => {
+            await timeDropdown.clickAddMinute();
+            await timeDropdown.clickAddMinute();
+          });
+
+          it('should loop the value to the maximum minute value', () => timeDropdown.has({ minute: 0 }));
+        });
+
+        describe('spinning through the minimum hour minute values', () => {
+          beforeEach(async () => {
+            await timeDropdown.fillHour('1');
+            await timeDropdown.fillMinute('00');
+          });
+
+          it('displays appropriate hour and minute values', () => timeDropdown.has({ minute: 0, hour: 1 }));
+
+          describe('decrement hours and minutes below the minimum', () => {
+            beforeEach(async () => {
+              await timeDropdown.clickDecrementHour();
+              await timeDropdown.clickDecrementMinute();
+            });
+
+            it('displays maximum hour and minute values', () => timeDropdown.has({ minute: 59, hour: 12 }));
+          });
         });
 
         describe('clicking the increment minutes and hours buttons', () => {
@@ -380,6 +416,35 @@ describe('Timepicker', () => {
           it('should leave the orinal value in the timepicker', () => timepicker.has({ value: expectedTime }));
         });
       });
+    });
+  });
+
+  describe('Timedropdown with 24 hour mode', () => {
+    beforeEach(async () => {
+      await mountWithContext((
+        <div>
+          <TimepickerHarness
+            initialValue={'6:00:00.000Z'}
+            id="timepicker-dropdown-test"
+            locale="de"
+            autoFocus
+          />
+          <div id="anywhere-else" />
+        </div>),
+      [{ prefix: 'stripes-components', translations: translationsDE }],
+      'de');
+
+      await timepicker.clickDropdownToggle();
+    });
+
+    it('should set the hour time to zero', () => timeDropdown.has({ hour: 0 }));
+
+    describe('decrementing below the minimum', () => {
+      beforeEach(async () => {
+        await timeDropdown.clickDecrementHour();
+      });
+
+      it('should loop to the maximum hour value', () => timeDropdown.has({ hour: 23 }));
     });
   });
 });


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-1104

Currently, the time values can go into negative or well beyond the 59 minute mark...

The Timepicker spinners should function within the ranges of their particular hour format, with a range of 0 - 59 for minutes and 0-23 for 24 hour format , 1-12 in 12 hour format.

This PR focuses on that logic to ensure a value within the ranges is set.
The main issue was a mistake in trying (and failing) to mutate a value.
Tests are added for both 12 and 24 hour modes.