### PR TITLE
Bump react-overlays from 4.1.1 to 5.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "prop-types-extra": "^1.1.0",
     "query-string": "^8.1.0",
     "react-highlight-words": "^0.18.0",
-    "react-overlays": "^4.1.1",
+    "react-overlays": "^5.2.1",
     "react-quill": "^1.3.3",
     "react-svg-loader": "^3.0.3",
     "react-transition-group": "^2.2.1",


### PR DESCRIPTION
PR #1982 doppelgänger

Bumps [react-overlays](https://github.com/react-bootstrap/react-overlays) from 4.1.1 to 5.2.1.
- [Release notes](https://github.com/react-bootstrap/react-overlays/releases)
- [Changelog](https://github.com/react-bootstrap/react-overlays/blob/master/CHANGELOG.md)
- [Commits](https://github.com/react-bootstrap/react-overlays/compare/v4.1.1...v5.2.1)

---
updated-dependencies:
- dependency-name: react-overlays dependency-type: direct:production update-type: version-update:semver-major ...