### PR TITLE
STCOM-1154: Provide onChange and ariaLabel props to TextArea component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Timepicker considers timezone when parsing value prop. Refs STCOM-1141.
 * PaneContent div should be position: relative to hide overflow from absolutely positioned contents. Refs STCOM-1148.
 * Adjust styles for overlay controls rendered in MCL rows. Refs STCOM-1149, UIRS-100.
+* Provide onChange and ariaLabel prop to TextArea component. Refs STCOM-1154.
 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)

--- a/lib/TextArea/TextArea.js
+++ b/lib/TextArea/TextArea.js
@@ -13,6 +13,8 @@ import Label from '../Label';
 
 class TextArea extends Component {
   static propTypes = {
+    ariaLabel: PropTypes.string,
+    ariaLabelledBy: PropTypes.string,
     autoFocus: PropTypes.bool,
     dirty: PropTypes.bool,
     disabled: PropTypes.bool,
@@ -65,13 +67,36 @@ class TextArea extends Component {
     type: 'text',
     validationEnabled: true,
     validStylesEnabled: false,
+    value: '',
   };
 
   constructor(props) {
     super(props);
 
+    this.handleChange = this.handleChange.bind(this);
+
     // if no id has been supplied, generate a unique one
     this.inputId = props.id ?? uniqueId('textarea-input-');
+
+    this.state = {
+      prevPropsValue: props.value,
+      value: props.value,
+    };
+  }
+
+  static getDerivedStateFromProps(props, state) {
+    const newState = {};
+
+    if (props.value !== state.prevPropsValue) {
+      newState.prevPropsValue = props.value;
+      newState.value = props.value;
+    }
+
+    if (Object.keys(newState).length > 0) {
+      return newState;
+    }
+
+    return null;
   }
 
   getRootStyle() {
@@ -94,9 +119,24 @@ class TextArea extends Component {
     );
   }
 
+  handleChange(event) {
+    const { onChange } = this.props;
+
+    this.setState({
+      value: event.target.value
+    });
+
+    // Fire callback
+    if (typeof onChange === 'function') {
+      onChange(event);
+    }
+  }
+
   render() {
     /* eslint-disable no-unused-vars */
     const {
+      ariaLabel,
+      ariaLabelledBy,
       autoFocus,
       dirty,
       endControl,
@@ -114,21 +154,26 @@ class TextArea extends Component {
       valid,
       validStylesEnabled,
       warning,
-      ...inputCustom
+      ...rest
     } = this.props;
-    /* eslint-enable no-unused-vars */
 
+    const inputCustom = omitProps(rest, ['id', 'validationEnabled', 'value', 'onChange']);
     const component = (
       <textarea
         aria-required={required}
         aria-invalid={!!(this.props.error)}
+        aria-label={inputCustom['aria-label'] || ariaLabel}
+        aria-labelledby={inputCustom['aria-labelledby'] || ariaLabelledBy}
         autoFocus={autoFocus}
         className={this.getInputStyle()}
         id={this.inputId}
         name={name}
         ref={inputRef}
         cols={fitContent ? this.props.value.length : undefined}
-        {...omitProps(inputCustom, ['id', 'validationEnabled'])}
+        value={this.state.value}
+        onChange={this.handleChange}
+        required={required}
+        {...inputCustom}
       />
     );
 

--- a/lib/TextArea/tests/TextArea-test.js
+++ b/lib/TextArea/tests/TextArea-test.js
@@ -91,4 +91,32 @@ describe('TextArea', () => {
 
     it('has \'cols\' property', () => textArea.has({ cols: `${value.length}` }));
   });
+
+  describe('supplying areaLabel', () => {
+    const textArea = Interactor();
+
+    beforeEach(async () => {
+      await mount(
+        <TextArea ariaLabel="test areaLabel" />
+      );
+    });
+
+    it('contains no axe errors - TextArea', runAxeTest);
+
+    it('applies the aria-label to the textarea', () => textArea.has({ ariaLabel: 'test areaLabel' }));
+  });
+
+  describe('supplying value', () => {
+    const textArea = Interactor();
+
+    beforeEach(async () => {
+      await mount(
+        <TextArea ariaLabel="test label" value="test value" />
+      );
+    });
+
+    it('contains no axe errors - TextArea', runAxeTest);
+
+    it('applies the value to the textarea', () => textArea.has({ value: 'test value' }));
+  });
 });


### PR DESCRIPTION
## Purpose
To provide **onChange**, **value**, and **ariaLabel** prop to **TextArea** component as it's done for TextField component e.g. to make it possible to provide a callback on textaria change and set ariaLabel (although it's possible to set it as 'aria-label' but added it for consistency)

## Refs
https://issues.folio.org/browse/STCOM-1154