### PR TITLE
STCOM-1150v2

### DIFF
--- a/lib/Timepicker/TimeDropdown.js
+++ b/lib/Timepicker/TimeDropdown.js
@@ -23,6 +23,7 @@ const propTypes = {
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired
   }).isRequired,
+  locale: PropTypes.string,
   mainControl: PropTypes.object,
   minuteIncrement: PropTypes.number,
   onBlur: PropTypes.func,
@@ -40,6 +41,7 @@ const propTypes = {
 
 const defaultProps = {
   hoursFormat: '24',
+  locale: 'en',
   minuteIncrement: 1,
   onSetTime: () => null,
 };
@@ -47,6 +49,10 @@ const defaultProps = {
 class TimeDropdown extends React.Component {
   constructor(props) {
     super(props);
+
+    if (moment.locales().includes(this.props.locale)) {
+      moment.locale(this.props.locale);
+    }
 
     // handle existing value...
     let initMoment;

--- a/lib/Timepicker/TimeDropdown.js
+++ b/lib/Timepicker/TimeDropdown.js
@@ -23,7 +23,6 @@ const propTypes = {
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired
   }).isRequired,
-  locale: PropTypes.string,
   mainControl: PropTypes.object,
   minuteIncrement: PropTypes.number,
   onBlur: PropTypes.func,
@@ -41,7 +40,6 @@ const propTypes = {
 
 const defaultProps = {
   hoursFormat: '24',
-  locale: 'en',
   minuteIncrement: 1,
   onSetTime: () => null,
 };
@@ -49,8 +47,6 @@ const defaultProps = {
 class TimeDropdown extends React.Component {
   constructor(props) {
     super(props);
-
-    moment.locale(this.props.locale);
 
     // handle existing value...
     let initMoment;

--- a/lib/Timepicker/TimeDropdown.js
+++ b/lib/Timepicker/TimeDropdown.js
@@ -50,9 +50,7 @@ class TimeDropdown extends React.Component {
   constructor(props) {
     super(props);
 
-    if (moment.locales().includes(this.props.locale)) {
-      moment.locale(this.props.locale);
-    }
+    moment.locale(this.props.locale);
 
     // handle existing value...
     let initMoment;

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -616,6 +616,7 @@ class Timepicker extends React.Component {
           mainControl={this.textfieldRef.current}
           onKeyDown={this.handleKeyDown}
           onBlur={this.hideTimepicker}
+          locale={this.locale}
           onNavigation={this.handleDateNavigation}
           id={this.testId}
           onClose={this.hideTimepicker}

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -616,7 +616,6 @@ class Timepicker extends React.Component {
           mainControl={this.textfieldRef.current}
           onKeyDown={this.handleKeyDown}
           onBlur={this.hideTimepicker}
-          locale={this.locale}
           onNavigation={this.handleDateNavigation}
           id={this.testId}
           onClose={this.hideTimepicker}

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -88,8 +88,8 @@ class Timepicker extends React.Component {
 
     // Set locale
     this.locale = props.locale || props.intl.locale;
-    if (moment.locales().includes(this.locale)) {
-      moment.locale(this.locale);
+    moment.locale(this.locale);
+    if (moment.locale() === this.locale.toLowerCase()) {
       this._timeFormat = moment.localeData()._longDateFormat.LT;
     } else {
       this._timeFormat = getLocalizedTimeFormatInfo(this.locale).timeFormat;

--- a/util/dateTimeUtils.js
+++ b/util/dateTimeUtils.js
@@ -48,7 +48,7 @@ export const getLocaleDateFormat = ({ intl }) => {
     format = getMomentLocalizedFormat(intl);
   }
 
-  return format;
+  return format.replace('\u202f', ' ');
 };
 
 // getLocalizedTimeFormatInfo() -

--- a/util/dateTimeUtils.js
+++ b/util/dateTimeUtils.js
@@ -48,7 +48,7 @@ export const getLocaleDateFormat = ({ intl }) => {
     format = getMomentLocalizedFormat(intl);
   }
 
-  return format.replace('\u202f', ' ');
+  return format.replaceAll('\u202f', ' ');
 };
 
 // getLocalizedTimeFormatInfo() -
@@ -128,7 +128,7 @@ export function getLocalizedTimeFormatInfo(locale) {
 
   return {
     ...formatInfo,
-    timeFormat,
+    timeFormat: timeFormat.replaceAll('\u202f', ' '),
     dayPeriods: [...dpOptions],
   };
 }


### PR DESCRIPTION
This PR checks that the moment's active locale matches the lowercase version of the locale passed through props/intl before using its static locale. If not, it falls back to getting a localized time format from Browser Intl API.

`moment` doesn't have an `en-SE` locale.. it falls back to `en` if it's attempted using `moment.locale('en-SE')` As far as time-picker is concerned, the discrepancy between them is that `en-SE` is a 24 hour format, but `en` is 12 hour... accurate formatting info is provided from browser INTL API, however, so that's what we can fall back to.