### PR TITLE
STCOM-1144 use svgr instead of react-svg-loader, jestify hopefully

### DIFF
--- a/.storybook/stcom-webpack.config.js
+++ b/.storybook/stcom-webpack.config.js
@@ -105,7 +105,5 @@ module.exports = async (config) => {
   ];
 
   config.module.rules.splice(svgRuleIndex,1, ...svgrRules);
-
-  console.log(JSON.stringify(config, null, 2 ));
   return config;
 }

--- a/.storybook/stcom-webpack.config.js
+++ b/.storybook/stcom-webpack.config.js
@@ -75,19 +75,18 @@ module.exports = async (config) => {
     config.module.rules = config.module.rules.concat([
     {
       test: /\.(jpe?g|png|gif)$/i,
-      loader: "file-loader"
+      type: 'asset/resource',
+      generator: {
+        filename: './img/[name].[contenthash].[ext]'
+      }
     },
-    
+
     {
       test: /\.(eot|ttf|woff|woff2?)$/,
-      use: [
-        {
-          loader: 'file-loader',
-          options: {
-            name: 'fonts/[name].[hash].[ext]'
-          }
-        }
-      ],
+      type: 'asset/resource',
+      generator: {
+        filename: './fonts/[name].[hash].[ext]'
+      }
     }
   ]);
 
@@ -95,10 +94,10 @@ module.exports = async (config) => {
   config.module.rules[svgRuleIndex] = {
       test: /\.svg$/,
       use: [
-        { 
+        {
           loader: '@svgr/webpack',
           options: {
-            name: '[name].svg' 
+            name: '[name].svg'
           }
         }
       ]

--- a/.storybook/stcom-webpack.config.js
+++ b/.storybook/stcom-webpack.config.js
@@ -91,17 +91,27 @@ module.exports = async (config) => {
   ]);
 
   const svgRuleIndex = config.module.rules.findIndex(r => { const t = new RegExp(r.test); return t.test('m.svg'); });
-  config.module.rules[svgRuleIndex] = {
-      test: /\.svg$/,
-      use: [
-        {
-          loader: '@svgr/webpack',
-          options: {
-            name: '[name].svg'
-          }
-        }
-      ]
-    };
+  // config.module.rules[svgRuleIndex] = {
+  //     test: /\.svg$/,
+  //     type: 'asset',
+  //     resourceQuery: /url/, // *.svg?url
+  //   };
 
+  const svgrRules = [
+    {
+      test: /\.svg$/,
+      type: 'asset',
+      resourceQuery: { not: [/icon/] }, // exclude built-in icons from stripes-components
+    },
+    {
+      test: /\.svg$/,
+      resourceQuery: /icon/,
+      use: ['@svgr/webpack'],
+    },
+  ];
+
+  config.module.rules.splice(svgRuleIndex,1, ...svgrRules);
+
+  console.log(JSON.stringify(config, null, 2 ));
   return config;
 }

--- a/.storybook/stcom-webpack.config.js
+++ b/.storybook/stcom-webpack.config.js
@@ -91,12 +91,6 @@ module.exports = async (config) => {
   ]);
 
   const svgRuleIndex = config.module.rules.findIndex(r => { const t = new RegExp(r.test); return t.test('m.svg'); });
-  // config.module.rules[svgRuleIndex] = {
-  //     test: /\.svg$/,
-  //     type: 'asset',
-  //     resourceQuery: /url/, // *.svg?url
-  //   };
-
   const svgrRules = [
     {
       test: /\.svg$/,

--- a/lib/Icon/Icon.js
+++ b/lib/Icon/Icon.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { pickBy } from 'lodash';
+import _pickBy from 'lodash/pickBy';
+import _get from 'lodash/get';
 import css from './Icon.css';
 import icons from './icons';
 
@@ -82,10 +83,10 @@ const Icon = React.forwardRef(({
     IconElement = icon;
   // Find icon in icons list
   } else if (typeof icon === 'string' && typeof icons[icon] === 'function') {
-    IconElement = icons[icon];
+    IconElement = _get(icons, icon, icons.default);
   }
 
-  const ariaAttributes = pickBy(rest, (_, key) => key.startsWith('aria'));
+  const ariaAttributes = _pickBy(rest, (_, key) => key.startsWith('aria'));
 
   return (
     <span

--- a/lib/Icon/Icon.js
+++ b/lib/Icon/Icon.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import _pickBy from 'lodash/pickBy';
-import _get from 'lodash/get';
+import { pickBy, get } from 'lodash';
 import css from './Icon.css';
 import icons from './icons';
 
@@ -83,10 +82,10 @@ const Icon = React.forwardRef(({
     IconElement = icon;
   // Find icon in icons list
   } else if (typeof icon === 'string' && typeof icons[icon] === 'function') {
-    IconElement = _get(icons, icon, icons.default);
+    IconElement = get(icons, icon, icons.default);
   }
 
-  const ariaAttributes = _pickBy(rest, (_, key) => key.startsWith('aria'));
+  const ariaAttributes = pickBy(rest, (_, key) => key.startsWith('aria'));
 
   return (
     <span

--- a/lib/Icon/icons.js
+++ b/lib/Icon/icons.js
@@ -19,7 +19,7 @@ let icons = { default: PlacholderSVG }
 // check to see if we're in the node test browser - this environment doesn't
 // use webpack to build, so it will failwhen require.context is executed for whatever reason.
 if (!navigator.userAgent.includes('jsdom')) {
-  const req = require.context('!!@svgr/webpack!./icons/', true, /\.svg$/);
+  const req = require.context('./icons/?icon=true', true, /\.svg$/);
   icons = req.keys().reduce((images, path) => Object.assign(images, {
     [path.slice(2, path.length - 4)]: req(path).default,
   }), {});

--- a/lib/Icon/icons.js
+++ b/lib/Icon/icons.js
@@ -6,14 +6,20 @@ import PropTypes from 'prop-types';
 import dotSpinner from './DotSpinner.css';
 import omitProps from '../../util/omitProps';
 
+const PlacholderSVG = ({ ...props }) => (
+  <svg {...props} viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+    <polygon points="0,100 50,25 50,75 100,0" />
+  </svg>
+);
+
 /**
  * Import SVG icons
  */
-let icons = { default: import('./icons/default.svg') };
+let icons = { default: PlacholderSVG }
 // check to see if we're in the node test browser - this environment doesn't
 // use webpack to build, so it will failwhen require.context is executed for whatever reason.
 if (!navigator.userAgent.includes('jsdom')) {
-  const req = require.context('!!react-svg-loader!./icons/', true, /\.svg$/);
+  const req = require.context('!!@svgr/webpack!./icons/', true, /\.svg$/);
   icons = req.keys().reduce((images, path) => Object.assign(images, {
     [path.slice(2, path.length - 4)]: req(path).default,
   }), {});

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@storybook/builder-webpack5": "^6.3.12",
     "@storybook/manager-webpack5": "^6.3.12",
     "@storybook/react": "^6.3.6",
-    "@svgr/webpack": "7.0.0",
+    "@svgr/webpack": "^7.0.0",
     "autoprefixer": "^10.4.13",
     "babel-loader": "^8.0.0",
     "babel-plugin-lodash": "^3.3.4",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@storybook/builder-webpack5": "^6.3.12",
     "@storybook/manager-webpack5": "^6.3.12",
     "@storybook/react": "^6.3.6",
-    "@svgr/webpack": "^5.5.0",
+    "@svgr/webpack": "7.0.0",
     "autoprefixer": "^10.4.13",
     "babel-loader": "^8.0.0",
     "babel-plugin-lodash": "^3.3.4",
@@ -101,7 +101,6 @@
   },
   "dependencies": {
     "@folio/stripes-react-hotkeys": "^3.0.5",
-    "@svgr/webpack": "^6.5.1",
     "classnames": "^2.2.5",
     "currency-codes": "^1.5.0",
     "dom-helpers": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "core-js": "^3.6.1",
     "eslint": "^8.31.0",
     "faker": "^4.1.0",
-    "file-loader": "^2.0.0",
     "karma-viewport": "^1.0.4",
     "mocha": "^10.2.0",
     "moment": "^2.29.0",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
   },
   "dependencies": {
     "@folio/stripes-react-hotkeys": "^3.0.5",
+    "@svgr/webpack": "^6.5.1",
     "classnames": "^2.2.5",
     "currency-codes": "^1.5.0",
     "dom-helpers": "^3.2.1",
@@ -120,7 +121,6 @@
     "react-highlight-words": "^0.18.0",
     "react-overlays": "^4.1.1",
     "react-quill": "^1.3.3",
-    "react-svg-loader": "^3.0.3",
     "react-transition-group": "^2.2.1",
     "react-virtualized-auto-sizer": "^1.0.2",
     "tai-password-strength": "^1.1.1"


### PR DESCRIPTION
Jest tests fail if `stripes-components` Icon isn't mocked - this was originally due to usage of webpack 'require.context' api to dynamically load all of the contents of the `icons` directory without having to manually maintain a list.

This PR 
 - removes the dependency `react-svg-loader`
 - replaces it with `@svgr/webpack`
 - sets up a 'default' for Icon to render in JSDOM...
 - falls back to the default if the provided 'icon' prop cannot be found.
 - removes the local webpack loader override.
 - The specific behavior from the override is now accomplished through resourceQueries. Built-in icon SVG imports will use the `?icon` query in their import path... all other SVG's will be inlined via stripes-webpack's configuration.
 
 This PR depends on https://github.com/folio-org/stripes-webpack/pull/92 in order to work.

 