### PR TITLE
Bump postcss-calc from 8.2.4 to 9.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "mocha": "^10.2.0",
     "moment": "^2.29.0",
     "postcss": "^8.4.2",
-    "postcss-calc": "^8.2.4",
+    "postcss-calc": "^9.0.1",
     "postcss-color-function": "folio-org/postcss-color-function",
     "postcss-custom-media": "^9.0.1",
     "postcss-custom-properties": "12.1.11",


### PR DESCRIPTION
PR #2063 doppelgänger

Bumps [postcss-calc](https://github.com/postcss/postcss-calc) from 8.2.4 to 9.0.1.
- [Release notes](https://github.com/postcss/postcss-calc/releases)
- [Changelog](https://github.com/postcss/postcss-calc/blob/master/CHANGELOG.md)
- [Commits](https://github.com/postcss/postcss-calc/commits/v9.0.1)

---
updated-dependencies:
- dependency-name: postcss-calc dependency-type: direct:development update-type: version-update:semver-major ...