### PR TITLE
STCOM-1074: MCL - Axe error... 'required children' 

### DIFF
--- a/lib/MultiColumnList/CenteredContainer.js
+++ b/lib/MultiColumnList/CenteredContainer.js
@@ -4,7 +4,7 @@ import { isFinite } from 'lodash';
 import Layout from '../Layout';
 import css from './MCLRenderer.css';
 
-const CenteredContainer = ({ innerRef, visible, width, children, style: styleProp }) => {
+const CenteredContainer = ({ innerRef, visible, width, children, role, style: styleProp }) => {
   // subtracting the margins to prevent horizontal scroll
   const endOfListWidth = isFinite(width) ? `${Math.max(width - 20, 200)}px` : '100%';
 
@@ -19,6 +19,7 @@ const CenteredContainer = ({ innerRef, visible, width, children, style: stylePro
           padding: `${visible ? null : 0}`,
           ...styleProp }
         }
+      role={role}
     >
       <Layout className="textCentered">
         {children}
@@ -30,6 +31,7 @@ const CenteredContainer = ({ innerRef, visible, width, children, style: stylePro
 CenteredContainer.propTypes = {
   children: PropTypes.node,
   innerRef: PropTypes.object,
+  role: PropTypes.string,
   style: PropTypes.object,
   visible: PropTypes.bool,
   width: PropTypes.number,

--- a/lib/MultiColumnList/LoadMorePaginationRow.js
+++ b/lib/MultiColumnList/LoadMorePaginationRow.js
@@ -59,11 +59,13 @@ const LoadMorePaginationRow = ({
         <div
           key={`${localRowIndex}-load-button`}
           style={{ position: virtualize ? 'absolute' : 'relative', top: `${position}px`, marginTop: '1rem' }}
+          role="row"
         >
           <CenteredContainer
             width={width || prevWidth || undefined}
             innerRef={pagingButtonRef}
             visible
+            role="gridcell"
           >
             <FormattedMessage id="stripes-components.mcl.itemsRequestedMessage">
               { ([message]) => (

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -40,7 +40,7 @@ import LoaderRow from './LoaderRow';
 import EndOfList from './EndOfList';
 import DimensionCache from './DimensionCache';
 
-import { getNextFocusable } from '../../util/getFocusableElements';
+import { getNextFocusable, FOCUSABLE_SELECTOR } from '../../util/getFocusableElements';
 import * as baseHandlers from './defaultHandlers';
 import { calculateColumnWidth3q } from './calculateWidth';
 import convertToPixels from './convertToPixels';
@@ -177,6 +177,18 @@ export const pagingTypes = {
   PREV_NEXT: 'prev-next',
   SCROLL: 'scroll'
 };
+
+// we only need a tab-index on the scrollcontainer if there are no other
+// focusable elements within it.
+function getScrollableTabIndex(scrollContainer) {
+  if (scrollContainer.current) {
+    const focusable = scrollContainer.current.querySelector(FOCUSABLE_SELECTOR);
+    if (focusable) {
+      return {};
+    }
+  }
+  return { tabIndex: '0' }
+}
 
 class MCLRenderer extends React.Component {
   static propTypes = {
@@ -1888,7 +1900,7 @@ class MCLRenderer extends React.Component {
             style={this.getScrollableStyle()}
             onScroll={this.handleScroll}
             ref={this.scrollContainer}
-            tabIndex="0" // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
+            {...getScrollableTabIndex(this.scrollContainer)}
           >
             <div
               className={rowContainerClass}

--- a/lib/MultiColumnList/PrevNextPaginationRow.js
+++ b/lib/MultiColumnList/PrevNextPaginationRow.js
@@ -90,10 +90,11 @@ const PrevNextPaginationRow = ({
             top: `${position}px`,
             marginTop: '1rem'
           }}
+          role="row"
         >
           <FormattedMessage id="stripes-components.mcl.itemsRequestedMessage">
             { ([message]) => (
-              <div className={css.mclPrevNextStickyContainer}>
+              <div className={css.mclPrevNextStickyContainer} role="gridcell">
                 <div className={css.mclPaginationCenterContainer}>
                   <div className={css.mclPrevNextButtonContainer}>
                     <PagingButton

--- a/lib/MultiColumnList/stories/MaxHeightVirtualized.js
+++ b/lib/MultiColumnList/stories/MaxHeightVirtualized.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import MultiColumnList from '../MultiColumnList';
+import TextLink from '../../TextLink';
 import { asyncGenerate } from './service';
 
 export default class MaxHeightVirtualized extends React.Component {
@@ -18,6 +19,11 @@ export default class MaxHeightVirtualized extends React.Component {
     }));
   }
 
+
+  formatter = {
+    title: (row) => <TextLink href="https://github.com/folio-org/stripes-components">{row.title}</TextLink>
+  }
+
   render() {
     const columnWidths = {
       'title': '100px'
@@ -28,11 +34,12 @@ export default class MaxHeightVirtualized extends React.Component {
         <MultiColumnList
           contentData={this.state.data}
           columnWidths={columnWidths}
-          visibleColumns={['index', 'title', 'date', 'email']}
+          visibleColumns={['title', 'index', 'date', 'email']}
           interactive={false}
           maxHeight={500}
           virtualize
           onNeedMoreData={this.requestMore}
+          formatter={this.formatter}
         />
       </div>
     );

--- a/lib/MultiColumnList/tests/MultiColumnList-test.js
+++ b/lib/MultiColumnList/tests/MultiColumnList-test.js
@@ -12,6 +12,7 @@ import {
   HTML as HTMLInteractor,
   runAxeTest,
   Button,
+  including,
 } from '@folio/stripes-testing';
 
 import { mountWithContext } from '../../../tests/helpers';
@@ -77,6 +78,10 @@ function withClientTop(comparator) {
   };
 }
 
+const tabIndexedElement = HTMLInteractor.extend('tab-indexed')
+  .filters({
+    tabIndex: el => el.tabIndex,
+  })
 
 let headerClicked = false;
 
@@ -108,6 +113,8 @@ describe('MultiColumnList', () => {
       await mcl.find(CellInteractor({ row: 0, columnIndex: 2 })).perform(assertWidthWithin(60, 80));
       await mcl.find(CellInteractor({ row: 0, columnIndex: 3 })).perform(assertWidthWithin(60, 80));
     });
+
+    it('adds a tabindex to scroll container since the table contains no focusable elements', () => tabIndexedElement({ tabIndex: 0, className: including('mclScrollable') }).exists());
   });
 
   describe('Basic data rendering', () => {
@@ -483,7 +490,8 @@ describe('MultiColumnList', () => {
                     {` since ${item.joinDate}`}
                   </div>
                 </>
-              )
+              ),
+              email: (item) => <a href={`mailto:${item.email}`}>{item.email}</a>
             }
           }
         />
@@ -506,6 +514,8 @@ describe('MultiColumnList', () => {
       it('displays specified columns', () => mcl.has({ columnCount: visibleCol.length }));
 
       it('renders the formatter', () => mcl.find(CellInteractor({ row: 3, columnIndex: 0 })).assert((el) => !!el.querySelector('[data-test-date-joined]')));
+
+      it('renders the scrollable container without a tabindex since it contains focusable elements (links)', () => tabIndexedElement({ tabIndex: -1, className: including('mclScrollable') }).exists());
     });
   });
 

--- a/util/getFocusableElements.js
+++ b/util/getFocusableElements.js
@@ -1,18 +1,19 @@
-/*  getNextFocusable() and getPreviousFocusable() -
-*    Returns next/previous focusable DOM element, respectively
-*   Params:
-*     currentElement
-*       (object) DOM element - starting element for search. Returns next focused element AFTER this element.
-*     includeContained
-*       (bool) Default: true. Will return the next focusable item within the current element. If false, returned
-*       element will be outside of the container,
-*      onlyContained
-*       (bool) Default: false. If true and includeContaining is true, the search is limited only to
-*        elements within the container.
-*     loop
-*       (bool) Default: true. Elements are chosen by index. If the index is beyond the end of the list,
-*       the first element will be returned.
-*       If the index is before the start of the list, the last element will be returned.
+/**
+ * @typedef {Function} getNextFocusable()
+ *    @description Returns next/previous focusable DOM element, respectively
+ *   Params:
+ *     @param {object} currentElement
+ *       DOM element - starting element for search. Returns next focused element AFTER this element.
+ *     @param {bool} includeContained
+ *       Default: true. Will return the next focusable item within the current element. If false, returned
+ *       element will be outside of the container,
+ *      @param {bool} onlyContained
+ *       Default: false. If true and includeContaining is true, the search is limited only to
+ *        elements within the container.
+ *     @param {bool} loop
+ *       Default: true. Elements are chosen by index. If the index is beyond the end of the list,
+ *       the first element will be returned.
+ *       If the index is before the start of the list, the last element will be returned.
 */
 
 import contains from 'dom-helpers/query/contains';
@@ -20,11 +21,12 @@ import matches from 'dom-helpers/query/matches';
 import first from 'lodash/first';
 import last from 'lodash/last';
 
+// eslint-disable-next-line max-len
+export const FOCUSABLE_SELECTOR = 'a:not([disabled]), button:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([disabled]):not([tabindex="-1"]), [tabIndex="-1"]:not([disabled]):focus';
+
 function getVisibleFocusableElements(container = document, includeContained, currentElement) {
   if (container.querySelectorAll) {
-    // eslint-disable-next-line max-len
-    const focusableSelector = 'a:not([disabled]), button:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([disabled]):not([tabindex="-1"]), [tabIndex="-1"]:not([disabled]):focus';
-    return Array.from(container.querySelectorAll(focusableSelector))
+    return Array.from(container.querySelectorAll(FOCUSABLE_SELECTOR))
       .filter((element) => {
         if (!includeContained) {
           if (element === currentElement) {


### PR DESCRIPTION
TLDR, MCL's that use links within the cells rather than row-level anchors perform fine with assistive technology. Axe-core has a couple of rules that seem to work in opposition to eachother given recent updates >=4.5.0. 

The axe rules themselves affecting this case are too generic and potentially wide sweeping to just turn off. `aria-required-children` checks for proper parent/child structure of elements with aria roles. It's a very important test to have for libraries that export complex widgets.

Maintainers of `axe-core` understand that their library [needs work with these detections](https://github.com/dequelabs/axe-core/issues/3888). There has been some work around the approach for `aria-required-children` but [suggesting an attribute such as `aria-busy`](https://github.com/dequelabs/axe-core/issues/3208) seems ill-advised if nothing is truly busy, despite that it stifles the axe errors - unfortunately, that's the path that *some developers may take since it's the shortest path to the goal of appeasing axe software.

Approach: conditionally render a tabindex on the scrollable container if it contains no focusable elements. The vast majority of our grids in FOLIO contain focusable elements, so this will  omit the `tabindex` attribute from those grids and calm those errors down. If there are any spots that persist, a check for the 'virtualize' prop may be necessary, but the fewer conditionals we can get away with, the better.

Elaborating on the problem, the WAI-ARIA spec includes DOM-descendents in their [definition of 'owned elements.'](https://www.w3.org/TR/wai-aria/#dfn-owned-element) By this definition, the structure in which MCL arranges its aria-roles of MCL (`grid` , `row`, `gridcell`) are acceptable and allow for screen readers to function normally. Role-less, non-interactive elements are ignored in these sort of hierarchy checks... but if so much as a `tabindex` is added to an element, it now causes a gap in the hierarchy (for axe's check) resulting in an error. Since there is another potential violation for [keyboard interaction with scrollable areas](https://dequeuniversity.com/rules/axe/4.3/scrollable-region-focusable?application=AxeChrome), [common](https://bvaughn.github.io/react-virtualized/#/components/Table) [virtualized components](https://ag-grid.com/examples/infinite-scrolling/simple/packages/vanilla/index.html) add a `tabindex`-ed element into their structures - and axe throws the error for them as well... If the `tabindex` on the scroll container is removed, then the error will go away *so long as there are focusable elements within the container - and that's the logic that this PR follows.
