### PR TITLE
Depbot_dup:  Remove dom-helpers dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Remove Accordion's problematic internal aria-label (it already has aria-labelledby for adequate labeling). Refs STCOM-1129.
 * Compile translations. Refs STCOM-1162.
 * Return filled rows and query from `useAdvancedSearch` hook. Fixes STCOM-1156.
+* Remove `dom-helpers` dependency. Resolves STCOM-1170.
 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -2,7 +2,6 @@ import React, { useState, useRef, useEffect } from 'react';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import moment from 'moment-timezone';
-import contains from 'dom-helpers/query/contains';
 import uniqueId from 'lodash/uniqueId';
 import pick from 'lodash/pick';
 import RootCloseWrapper from '../../util/RootCloseWrapper';
@@ -301,10 +300,10 @@ const Datepicker = (
   };
 
   const datePickerIsFocused = () => {
-    if (contains(container.current, document.activeElement) &&
+    if (container.current.contains(document.activeElement) &&
       document.activeElement !== document.body) {
       if (pickerRef.current) {
-        return (contains(pickerRef.current, document.activeElement));
+        return (pickerRef.current.contains(document.activeElement));
       }
       return true;
     }
@@ -355,7 +354,7 @@ const Datepicker = (
   };
 
   const handleRootClose = (e) => {
-    if (!contains(container.current, e.target) || !contains(pickerRef.current, e.target)) {
+    if (!container.current.contains(e.target) || !pickerRef.current.contains(e.target)) {
       if (!datePickerIsFocused()) {
         setShowCalendar(false);
       }

--- a/lib/Dropdown/Dropdown.js
+++ b/lib/Dropdown/Dropdown.js
@@ -2,7 +2,6 @@
 import React, { cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import contains from 'dom-helpers/query/contains';
 import css from './Dropdown.css';
 import Popdown from './Popdown';
 import omit from '../../util/omitProps';
@@ -171,7 +170,7 @@ class Dropdown extends React.Component {
     if (onToggle) {
       if (this.props.open && this.menu.current) {
         const menuParent = this.menu.current.node || this.menu.current;
-        if (contains(menuParent, document.activeElement)) {
+        if (menuParent.contains(document.activeElement)) {
           if (this.toggle && this.toggle.current) {
             this.toggle.current.focus();
           }

--- a/lib/Dropdown/Popdown.js
+++ b/lib/Dropdown/Popdown.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import isBoolean from 'lodash/isBoolean';
-import contains from 'dom-helpers/query/contains';
 import PropTypes from 'prop-types';
 import DropdownButton from '../DropdownButton';
 import Popper from '../Popper';
@@ -31,7 +30,7 @@ const defaultFocusHandlers = {
     if (firstItem) firstItem.focus();
   },
   close: (trigger, menu) => {
-    if (contains(menu, document.activeElement)) {
+    if (menu.contains(document.activeElement)) {
       trigger.focus();
     }
   }

--- a/lib/FocusLink/FocusLink.js
+++ b/lib/FocusLink/FocusLink.js
@@ -15,7 +15,7 @@ const propTypes = {
   showOnFocus: PropTypes.bool,
   tabIndex: PropTypes.number,
   target: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-  targetNextAfter: PropTypes.element,
+  targetNextAfter: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
 };
 
 const FocusLink = ({
@@ -51,7 +51,11 @@ const FocusLink = ({
   const focusNext = () => {
     let nextFocusable;
     if (targetNextAfter) {
-      nextFocusable = getNextFocusable(targetNextAfter, false);
+      if(typeof targetNextAfter === 'function') {
+        nextFocusable = getNextFocusable(targetNextAfter(), false);
+      } else {
+        nextFocusable = getNextFocusable(targetNextAfter, false);
+      }
     } else {
       nextFocusable = getNextFocusable(link, false);
     }

--- a/lib/FocusLink/FocusLink.js
+++ b/lib/FocusLink/FocusLink.js
@@ -51,7 +51,7 @@ const FocusLink = ({
   const focusNext = () => {
     let nextFocusable;
     if (targetNextAfter) {
-      if(typeof targetNextAfter === 'function') {
+      if (typeof targetNextAfter === 'function') {
         nextFocusable = getNextFocusable(targetNextAfter(), false);
       } else {
         nextFocusable = getNextFocusable(targetNextAfter, false);

--- a/lib/FocusLink/tests/FocusLinkHarness.js
+++ b/lib/FocusLink/tests/FocusLinkHarness.js
@@ -1,0 +1,19 @@
+import React, { useRef } from 'react';
+import FocusLink from '../FocusLink';
+
+export default function FocusLinkHarness({testId, targetOnFocus, listProps, ...props}) {
+  const list = useRef(null);
+  const getList = () => list.current;
+  return (
+    <>
+      <FocusLink targetNextAfter={ getList} {...props }>
+        <span>Test focus link</span>
+      </FocusLink>
+      <ul ref={list} {...listProps}>
+        <li><input type="text" name="test"/></li>
+        <li><button>test</button></li>
+      </ul>
+      <input type="text" name="test" id={testId} onFocus={targetOnFocus}/>
+    </>
+  );
+}

--- a/lib/FocusLink/tests/FocusLinkWithoutTarget.js
+++ b/lib/FocusLink/tests/FocusLinkWithoutTarget.js
@@ -6,7 +6,7 @@ import { converge, Keyboard } from '@folio/stripes-testing';
 import { mount } from '../../../tests/helpers';
 import FocusLink from '../FocusLink';
 import FocusLinkInteractor from './FocusLinkInteractor';
-
+import FocusLinkHarness from './FocusLinkHarness';
 
 const testId = 'test';
 const testComponent = 'div';
@@ -48,7 +48,7 @@ describe('FocusLink', () => {
 
 describe('FocusLink with targetNextAfter prop', () => {
   const focusLink = new FocusLinkInteractor();
-  let focusSpy;
+  let focusSpy = sinon.spy();
   let testNextInput;
 
   afterEach(() => {
@@ -59,13 +59,11 @@ describe('FocusLink with targetNextAfter prop', () => {
     await mount(
       <>
         <input id={testId} />
-        <FocusLink targetNextAfter={targetNextAfter}>
-          Focus Link
-        </FocusLink>
+        <FocusLinkHarness testId={'testId2'} targetOnFocus={focusSpy} listProps={{ tabIndex: 0 }}/>
       </>
     );
-    testNextInput = document.getElementById(testId);
-    focusSpy = sinon.spy(testNextInput, 'focus');
+    // testNextInput = document.getElementById('testId2');
+    // focusSpy = sinon.spy(testNextInput, 'focus');
   });
 
   it('shoud render link', () => focusLink.exists());
@@ -75,6 +73,6 @@ describe('FocusLink with targetNextAfter prop', () => {
       await focusLink.click();
     });
 
-    it('should make the targed focused', () => converge(() => focusSpy.called));
+    it('should make the targed focused', () => converge(() => { if(!focusSpy.called) throw (new Error('target not focused')); }));
   });
 });

--- a/lib/FocusLink/tests/FocusLinkWithoutTarget.js
+++ b/lib/FocusLink/tests/FocusLinkWithoutTarget.js
@@ -34,7 +34,7 @@ describe('FocusLink', () => {
     focusSpy = sinon.spy(testInput, 'focus');
   });
 
-  it('shoud render link', () => focusLink.exists());
+  it('should render link', () => focusLink.exists());
 
   describe('Press on the Enter button', () => {
     beforeEach(async () => {
@@ -62,8 +62,6 @@ describe('FocusLink with targetNextAfter prop', () => {
         <FocusLinkHarness testId={'testId2'} targetOnFocus={focusSpy} listProps={{ tabIndex: 0 }}/>
       </>
     );
-    // testNextInput = document.getElementById('testId2');
-    // focusSpy = sinon.spy(testNextInput, 'focus');
   });
 
   it('shoud render link', () => focusLink.exists());

--- a/lib/Layer/Layer.js
+++ b/lib/Layer/Layer.js
@@ -6,7 +6,6 @@ import React from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import componentOrElement from 'prop-types-extra/lib/componentOrElement';
-import contains from 'dom-helpers/query/contains';
 import trapFocus from '../../util/trapFocus';
 import css from './Layer.css';
 import { withPaneset } from '../Paneset/PanesetContext';
@@ -93,7 +92,7 @@ class Layer extends React.Component {
     resizer.suspend();
 
     if (autoFocus && this.contentRef.current) {
-      if (!contains(this.contentRef.current, document.activeElement)) {
+      if (!this.contentRef.current.contains(document.activeElement)) {
         this.contentRef.current.focus();
       }
     }

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import contains from 'dom-helpers/query/contains';
 import {
   noop,
   uniqueId,
@@ -197,7 +196,7 @@ class MultiSelection extends React.Component {
   };
 
   handleBlur = (e) => {
-    if (!contains(e.target, this.container.current)) {
+    if (!e.target.contains(this.container.current)) {
       this.setState({ focused: false });
     }
   };

--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -6,8 +6,6 @@ import uniqueId from 'lodash/uniqueId';
 import isEqual from 'lodash/isEqual';
 import isEmpty from 'lodash/isEmpty';
 import throttle from 'lodash/throttle';
-import contains from 'dom-helpers/query/contains';
-import matches from 'dom-helpers/query/matches';
 import { FormattedMessage } from 'react-intl';
 import TextFieldIcon from '../TextField/TextFieldIcon';
 import RootCloseWrapper from '../../util/RootCloseWrapper';
@@ -452,7 +450,7 @@ class SingleSelect extends React.Component {
         this.hideList();
         break;
       case 32: // space
-        if (!this.state.filtering || matches(e.target, 'li')) {
+        if (!this.state.filtering || e.target.matches('li')) {
           if (selected) {
             this.handleChoose(this.state.cursoredValue, this.state.cursoredLabel);
             this.thrToggleList();
@@ -526,8 +524,8 @@ class SingleSelect extends React.Component {
   hideOnBlur() {
     if (!this.state.showList) {
       if (this.container && document.activeElement !== document.body) {
-        if (!contains(this.selectList, document.activeElement)) {
-          if (!contains(this.container, document.activeElement)) {
+        if (!this.selectList.contains(document.activeElement)) {
+          if (!this.container.contains(document.activeElement)) {
             this.hideList();
           }
         }
@@ -547,8 +545,8 @@ class SingleSelect extends React.Component {
     if (this.state.showList) {
       if (this.container.current && this.selectList.current) {
         // be sure that nothing in the select is in focus before closing the option list.
-        if (!contains(this.container.current, document.activeElement) &&
-          !contains(this.selectList.current, document.activeElement)) {
+        if (!this.container.current.contains(document.activeElement) &&
+          !this.selectList.current.contains(document.activeElement)) {
           // go ahead and execute redux-form validation...
           if (this.props.onBlur) {
             this.props.onBlur();

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "@folio/stripes-react-hotkeys": "^3.0.5",
     "classnames": "^2.2.5",
     "currency-codes": "^2.1.0",
-    "dom-helpers": "^5.2.1",
     "downshift": "^2.0.16",
     "flexboxgrid2": "^7.2.0",
     "hoist-non-react-statics": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@folio/stripes-react-hotkeys": "^3.0.5",
     "classnames": "^2.2.5",
     "currency-codes": "^2.1.0",
-    "dom-helpers": "^3.2.1",
+    "dom-helpers": "^5.2.1",
     "downshift": "^2.0.16",
     "flexboxgrid2": "^7.2.0",
     "hoist-non-react-statics": "^3.1.0",

--- a/util/getFocusableElements.js
+++ b/util/getFocusableElements.js
@@ -16,8 +16,6 @@
  *       If the index is before the start of the list, the last element will be returned.
 */
 
-import contains from 'dom-helpers/query/contains';
-import matches from 'dom-helpers/query/matches';
 import first from 'lodash/first';
 import last from 'lodash/last';
 
@@ -32,12 +30,12 @@ function getVisibleFocusableElements(container = document, includeContained, cur
           if (element === currentElement) {
             return true;
           }
-          if (currentElement && contains(currentElement, element)) {
+          if (currentElement && currentElement.contains(element)) {
             return false;
           }
         }
 
-        if (matches(element, '[data-focus-exclude]')) {
+        if (element.matches('[data-focus-exclude]')) {
           return false;
         }
 

--- a/util/trapFocus.js
+++ b/util/trapFocus.js
@@ -1,4 +1,3 @@
-import contains from 'dom-helpers/query/contains';
 
 const getDefaultExceptions = () => [
   document.getElementById('OverlayContainer'),
@@ -8,10 +7,10 @@ const getDefaultExceptions = () => [
 
 export default function trapFocus(container, exceptions) {
   if (container && container.className !== document.activeElement.className) {
-    if (!contains(container, document.activeElement)) {
+    if (!container.contains(document.activeElement)) {
       if ([...getDefaultExceptions(), ...exceptions].filter((e) => {
         if (!e) return false;
-        return contains(e, document.activeElement);
+        return e.contains(document.activeElement);
       }).length === 0) {
         container.focus();
       }


### PR DESCRIPTION
After seeing how wack that repo is, (Changelog: `Feature: 'remove alot of code'`... `Feature: publish dir ` (not in a breaking version!))I decided it's time to just eliminate it, as all functionality we used from it is now provided by browsers - `element.contains()` and `element.matches()`... um... JSDOM, hold on to your butt!

Probably pending some jest tests to see if this is an issue.... if it is, maybe we can just polyfill these guys for that environment somehow rather than re-introducing this dependency.

~~Bumps [dom-helpers](https://github.com/react-bootstrap/dom-helpers) from 3.4.0 to 5.2.1.~~

~~updated-dependencies:~~
