### PR TITLE
STCOM-1105 - MCL sortable header focus styles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Timepicker conforms to redux-form's expected blur behavior. Refs STCOM-1119.
 * Add optgroup example  of `Select` component in storybook. Refs STCOM-1121.
 * Fix Convert24hr function of timepicker to fix 'invalid date' message when timedropdown is used. Refs STCOM-1120.
+* Fix MCL Columnheaders' focus styling. Refs STCOM-1105.
 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)

--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -186,7 +186,7 @@
   color: var(--color-text);
 
   &:focus-within {
-    box-shadow: inner 0 5px 0 0 var(--color-fill-focus);
+    box-shadow: inset 0 -5px 0 0 var(--color-fill-focus);
   }
 
   &.mclClickable {


### PR DESCRIPTION
No more blind pressing of the 'tab' key when focus reaches this part....

Refs [STCOM-1105](https://issues.folio.org/browse/STCOM-1105)

![header-focus](https://user-images.githubusercontent.com/20704067/222762931-3c7b9d64-7de1-41e2-afe9-3cb013e58326.gif)
