### PR TITLE
Bump react-highlight-words from 0.18.0 to 0.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "prop-types": "^15.5.10",
     "prop-types-extra": "^1.1.0",
     "query-string": "^8.1.0",
-    "react-highlight-words": "^0.18.0",
+    "react-highlight-words": "^0.20.0",
     "react-overlays": "^4.1.1",
     "react-quill": "^1.3.3",
     "react-svg-loader": "^3.0.3",


### PR DESCRIPTION
PR #1973 doppelgänger

Bumps [react-highlight-words](https://github.com/bvaughn/react-highlight-words) from 0.18.0 to 0.20.0.
- [Release notes](https://github.com/bvaughn/react-highlight-words/releases)
- [Commits](https://github.com/bvaughn/react-highlight-words/compare/v0.18.0...v0.20.0)

---
updated-dependencies:
- dependency-name: react-highlight-words dependency-type: direct:production update-type: version-update:semver-minor ...