### PR TITLE
STCOM-1144 remove unused svg-related deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "react-highlight-words": "^0.20.0",
     "react-overlays": "^5.2.1",
     "react-quill": "^2.0.0",
-    "react-svg-loader": "^3.0.3",
     "react-transition-group": "^4.4.5",
     "react-virtualized-auto-sizer": "^1.0.2",
     "tai-password-strength": "^1.1.1"


### PR DESCRIPTION
Remove unused SVG dependencies. We missed this in the scope of the previous PR #2115.

Refs [STCOM-1144](https://issues.folio.org/browse/STCOM-1144)