### PR TITLE
STCOM-1185 Number spinners are missing from input[type=number]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@
 * Add `graph` icon. Refs STCOM-1187.
 * `<AccordionSet/>` bugfix - fix for Accordions reverting to their initial open/close state when outer component is updated. Fixes STCOM-1188.
 * Unpin `moment` from `2.24`; STRIPES-678 resolved long ago. Resolves CVE-2022-24785.
-    
+* Always display spinner buttons on `input[type="number"]`. Resolves STCOM-1185.
+
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)
 

--- a/lib/TextField/stories/BasicUsage.js
+++ b/lib/TextField/stories/BasicUsage.js
@@ -13,6 +13,11 @@ const BasicUsage = () => (
       label="Field with label"
       placeholder="Placeholder Text"
     />
+    <TextField
+      type="number"
+      label="Number Field with label"
+      placeholder="#"
+    />
     <div id="myLabel">TaxtField</div>
     <TextField
       aria-labelledby="myLabel"

--- a/lib/global.css
+++ b/lib/global.css
@@ -146,6 +146,11 @@ input[type="search"]::-webkit-search-cancel-button,
 input[type="search"]::-webkit-search-results-button,
 input[type="search"]::-webkit-search-results-decoration { display: none; }
 
+/* displays number spinners on non-focused in Chrome */
+input[type="number"]::-webkit-inner-spin-button {
+  opacity: 1;
+}
+
 :global(.fullWidth) {
   width: 100% !important;
 }


### PR DESCRIPTION
This symptom is present in Chrome, but not Firefox.
Default behavior in Chrome is to only display spinner buttons on number inputs when the input is hovered or focused.

The approach: add a global style to always set the opacity of the `-webkit-inner-spin-button` to `1`, making it visible.
