### PR TITLE
STCOM-1186 Provide the `getFieldUniqueKey` prop to define a key for the list items in the `<RepeatableField>` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Upgrade `react-transition-group` from 2.9.0 to 4.4.5. Refs STCOM-1175.
 * Expand options of MetaSection component. Refs STCOM-1171.
 * Provide the searchableOptions prop to the SearchField component to use it as children for options in the Select component. Refs STCOM-1183.
+* Provide the `getFieldUniqueKey` prop to define a `key` for the list items in the `<RepeatableField>` component. Refs STCOM-1186.
 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)

--- a/lib/RepeatableField/RepeatableField.js
+++ b/lib/RepeatableField/RepeatableField.js
@@ -103,7 +103,7 @@ class RepeatableField extends Component {
             {fields.map((field, index) => (
               <li
                 className={css.repeatableFieldItem}
-                key={getFieldUniqueKey(field, index, fields) || index}
+                key={getFieldUniqueKey(field, index, fields)}
                 data-test-repeatable-field-list-item
               >
                 <div className={css.repeatableFieldItemContent}>

--- a/lib/RepeatableField/RepeatableField.js
+++ b/lib/RepeatableField/RepeatableField.js
@@ -21,6 +21,7 @@ class RepeatableField extends Component {
       PropTypes.array,
       PropTypes.object
     ]).isRequired,
+    getFieldUniqueKey: PropTypes.func,
     hasMargin: PropTypes.bool,
     headLabels: PropTypes.node,
     id: PropTypes.string,
@@ -37,6 +38,7 @@ class RepeatableField extends Component {
     canAdd: true,
     canRemove: true,
     hasMargin: true,
+    getFieldUniqueKey: (_field, index) => index,
   };
 
   render() {
@@ -46,6 +48,7 @@ class RepeatableField extends Component {
       canRemove,
       className,
       fields,
+      getFieldUniqueKey,
       hasMargin,
       headLabels,
       id,
@@ -100,7 +103,7 @@ class RepeatableField extends Component {
             {fields.map((field, index) => (
               <li
                 className={css.repeatableFieldItem}
-                key={index}
+                key={getFieldUniqueKey(field, index, fields) || index}
                 data-test-repeatable-field-list-item
               >
                 <div className={css.repeatableFieldItemContent}>

--- a/lib/RepeatableField/readme.md
+++ b/lib/RepeatableField/readme.md
@@ -161,6 +161,7 @@ canRemove | boolean | Flag to enable/disable remove button | true
 className | string | Adds a custom class name for the root element |
 emptyMessage | string | Text for when there are no rows; can be left blank |
 fields | array or object | Values that go with field rows | &#10004;
+getFieldUniqueKey | func | A function that returns a unique value as the `key` prop for each field in an array. If not provided, it will default to the index of the field in the array. |
 hasMargin | bool | Applies margin on top and bottom | true | 
 headLabels | node | Element that displays heading field labels. Developer should care about accessibility if this property is used (see an example).   |
 id | string | Adds an ID for the root element and prefixed ID's for the default add button |


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/STCOM-1186

Since the React library insists that keys must be unique and not change during rendering, the ability to specify a key for each element should prevent possible bugs.

Basically, this improvement is meant to help fix [UISACQCOMP-154](https://issues.folio.org/browse/UISACQCOMP-154): changing the order of items in an array (deleting, adding) causes an incorrect display of them, which is associated with using the index of this field as a `key` prop.

## Learning
Why it's not OK to use an item's index as key - https://react.dev/learn/rendering-lists#why-does-react-need-keys

## Approach
Provide `getFieldUniqueKey` as a prop for the `<RepeatableField>` component. This function accepts `field`, `index`, and `fields` as arguments.

Set the default `getFieldUniqueKey` prop which will return a function that will return an item's index.

## POC

##### Using items indexes as a `key` prop:
![chrome_VINMkBpCT7](https://github.com/folio-org/stripes-components/assets/88109087/fc6a44da-437a-4717-8e3c-34041a0fe91b)

##### Using unique identifiers as a `key` prop:
![chrome_VcaZZgdgnX](https://github.com/folio-org/stripes-components/assets/88109087/13e1e715-c8bc-410f-a75d-1f80faa9ab49)


