### PR TITLE
Bump currency-codes from 1.5.1 to 2.1.0

### DIFF
--- a/lib/CurrencySelect/tests/CurrencySelect-test.js
+++ b/lib/CurrencySelect/tests/CurrencySelect-test.js
@@ -32,7 +32,7 @@ describe('CurrencySelect', () => {
   });
 
   describe('utility functions', () => {
-    const CURRENCY_COUNT = 160;
+    const CURRENCY_COUNT = 161;
     it('expects currency maps to contain the same element counts', () => {
       expect(Object.keys(currenciesByCode).length).to.equal(CURRENCY_COUNT);
       expect(Object.keys(currenciesByName).length).to.equal(CURRENCY_COUNT);

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   "dependencies": {
     "@folio/stripes-react-hotkeys": "^3.0.5",
     "classnames": "^2.2.5",
-    "currency-codes": "^1.5.0",
+    "currency-codes": "^2.1.0",
     "dom-helpers": "^3.2.1",
     "downshift": "^2.0.16",
     "flexboxgrid2": "^7.2.0",


### PR DESCRIPTION
PR #1971 doppelgänger

Bumps [currency-codes](https://github.com/freeall/currency-codes) from 1.5.1 to 2.1.0.
- [Release notes](https://github.com/freeall/currency-codes/releases)
- [Commits](https://github.com/freeall/currency-codes/compare/v1.5.1...v2.1.0)

---
updated-dependencies:
- dependency-name: currency-codes dependency-type: direct:production update-type: version-update:semver-major ...