### PR TITLE
STCOM-1189 add pagingOffset prop to MCL

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -242,6 +242,7 @@ class MCLRenderer extends React.Component {
     pagingCanGoNext: PropTypes.bool,
     pagingCanGoPrevious: PropTypes.bool,
     pagingType: PropTypes.oneOf(Object.values(pagingTypes)),
+    pagingOffset: PropTypes.number,
     rowFormatter: PropTypes.func,
     rowMetadata: PropTypes.arrayOf(PropTypes.string),
     rowProps: PropTypes.object,
@@ -1240,6 +1241,7 @@ class MCLRenderer extends React.Component {
       virtualize,
       pagingType,
       hidePageIndices,
+      pagingOffset,
     } = this.props;
 
     const {
@@ -1294,8 +1296,8 @@ class MCLRenderer extends React.Component {
           setFocusIndex={this.setFocusIndex}
           staticBody={staticBody}
           virtualize={virtualize}
-          dataStartIndex={dataStartIndex + 1}
-          dataEndIndex={dataEndIndex + 1}
+          dataStartIndex={typeof pagingOffset !== 'undefined' ? pagingOffset + 1 : dataStartIndex + 1}
+          dataEndIndex={typeof pagingOffset !== 'undefined' ? pagingOffset + dataEndIndex + 1 : dataEndIndex + 1}
           hidePageIndices={hidePageIndices}
         />
       );

--- a/lib/MultiColumnList/stories/MultiColumnList.stories.js
+++ b/lib/MultiColumnList/stories/MultiColumnList.stories.js
@@ -16,6 +16,7 @@ import Resizing from './Resizing';
 import ClickableRows from './ClickableRows';
 import ColumnWidthHints from './ColumnWidthHints';
 import PrevNextPaging from './PrevNextPaging';
+import PrevNextOffsetPaging from './PrevNextOffsetPaging';
 import ItemToView from './ItemToView';
 import StickyColumns from './StickyColumns';
 import VariableWidthHints from './VariableWidthHints';
@@ -104,3 +105,8 @@ export const _WithInputs = () => <WithInputs />;
 _WithInputs.story = {
   name: 'With Inputs'
 };
+
+export const _PrevNextOffsetPaging = () => <PrevNextOffsetPaging />;
+_PrevNextOffsetPaging.story = {
+  name: 'Prev/Next Offset'
+}

--- a/lib/MultiColumnList/stories/PrevNextOffsetPaging.js
+++ b/lib/MultiColumnList/stories/PrevNextOffsetPaging.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import MultiColumnList from '../MultiColumnList';
+import { asyncGenerate } from './service';
+
+export default class PrevNextPagingOffset extends React.Component {
+  constructor() {
+    super();
+    this.endReached = false;
+    this.state = {
+      dataA: [],
+      dataB: [],
+      widths: {
+        index: '100px',
+        title: '150px',
+        date: '200px',
+        email: '50%',
+      },
+      offset: 0,
+    };
+    this.requestMoreA(100, 0);
+  }
+
+  requestMoreA = async (amount, index) => {
+    const newData = await asyncGenerate(amount, 0, 3000);
+    this.setState(() => ({
+      dataA: newData,
+      offset: index,
+    }));
+  }
+
+  render() {
+    const { dataB, dataA, widths, offset } = this.state;
+    this.endReached = dataB.length > 500;
+    return (
+      <>
+        <div style={{ display: 'flex' }}>
+          <div style={{ width: '480px', height:'400px' }}>
+            <h2>Using totalCount prop</h2>
+            <MultiColumnList
+              contentData={dataA}
+              columnWidths={widths}
+              onNeedMoreData={this.requestMoreA}
+              visibleColumns={['index', 'title', 'date', 'email']}
+              interactive={false}
+              maxHeight={500}
+              pageAmount={100}
+              totalCount={10000}
+              pagingType="prev-next"
+              pagingOffset={offset}
+            />
+          </div>
+        </div>
+      </>
+    );
+  }
+}


### PR DESCRIPTION
Adds a pagingOffset prop to MCL. This should allow you to control the number on the pagination. This number + 1 will be what renders as the pagination start index.  I think MCL has everything else it needs internally (pageSize, remaining etc) to figure out what the ending number should be.