### PR TITLE
CVE-2022-24785 unpin moment from v2.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@
 * Bugfix for `<MultiSelection>` - onRemove should support remove button clicks and list de-selection as it does backspace. Refs STCOM-1106.
 * Add `graph` icon. Refs STCOM-1187.
 * `<AccordionSet/>` bugfix - fix for Accordions reverting to their initial open/close state when outer component is updated. Fixes STCOM-1188.
-
+* Unpin `moment` from `2.24`; STRIPES-678 resolved long ago. Resolves CVE-2022-24785.
+    
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)
 

--- a/package.json
+++ b/package.json
@@ -130,8 +130,5 @@
     "react-intl": "^5.0.0",
     "react-redux": "^8.0.5",
     "react-router-dom": "^5.2.0"
-  },
-  "resolutions": {
-    "moment": "~2.24.0"
   }
 }


### PR DESCRIPTION
Unpin moment from v2.24; [STRIPES-678](https://issues.folio.org/browse/STRIPES-678) was resolved long long ago and moment < 2.29 suffers from CVE-2022-24785.