### PR TITLE
STCOM-1128 Handle timezone conversion with defaultOutputFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix Convert24hr function of timepicker to fix 'invalid date' message when timedropdown is used. Refs STCOM-1120.
 * Fix MCL Columnheaders' focus styling. Refs STCOM-1105.
 * Fix keyboard interaction with MCL Columnheaders - Enter and Spacebar can now be used to 'click' them. Refs STCOM-680.
+* Implement timeZone support in `<Timepicker/>` default output formatter. Refs STCOM-1128.
 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -46,8 +46,11 @@ const defaultParser = (value, timezone, timeFormat, intl) => { // eslint-disable
 
 // Not all parameter keys may be used in this function, but they are provided as a convenience for
 // overrides to the props using this as default.
-const defaultOutputFormatter = ({ value, formats, timezone, intl }) => { // eslint-disable-line no-unused-vars
+const defaultOutputFormatter = ({ value, formats, timezone = 'utc', intl }) => { // eslint-disable-line no-unused-vars
   let isoTime = moment.utc(value, formats);
+  if (timezone !== 'utc') {
+    isoTime = moment.tz(value, formats, timezone);
+  }
   if (isoTime.isValid()) {
     isoTime = isoTime.toISOString();
     const timeSplit = isoTime.split('T');
@@ -138,7 +141,7 @@ const Timepicker = ({
     ) : '',
     formatted: valueProp ? outputFormatter({
       value: valueProp,
-      timeZone: timeZoneProp || intl.timeZone,
+      timezone: timeZoneProp || intl.timeZone,
       formats: timeFormat.includes('A') ? twelveHourFormats : twentyFourHourFormats,
     }) : ''
   });
@@ -204,7 +207,7 @@ const Timepicker = ({
       if (parsed !== timePair.timeString) {
         const hiddenValue = outputFormatter({
           value,
-          timeZone: timeZoneProp || intl.timeZone,
+          timezone: timeZoneProp || intl.timeZone,
           formats: timeFormat.includes('A') ? twelveHourFormats : twentyFourHourFormats
         });
         timeValues = { timeString: parsed, formatted: hiddenValue };

--- a/lib/Timepicker/stories/BasicUsage.js
+++ b/lib/Timepicker/stories/BasicUsage.js
@@ -2,30 +2,44 @@
  * Timepicker: Basic Usage
  */
 
-import React from 'react';
+import React, {useState} from 'react';
 import Timepicker from '../Timepicker';
 
-const BasicUsage = () => (
-  <div>
-    <Timepicker
-      label="Time"
-    />
-    <br />
-    <div>Using aria-label:</div>
-    <Timepicker
-      aria-label="Example Time"
-    />
-    <br />
-    <Timepicker
-      label="Time (read only)"
-      readOnly
-    />
-    <br />
-    <Timepicker
-      label="Time (disabled)"
-      disabled
-    />
-  </div>
-);
-
+const BasicUsage = () => {
+  const [time, updateTime] = useState('3:00 AM');
+  const [timeZoned, updateTimeZoned] = useState('3:00 AM');
+  const timeZone = 'America/Barbados'
+  return (
+    <div>
+      <div>State time: {time}</div>
+      <div>State time(Barbados): {timeZoned}</div>
+      <Timepicker
+        label="Time"
+        onChange={(e) => updateTime(e.target.value)}
+        useInput
+      />
+      <Timepicker
+        label="Time (Barbados)"
+        onChange={(e) => updateTimeZoned(e.target.value)}
+        timeZone={timeZone}
+        useInput
+      />
+      <br />
+      <div>Using aria-label:</div>
+      <Timepicker
+        aria-label="Example Time"
+      />
+      <br />
+      <Timepicker
+        label="Time (read only)"
+        readOnly
+      />
+      <br />
+      <Timepicker
+        label="Time (disabled)"
+        disabled
+      />
+    </div>
+  );
+}
 export default BasicUsage;

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -190,6 +190,7 @@ describe('Timepicker', () => {
         <Timepicker
           onChange={(event) => { timeOutput = event?.target.value; }}
           timeZone="America/Los_Angeles"
+          useInput
         />
       );
 

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -187,7 +187,7 @@ describe('Timepicker', () => {
     });
   });
 
-  describe('selecting a time with timeZone prop (Los Angeles)', () => {
+  describe('selecting a time with timeZone prop (Los Angeles) (RFF)', () => {
     const tz = 'America/Los_Angeles';
     const testTime = moment().tz(tz).isDST() ? '00:00:00.000Z' : '01:00:00.000Z';
     let timeOutput = '';
@@ -195,9 +195,10 @@ describe('Timepicker', () => {
       timeOutput = '';
       await mountWithContext(
         <TimepickerHarness
-          onChange={(e) => { timeOutput = e.target.value; }}
+          input={{
+            onChange: (e) => { timeOutput = e.target.value; }
+          }}
           timeZone={tz}
-          useInput
         />
       );
 
@@ -211,7 +212,7 @@ describe('Timepicker', () => {
     ));
   });
 
-  describe('selecting a time with timeZone prop (Barbados)', () => {
+  describe('selecting a time with timeZone prop (Barbados) (RFF)', () => {
     const tz = 'America/Barbados';
     const testTime = moment().tz(tz).isDST() ? '19:20:00.000Z' : '20:20:00.000Z';
     let timeOutput;
@@ -219,9 +220,10 @@ describe('Timepicker', () => {
       timeOutput = '';
       await mountWithContext(
         <TimepickerHarness
-          onChange={(e) => { timeOutput = e.target.value; }}
+          input={{
+            onChange: (e) => { timeOutput = e.target.value; }
+          }}
           timeZone={tz}
-          useInput
         />
       );
 
@@ -232,30 +234,6 @@ describe('Timepicker', () => {
     it('displays full time in field', () => timepicker.has({ value: '4:20 PM' }));
     it('calls onChange with appropriate time', () => converge(
       () => { if (timeOutput !== testTime) throw new Error(`timeOutput is "${timeOutput}", expected "${testTime}"`); }
-    ));
-  });
-
-  describe('selecting a time with timeZone prop', () => {
-    let timeOutput;
-    const tz = 'America/Los_Angeles';
-    const testValue = moment().tz(tz).isDST() ? '00:00:00.000Z' : '01:00:00.000Z';
-    beforeEach(async () => {
-      timeOutput = '';
-
-      await mountWithContext(
-        <Timepicker
-          input={{
-            onChange: (e) => { timeOutput = e.target.value; },
-          }}
-          timeZone={tz}
-        />
-      );
-
-      await timepicker.fillIn('05:00 PM');
-    });
-
-    it('returns an ISO 8601 time string for specific time zone', () => converge(
-      () => { if (timeOutput !== testValue) throw new Error(`timeOutput is "${timeOutput}", expected "${testValue}"`); }
     ));
   });
 

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -9,6 +9,7 @@ import {
   including,
   converge,
   Keyboard,
+  HTML
 } from '@folio/stripes-testing';
 
 import translationsDE from '../../../translations/stripes-components/de';
@@ -22,7 +23,7 @@ import {
 } from './timepicker-interactor-bt';
 
 
-describe('Timepicker', () => {
+describe.only('Timepicker', () => {
   const timepicker = TimepickerInteractor();
   const timeDropdown = TimepickerDropdownInteractor();
 
@@ -180,24 +181,40 @@ describe('Timepicker', () => {
     });
   });
 
-  describe('selecting a time with timeZone prop', () => {
-    let timeOutput;
-
+  describe('selecting a time with timeZone prop (Los Angeles)', () => {
+    const tz = 'America/Los_Angeles';
+    const testTime = moment().tz(tz).isDST() ? '00:00:00.000Z' : '01:00:00.000Z';
     beforeEach(async () => {
-      timeOutput = '';
-
       await mountWithContext(
-        <Timepicker
-          onChange={(event) => { timeOutput = event?.target.value; }}
-          timeZone="America/Los_Angeles"
+        <TimepickerHarness
+          timeZone={tz}
           useInput
         />
       );
 
-      await timepicker.fillIn('05:00 PM');
+      await timepicker.fillIn('05:00 P');
     });
 
-    it('emits an event with the time formatted as displayed', () => converge(() => timeOutput === '05:00 PM'));
+    it('emits an event with the time accounting for timezone', () => HTML({ id: 'state-time', text: testTime }).exists());
+    it('displays full time in field', () => timepicker.has({ value: '5:00 PM' }));
+  });
+
+  describe('selecting a time with timeZone prop (Barbados)', () => {
+    const tz = 'America/Barbados';
+    const testTime = moment().tz(tz).isDST() ? '19:20:00.000Z' : '20:20:00.000Z';
+    beforeEach(async () => {
+      await mountWithContext(
+        <TimepickerHarness
+          timeZone={tz}
+          useInput
+        />
+      );
+
+      await timepicker.fillIn('04:20 P');
+    });
+
+    it('emits an event with the time accounting for timezone', () => HTML({ id: 'state-time', text: testTime }).exists());
+    it('displays full time in field', () => timepicker.has({ value: '4:20 PM' }));
   });
 
   describe('selecting a time with timeZone prop', () => {

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -23,7 +23,7 @@ import {
 } from './timepicker-interactor-bt';
 
 
-describe.only('Timepicker', () => {
+describe('Timepicker', () => {
   const timepicker = TimepickerInteractor();
   const timeDropdown = TimepickerDropdownInteractor();
 

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -61,7 +61,9 @@ describe.only('Timepicker', () => {
       await timepicker.fillIn('05:00 PM');
     });
 
-    it('emits an event with the time formatted as displayed', () => converge(() => timeOutput === '05:00 PM'));
+    it('emits an event with the time formatted as displayed', () => converge(
+      () => { if (timeOutput !== '05:00 PM') throw new Error(`timeOutput is "${timeOutput}", expected "05:00PM".`) }
+    ));
 
     describe('opening the time dropdown with a 12-hour value in the input', () => {
       beforeEach(async () => {
@@ -80,7 +82,9 @@ describe.only('Timepicker', () => {
         await timepicker.fillIn('');
       });
 
-      it('emits an event with the time formatted as displayed', () => converge(() => timeOutput === ''));
+      it('emits an event with the time formatted as displayed', () => converge(
+        () => { if (timeOutput !== '') throw new Error(`timeOutput is "${timeOutput}", expected ""`); }
+      ));
     });
 
     describe('setting an incomplete value', () => {
@@ -109,7 +113,9 @@ describe.only('Timepicker', () => {
       await timepicker.fillIn('05:00 PM');
     });
 
-    it('emits an event with the time formatted as displayed', () => converge(() => (timeOutput === '05:00 PM')));
+    it('emits an event with the time formatted as displayed', () => converge(
+      () => { if (timeOutput !== '05:00 PM') throw new Error(`timeOutput is "${timeOutput}", expected "05:00 PM"`); }
+    ));
 
     describe('picking a time in a non-english locale', () => {
       beforeEach(async () => {
@@ -184,9 +190,12 @@ describe.only('Timepicker', () => {
   describe('selecting a time with timeZone prop (Los Angeles)', () => {
     const tz = 'America/Los_Angeles';
     const testTime = moment().tz(tz).isDST() ? '00:00:00.000Z' : '01:00:00.000Z';
+    let timeOutput = '';
     beforeEach(async () => {
+      timeOutput = '';
       await mountWithContext(
         <TimepickerHarness
+          onChange={(e) => { timeOutput = e.target.value; }}
           timeZone={tz}
           useInput
         />
@@ -197,14 +206,20 @@ describe.only('Timepicker', () => {
 
     it('emits an event with the time accounting for timezone', () => HTML({ id: 'state-time', text: testTime }).exists());
     it('displays full time in field', () => timepicker.has({ value: '5:00 PM' }));
+    it('calls onChange with appropriate time', () => converge(
+      () => { if (timeOutput !== testTime) throw new Error(`timeOutput is "${timeOutput}", expected "${testTime}"`); }
+    ));
   });
 
   describe('selecting a time with timeZone prop (Barbados)', () => {
     const tz = 'America/Barbados';
     const testTime = moment().tz(tz).isDST() ? '19:20:00.000Z' : '20:20:00.000Z';
+    let timeOutput;
     beforeEach(async () => {
+      timeOutput = '';
       await mountWithContext(
         <TimepickerHarness
+          onChange={(e) => { timeOutput = e.target.value; }}
           timeZone={tz}
           useInput
         />
@@ -215,19 +230,22 @@ describe.only('Timepicker', () => {
 
     it('emits an event with the time accounting for timezone', () => HTML({ id: 'state-time', text: testTime }).exists());
     it('displays full time in field', () => timepicker.has({ value: '4:20 PM' }));
+    it('calls onChange with appropriate time', () => converge(
+      () => { if (timeOutput !== testTime) throw new Error(`timeOutput is "${timeOutput}", expected "${testTime}"`); }
+    ));
   });
 
   describe('selecting a time with timeZone prop', () => {
     let timeOutput;
     const tz = 'America/Los_Angeles';
-
+    const testValue = moment().tz(tz).isDST() ? '00:00:00.000Z' : '01:00:00.000Z';
     beforeEach(async () => {
       timeOutput = '';
 
       await mountWithContext(
         <Timepicker
           input={{
-            onChange: (value) => { timeOutput = value; },
+            onChange: (e) => { timeOutput = e.target.value; },
           }}
           timeZone={tz}
         />
@@ -236,7 +254,9 @@ describe.only('Timepicker', () => {
       await timepicker.fillIn('05:00 PM');
     });
 
-    it('returns an ISO 8601 time string for specific time zone', () => converge(() => (timeOutput === moment().tz(tz).isDST() ? '00:00:00.000Z' : '01:00:00.000Z')));
+    it('returns an ISO 8601 time string for specific time zone', () => converge(
+      () => { if (timeOutput !== testValue) throw new Error(`timeOutput is "${timeOutput}", expected "${testValue}"`); }
+    ));
   });
 
   describe('Timedropdown', () => {

--- a/lib/Timepicker/tests/TimepickerHarness.js
+++ b/lib/Timepicker/tests/TimepickerHarness.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import _omit from 'lodash/omit';
 import Timepicker from '../Timepicker';
 import Button from '../../Button';
-import _omit from 'lodash/omit';
+
 
 export default ({ initialValue = '', ...props }) => {
   const [time, updateTime] = React.useState(initialValue);

--- a/lib/Timepicker/tests/TimepickerHarness.js
+++ b/lib/Timepicker/tests/TimepickerHarness.js
@@ -1,20 +1,43 @@
 import React from 'react';
 import Timepicker from '../Timepicker';
 import Button from '../../Button';
+import _omit from 'lodash/omit';
 
 export default ({ initialValue = '', ...props }) => {
   const [time, updateTime] = React.useState(initialValue);
 
   const handleClearTime = React.useRef(() => { updateTime(''); }).current;
 
+  const handleChange = (e) => {
+    updateTime(e.target.value);
+    if (props.onChange) {
+      props.onChange(e);
+    }
+  }
+
+  const getAdjustedProps = (harnessProps) => {
+    const restProps = _omit(harnessProps, 'onChange');
+    return props.useInput ?
+      {
+        input: {
+          onChange: handleChange,
+        },
+        ...restProps
+      } :
+      {
+        ...restProps
+      };
+  }
+
   return (
     <>
       <Button onClick={handleClearTime}>clear time</Button>
+      <div>State time: <span id="state-time">{time}</span></div>
       <div>
         <Timepicker
           value={time}
-          onChange={(e) => { updateTime(e.target.value); }}
-          {...props}
+          onChange={handleChange}
+          {...getAdjustedProps(props)}
         />
       </div>
     </>

--- a/lib/Timepicker/tests/TimepickerHarness.js
+++ b/lib/Timepicker/tests/TimepickerHarness.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import _omit from 'lodash/omit';
 import Timepicker from '../Timepicker';
 import Button from '../../Button';
 
@@ -17,16 +16,19 @@ export default ({ initialValue = '', ...props }) => {
   }
 
   const getAdjustedProps = (harnessProps) => {
-    const restProps = _omit(harnessProps, 'onChange');
-    return props.useInput ?
+    return harnessProps.input ?
       {
+        ...harnessProps,
         input: {
-          onChange: handleChange,
+          onChange: (e) => {
+            harnessProps.input.onChange(e);
+            handleChange(e);
+          }
         },
-        ...restProps
       } :
       {
-        ...restProps
+        onChange: handleChange,
+        ...harnessProps
       };
   }
 
@@ -37,7 +39,6 @@ export default ({ initialValue = '', ...props }) => {
       <div>
         <Timepicker
           value={time}
-          onChange={handleChange}
           {...getAdjustedProps(props)}
         />
       </div>


### PR DESCRIPTION
Problem: time should convert to utc for backend values in respect to the provided timezone.

This PR includes a call to moment.tz in case the timezone is something besides `utc` and still uses `moment.utc()` for cases where it doesn't receive a timezone (rare) instead of always using utc.
