### PR TITLE
STCOM-1150: Remove unchecked calls to Moment.locale

### DIFF
--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -124,7 +124,10 @@ class Calendar extends React.Component {
   constructor(props) {
     super(props);
 
-    moment.locale(this.props.intl.locale || this.props.locale);
+    const computedLocale = this.props.intl.locale || this.props.locale;
+    if (moment.locales().includes(computedLocale)) {
+      moment.locale(computedLocale);
+    }
 
     const { selectedDate, dateFormat } = this.props;
 

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -594,6 +594,8 @@ describe('Datepicker', () => {
       await datepicker.openCalendar();
     });
 
+    it('does not poison moment locale cache', () => expect(moment.locales()).to.not.include('en-se'));
+
     it('renders Monday as the first day of the week', () => Weekday('Mon', { index: 0 }).exists());
 
     it('renders weekday and month days in correct alignment', async () => {

--- a/lib/Timepicker/TimeDropdown.js
+++ b/lib/Timepicker/TimeDropdown.js
@@ -23,6 +23,7 @@ const propTypes = {
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired
   }).isRequired,
+  locale: PropTypes.string,
   mainControl: PropTypes.object,
   minuteIncrement: PropTypes.number,
   onBlur: PropTypes.func,
@@ -40,6 +41,7 @@ const propTypes = {
 
 const defaultProps = {
   hoursFormat: '24',
+  locale: 'en',
   minuteIncrement: 1,
   onSetTime: () => null,
 };
@@ -47,6 +49,10 @@ const defaultProps = {
 class TimeDropdown extends React.Component {
   constructor(props) {
     super(props);
+
+    if (moment.locales().includes(this.props.locale)) {
+      moment.locale(this.props.locale);
+    }
 
     // handle existing value...
     let initMoment;

--- a/lib/Timepicker/TimeDropdown.js
+++ b/lib/Timepicker/TimeDropdown.js
@@ -23,7 +23,6 @@ const propTypes = {
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired
   }).isRequired,
-  locale: PropTypes.string,
   mainControl: PropTypes.object,
   minuteIncrement: PropTypes.number,
   onBlur: PropTypes.func,
@@ -41,7 +40,6 @@ const propTypes = {
 
 const defaultProps = {
   hoursFormat: '24',
-  locale: 'en',
   minuteIncrement: 1,
   onSetTime: () => null,
 };
@@ -49,8 +47,6 @@ const defaultProps = {
 class TimeDropdown extends React.Component {
   constructor(props) {
     super(props);
-
-    moment.locale(this.props.locale);
 
     // handle existing value...
     let initMoment;

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -616,6 +616,7 @@ class Timepicker extends React.Component {
           mainControl={this.textfieldRef.current}
           onKeyDown={this.handleKeyDown}
           onBlur={this.hideTimepicker}
+          locale={this.locale}
           onNavigation={this.handleDateNavigation}
           id={this.testId}
           onClose={this.hideTimepicker}

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -616,7 +616,6 @@ class Timepicker extends React.Component {
           mainControl={this.textfieldRef.current}
           onKeyDown={this.handleKeyDown}
           onBlur={this.hideTimepicker}
-          locale={this.locale}
           onNavigation={this.handleDateNavigation}
           id={this.testId}
           onClose={this.hideTimepicker}

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -109,7 +109,7 @@ describe('Timepicker', () => {
     it('emits an event with the time formatted as displayed', () => converge(() => (timeOutput === '05:00 PM')));
   });
 
-  describe('correctly handles unknown locales', () => {
+  describe('correctly handles unknown locales (en-SE)', () => {
     beforeEach(async () => {
       await mountWithContext(
         <Timepicker

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -1,6 +1,8 @@
+import { expect } from 'chai';
 import React from 'react';
 import { describe, beforeEach, it } from 'mocha';
-import moment from 'moment-timezone';
+import moment from 'moment';
+import momentTz from 'moment-timezone';
 import {
   runAxeTest,
   HTML,
@@ -107,6 +109,21 @@ describe('Timepicker', () => {
     it('emits an event with the time formatted as displayed', () => converge(() => (timeOutput === '05:00 PM')));
   });
 
+  describe('correctly handles unknown locales', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <Timepicker
+          id="timepicker-locale-test"
+          locale="en-SE"
+        />
+      );
+
+      await timepicker.clickInput();
+    });
+
+    it('does not poison moment locale cache', () => expect(moment.locales()).to.not.include('en-se'));
+  });
+
   describe('selecting a time with timeZone prop', () => {
     let timeOutput;
 
@@ -166,7 +183,7 @@ describe('Timepicker', () => {
         await timepicker.fillIn('05:00 PM');
       });
 
-      it('returns an ISO 8601 time string for specific time zone', () => converge(() => (timeOutput === moment().tz(tz).isDST() ? '00:00:00.000Z' : '01:00:00.000Z')));
+      it('returns an ISO 8601 time string for specific time zone', () => converge(() => (timeOutput === momentTz().tz(tz).isDST() ? '00:00:00.000Z' : '01:00:00.000Z')));
     });
   });
 

--- a/util/dateTimeUtils.js
+++ b/util/dateTimeUtils.js
@@ -48,7 +48,7 @@ export const getLocaleDateFormat = ({ intl }) => {
     format = getMomentLocalizedFormat(intl);
   }
 
-  return format;
+  return format.replace('\u202f', ' ');
 };
 
 // getLocalizedTimeFormatInfo() -

--- a/util/dateTimeUtils.js
+++ b/util/dateTimeUtils.js
@@ -48,7 +48,7 @@ export const getLocaleDateFormat = ({ intl }) => {
     format = getMomentLocalizedFormat(intl);
   }
 
-  return format.replace('\u202f', ' ');
+  return format.replaceAll('\u202f', ' ');
 };
 
 // getLocalizedTimeFormatInfo() -
@@ -128,7 +128,7 @@ export function getLocalizedTimeFormatInfo(locale) {
 
   return {
     ...formatInfo,
-    timeFormat,
+    timeFormat: timeFormat.replaceAll('\u202f', ' '),
     dayPeriods: [...dpOptions],
   };
 }

--- a/util/dateTimeUtils.js
+++ b/util/dateTimeUtils.js
@@ -48,6 +48,8 @@ export const getLocaleDateFormat = ({ intl }) => {
     format = getMomentLocalizedFormat(intl);
   }
 
+  // replace narrow non-breaking space introduced in ICU 72.1
+  // see https://github.com/nodejs/node/issues/46123
   return format.replaceAll('\u202f', ' ');
 };
 


### PR DESCRIPTION
# [Jira STCOM-1150](https://issues.folio.org/browse/STCOM-1150)

This fixes the bug reported in [STCOM-1150](https://issues.folio.org/browse/STCOM-1150) and causing [UICAL-267](https://issues.folio.org/browse/UICAL-267) by removing the erroneous call to `moment.locale`.

To summarize [this Slack thread](https://folio-project.slack.com/archives/C210UCHQ9/p1680101882014399), the call to `moment.locale` for locales unknown to Moment (such as `en-SE` for Swedish English) caused Moment to fallback to default locale settings, however, it would also cache these default settings as the correct locale for `en-SE`.  When `Timepicker` later checked to see if Moment knew the locale, Moment then reported that it did, returning incorrectly assumed locale information, resulting in 24-hour `Timepicker`s switching to 12-hour at reconstruction.

@JohnC-80 / @zburke one of y'all will likely want to clone this branch over to `folio-org` to check CI (I don't have permissions here), however, running tests revealed no new failures (the only date-related failure was due to the change of the space in locale times during a recent Chrome update (replaced with `\u202f`)).  Fixed that here too, for sanity's sake.