### PR TITLE
STCOM-680 - fix MCL sorting via keyboard keys (enter, space click focused header)

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -1625,7 +1625,8 @@ class MCLRenderer extends React.Component {
             className={css.mclHeaderOuter}
             data-test-clickable-header
             onClick={(e) => { this.handleHeaderClick(e, header); }}
-            onKeyPress={(e) => { if (e.keyCode === 32 || e.keyCode === 13) { this.handleHeaderClick(e, header); } }}
+            onKeyDown={(e) => { if (e.key === 'Enter') { this.handleHeaderClick(e, header); } }}
+            onKeyUp={(e) => { if (e.key === ' ') { this.handleHeaderClick(e, header); } }}
             id={clickableId}
           >
             <div className={css.mclHeaderInner}>


### PR DESCRIPTION
Hand-in-hand with focus styles, appropriate keyboard behavior also applied. The focused column header can be clicked via 'Enter' key (keydown) or 'Spacebar' (keyup) (common button behavior)
