### PR TITLE
STCOM-1199: Add current for selectList and container refs due to removal of dom-helpers dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * Add `pagingOffset` prop to `<MultiColumnList/>`. Resoves STCOM-1189.
 * Adjust scroll position to the top for non-sparse array. Resolves STCOM-1196.
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs STCOM-1198.
+* Add `current` for `selectList` and `container` refs due to removal of dom-helpers dependency. Refs STCOM-1199.
 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)

--- a/lib/Selection/SingleSelect.js
+++ b/lib/Selection/SingleSelect.js
@@ -524,8 +524,8 @@ class SingleSelect extends React.Component {
   hideOnBlur() {
     if (!this.state.showList) {
       if (this.container && document.activeElement !== document.body) {
-        if (!this.selectList.contains(document.activeElement)) {
-          if (!this.container.contains(document.activeElement)) {
+        if (!this.selectList.current.contains(document.activeElement)) {
+          if (!this.container.current.contains(document.activeElement)) {
             this.hideList();
           }
         }


### PR DESCRIPTION
## Purpose
Add `current` for `selectList` and `container` refs due to the removal of dom-helpers dependency.

## Issue
[STCOM-1199](https://issues.folio.org/browse/STCOM-1199)

## Screencast of the issue


https://github.com/folio-org/stripes-components/assets/77053927/43542479-715d-4812-ba3c-389838332f3e

