### PR TITLE
STCOM-1146 lock to react-virtual-auto-sizer 1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-components
 
+## 11.0.4 IN PROGRESS
+
+* Lock `react-virtual-auto-sizer` to prevent test failures. Refs STCOM-1146.
+
 ## [11.0.3](https://github.com/folio-org/stripes-components/tree/v11.0.3) (2023-03-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v11.0.2...v11.0.3)
 

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "react-quill": "^1.3.3",
     "react-svg-loader": "^3.0.3",
     "react-transition-group": "^2.2.1",
-    "react-virtualized-auto-sizer": "^1.0.2",
+    "react-virtualized-auto-sizer": "1.0.7",
     "tai-password-strength": "^1.1.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Substantial internal reworking in RVAS >= 1.0.8 broke tests across many of our apps. Our apps provide a test harness that provides some missing browser APIs that RVAS used to leverage. RVAS now uses different APIs, causing it to behave differently in a test env.

Pinning a version is always double edged. Here, we're doing it so we can get our tests back on track with a small change in one place rather than needing to reimplement our test-harnesses in every repo.

Refs [STCOM-1146](https://issues.folio.org/browse/STCOM-1146)