### PR TITLE
STCOM-1137: Add auto placement to <Popper> component

### DIFF
--- a/lib/Dropdown/readme.md
+++ b/lib/Dropdown/readme.md
@@ -74,7 +74,7 @@ Name | type | description | default | required
 `open` | bool | required for controlled usage only. A boolean to tell `<Dropdown>` to display its menu or not. | | controlled-only
 `onToggle` | func | callback for updating the open/closed state for controlled use. | | controlled-only
 `usePortal` | bool | whether or not the internal `Popper` component should render the menu to the `#OverlayContainer` or not. | true |
-`placement` | string | string representing one of several different placements... "cardinal" positions: `top`, `bottom`, `left`, `right` with hyphenated cross-axis `start` and `end`. (`bottom-start` for lower-right renders dropdown below trigger, aligned with the flex-start side. This accounds for proper rtl positioning). | `bottom` |
+`placement` | string |  See available options in the <a href="https://github.com/folio-org/stripes-components/tree/master/lib/Popper" target="_blank">Popper documentation</a>. | `bottom` |
 `modifiers` | object | `Popper.js` uses a collection of modifiers which ultimately define the location of the menu element. This prop can be used to make small adjustments to positioning or affect behavior in overflow situations (`flip` modifier). For more details, please, go to https://popper.js.org/popper-documentation.html#modifiers. | `{flip: { boundariesElement: 'scrollParent', padding: 10 }, preventOverflow: { boundariesElement: 'scrollParent', padding: 10 }}` |
 `relativePosition` | bool | in [some cases](https://stackoverflow.com/questions/54984952/popper-js-and-flex-end-causing-body-overflow), Popper.js requires relative positioning on the parent element of the anchor to adequately prevent overflow |
 

--- a/lib/Popper/Popper.js
+++ b/lib/Popper/Popper.js
@@ -17,6 +17,7 @@ export const AVAILABLE_PLACEMENTS = [
   'left-end',
   'right-start',
   'right-end',
+  'auto',
 ];
 
 const [DEFAULT_PLACEMENT] = AVAILABLE_PLACEMENTS;

--- a/lib/Popper/readme.md
+++ b/lib/Popper/readme.md
@@ -22,7 +22,7 @@ Name | type | description | default | required
 --- | --- | --- | --- | ---
 isOpen | boolean | Responsible for displaying of the overlay component | | |
 onUpdate | function | Callback to be called on every change of the PopperJS instance. Returns all data set of the instance. 
-placement | string | Overlay placement. Available values: `top`, `bottom`, `left`, `right`. Each placement can have a variation: `-start`, `-end`. E.g. `top-start`, `left-start`. | `bottom` | |
+placement | string | Overlay placement. Available values: `auto`, `top`, `bottom`, `left`, `right`. Each placement can have a variation: `-start`, `-end`. E.g. `top-start`, `left-start`. | `bottom` | |
 portal | node | When is provided, overlay renders inside provided portal. | | |
 anchorRef | object | Reference to anchor element |  | yes |
 children | component | Component to be passed as an overlay |  | yes |

--- a/lib/Tooltip/readme.md
+++ b/lib/Tooltip/readme.md
@@ -108,6 +108,7 @@ Update the placement of the `<Tooltip>` relative to the trigger component using 
 - left-end
 - right-start
 - right-end
+- auto
 
 ## Props
 Name | Type | Description | Required | Default


### PR DESCRIPTION
# [STCOM-1137](https://issues.folio.org/browse/STCOM-1137)

This change allows `auto` to be specified for popper component placements; this is a valid placement based on the [popper documentation](https://popper.js.org/docs/v1/#Popper.placements).