### PR TITLE
STCOM-1159 - TextLink styles within ':active" interactive elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Return filled rows and query from `useAdvancedSearch` hook. Fixes STCOM-1156.
 * Remove `dom-helpers` dependency. Resolves STCOM-1170.
 * Center MCL prev-next pagination to scrollParent. Resolves STCOM-1158.
+* Add style to `<TextLink>` to account for interactionStyles' `:active` style. Refs STCOM-1159.
 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)

--- a/lib/TextLink/TextLink.css
+++ b/lib/TextLink/TextLink.css
@@ -112,3 +112,8 @@ div[class*="Selected"] {
     }
   }
 }
+
+div[class*="interactionStyles"]:active .root {
+  color: var(--color-link-current);
+  text-decoration-color: var(--color-link-current);
+}


### PR DESCRIPTION
Problem:
The `:active` state of `interactionStyles` turns elements completely primary blue by default. This has the sideffect of hiding anchor text as it blends in perfectly with the background color. This PR adds a selector/style to `<TextLink>` to account for that styling.
Data-import before change:
![image](https://github.com/folio-org/stripes-components/assets/20704067/ba0cb7af-893c-4b87-b32f-9194899254e4)

From Data-import after change:
![image](https://github.com/folio-org/stripes-components/assets/20704067/77f55cd5-d8a6-469c-9e0a-4371b0b2f961)
