### PR TITLE
STCOM-1118 Timepicker dropdown not spinning values when value is empty.

### DIFF
--- a/lib/Timepicker/TimeDropdown.js
+++ b/lib/Timepicker/TimeDropdown.js
@@ -157,9 +157,16 @@ const TimeDropdown = ({
   const hourMax = useRef(hoursFormat === '24' ? 23 : 12).current;
   const hourMin = useRef(hoursFormat === '24' ? 0 : 1).current;
   const dayPeriods = hoursFormat === '12' && getListofDayPeriods(intl.locale);
-  const [hour, setHour] = useState(selectedTime && moment(selectedTime, timeFormat)
-    .format(`${hoursFormat === '24' ? 'HH' : 'h'}`));
-  const [minute, setMinute] = useState(selectedTime && moment(selectedTime, timeFormat).format('mm'));
+  const [hour, setHour] = useState(
+    selectedTime ?
+      moment(selectedTime, timeFormat).format(`${hoursFormat === '24' ? 'HH' : 'h'}`) :
+      moment().format(`${hoursFormat === '24' ? 'HH' : 'h'}`)
+  );
+  const [minute, setMinute] = useState(
+    selectedTime ?
+      moment(selectedTime, timeFormat).format('mm') :
+      moment().format('mm')
+  );
   const [period, setPeriod] = useState(deriveDefaultTimePeriod(selectedTime, hoursFormat, timeFormat, dayPeriods));
   const hoursInput = useRef(null);
   const confirmButton = useRef(null);
@@ -171,7 +178,7 @@ const TimeDropdown = ({
         if (!curHour) adjustedHour = '12';
         let newHour = parseInt(adjustedHour, 10);
         newHour = rangedIncrement(newHour, amount, hourMin, hourMax, add, true);
-        newHour = padZero(newHour);
+        newHour = hoursFormat === '24' ? padZero(newHour) : newHour;
         return newHour;
       });
     } else if (unit === 'minute') {
@@ -202,10 +209,11 @@ const TimeDropdown = ({
 
   const handleBlur = (e, unit) => {
     let parsedValue = parseInt(e.target.value, 10);
-    parsedValue = padZero(parsedValue);
     if (unit === 'hour') {
+      if (hoursFormat === '24') parsedValue = padZero(parsedValue);
       setHour(parsedValue);
     } else {
+      parsedValue = padZero(parsedValue);
       setMinute(parsedValue);
     }
   };

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -63,7 +63,7 @@ const TimepickerInteractor = TextField.extend('timepicker')
     clickClear: ({ find }) => find(IconButton({ icon: 'times-circle-solid' })).click()
   });
 
-describe('Timepicker', () => {
+describe.only('Timepicker', () => {
   const timepicker = TimepickerInteractor();
   const timeDropdown = TimepickerDropdownInteractor();
 
@@ -78,6 +78,15 @@ describe('Timepicker', () => {
   it('does not have a value in the input', () => timepicker.has({ value: '' }));
 
   it('has an id on the input element', () => timepicker.has({ id: 'timepicker-test' }));
+
+  describe('opening the dropdown with no time selected', () => {
+    beforeEach(async () => {
+      await timepicker.clickDropdownToggle();
+    });
+
+    it('displays the time dropdown', () => timeDropdown.exists());
+    it('displays the current time in the time dropdown', () => timeDropdown.has({ hour: parseInt(moment().format('h'), 10), minute: parseInt(moment().format('mm'), 10) }));
+  });
 
   describe('selecting a time', () => {
     let timeOutput;


### PR DESCRIPTION
Pre-refactor `<Timepicker>` would default to using the current time in its `TimeDrpodown` if the selected time value was empty. The refactor should behave in the same way, enabling spinner buttons to work.

Approach, modify the initial state of TimeDropdown for the case where the `selectedTime` prop is empty. The initial state will be equal to `moment()` with the applicable `format()` call depending on whether it's in the hour or minute field.