### PR TITLE
STCOM-1119 Timepicker vs React-fin- er, um Redux-form (aka stsmacom's ChangeDueDateDialog)

### DIFF
--- a/lib/Datepicker/readme.md
+++ b/lib/Datepicker/readme.md
@@ -8,9 +8,6 @@ import { Datepicker } from '@folio/stripes/components';
 //or pass as component within a form...
 <Field component={Datepicker} />
 ```
-outputBackendValue: PropTypes.bool,
-  outputFormatter: PropTypes.func,
-  parser: PropTypes.func,
 
 ## Props
 Name | type | description | default | required

--- a/lib/Timepicker/TimeDropdown.js
+++ b/lib/Timepicker/TimeDropdown.js
@@ -157,9 +157,16 @@ const TimeDropdown = ({
   const hourMax = useRef(hoursFormat === '24' ? 23 : 12).current;
   const hourMin = useRef(hoursFormat === '24' ? 0 : 1).current;
   const dayPeriods = hoursFormat === '12' && getListofDayPeriods(intl.locale);
-  const [hour, setHour] = useState(selectedTime && moment(selectedTime, timeFormat)
-    .format(`${hoursFormat === '24' ? 'HH' : 'h'}`));
-  const [minute, setMinute] = useState(selectedTime && moment(selectedTime, timeFormat).format('mm'));
+  const [hour, setHour] = useState(
+    selectedTime ?
+      moment(selectedTime, timeFormat).format(`${hoursFormat === '24' ? 'HH' : 'h'}`) :
+      moment().format(`${hoursFormat === '24' ? 'HH' : 'h'}`)
+  );
+  const [minute, setMinute] = useState(
+    selectedTime ?
+      moment(selectedTime, timeFormat).format('mm') :
+      moment().format('mm')
+  );
   const [period, setPeriod] = useState(deriveDefaultTimePeriod(selectedTime, hoursFormat, timeFormat, dayPeriods));
   const hoursInput = useRef(null);
   const confirmButton = useRef(null);
@@ -171,7 +178,7 @@ const TimeDropdown = ({
         if (!curHour) adjustedHour = '12';
         let newHour = parseInt(adjustedHour, 10);
         newHour = rangedIncrement(newHour, amount, hourMin, hourMax, add, true);
-        newHour = padZero(newHour);
+        newHour = hoursFormat === '24' ? padZero(newHour) : newHour;
         return newHour;
       });
     } else if (unit === 'minute') {
@@ -202,10 +209,11 @@ const TimeDropdown = ({
 
   const handleBlur = (e, unit) => {
     let parsedValue = parseInt(e.target.value, 10);
-    parsedValue = padZero(parsedValue);
     if (unit === 'hour') {
+      if (hoursFormat === '24') parsedValue = padZero(parsedValue);
       setHour(parsedValue);
     } else {
+      parsedValue = padZero(parsedValue);
       setMinute(parsedValue);
     }
   };

--- a/lib/Timepicker/TimeDropdown.js
+++ b/lib/Timepicker/TimeDropdown.js
@@ -129,6 +129,7 @@ const propTypes = {
   mainControl: deprecated(PropTypes.object, 'no longer needed - handle focus management in onSetTime'), // eslint-disable-line
   minuteIncrement: PropTypes.number,
   onBlur: deprecated(PropTypes.func, 'focus trapped automatically'), //eslint-disable-line
+  onFocus: PropTypes.func,
   onHide: PropTypes.func,
   onSetTime: PropTypes.func,
   rootRef: PropTypes.oneOfType([
@@ -146,11 +147,12 @@ const TimeDropdown = ({
   id,
   intl: intlProp,
   minuteIncrement = 1,
-  onHide = ()=>{}, // eslint-disable-line
+  onHide = () => {}, // eslint-disable-line
   onSetTime,
   rootRef,
   selectedTime,
   timeFormat,
+  onFocus = () => {},
 }) => {
   const intlContext = useIntl();
   const intl = intlProp || intlContext;
@@ -254,6 +256,7 @@ const TimeDropdown = ({
       data-test-timepicker-dropdown
       onSubmit={confirmTime}
       onKeyDown={handleKeyDown}
+      onFocus={onFocus}
     >
       <>
         <FocusLink

--- a/lib/Timepicker/TimeDropdown.js
+++ b/lib/Timepicker/TimeDropdown.js
@@ -159,10 +159,11 @@ const TimeDropdown = ({
   const hourMax = useRef(hoursFormat === '24' ? 23 : 12).current;
   const hourMin = useRef(hoursFormat === '24' ? 0 : 1).current;
   const dayPeriods = hoursFormat === '12' && getListofDayPeriods(intl.locale);
+  const hoursFormatCharacter = useRef(`${hoursFormat === '24' ? 'HH' : 'h'}`).current;
   const [hour, setHour] = useState(
     selectedTime ?
-      moment(selectedTime, timeFormat).format(`${hoursFormat === '24' ? 'HH' : 'h'}`) :
-      moment().format(`${hoursFormat === '24' ? 'HH' : 'h'}`)
+      moment(selectedTime, timeFormat).format(hoursFormatCharacter) :
+      moment().format(hoursFormatCharacter)
   );
   const [minute, setMinute] = useState(
     selectedTime ?
@@ -193,7 +194,7 @@ const TimeDropdown = ({
         return newMinute;
       });
     }
-  }, [hourMax, hourMin]);
+  }, [hourMax, hourMin, hoursFormat]);
 
   useEffect(() => () => onHide(), []); // eslint-disable-line
 

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -70,7 +70,9 @@ const propTypes = {
   locale: PropTypes.string,
   marginBottom0: PropTypes.bool,
   modifiers: PropTypes.object,
+  onBlur: PropTypes.func,
   onChange: PropTypes.func,
+  onFocus: PropTypes.func,
   outputFormatter: PropTypes.func,
   parser: PropTypes.func,
   placement: PropTypes.oneOf(AVAILABLE_PLACEMENTS),
@@ -373,7 +375,9 @@ Timepicker.propTypes = propTypes;
 
 export default FormField(
   Timepicker,
-  ({ meta }) => ({
+  ({ input, meta }) => ({
+    onBlur: input?.onBlur,
+    onFocus: input?.onFocus,
     dirty: meta?.dirty,
     error: (meta?.touched && meta?.error ? meta.error : ''),
     valid: meta?.valid,

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -95,7 +95,7 @@ const Timepicker = ({
   modifiers,
   onChange,
   outputFormatter = defaultOutputFormatter,
-  outputBackendValue = false,
+  outputBackendValue = true,
   parser = defaultParser,
   placement,
   screenReaderMessage,
@@ -262,7 +262,7 @@ const Timepicker = ({
   */
   const handleChange = (e) => {
     candidate.current = Object.assign(candidate.current, maybeUpdateValue(e.target.value));
-    if (useInput && onChange) {
+    if ((!useInput || !outputBackendValue) && onChange) {
       onChange(e, e.target.value, candidate.current.timeString);
     } else if (typeof candidate.current.formatted === 'string' &&
       candidate.current.formatted !== hiddenInput.current.value) {
@@ -272,7 +272,7 @@ const Timepicker = ({
 
   // for final-form so it can have a native change event rather than a fabricated thing...
   const onChangeFormatted = (e) => {
-    if (!useInput && onChange) {
+    if (useInput && onChange) {
       const { timeString, formatted } = candidate.current;
       onChange(e, formatted, timeString);
     }
@@ -404,6 +404,7 @@ const Timepicker = ({
             onHide={hideTimepicker}
             selectedTime={timePair.timeString}
             timeFormat={timeFormat}
+            onFocus={handleInternalFocus}
             rootRef={dropdownRef}
             id={testId}
             onClose={() => setShowDropdown(false)}
@@ -425,5 +426,6 @@ export default FormField(
     error: (meta?.touched && meta?.error ? meta.error : ''),
     valid: meta?.valid,
     warning: (meta?.touched ? parseMeta(meta, 'warning') : ''),
+    useInput: true,
   })
 );

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -301,7 +301,8 @@ const Timepicker = ({
 
   // the way that redux-form treats blurs is to trigger an onChange event on the target.
   // this holds onto the event until blur has passed out of the component/dropdown, controls.
-  // without this treatment, the time can end up blank
+  // without this treatment, the time can end up blank.
+  // the timeout is used to ensure the hidden input's value is updated. This is candidate for refactor...
   const queueBlur = (e) => {
     blurTimeout.current = setTimeout(() => {
       if (onBlur) {

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -299,6 +299,9 @@ const Timepicker = ({
   const { readOnly, disabled, label } = inputProps;
   const screenReaderFormat = timeFormat.split('').join(' ');
 
+  // the way that redux-form treats blurs is to trigger an onChange event on the target.
+  // this holds onto the event until blur has passed out of the component/dropdown, controls.
+  // without this treatment, the time can end up blank
   const queueBlur = (e) => {
     blurTimeout.current = setTimeout(() => {
       if (onBlur) {

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -73,6 +73,7 @@ const propTypes = {
   onBlur: PropTypes.func,
   onChange: PropTypes.func,
   onFocus: PropTypes.func,
+  outputBackendValue: PropTypes.bool,
   outputFormatter: PropTypes.func,
   parser: PropTypes.func,
   placement: PropTypes.oneOf(AVAILABLE_PLACEMENTS),
@@ -94,6 +95,7 @@ const Timepicker = ({
   modifiers,
   onChange,
   outputFormatter = defaultOutputFormatter,
+  outputBackendValue = false,
   parser = defaultParser,
   placement,
   screenReaderMessage,
@@ -103,12 +105,15 @@ const Timepicker = ({
   useInput,
   usePortal,
   value: valueProp,
+  onBlur,
+  onFocus,
   ...inputProps
 }) => {
   const input = useRef(null);
   const hiddenInput = useRef(null);
   const srStatus = useRef(null);
   const container = useRef(null);
+  const blurTimeout = useRef(null);
   const dropdownRef = useRef(null);
   const testId = useRef(uniqueId('-timepicker')).current;
   const intlContext = useIntl();
@@ -294,6 +299,39 @@ const Timepicker = ({
   const { readOnly, disabled, label } = inputProps;
   const screenReaderFormat = timeFormat.split('').join(' ');
 
+  const queueBlur = (e) => {
+    blurTimeout.current = setTimeout(() => {
+      if (onBlur) {
+        if (useInput) {
+          onBlur({
+            target: outputBackendValue ? hiddenInput.current : input.current,
+            stopPropagation: () => {},
+            preventDefault: () => {},
+            defaultPrevented: true,
+          });
+        } else {
+          onBlur(e);
+        }
+      }
+    });
+  };
+
+  const cancelBlur = () => {
+    clearTimeout(blurTimeout.current);
+  };
+
+  const handleInternalBlur = (e) => {
+    e.preventDefault();
+    queueBlur(e);
+  };
+
+  const handleInternalFocus = (e) => {
+    cancelBlur();
+    if (onFocus) {
+      onFocus(e);
+    }
+  };
+
   let ariaLabel;
   if (readOnly || disabled) {
     ariaLabel = `${label}`;
@@ -319,7 +357,12 @@ const Timepicker = ({
 
   return (
     <>
-      <div style={{ position: 'relative', width: '100%' }} ref={container}>
+      <div
+        style={{ position: 'relative', width: '100%' }}
+        ref={container}
+        onFocus={handleInternalFocus}
+        onBlur={handleInternalBlur}
+      >
         <SRStatus ref={srStatus} />
         <TextField
           {...inputProps}

--- a/lib/Timepicker/tests/Timepicker-reduxform-test.js
+++ b/lib/Timepicker/tests/Timepicker-reduxform-test.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import { describe, beforeEach, it } from 'mocha';
+import sinon from 'sinon';
+import { Field } from 'redux-form';
+import {
+  converge,
+} from '@folio/stripes-testing';
+
+import { mountWithContext } from '../../../tests/helpers';
+import TestForm from '../../../tests/TestForm';
+
+import Timepicker from '../Timepicker';
+
+import {
+  Timepicker as TimepickerInteractor,
+  TimeDropdown as TimepickerDropdownInteractor
+} from './timepicker-interactor-bt';
+
+describe('Timepicker with redux form', () => {
+  const timepicker = TimepickerInteractor({ id: 'test-time' });
+  const timedropdown = TimepickerDropdownInteractor();
+  describe('selecting a time', () => {
+    let timeOutput;
+    const handleChange = sinon.spy((e) => {
+      timeOutput = e.target.value;
+    });
+    beforeEach(async () => {
+      timeOutput = '';
+      await handleChange.resetHistory();
+      await mountWithContext(
+        <TestForm>
+          <Field
+            component={
+              ({ input, meta }) => {
+                input.onChange = (e) => {
+                  input.onChange(e);
+                  handleChange(e);
+                };
+                return (
+                  <Timepicker
+                    input={input}
+                    meta={meta}
+                    id="test-time"
+                  />
+                )
+              }}
+            name="time"
+          />
+        </TestForm>
+      );
+
+      await timepicker.fillIn('05:00 PM');
+    });
+
+    it('returns an ISO 8601 time string at UTC', () => converge(() => timeOutput === '17:00:00.000Z'));
+    it('calls the handler multiple times - on change and onBlur', () => converge(() => handleChange.calledTwice));
+
+    describe('opening the dropdown', () => {
+      beforeEach(async () => {
+        await timepicker.clickDropdownToggle();
+      });
+
+      it('focuses the timeDropdown', () => timedropdown.has({ focused: true }));
+      it('retains the correct value in the input', () => timepicker.has({ value: '05:00 PM' }));
+    })
+  });
+});

--- a/lib/Timepicker/tests/Timepicker-reduxform-test.js
+++ b/lib/Timepicker/tests/Timepicker-reduxform-test.js
@@ -38,7 +38,7 @@ describe('Timepicker with redux form', () => {
         />
       );
 
-      await timepicker.fillIn('05:00 PM');
+      await timepicker.fillIn('5:00 PM');
     });
 
     it('returns an ISO 8601 time string at UTC', () => converge(() => timeOutput === '17:00:00.000Z'));
@@ -50,7 +50,7 @@ describe('Timepicker with redux form', () => {
       });
 
       it('focuses the timeDropdown', () => timedropdown.has({ focused: true }));
-      it('retains the correct value in the input', () => timepicker.has({ value: '05:00 PM' }));
-    })
+      it('retains the correct value in the input', () => timepicker.has({ value: '5:00 PM' }));
+    });
   });
 });

--- a/lib/Timepicker/tests/Timepicker-reduxform-test.js
+++ b/lib/Timepicker/tests/Timepicker-reduxform-test.js
@@ -27,26 +27,15 @@ describe('Timepicker with redux form', () => {
     beforeEach(async () => {
       timeOutput = '';
       await handleChange.resetHistory();
+      const input = {
+        onChange: (e) => handleChange(e),
+        onBlur: (e) => handleChange(e)
+      }
       await mountWithContext(
-        <TestForm>
-          <Field
-            component={
-              ({ input, meta }) => {
-                input.onChange = (e) => {
-                  input.onChange(e);
-                  handleChange(e);
-                };
-                return (
-                  <Timepicker
-                    input={input}
-                    meta={meta}
-                    id="test-time"
-                  />
-                )
-              }}
-            name="time"
-          />
-        </TestForm>
+        <Timepicker
+          input={input}
+          id="test-time"
+        />
       );
 
       await timepicker.fillIn('05:00 PM');

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -63,7 +63,7 @@ const TimepickerInteractor = TextField.extend('timepicker')
     clickClear: ({ find }) => find(IconButton({ icon: 'times-circle-solid' })).click()
   });
 
-describe.only('Timepicker', () => {
+describe('Timepicker', () => {
   const timepicker = TimepickerInteractor();
   const timeDropdown = TimepickerDropdownInteractor();
 

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { describe, beforeEach, it } from 'mocha';
 import moment from 'moment-timezone';
+import sinon from 'sinon';
+import { Field } from 'redux-form';
 import {
   runAxeTest,
   HTML,
@@ -60,7 +62,15 @@ const TimepickerInteractor = TextField.extend('timepicker')
     clickDropdownToggle: ({ find }) => find(IconButton({ icon: 'clock' })).click(),
     clickInput: ({ perform }) => perform((el) => el.querySelector('input').click()),
     focusDropdownButton: ({ find }) => find(IconButton({ icon: 'clock' })).focus(),
-    clickClear: ({ find }) => find(IconButton({ icon: 'times-circle-solid' })).click()
+    clickClear: ({ find }) => find(IconButton({ icon: 'times-circle-solid' })).click(),
+    fillInput: ({ find }, value) => find(TextField())
+      .perform((el) => {
+        const node = el.querySelector('input');
+        const property = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(node), 'value');
+        property.set.call(node, value);
+        node.dispatchEvent(new InputEvent('input', { inputType: 'insertFromPaste', bubbles: true, cancelable: false }));
+      }),
+    blur: () => document.body.click(),
   });
 
 describe('Timepicker', () => {
@@ -243,15 +253,28 @@ describe('Timepicker', () => {
   describe('coupled to redux form', () => {
     describe('selecting a time', () => {
       let timeOutput;
-
+      let handleChange = sinon.spy((e) => {
+        timeOutput = e.target.value;
+      });
       beforeEach(async () => {
         timeOutput = '';
-
+        handleChange.resetHistory()
         await mountWithContext(
-          <Timepicker
-            input={{
-              onChange: (value) => { timeOutput = value; },
-            }}
+          <Field
+            component={
+              ({ input, meta }) => {
+                input.onChange = (e) => {
+                  input.onChange(e);
+                  handleChange(e);
+                };
+                return (
+                  <Timepicker
+                    input={input}
+                    meta={meta}
+                  />
+                )
+              }}
+            name="time"
           />
         );
 
@@ -259,6 +282,7 @@ describe('Timepicker', () => {
       });
 
       it('returns an ISO 8601 time string at UTC', () => converge(() => timeOutput === '17:00:00.000Z'));
+      it.only('calls the handler multiple times - on change and onBlur', () => converge(() => handleChange.calledTwice() === true));
     });
 
     describe('selecting a time with timeZone prop', () => {

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -63,7 +63,7 @@ const TimepickerInteractor = TextField.extend('timepicker')
     clickClear: ({ find }) => find(IconButton({ icon: 'times-circle-solid' })).click()
   });
 
-describe('Timepicker', () => {
+describe.only('Timepicker', () => {
   const timepicker = TimepickerInteractor();
   const timeDropdown = TimepickerDropdownInteractor();
 
@@ -78,6 +78,15 @@ describe('Timepicker', () => {
   it('does not have a value in the input', () => timepicker.has({ value: '' }));
 
   it('has an id on the input element', () => timepicker.has({ id: 'timepicker-test' }));
+
+  describe('opening the dropdown with no time selected', () => {
+    beforeEach(async () => {
+      await timepicker.clickDropdownToggle();
+    });
+
+    it('displays the time dropdown', () => timeDropdown.exists());
+    it('displays the current time in the time dropdown', () => timeDropdown.has({ hour: parseInt(moment().format('h'), 10), minute: parseInt(moment().format('mm'), 10) }));
+  });
 
   describe('selecting a time', () => {
     let timeOutput;

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -285,30 +285,30 @@ describe('Timepicker', () => {
       });
 
       it('returns an ISO 8601 time string at UTC', () => converge(() => timeOutput === '17:00:00.000Z'));
-      it('calls the handler multiple times - on change and onBlur', () => converge(() => handleChange.calledTwice === true));
+      it('calls the handler multiple times - on change and onBlur', () => converge(() => handleChange.calledTwice));
+    });
+  });
+
+  describe('selecting a time with timeZone prop', () => {
+    let timeOutput;
+    const tz = 'America/Los_Angeles';
+
+    beforeEach(async () => {
+      timeOutput = '';
+
+      await mountWithContext(
+        <Timepicker
+          input={{
+            onChange: (value) => { timeOutput = value; },
+          }}
+          timeZone={tz}
+        />
+      );
+
+      await timepicker.fillIn('05:00 PM');
     });
 
-    describe('selecting a time with timeZone prop', () => {
-      let timeOutput;
-      const tz = 'America/Los_Angeles';
-
-      beforeEach(async () => {
-        timeOutput = '';
-
-        await mountWithContext(
-          <Timepicker
-            input={{
-              onChange: (value) => { timeOutput = value; },
-            }}
-            timeZone={tz}
-          />
-        );
-
-        await timepicker.fillIn('05:00 PM');
-      });
-
-      it('returns an ISO 8601 time string for specific time zone', () => converge(() => (timeOutput === moment().tz(tz).isDST() ? '00:00:00.000Z' : '01:00:00.000Z')));
-    });
+    it('returns an ISO 8601 time string for specific time zone', () => converge(() => (timeOutput === moment().tz(tz).isDST() ? '00:00:00.000Z' : '01:00:00.000Z')));
   });
 
   describe('Timedropdown', () => {

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -1,13 +1,8 @@
 import React from 'react';
 import { describe, beforeEach, it } from 'mocha';
 import moment from 'moment-timezone';
-import sinon from 'sinon';
-import { Field } from 'redux-form';
 import {
   runAxeTest,
-  HTML,
-  TextField,
-  IconButton,
   Button,
   including,
   converge,
@@ -17,62 +12,13 @@ import {
 import translationsDE from '../../../translations/stripes-components/de';
 
 import { mountWithContext } from '../../../tests/helpers';
-import TestForm from '../../../tests/TestForm';
-
 import Timepicker from '../Timepicker';
 import TimepickerHarness from './TimepickerHarness';
+import {
+  Timepicker as TimepickerInteractor,
+  TimeDropdown as TimepickerDropdownInteractor
+} from './timepicker-interactor-bt';
 
-const TimepickerDropdownInteractor = HTML.extend('time dropdown')
-  .selector('[data-test-timepicker-dropdown]')
-  .filters({
-    periodToggle: Button({ id: including('period-toggle') }).exists(),
-    hour: (el) => {
-      const node = el.querySelector('input[data-test-timepicker-dropdown-hours-input]');
-      return node.value ? parseInt(node.value, 10) : '';
-    },
-    minute: (el) => {
-      const node = el.querySelector('input[data-test-timepicker-dropdown-minutes-input]');
-      return node.value ? parseInt(node.value, 10) : '';
-    }
-  })
-  .actions({
-    clickPeriodToggle: ({ find }) => find(Button({ id: including('period-toggle') })).click(),
-    fillHour: ({ find }, value) => find(TextField({ id: including('hour-input') }))
-      .perform((el) => {
-        const node = el.querySelector('input');
-        const property = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(node), 'value');
-        property.set.call(node, value);
-        node.dispatchEvent(new InputEvent('input', { inputType: 'insertFromPaste', bubbles: true, cancelable: false }));
-      }),
-    fillMinute: ({ find }, value) => find(TextField({ id: including('minute-input') }))
-      .perform((el) => {
-        const node = el.querySelector('input');
-        const property = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(node), 'value');
-        property.set.call(node, value);
-        node.dispatchEvent(new InputEvent('input', { inputType: 'insertFromPaste', bubbles: true, cancelable: false }));
-      }),
-    clickConfirm: ({ find }) => find(Button({ id: including('set-time') })).click(),
-    clickAddMinute: ({ find }) => find(IconButton({ id: including('next-minute') })).click(),
-    clickAddHour: ({ find }) => find(IconButton({ id: including('next-hour') })).click(),
-    clickDecrementMinute: ({ find }) => find(IconButton({ id: including('prev-minute') })).click(),
-    clickDecrementHour: ({ find }) => find(IconButton({ id: including('prev-hour') })).click(),
-  });
-
-const TimepickerInteractor = TextField.extend('timepicker')
-  .actions({
-    clickDropdownToggle: ({ find }) => find(IconButton({ icon: 'clock' })).click(),
-    clickInput: ({ perform }) => perform((el) => el.querySelector('input').click()),
-    focusDropdownButton: ({ find }) => find(IconButton({ icon: 'clock' })).focus(),
-    clickClear: ({ find }) => find(IconButton({ icon: 'times-circle-solid' })).click(),
-    fillInput: ({ find }, value) => find(TextField())
-      .perform((el) => {
-        const node = el.querySelector('input');
-        const property = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(node), 'value');
-        property.set.call(node, value);
-        node.dispatchEvent(new InputEvent('input', { inputType: 'insertFromPaste', bubbles: true, cancelable: false }));
-      }),
-    blur: () => document.body.click(),
-  });
 
 describe('Timepicker', () => {
   const timepicker = TimepickerInteractor();
@@ -249,44 +195,6 @@ describe('Timepicker', () => {
     });
 
     it('emits an event with the time formatted as displayed', () => converge(() => timeOutput === '05:00 PM'));
-  });
-
-  describe('coupled to redux form', () => {
-    describe('selecting a time', () => {
-      let timeOutput;
-      const handleChange = sinon.spy((e) => {
-        timeOutput = e.target.value;
-      });
-      beforeEach(async () => {
-        timeOutput = '';
-        handleChange.resetHistory();
-        await mountWithContext(
-          <TestForm>
-            <Field
-              component={
-                ({ input, meta }) => {
-                  input.onChange = (e) => {
-                    input.onChange(e);
-                    handleChange(e);
-                  };
-                  return (
-                    <Timepicker
-                      input={input}
-                      meta={meta}
-                    />
-                  )
-                }}
-              name="time"
-            />
-          </TestForm>
-        );
-
-        await timepicker.fillIn('05:00 PM');
-      });
-
-      it('returns an ISO 8601 time string at UTC', () => converge(() => timeOutput === '17:00:00.000Z'));
-      it('calls the handler multiple times - on change and onBlur', () => converge(() => handleChange.calledTwice));
-    });
   });
 
   describe('selecting a time with timeZone prop', () => {

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -17,6 +17,7 @@ import {
 import translationsDE from '../../../translations/stripes-components/de';
 
 import { mountWithContext } from '../../../tests/helpers';
+import TestForm from '../../../tests/TestForm';
 
 import Timepicker from '../Timepicker';
 import TimepickerHarness from './TimepickerHarness';
@@ -253,36 +254,38 @@ describe('Timepicker', () => {
   describe('coupled to redux form', () => {
     describe('selecting a time', () => {
       let timeOutput;
-      let handleChange = sinon.spy((e) => {
+      const handleChange = sinon.spy((e) => {
         timeOutput = e.target.value;
       });
       beforeEach(async () => {
         timeOutput = '';
-        handleChange.resetHistory()
+        handleChange.resetHistory();
         await mountWithContext(
-          <Field
-            component={
-              ({ input, meta }) => {
-                input.onChange = (e) => {
-                  input.onChange(e);
-                  handleChange(e);
-                };
-                return (
-                  <Timepicker
-                    input={input}
-                    meta={meta}
-                  />
-                )
-              }}
-            name="time"
-          />
+          <TestForm>
+            <Field
+              component={
+                ({ input, meta }) => {
+                  input.onChange = (e) => {
+                    input.onChange(e);
+                    handleChange(e);
+                  };
+                  return (
+                    <Timepicker
+                      input={input}
+                      meta={meta}
+                    />
+                  )
+                }}
+              name="time"
+            />
+          </TestForm>
         );
 
         await timepicker.fillIn('05:00 PM');
       });
 
       it('returns an ISO 8601 time string at UTC', () => converge(() => timeOutput === '17:00:00.000Z'));
-      it.only('calls the handler multiple times - on change and onBlur', () => converge(() => handleChange.calledTwice() === true));
+      it('calls the handler multiple times - on change and onBlur', () => converge(() => handleChange.calledTwice === true));
     });
 
     describe('selecting a time with timeZone prop', () => {

--- a/lib/Timepicker/tests/timepicker-interactor-bt.js
+++ b/lib/Timepicker/tests/timepicker-interactor-bt.js
@@ -1,0 +1,52 @@
+import {
+  HTML,
+  TextField,
+  IconButton,
+  Button,
+  including,
+} from '@folio/stripes-testing';
+
+export const TimeDropdown = HTML.extend('time dropdown')
+  .selector('[data-test-timepicker-dropdown]')
+  .filters({
+    periodToggle: Button({ id: including('period-toggle') }).exists(),
+    hour: (el) => {
+      const node = el.querySelector('input[data-test-timepicker-dropdown-hours-input]');
+      return node.value ? parseInt(node.value, 10) : '';
+    },
+    minute: (el) => {
+      const node = el.querySelector('input[data-test-timepicker-dropdown-minutes-input]');
+      return node.value ? parseInt(node.value, 10) : '';
+    },
+    focused: (el) => el.contains(document.activeElement)
+  })
+  .actions({
+    clickPeriodToggle: ({ find }) => find(Button({ id: including('period-toggle') })).click(),
+    fillHour: ({ find }, value) => find(TextField({ id: including('hour-input') }))
+      .perform((el) => {
+        const node = el.querySelector('input');
+        const property = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(node), 'value');
+        property.set.call(node, value);
+        node.dispatchEvent(new InputEvent('input', { inputType: 'insertFromPaste', bubbles: true, cancelable: false }));
+      }),
+    fillMinute: ({ find }, value) => find(TextField({ id: including('minute-input') }))
+      .perform((el) => {
+        const node = el.querySelector('input');
+        const property = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(node), 'value');
+        property.set.call(node, value);
+        node.dispatchEvent(new InputEvent('input', { inputType: 'insertFromPaste', bubbles: true, cancelable: false }));
+      }),
+    clickConfirm: ({ find }) => find(Button({ id: including('set-time') })).click(),
+    clickAddMinute: ({ find }) => find(IconButton({ id: including('next-minute') })).click(),
+    clickAddHour: ({ find }) => find(IconButton({ id: including('next-hour') })).click(),
+    clickDecrementMinute: ({ find }) => find(IconButton({ id: including('prev-minute') })).click(),
+    clickDecrementHour: ({ find }) => find(IconButton({ id: including('prev-hour') })).click(),
+  });
+
+export const Timepicker = TextField.extend('timepicker')
+  .actions({
+    clickDropdownToggle: ({ find }) => find(IconButton({ icon: 'clock' })).click(),
+    clickInput: ({ perform }) => perform((el) => el.querySelector('input').click()),
+    focusDropdownButton: ({ find }) => find(IconButton({ icon: 'clock' })).focus(),
+    clickClear: ({ find }) => find(IconButton({ icon: 'times-circle-solid' })).click(),
+  });

--- a/util/dateTimeUtils.js
+++ b/util/dateTimeUtils.js
@@ -47,7 +47,14 @@ export const getLocaleDateFormat = ({ intl, config }) => {
           format += 'YYYY';
           break;
         case 'literal':
-          format += p.value;
+          // An ICU 72 update places a unicode character \u202f (non-breaking space) before day period (am/pm).
+          // This can make for differences that are imperceptible to humans, but automated tests know!
+          // the \u202f character is best detected via its charCode... 8239
+          if (p.value.charCodeAt(0) === 8239) {
+            format += ' ';
+          } else {
+            format += p.value;
+          }
           break;
         default:
           break;
@@ -109,6 +116,7 @@ export function getLocalizedTimeFormatInfo(locale) {
     // something in the form of HH:mm or HH:mm A that could be fed to a library like moment.
     if (i === dateArray.length - 1) {
       dateFields.forEach((p) => {
+        let adjustedValue;
         switch (p.type) {
           case 'hour':
             timeFormat += 'HH';
@@ -117,8 +125,15 @@ export function getLocalizedTimeFormatInfo(locale) {
             timeFormat += 'mm';
             break;
           case 'literal':
-            timeFormat += p.value;
-            if (p.value !== ' ' && !formatInfo.separator) {
+            adjustedValue = p.value;
+            // An ICU 72 update places a unicode character \u202f (non-breaking space) before day period (am/pm).
+            // This can make for differences that are imperceptible to humans, but automated tests know!
+            // the \u202f character is best detected via its charCode... 8239
+            if (adjustedValue.charCodeAt(0) === 8239) {
+              adjustedValue = ' ';
+            }
+            timeFormat += adjustedValue;
+            if (adjustedValue !== ' ' && !formatInfo.separator) {
               formatInfo.separator = p.value;
             }
             break;


### PR DESCRIPTION
Fixes https://issues.folio.org/browse/STCOM-1119

Datepicker stumbled this issue when it went through its own refactor. It's the same case with timepicker - ugly as it is, it needs to conform to react-final-er-um.. redux-form's [behavior of an `onChange` event being triggered  onBlur](https://github.com/redux-form/redux-form/blob/master/src/ConnectedField.js#L176). Someone please bury it under its pile of open github issues.

Approach - handle blurs internally in the component where  `redux-form` is appeased with an event-shaped sacrifice so that it won't blank out the value or just give up and swallow any triggered error.