### PR TITLE
STCOM-1149, UIRS-100 - Overlay inputs within MCL.

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -58,7 +58,7 @@
   background-color: var(--color-fill-table-row-even);
 
   &:focus-within {
-    z-index: 3;
+    z-index: 2;
   }
 
   &:not(:focus-within) {

--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -57,6 +57,14 @@
   outline: none;
   background-color: var(--color-fill-table-row-even);
 
+  &:focus-within {
+    z-index: 3;
+  }
+
+  &:not(:focus-within) {
+    z-index: 0;
+  }
+
   &:visited {
     color: var(--color-text);
   }
@@ -272,7 +280,6 @@
   flex-shrink: 0;
   flex-grow: 0;
   flex-basis: auto;
-  overflow: hidden;
   text-align: left;
   word-break: break-word;
 

--- a/lib/MultiColumnList/stories/MultiColumnList.stories.js
+++ b/lib/MultiColumnList/stories/MultiColumnList.stories.js
@@ -19,6 +19,7 @@ import PrevNextPaging from './PrevNextPaging';
 import ItemToView from './ItemToView';
 import StickyColumns from './StickyColumns';
 import VariableWidthHints from './VariableWidthHints';
+import WithInputs from './WithInputs';
 
 export default {
   title: 'MultiColumnList',
@@ -98,3 +99,8 @@ _ClickableRows.story = {
 };
 
 export const _StickyColumns = () => <StickyColumns />;
+export const _WithInputs = () => <WithInputs />;
+
+_WithInputs.story = {
+  name: 'With Inputs'
+};

--- a/lib/MultiColumnList/stories/StickyColumns.js
+++ b/lib/MultiColumnList/stories/StickyColumns.js
@@ -2,7 +2,23 @@ import React from 'react';
 import MultiColumnList from '../MultiColumnList';
 import Checkbox from '../../Checkbox';
 import Button from '../../Button';
+import Selection from '../../Selection';
 import { asyncGenerate, syncGenerate } from './service';
+
+const options = [
+  {
+    value: 'always',
+    label: 'always',
+  },
+  {
+    value: 'sometimes',
+    label: 'sometimes',
+  },
+  {
+    value: 'never',
+    label: 'never',
+  }
+];
 
 export default class CheckboxSelect extends React.Component {
   constructor() {
@@ -24,6 +40,14 @@ export default class CheckboxSelect extends React.Component {
         />),
       action: () => (
         <Button buttonStyle="primary">Download</Button>
+      ),
+      email: () => (
+      <Selection
+          ariaLabel="email"
+          dataOptions={options}
+          id="emailSelect"
+          placeholder="Select email setting"
+        />
       )
     };
   }

--- a/lib/MultiColumnList/stories/WithInputs.js
+++ b/lib/MultiColumnList/stories/WithInputs.js
@@ -1,0 +1,112 @@
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+import MultiColumnList from '../MultiColumnList';
+import Button from '../../Button';
+import Selection from '../../Selection';
+import Dropdown from '../../Dropdown';
+import DropdownMenu from '../../DropdownMenu';
+import MultiSelection from '../../MultiSelection';
+import data from './dummyData';
+
+const options = [
+  {
+    value: 'always',
+    label: 'always',
+  },
+  {
+    value: 'sometimes',
+    label: 'sometimes',
+  },
+  {
+    value: 'never',
+    label: 'never',
+  }
+];
+
+
+export default class Formatter extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      selected: data[3],
+      mclKey: 0,
+    };
+
+    this.portalEl = document.getElementById('OverlayContainer');
+
+
+    this.listFormatter = {
+      action: ({ active, rowIndex }) => (
+        <Dropdown
+          renderTrigger={({ getTriggerProps }) => <Button {...getTriggerProps()}>Open dropdown</Button>}
+          renderMenu={() => (
+            <DropdownMenu data-role="menu" aria-label="available options" onToggle={action('onToggle')}>
+              <ul>
+                <li>Example 1</li>
+                <li>Example 2</li>
+                <li>Example 1</li>
+                <li>Example 2</li>
+                <li>Example 1</li>
+                <li>Example 2</li>
+                <li>Example 1</li>
+                <li>Example 2</li>
+                <li>Example 1</li>
+                <li>Example 2</li>
+              </ul>
+            </DropdownMenu>
+              )}
+            />
+      ),
+      phone: () => (
+        <Selection
+          ariaLabel="phone"
+          dataOptions={options}
+          id="phoneSelect"
+          placeholder="Select phone setting"
+        />
+      ),
+      patronGroup: () => (
+        <MultiSelection
+          ariaLabel="phone"
+          dataOptions={options}
+          id="patronSelect"
+          placeholder="Select patron group(s)"
+        />
+      )
+    };
+  }
+
+  onRowClick = (e, row) => {
+    action('button-click');
+    this.setState({ selected: row });
+  }
+
+  resetMCL = () => {
+    this.setState(curState => ({
+      mclKey: curState.mclKey + 1
+    }));
+  }
+
+  render() {
+    return (
+      <>
+        <Button onClick={this.resetMCL}>Reinitialize</Button>
+        <MultiColumnList
+          striped
+          key={this.state.mclKey}
+          contentData={data}
+          formatter={this.listFormatter}
+          selectedRow={this.state.selected}
+          onRowClick={this.onRowClick}
+          visibleColumns={['name', 'patronGroup', 'phone', 'action']}
+          columnMapping={{
+            name: 'Name',
+            patronGroup: 'Patron group',
+            phone: 'Phone',
+            action: 'Action'
+          }}
+        />
+      </>
+    );
+  }
+}

--- a/lib/Selection/Selection.css
+++ b/lib/Selection/Selection.css
@@ -35,11 +35,23 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
+  background-color: var(--color-fill-form-element);
 
   &.marginBottom0 {
     /* stylelint-disable-next-line length-zero-no-unit */
     margin-bottom: 0;
   }
+}
+
+[class*=interactionStyles] .selectionControl {
+  background-color: var(--bg);
+  &:active {
+    color: var(--color-text);
+  }
+}
+
+[class*=interactionStyles]:active .selectionControl {
+  color: var(--color-text);
 }
 
 .selectionFilterContainer {
@@ -100,6 +112,7 @@
   cursor: default;
   display: flex;
   justify-content: space-between;
+  color: var(--color-text);
 
   &.selected {
     background: var(--color-fill-current);

--- a/lib/sharedStyles/interactionStyles.css
+++ b/lib/sharedStyles/interactionStyles.css
@@ -23,10 +23,6 @@
   z-index: 1;
 }
 
-.interactionStyles * {
-  z-index: 2;
-}
-
 /**
  * Disabled state
  */
@@ -189,7 +185,6 @@
 .interactionStylesControl:active > .interactionStyles,
 .interactionStyles:active {
   color: #fff;
-  & * { color: #fff; }
   & svg { fill: #fff; }
 }
 


### PR DESCRIPTION
Selection, MultiSelection, Dropdowns, etc... They can all have a place within an EditableList, which is basically a dressed-up MCL with a custom row formatter. This PR adjusts some interaction styles to ensure these components are functional.

Approach - 
one thing to be removed: `.interactionStyle *` that set a `z-index: 2` ... `*` selectors are handy, but very difficult to track down - and their extra level of specificity makes it even worse. `Z-index` is definitely something that should be touched sparingly and only with reason, probably not something that you want or need to be cascaded.  

MCLRows containing focus get their `z-index` boosted, so the row and its containing elements will go to the top of the stack.

Additional: Selection has some adjustments as well to adjust its display within "Selected" MCL rows as well as some adjustments to prevent its text from flashing when the control or row is clicked. 