### PR TITLE
STCOM-1153 re-lock webpack to ~5.68.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "react-router-dom": "^5.2.0"
   },
   "resolutions": {
-    "moment": "~2.24.0"
+    "moment": "~2.24.0",
+    "webpack": "~5.68.0"
   }
 }

--- a/util/tests/dateUtils-test.js
+++ b/util/tests/dateUtils-test.js
@@ -64,7 +64,11 @@ describe('Date Utilities', () => {
   describe('get locale time format - en-US', () => {
     let timeFormat;
     beforeEach(async () => {
-      timeFormat = getLocalizedTimeFormatInfo('en-US'); // eslint-disable-line
+      timeFormat = getLocalizedTimeFormatInfo('en-US');
+
+      // Oh ICU 72, how do I hate thee? Let me count the ways.
+      // https://github.com/nodejs/node/issues/46123
+      timeFormat.timeFormat = timeFormat.timeFormat.replaceAll('\u202f', ' ');
     });
 
     it('returns the time format according to the passed locale', () => {


### PR DESCRIPTION
`webpack` was unlocked from `~5.68.0` in tip-of-master branches which are leveraged here in CI, so even though the correct value is in place in `devDependencies`, newer versions are sneaking in via the CI builds of `stripes-cli` and `eslint-config-stripes`.

Refs [STCOM-1153](https://issues.folio.org/browse/STCOM-1153)