### PR TITLE
STCOM-1155: Fix the key property for <SelectOption/> to fix duplications when the label is not unique.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Timepicker considers timezone when parsing value prop. Refs STCOM-1141.
 * PaneContent div should be position: relative to hide overflow from absolutely positioned contents. Refs STCOM-1148.
 * Adjust styles for overlay controls rendered in MCL rows. Refs STCOM-1149, UIRS-100.
+* Fix the `key` property for `<SelectOption/>` to fix duplications when the label is not unique. Refs STCOM-1155.
 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)

--- a/lib/MultiSelection/MultiSelectOptionsList.js
+++ b/lib/MultiSelection/MultiSelectOptionsList.js
@@ -34,7 +34,6 @@ class MultiSelectOptionsList extends React.Component {
     inputValue: PropTypes.string,
     internalChangeCallback: PropTypes.func,
     isOpen: PropTypes.bool,
-    itemToString: PropTypes.func,
     maxHeight: PropTypes.number,
     modifiers: PropTypes.object,
     placeholder: PropTypes.string,
@@ -111,7 +110,6 @@ class MultiSelectOptionsList extends React.Component {
       getInputProps,
       inputRef,
       isOpen,
-      itemToString,
       getMenuProps,
       getItemProps,
       selectedItems,
@@ -165,7 +163,7 @@ class MultiSelectOptionsList extends React.Component {
           { renderedItems && renderedItems.length > 0 &&
           renderedItems.map((item, index) => (
             <SelectOption
-              key={`${itemToString(item)}`}
+              key={`${item.label}-${item.value}`}
               {...getItemProps({
                 item,
                 index,

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -425,7 +425,6 @@ class MultiSelection extends React.Component {
               getMenuProps,
               getItemProps,
               maxHeight,
-              itemToString,
               placeholder: renderedPlaceholder,
               inputKeyDown: this.handleInputKeyDown,
               selectedItems,


### PR DESCRIPTION
## Purpose
Fix the `key` property for `<SelectOption/>` to fix duplications when the label is not unique.

<details>
<summary>Screencast of the issue.</summary>

https://user-images.githubusercontent.com/77053927/233616927-539123e0-7ac5-4315-9f37-507942b04938.mp4


</details>


## Issues
[STCOM-1155](https://issues.folio.org/browse/STCOM-1155)

## Screencast



https://user-images.githubusercontent.com/77053927/233617539-7703942b-f61d-4b42-a5cc-9b9537b9d7d6.mp4




