### PR TITLE
STCOM-1156 Return filled rows and query from `useAdvancedSearch` hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@
 * Provide onChange and ariaLabel prop to TextArea component. Refs STCOM-1154.
 * Omit `webpack` dependency; it is not used directly and is supplied indirectly via `@folio/stripes-cli`. Refs STCOM-1153.
 * Add styling for search fields to remove the `x` cancel icon that went away when we upgraded `normalize.css` . Refs STCOM-1157.
-* Remove Accordion's problematic internal aria-label (it already has aria-labelledby for adequate labeling. Refs STCOM-1129.
+* Remove Accordion's problematic internal aria-label (it already has aria-labelledby for adequate labeling). Refs STCOM-1129.
+* Return filled rows and query from `useAdvancedSearch` hook. Fixes STCOM-1156.
 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)

--- a/index.js
+++ b/index.js
@@ -115,6 +115,7 @@ export { default as SearchField } from './lib/SearchField';
 export { default as ConflictDetectionBanner } from './lib/ConflictDetectionBanner';
 export {
   AdvancedSearch,
+  useAdvancedSearch,
   defaultQueryBuilder as defaultAdvancedSearchQueryBuilder,
   BOOLEAN_OPERATORS as ADVANCED_SEARCH_BOOLEAN_OPERATORS,
 } from './lib/AdvancedSearch';

--- a/lib/AdvancedSearch/AdvancedSearch.js
+++ b/lib/AdvancedSearch/AdvancedSearch.js
@@ -7,10 +7,7 @@ import AdvancedSearchRow from './components/AdvancedSearchRow';
 import useAdvancedSearch from './hooks/useAdvancedSearch';
 import defaultQueryBuilder from './utilities/defaultQueryBuilder';
 import filterFilledRows from './utilities/filterFilledRows';
-
-const defaultRowFormatter = (searchOption, query, comparator) => {
-  return `${searchOption}${comparator}${query}`;
-};
+import defaultRowFormatter from './utilities/defaultRowFormatter';
 
 const propTypes = {
   children: PropTypes.func.isRequired,

--- a/lib/AdvancedSearch/hooks/useAdvancedSearch/useAdvancedSearch.js
+++ b/lib/AdvancedSearch/hooks/useAdvancedSearch/useAdvancedSearch.js
@@ -3,11 +3,14 @@ import {
   useState,
   useMemo,
 } from 'react';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
+import noop from 'lodash/noop';
 import { useIntl } from 'react-intl';
 
 import splitQueryRows from '../../utilities/splitQueryRows';
 import filterFilledRows from '../../utilities/filterFilledRows';
+import defaultQueryBuilder from '../../utilities/defaultQueryBuilder';
+import defaultRowFormatter from '../../utilities/defaultRowFormatter';
 import {
   ROW_COUNT,
   FIELD_NAMES,
@@ -30,11 +33,11 @@ const createInitialRowState = (firstRowInitialSearch, defaultSearchOptionValue) 
 const useAdvancedSearch = ({
   defaultSearchOptionValue,
   firstRowInitialSearch,
-  onCancel,
-  onSearch,
-  queryBuilder,
-  rowFormatter,
-  searchOptions,
+  onCancel = noop,
+  onSearch = noop,
+  queryBuilder = defaultQueryBuilder,
+  rowFormatter = defaultRowFormatter,
+  searchOptions = [],
 }) => {
   const initialRowState = useMemo(() => {
     const initialRows = createInitialRowState(firstRowInitialSearch, defaultSearchOptionValue);
@@ -45,6 +48,7 @@ const useAdvancedSearch = ({
   const [rowState, setRowState] = useState(initialRowState);
   const [showEmptyFirstRowMessage, setShowEmptyFirstRowMessage] = useState(false);
   const [prevFirstRowInitialSearch, setPrevFirstRowInitialSearch] = useState(firstRowInitialSearch);
+  const filledRows = useMemo(() => filterFilledRows(splitQueryRows(rowState)), [rowState]);
 
   const searchOptionsWithQuery = useMemo(() => (
     [{
@@ -68,9 +72,7 @@ const useAdvancedSearch = ({
   };
 
   const handleSearch = useCallback(() => {
-    const splitRows = filterFilledRows(splitQueryRows(rowState));
-
-    if (!splitRows.length) {
+    if (!filledRows.length) {
       setShowEmptyFirstRowMessage(true);
 
       return;
@@ -78,10 +80,10 @@ const useAdvancedSearch = ({
 
     setShowEmptyFirstRowMessage(false);
 
-    const query = queryBuilder(splitRows, rowFormatter);
+    const query = queryBuilder(filledRows, rowFormatter);
 
-    onSearch(query, splitRows);
-  }, [queryBuilder, onSearch, rowState, rowFormatter]);
+    onSearch(query, filledRows);
+  }, [filledRows, queryBuilder, onSearch, rowFormatter]);
 
   const handleCancel = useCallback(onCancel, [onCancel]);
 
@@ -101,6 +103,8 @@ const useAdvancedSearch = ({
     rowState,
     searchOptionsWithQuery,
     showEmptyFirstRowMessage,
+    filledRows,
+    query: queryBuilder(filledRows, rowFormatter),
   };
 };
 

--- a/lib/AdvancedSearch/index.js
+++ b/lib/AdvancedSearch/index.js
@@ -1,3 +1,4 @@
 export { default as AdvancedSearch } from './AdvancedSearch';
+export { default as useAdvancedSearch } from './hooks/useAdvancedSearch';
 export { default as defaultQueryBuilder } from './utilities/defaultQueryBuilder';
 export { BOOLEAN_OPERATORS } from './constants';

--- a/lib/AdvancedSearch/readme.md
+++ b/lib/AdvancedSearch/readme.md
@@ -96,3 +96,49 @@ defaultSearchOptionValue | string | One of the options in `searchOptions` that w
 firstRowInitialSearch | object | Object with shape `{ query, option }` - will be used to populate first row with default values | false
 rowFormatter | func | Function that will be used to combine boolean, query and search option of each row. Signature: `(searchOption, query, bool, comparator) => {...}`. Returned values will be used by `queryBuilder` to join them together. *Note:* no need to add `bool` to resulting string here - it will be added by `queryBuilder`. | false
 queryBuilder | func | Function that will be used to construct the search query. Signature: `(rows, rowFormatter) => {...}`. `rows` - array of shapes `{ query, searchOption, query }`, `rowFormatter` - the prop. Returned value will be passed as the first argument to `onSearch`. | false
+
+## useAdvancedSearch
+`stripes-components` also provides the `useAdvancedSearch` hook. It has the same API as the `<AdvancedSearch>` component, but doesn't render the UI. The hook can be used to get formatted advanced search rows and query outside of `<AdvancedSearch>` component. For example, when you need to run advanced search on page load with initial query from URL 
+
+```js
+/// SearchForm.js
+
+const SearchForm = (...) => {
+  ...
+  return (
+    ...
+    <AdvancedSearch // regular use of AdvancedSearch that shows the modal
+      open
+      searchOptions={advancedSearchOptions}
+      defaultSearchOptionValue={searchableIndexesValues.KEYWORD}
+      firstRowInitialSearch={advancedSearchDefaultSearch}
+      onSearch={handleAdvancedSearch}
+      onCancel={() => setIsAdvancedSearchOpen(false)}
+    >
+      ...
+
+    </AdvancedSearch>
+  );
+}
+
+
+/// SearchRoute.js
+
+const SearchRoute = (...) => {
+  const { query, option } = queryString.parse(location.search);
+  
+  const { filledRows, query: formattedQuery } = useAdvancedSearch({
+    defaultSearchOptionValue: 'keyword',
+    firstRowInitialSearch: { query, option },
+  });
+
+  // here `formattedQuery` can be used to make a request to BE
+
+  useEffect(() => {
+    fetch(`/some-url?query=${formattedQuery}`);
+  }, []);
+
+  return (...);
+}
+
+```

--- a/lib/AdvancedSearch/utilities/defaultRowFormatter.js
+++ b/lib/AdvancedSearch/utilities/defaultRowFormatter.js
@@ -1,0 +1,5 @@
+const defaultRowFormatter = (searchOption, query, comparator) => {
+  return `${searchOption}${comparator}${query}`;
+};
+
+export default defaultRowFormatter;


### PR DESCRIPTION
## Description
Return formatted `filledRows` and `query` from `useAdvancedSearch` hook to be used for initial search on page load without needing to open Advanced Search modal
Export `useAdvancedSearch` from `stripes-components`

## Screenshots

https://github.com/folio-org/stripes-components/assets/19309423/43adc3b9-c1bd-43d2-bfb0-51e77e6433e3

## Issues
[STCOM-1156](https://issues.folio.org/browse/STCOM-1156)

## Related PRs
https://github.com/folio-org/stripes-authority-components/pull/80