### PR TITLE
STCOM-1148 absolutely positioned content can block pane header.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Internalize the react-flexbox-grid dependency. Refs STCOM-1127.
 * Set TextLink color to white on selected MCL rows. Refs STCOM-1122.
 * Timepicker considers timezone when parsing value prop. Refs STCOM-1141.
+* PaneContent div should be position: relative to hide overflow from absolutely positioned contents. Refs STCOM-1148.
 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)

--- a/lib/Pane/Pane.css
+++ b/lib/Pane/Pane.css
@@ -46,6 +46,7 @@
   width: 100%;
   overflow: auto;
   outline: 0;
+  position: relative;
 
   &.hasPadding {
     padding: var(--gutter-static);


### PR DESCRIPTION
[STCOM-1148](https://issues.folio.org/browse/STCOM-1148)

*Problem* -  absolutely positioned content such as smart-components' NoResultsMessage will bust right out of Pane's content div, despite it having `overflow: hidden` applied in its CSS. In order to cull the overflow of non-static elements, the content containing div should be 'positioned' as well.

Approach - 
Set `position: relative` on pane's content div's class.

### Screenshot 🎉 
hooray, action dropdowns now work when results are empty.
![image](https://user-images.githubusercontent.com/20704067/231587418-f5ac3354-3231-4f7f-92cc-173f5ddb689f.png)
