### PR TITLE
STCOM-1157 Two X's displayed on search fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Adjust styles for overlay controls rendered in MCL rows. Refs STCOM-1149, UIRS-100.
 * Provide onChange and ariaLabel prop to TextArea component. Refs STCOM-1154.
 * Omit `webpack` dependency; it is not used directly and is supplied indirectly via `@folio/stripes-cli`. Refs STCOM-1153.
+* Add styling for search fields to remove the `x` cancel icon that went away when we upgraded `normalize.css` . Refs STCOM-1157.
 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)

--- a/lib/global.css
+++ b/lib/global.css
@@ -136,6 +136,16 @@ button {
   }
 }
 
+/* clears the ‘X’ from Internet Explorer */
+input[type=search]::-ms-clear { display: none; width : 0; height: 0; }
+input[type=search]::-ms-reveal { display: none; width : 0; height: 0; }
+
+/* clears the ‘X’ from Chrome */
+input[type="search"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-results-button,
+input[type="search"]::-webkit-search-results-decoration { display: none; }
+
 :global(.fullWidth) {
   width: 100% !important;
 }


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-1157

These styles went away when we recently upgraded the `normalize.css` dependency. This PR simply re-adds them in our global styles.

Before:
![image](https://user-images.githubusercontent.com/20704067/234595799-1874864f-1fa2-470b-9b38-de770ec78c59.png)

After: 
![image](https://user-images.githubusercontent.com/20704067/234596142-8a134385-5080-4913-8247-389ad855d211.png)
