### PR TITLE
STCOM-1183: Provide the searchableOptions prop to the SearchField component to use it as children for options in the Select component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Upgrade `postcss-calc` from v8 to v9.0.1. Refs STCOM-1174.
 * Upgrade `react-transition-group` from 2.9.0 to 4.4.5. Refs STCOM-1175.
 * Expand options of MetaSection component. Refs STCOM-1171.
+* Provide the searchableOptions prop to the SearchField component to use it as children for options in the Select component. Refs STCOM-1183.
 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)

--- a/lib/SearchField/SearchField.js
+++ b/lib/SearchField/SearchField.js
@@ -37,6 +37,10 @@ const propTypes = {
     value: PropTypes.string,
   })),
   searchableIndexesPlaceholder: PropTypes.string,
+  searchableOptions: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]),
   selectedIndex: PropTypes.string,
   value: PropTypes.string,
 };
@@ -54,6 +58,7 @@ const SearchField = (props) => {
     loading,
     clearSearchId,
     searchableIndexes,
+    searchableOptions,
     onChangeIndex,
     selectedIndex,
     searchableIndexesPlaceholder,
@@ -69,13 +74,13 @@ const SearchField = (props) => {
   const hasSearchableIndexes = Array.isArray(searchableIndexes);
   const intl = useIntl();
 
-  if (hasSearchableIndexes) {
+  if (hasSearchableIndexes || searchableOptions) {
     const indexLabel = intl.formatMessage({ id: 'stripes-components.searchFieldIndex' });
 
     searchableIndexesDropdown = (
       <Select
         aria-label={indexLabel}
-        dataOptions={searchableIndexes}
+        dataOptions={searchableOptions ? undefined : searchableIndexes}
         disabled={loading}
         id={`${id}-qindex`}
         marginBottom0
@@ -84,7 +89,9 @@ const SearchField = (props) => {
         selectClass={css.select}
         value={selectedIndex}
         name={indexName}
-      />
+      >
+        {searchableOptions}
+      </Select>
     );
   }
 
@@ -121,7 +128,7 @@ const SearchField = (props) => {
         onChange={onChange}
         onClearField={onClear}
         placeholder={inputPlaceholder}
-        startControl={!hasSearchableIndexes ? searchIcon : null}
+        startControl={!hasSearchableIndexes && !searchableOptions ? searchIcon : null}
         type="search"
         value={value || ''}
         readOnly={loading || rest.readOnly}
@@ -133,6 +140,7 @@ const SearchField = (props) => {
 SearchField.propTypes = propTypes;
 SearchField.defaultProps = {
   loading: false,
+  searchableOptions: null,
 };
 
 export default SearchField;

--- a/lib/SearchField/readme.md
+++ b/lib/SearchField/readme.md
@@ -40,6 +40,35 @@ The component supports adding an array of searchable indexes which adds a select
   />
 ```
 
+## Usage with searchable options
+The component supports adding custom searchable options, e.g. if the `<optgroup>` tag is required.
+
+```
+  import SearchField from '@folio/stripes/components';
+
+  const searchableOptions = (
+    <optgroup label="Fruits">
+      <option value={apples}>Apples</option>
+      <option value={bananas}>Bananas</option>
+    </optgroup>
+    <optgroup label="Vegetables">
+      <option value={tomatoes}>Tomatoes</option>
+    </optgroup>
+  );
+
+  <SearchField
+    onChange={...}
+    value={...}
+    onClear={...}
+    placeholder="Search for something"
+
+    searchableOptions={searchableOptions}
+    onChangeIndex={() => ...}
+    selectedIndex={...}
+    searchableIndexesPlaceholder="Search for these fields.."
+  />
+```
+
 ## Props
 This component supports the same props as the TextField component among other props.
 
@@ -59,9 +88,10 @@ clearSearchId | string | Adds id to the clear search icon
 ### With searchable indexes
 Additional props for adding searchable indexes/fields.
 
-Name | type | Description
--- | -- | --
-searchableIndexes | array of objects | Adds a list of searchable indexes/fields
-selectedIndex | string | Currently selected index
-onChangeIndex | function | On change handler for when changing index
-searchableIndexesPlaceholder | string | Control the placeholder of the select field
+Name | type                 | Description
+-- |----------------------| --
+searchableIndexes | array of objects     | Adds a list of searchable indexes/fields
+searchableOptions | nodes/array of nodes | Adds a list of custom searchable indexes/fields
+selectedIndex | string               | Currently selected index
+onChangeIndex | function             | On change handler for when changing index
+searchableIndexesPlaceholder | string               | Control the placeholder of the select field

--- a/lib/SearchField/tests/SearchField-test.js
+++ b/lib/SearchField/tests/SearchField-test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { describe, beforeEach, it } from 'mocha';
+import { expect } from 'chai';
 import { SearchField as Interactor, runAxeTest } from '@folio/stripes-testing';
 
 import { mountWithContext } from '../../../tests/helpers';
@@ -125,6 +126,79 @@ describe('SearchField', () => {
       });
 
       it('should update the placeholder', () => searchField.has({ placeholder: PLACEHOLDER_SUBJECT }));
+    });
+  });
+
+  describe('when both searchableIndexes and searchableOptions are passed', () => {
+    const searchableIndexes = [
+      { label: LABEL_SUBJECT, value: 'subject', placeholder: PLACEHOLDER_SUBJECT },
+    ];
+
+    const searchableOptions = (
+      <optgroup label="Fruits">
+        <option value="Watermelon">watermelon</option>
+      </optgroup>
+    );
+
+    beforeEach(async () => {
+      await mountWithContext(
+        <SearchField
+          id="searchFieldTest"
+          searchableIndexes={searchableIndexes}
+          searchableOptions={searchableOptions}
+        />
+      );
+    });
+
+    it('should not render options from searchableIndexes', () => searchField.perform(el => {
+      expect(el.querySelector(`option[value="${LABEL_SUBJECT}"]`)).to.be.null;
+    }));
+  });
+
+  describe('when searchableOptions is passed', () => {
+    const searchableOptions = (
+      <optgroup label="Options">
+        <option value="option1">Option1</option>
+        <option value="option2">Option2</option>
+      </optgroup>
+    );
+
+    class SearchFieldHarness extends React.Component {
+      constructor(props) {
+        super(props);
+
+        this.state = {
+          searchFieldIndex: 'identifier',
+        };
+      }
+
+      render() {
+        return (
+          <SearchField
+            onChangeIndex={(e) => { this.setState({ searchFieldIndex: e.target.value }); }}
+            searchableOptions={searchableOptions}
+            selectedIndex={this.state.searchFieldIndex}
+          />
+        );
+      }
+    }
+
+    beforeEach(async () => {
+      await mountWithContext(
+        <SearchFieldHarness />
+      );
+    });
+
+    it('should not render startControlElement', () => searchField.perform(el => {
+      expect(el.querySelector(`div[class^="startControls---"]`)).to.be.null;
+    }));
+
+    describe('changing the index', () => {
+      beforeEach(async () => {
+        await searchField.selectIndex('Option2');
+      });
+
+      it('should select a new option', () => searchField.has({ selectedFilter: 'option2' }));
     });
   });
 });


### PR DESCRIPTION
## Purpose
Provide the `searchableOptions` prop to the `SearchField` component to use it as `children` for options in the `Select` component to be able to utilize the `<optgroup>` tag and not just the `<option>`.

## Issues
[STCOM-1183](https://issues.folio.org/browse/STCOM-1183)

## Related PRs
[ui-inventory/pull/2195](https://github.com/folio-org/ui-inventory/pull/2195)
[stripes-acq-components/pull/710](https://github.com/folio-org/stripes-acq-components/pull/710)

## Screencast


https://github.com/folio-org/stripes-components/assets/77053927/d7f78f3c-cef9-4aa4-a502-1d42580fb705


