### PR TITLE
STCOM-1115 Pin prev/next pagination to bottom of search results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * Add `pagingOffset` prop to `<MultiColumnList/>`. Resoves STCOM-1189.
 * Adjust scroll position to the top for non-sparse array. Resolves STCOM-1196.
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs STCOM-1198.
+* Move prev/next pagination outside of MCL's scrollable div. Refs STCOM-1115.
 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Always display spinner buttons on `input[type="number"]`. Resolves STCOM-1185.
 * Add `pagingOffset` prop to `<MultiColumnList/>`. Resoves STCOM-1189.
 * Adjust scroll position to the top for non-sparse array. Resolves STCOM-1196.
+* *BREAKING* bump `react-intl` to `v6.4.4`. Refs STCOM-1198.
 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -241,8 +241,8 @@ class MCLRenderer extends React.Component {
     pagingButtonLabel: PropTypes.node,
     pagingCanGoNext: PropTypes.bool,
     pagingCanGoPrevious: PropTypes.bool,
-    pagingType: PropTypes.oneOf(Object.values(pagingTypes)),
     pagingOffset: PropTypes.number,
+    pagingType: PropTypes.oneOf(Object.values(pagingTypes)),
     rowFormatter: PropTypes.func,
     rowMetadata: PropTypes.arrayOf(PropTypes.string),
     rowProps: PropTypes.object,
@@ -299,6 +299,7 @@ class MCLRenderer extends React.Component {
 
     this.rowContainer = React.createRef();
     this.headerRow = React.createRef();
+    this.paginationContainer = React.createRef();
     this.headerContainer = React.createRef();
     this.scrollContainer = React.createRef();
     this.endOfList = React.createRef();
@@ -306,6 +307,7 @@ class MCLRenderer extends React.Component {
     this.status = React.createRef();
 
     this.headerHeight = 0;
+    this.paginationHeight = 0;
     this.focusedRowIndex = null;
     this.maximumRowHeight = 30;
     this.keyId = uniqueId('mcl');
@@ -624,6 +626,10 @@ class MCLRenderer extends React.Component {
       // headerRow height is used to calculate the height of the scrollContainer
       if (this.headerRow.current) {
         this.headerHeight = this.headerRow.current.offsetHeight;
+      }
+
+      if (this.paginationContainer.current) {
+        this.paginationHeight = this.paginationContainer.current.offsetHeight;
       }
 
       // update average height if we don't have it...
@@ -1256,16 +1262,12 @@ class MCLRenderer extends React.Component {
       pagingButtonLabel,
       virtualize,
       pagingType,
-      hidePageIndices,
-      pagingOffset,
     } = this.props;
 
     const {
       prevWidth,
       loading,
       staticBody,
-      dataStartIndex,
-      dataEndIndex,
     } = this.state;
 
     if (pagingType === pagingTypes.LOAD_MORE) {
@@ -1289,33 +1291,6 @@ class MCLRenderer extends React.Component {
           staticBody={staticBody}
           virtualize={virtualize}
           width={width}
-        />
-      );
-    } else if (pagingType === pagingTypes.PREV_NEXT) {
-      return (
-        <PrevNextPaginationRow
-          activeNext={this.getCanGoNext()}
-          activePrevious={this.getCanGoPrevious()}
-          dataEndReached={dataEndReached}
-          handleLoadMore={this.handleLoadMore}
-          id={id}
-          key="mcl-prev-next-pagination-row"
-          keyId={this.keyId}
-          loading={loading}
-          pageAmount={pageAmount}
-          pagingButtonLabel={pagingButtonLabel}
-          pagingButtonRef={this.pageButton}
-          positionCache={this.positionCache}
-          rowHeightCache={this.rowHeightCache}
-          rowIndex={rowIndex}
-          sendMessage={this.sendMessage}
-          setFocusIndex={this.setFocusIndex}
-          staticBody={staticBody}
-          virtualize={virtualize}
-          dataStartIndex={typeof pagingOffset !== 'undefined' ? pagingOffset + 1 : dataStartIndex + 1}
-          dataEndIndex={typeof pagingOffset !== 'undefined' ? pagingOffset + dataEndIndex + 1 : dataEndIndex + 1}
-          hidePageIndices={hidePageIndices}
-          pagingOffset={pagingOffset}
         />
       );
     } else {
@@ -1381,7 +1356,7 @@ class MCLRenderer extends React.Component {
     let renderPosition = firstIndex;
 
     this.rowHeightCache.fillerItem = heightIncrement;
-
+    let lastIndex = firstIndex;
     for (
       let rowIndex = firstIndex;
       ((currentTop <= bodyExtent) && (virtualize && totalCount ? rowIndex < totalCount : true));
@@ -1400,10 +1375,12 @@ class MCLRenderer extends React.Component {
           currentTop = bodyExtent;
           rows.push(this.renderPagingRow(rowIndex));
         }
-      } else if (pagingType === pagingTypes.PREV_NEXT) {
-        currentTop = bodyExtent;
-        rows.push(this.renderPagingRow(rowIndex));
       }
+      // } else if (pagingType === pagingTypes.PREV_NEXT) {
+      //   currentTop = bodyExtent;
+      //   rows.push(this.renderPagingRow(rowIndex));
+      // }
+      lastIndex = rowIndex;
     }
 
     const endIndex = onNeedMoreData ? renderPosition : dataRowsRendered;
@@ -1411,7 +1388,7 @@ class MCLRenderer extends React.Component {
     this.rowCount = endIndex - firstIndex;
     rows.push(this.renderEndOfList(endIndex, renderPosition));
 
-    return rows;
+    return { renderedRows: rows, lastIndex }
   }
 
   renderCells = (rowIndex, rowData) => {
@@ -1817,9 +1794,9 @@ class MCLRenderer extends React.Component {
 
     // maxHeight will use bodyHeight if bodyHeight is less...
     if (bodyHeight && maxHeight) {
-      scrollableStyle.height = Math.min(bodyHeight, maxHeight - this.headerHeight);
+      scrollableStyle.height = Math.min(bodyHeight, maxHeight - this.headerHeight - this.paginationHeight);
     } else if (heightVar > 0) { // if we've got a positive height prop, use it...
-      scrollableStyle.height = heightVar - this.headerHeight;
+      scrollableStyle.height = heightVar - this.headerHeight - this.paginationHeight;
     }
 
     // avoid setting a 0px height
@@ -1863,7 +1840,21 @@ class MCLRenderer extends React.Component {
       totalCount,
       loading,
       hasMargin,
+      pagingType,
+      pageAmount,
+      virtualize,
+      hidePageIndices,
+      pagingOffset,
+      pagingButtonLabel,
+      dataEndReached,
+      id
     } = this.props;
+
+    const {
+      staticBody,
+      dataStartIndex,
+      dataEndIndex,
+    } = this.state;
 
     // if grid is hidden, (containing elements set to display: none) return null.
     if (this.resetIfGridHidden()) {
@@ -1885,7 +1876,7 @@ class MCLRenderer extends React.Component {
     }
 
     const renderedHeaders = this.renderHeaders();
-    const renderedRows = this.renderRows();
+    const { renderedRows, lastIndex } = this.renderRows();
 
     const rowContainerClass = (typeof getRowContainerClass === 'function')
       ? getRowContainerClass(css.mclRowContainer)
@@ -1931,6 +1922,35 @@ class MCLRenderer extends React.Component {
               {renderedRows}
             </div>
           </div>
+          {
+            pagingType === pagingTypes.PREV_NEXT && (
+              <PrevNextPaginationRow
+                activeNext={this.getCanGoNext()}
+                activePrevious={this.getCanGoPrevious()}
+                dataEndReached={dataEndReached}
+                handleLoadMore={this.handleLoadMore}
+                id={id}
+                key="mcl-prev-next-pagination-row"
+                keyId={this.keyId}
+                loading={loading}
+                pageAmount={pageAmount}
+                pagingButtonLabel={pagingButtonLabel}
+                pagingButtonRef={this.pageButton}
+                positionCache={this.positionCache}
+                rowHeightCache={this.rowHeightCache}
+                rowIndex={lastIndex}
+                sendMessage={this.sendMessage}
+                setFocusIndex={this.setFocusIndex}
+                staticBody={staticBody}
+                virtualize={virtualize}
+                dataStartIndex={typeof pagingOffset !== 'undefined' ? pagingOffset + 1 : dataStartIndex + 1}
+                dataEndIndex={typeof pagingOffset !== 'undefined' ? pagingOffset + dataEndIndex + 1 : dataEndIndex + 1}
+                hidePageIndices={hidePageIndices}
+                pagingOffset={pagingOffset}
+                containerRef={this.paginationContainer}
+              />
+            )
+          }
           {
             loading &&
             <div className={css.mclContentLoadingRow}>

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -1892,7 +1892,7 @@ class MCLRenderer extends React.Component {
             ref={this.container}
             role="grid"
             aria-rowcount={this.getAccessibleRowCount()}
-            className={classnames( { [css.hasMargin]: hasMargin })}
+            className={classnames({ [css.hasMargin]: hasMargin })}
             data-total-count={totalCount}
           >
             <div ref={this.headerContainer} className={css.mclHeaderContainer}>

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -1884,15 +1884,15 @@ class MCLRenderer extends React.Component {
 
     return (
       <HotKeys handlers={this.handlers} noWrapper>
+        <div className={css.mclContainer} style={this.getOuterElementStyle()}>
         <SRStatus ref={this.status} />
         <div
-          style={this.getOuterElementStyle()}
           tabIndex="0" // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
           id={this.props.id}
           ref={this.container}
           role="grid"
           aria-rowcount={this.getAccessibleRowCount()}
-          className={classnames(css.mclContainer, { [css.hasMargin]: hasMargin })}
+          className={classnames( { [css.hasMargin]: hasMargin })}
           data-total-count={totalCount}
         >
           <div ref={this.headerContainer} className={css.mclHeaderContainer}>
@@ -1923,6 +1923,15 @@ class MCLRenderer extends React.Component {
             </div>
           </div>
           {
+            loading &&
+            <div className={css.mclContentLoadingRow}>
+              <div className={css.mclContentLoading}>
+                <Icon icon="spinner-ellipsis" width="35px" />
+              </div>
+            </div>
+          }
+        </div>
+        {
             pagingType === pagingTypes.PREV_NEXT && (
               <PrevNextPaginationRow
                 activeNext={this.getCanGoNext()}
@@ -1950,14 +1959,6 @@ class MCLRenderer extends React.Component {
                 containerRef={this.paginationContainer}
               />
             )
-          }
-          {
-            loading &&
-            <div className={css.mclContentLoadingRow}>
-              <div className={css.mclContentLoading}>
-                <Icon icon="spinner-ellipsis" width="35px" />
-              </div>
-            </div>
           }
         </div>
       </HotKeys>

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -307,7 +307,7 @@ class MCLRenderer extends React.Component {
     this.status = React.createRef();
 
     this.headerHeight = 0;
-    this.paginationHeight = 0;
+    this.paginationHeight = 40;
     this.focusedRowIndex = null;
     this.maximumRowHeight = 30;
     this.keyId = uniqueId('mcl');
@@ -1376,10 +1376,6 @@ class MCLRenderer extends React.Component {
           rows.push(this.renderPagingRow(rowIndex));
         }
       }
-      // } else if (pagingType === pagingTypes.PREV_NEXT) {
-      //   currentTop = bodyExtent;
-      //   rows.push(this.renderPagingRow(rowIndex));
-      // }
       lastIndex = rowIndex;
     }
 
@@ -1773,6 +1769,7 @@ class MCLRenderer extends React.Component {
     const {
       height,
       maxHeight,
+      pagingType,
     } = this.props;
 
     const { bodyHeight, prevHeight } = this.state;
@@ -1788,15 +1785,17 @@ class MCLRenderer extends React.Component {
       scrollableStyle.overflow = 'auto';
     }
 
+    const paginationHeight = pagingType === pagingTypes.PREV_NEXT ? this.paginationHeight : 0;
+
     /* State.bodyHeight will be filled in later if it isn't already...
     *  which will set the height for the extent of the data rows;
     */
 
     // maxHeight will use bodyHeight if bodyHeight is less...
     if (bodyHeight && maxHeight) {
-      scrollableStyle.height = Math.min(bodyHeight, maxHeight - this.headerHeight - this.paginationHeight);
+      scrollableStyle.height = Math.min(bodyHeight, maxHeight - this.headerHeight - paginationHeight);
     } else if (heightVar > 0) { // if we've got a positive height prop, use it...
-      scrollableStyle.height = heightVar - this.headerHeight - this.paginationHeight;
+      scrollableStyle.height = heightVar - this.headerHeight - paginationHeight;
     }
 
     // avoid setting a 0px height
@@ -1854,6 +1853,7 @@ class MCLRenderer extends React.Component {
       staticBody,
       dataStartIndex,
       dataEndIndex,
+      loading: loadingState,
     } = this.state;
 
     // if grid is hidden, (containing elements set to display: none) return null.
@@ -1932,7 +1932,7 @@ class MCLRenderer extends React.Component {
                 id={id}
                 key="mcl-prev-next-pagination-row"
                 keyId={this.keyId}
-                loading={loading}
+                loading={loadingState}
                 pageAmount={pageAmount}
                 pagingButtonLabel={pagingButtonLabel}
                 pagingButtonRef={this.pageButton}

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -1885,81 +1885,81 @@ class MCLRenderer extends React.Component {
     return (
       <HotKeys handlers={this.handlers} noWrapper>
         <div className={css.mclContainer} style={this.getOuterElementStyle()}>
-        <SRStatus ref={this.status} />
-        <div
-          tabIndex="0" // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
-          id={this.props.id}
-          ref={this.container}
-          role="grid"
-          aria-rowcount={this.getAccessibleRowCount()}
-          className={classnames( { [css.hasMargin]: hasMargin })}
-          data-total-count={totalCount}
-        >
-          <div ref={this.headerContainer} className={css.mclHeaderContainer}>
-            <div
-              className={this.getHeaderStyle()}
-              style={{ display: 'flex' }}
-              ref={this.headerRow}
-              role="row"
-              aria-rowindex="1"
-            >
-              {renderedHeaders}
-            </div>
-          </div>
+          <SRStatus ref={this.status} />
           <div
-            className={css.mclScrollable}
-            style={this.getScrollableStyle()}
-            onScroll={this.handleScroll}
-            ref={this.scrollContainer}
-            {...getScrollableTabIndex(this.scrollContainer)}
+            tabIndex="0" // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
+            id={this.props.id}
+            ref={this.container}
+            role="grid"
+            aria-rowcount={this.getAccessibleRowCount()}
+            className={classnames( { [css.hasMargin]: hasMargin })}
+            data-total-count={totalCount}
           >
-            <div
-              className={rowContainerClass}
-              role="rowgroup"
-              style={this.getRowContainerStyle()}
-              ref={this.rowContainer}
-            >
-              {renderedRows}
-            </div>
-          </div>
-          {
-            loading &&
-            <div className={css.mclContentLoadingRow}>
-              <div className={css.mclContentLoading}>
-                <Icon icon="spinner-ellipsis" width="35px" />
+            <div ref={this.headerContainer} className={css.mclHeaderContainer}>
+              <div
+                className={this.getHeaderStyle()}
+                style={{ display: 'flex' }}
+                ref={this.headerRow}
+                role="row"
+                aria-rowindex="1"
+              >
+                {renderedHeaders}
               </div>
             </div>
-          }
-        </div>
-        {
-            pagingType === pagingTypes.PREV_NEXT && (
-              <PrevNextPaginationRow
-                activeNext={this.getCanGoNext()}
-                activePrevious={this.getCanGoPrevious()}
-                dataEndReached={dataEndReached}
-                handleLoadMore={this.handleLoadMore}
-                id={id}
-                key="mcl-prev-next-pagination-row"
-                keyId={this.keyId}
-                loading={loadingState}
-                pageAmount={pageAmount}
-                pagingButtonLabel={pagingButtonLabel}
-                pagingButtonRef={this.pageButton}
-                positionCache={this.positionCache}
-                rowHeightCache={this.rowHeightCache}
-                rowIndex={lastIndex}
-                sendMessage={this.sendMessage}
-                setFocusIndex={this.setFocusIndex}
-                staticBody={staticBody}
-                virtualize={virtualize}
-                dataStartIndex={typeof pagingOffset !== 'undefined' ? pagingOffset + 1 : dataStartIndex + 1}
-                dataEndIndex={typeof pagingOffset !== 'undefined' ? pagingOffset + dataEndIndex + 1 : dataEndIndex + 1}
-                hidePageIndices={hidePageIndices}
-                pagingOffset={pagingOffset}
-                containerRef={this.paginationContainer}
-              />
-            )
-          }
+            <div
+              className={css.mclScrollable}
+              style={this.getScrollableStyle()}
+              onScroll={this.handleScroll}
+              ref={this.scrollContainer}
+              {...getScrollableTabIndex(this.scrollContainer)}
+            >
+              <div
+                className={rowContainerClass}
+                role="rowgroup"
+                style={this.getRowContainerStyle()}
+                ref={this.rowContainer}
+              >
+                {renderedRows}
+              </div>
+            </div>
+            {
+              loading &&
+              <div className={css.mclContentLoadingRow}>
+                <div className={css.mclContentLoading}>
+                  <Icon icon="spinner-ellipsis" width="35px" />
+                </div>
+              </div>
+            }
+          </div>
+          {
+              pagingType === pagingTypes.PREV_NEXT && (
+                <PrevNextPaginationRow
+                  activeNext={this.getCanGoNext()}
+                  activePrevious={this.getCanGoPrevious()}
+                  dataEndReached={dataEndReached}
+                  handleLoadMore={this.handleLoadMore}
+                  id={id}
+                  key="mcl-prev-next-pagination-row"
+                  keyId={this.keyId}
+                  loading={loadingState}
+                  pageAmount={pageAmount}
+                  pagingButtonLabel={pagingButtonLabel}
+                  pagingButtonRef={this.pageButton}
+                  positionCache={this.positionCache}
+                  rowHeightCache={this.rowHeightCache}
+                  rowIndex={lastIndex}
+                  sendMessage={this.sendMessage}
+                  setFocusIndex={this.setFocusIndex}
+                  staticBody={staticBody}
+                  virtualize={virtualize}
+                  dataStartIndex={typeof pagingOffset !== 'undefined' ? pagingOffset + 1 : dataStartIndex + 1}
+                  dataEndIndex={typeof pagingOffset !== 'undefined' ? pagingOffset + dataEndIndex + 1 : dataEndIndex + 1} // eslint-disable-line
+                  hidePageIndices={hidePageIndices}
+                  pagingOffset={pagingOffset}
+                  containerRef={this.paginationContainer}
+                />
+              )
+            }
         </div>
       </HotKeys>
     );

--- a/lib/MultiColumnList/PrevNextPaginationRow.js
+++ b/lib/MultiColumnList/PrevNextPaginationRow.js
@@ -3,13 +3,12 @@ import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import Icon from '../Icon';
 import PagingButton from './PagingButton';
-import RowPositioner from './RowPositioner';
-import CenteredContainer from './CenteredContainer';
 import css from './MCLRenderer.css';
 
 const propTypes = {
   activeNext: PropTypes.bool,
   activePrevious: PropTypes.bool,
+  containerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   dataEndIndex: PropTypes.number,
   dataEndReached: PropTypes.bool,
   dataStartIndex: PropTypes.number,
@@ -19,19 +18,16 @@ const propTypes = {
   keyId: PropTypes.string,
   loading: PropTypes.bool,
   pageAmount: PropTypes.number,
-  positionCache: PropTypes.object,
-  rowHeightCache: PropTypes.object,
+  pagingOffset: PropTypes.number,
   rowIndex: PropTypes.number,
   sendMessage: PropTypes.func,
   setFocusIndex: PropTypes.func,
-  staticBody: PropTypes.bool,
-  virtualize: PropTypes.bool,
-  pagingOffset: PropTypes.number
 };
 
 const PrevNextPaginationRow = ({
   activeNext,
   activePrevious,
+  containerRef,
   dataEndReached,
   handleLoadMore,
   id,
@@ -39,12 +35,8 @@ const PrevNextPaginationRow = ({
   loading,
   pageAmount,
   pagingOffset,
-  positionCache,
-  rowHeightCache,
   rowIndex,
   sendMessage,
-  staticBody,
-  virtualize,
   dataStartIndex,
   dataEndIndex,
   hidePageIndices,
@@ -75,80 +67,59 @@ const PrevNextPaginationRow = ({
   const message = formatMessage({ id: 'stripes-components.mcl.itemsRequestedMessage' });
 
   return (
-    <RowPositioner
-      key={`load-button-positioner-${rowIndex}-${keyId}`}
-      gridId={id}
-      heightCache={rowHeightCache}
-      positionCache={positionCache}
-      shouldPosition={!staticBody}
-      rowIndex={rowIndex}
-    >
-      {({ localRowIndex, position }) => (
-        <div
-          key={`${localRowIndex}-pagination-row`}
-          style={{
-            width: '100%',
-            position: virtualize ? 'absolute' : 'relative',
-            top: `${position}px`,
-            marginTop: '1rem'
+    <div style={{ padding: '8px 0' }} ref={containerRef}>
+      <div className={css.mclPaginationCenterContainer}>
+        <PagingButton
+          onClick={() => {
+            if (typeof pagingOffset !== 'undefined') {
+              setFocusIndex(0);
+              handleLoadMore(pageAmount, pagingOffset - pageAmount, 'prev');
+            } else {
+              const remainder = rowIndex % pageAmount;
+
+              const rowIndexForPrevButton = remainder === 0
+                ? rowIndex - (pageAmount * 2)
+                : rowIndex - (pageAmount + remainder);
+
+              setFocusIndex(rowIndexForPrevButton);
+              handleLoadMore(pageAmount, rowIndexForPrevButton, 'prev');
+            }
           }}
-        >
-          <CenteredContainer visible style={{ position: 'sticky' }}>
-            <div className={css.mclPaginationCenterContainer}>
-              <PagingButton
-                onClick={() => {
-                  if (typeof pagingOffset !== 'undefined' ) {
-                    setFocusIndex(0);
-                    handleLoadMore(pageAmount, pagingOffset - pageAmount, 'prev');
-                  } else {
-                    const remainder = rowIndex % pageAmount;
-
-                    const rowIndexForPrevButton = remainder === 0
-                      ? rowIndex - (pageAmount * 2)
-                      : rowIndex - (pageAmount + remainder);
-
-                    setFocusIndex(rowIndexForPrevButton);
-                    handleLoadMore(pageAmount, rowIndexForPrevButton, 'prev');
-                  }
-                }}
-                sendMessage={sendMessage}
-                loadingMessage={message}
-                disabled={isPrevButtonDisabled}
-                pagingButtonLabel={previousLabel}
-                buttonStyle="none"
-                bottomMargin0
-                data-test-prev-paging-button
-                id={`${id || keyId}-prev-paging-button`}
-              />
-              {!hidePageIndices && (
-                <div className={css.mclPrevNextPageInfoContainer}>
-                  <div>{dataStartIndex}</div>&nbsp;-&nbsp;<div>{dataEndIndex}</div>
-                </div>
-              )}
-              <PagingButton
-                onClick={() => {
-                  if (typeof pagingOffset !== 'undefined' ) {
-                    setFocusIndex(0);
-                    handleLoadMore(pageAmount, pagingOffset + pageAmount, 'next');
-                  } else {
-                    setFocusIndex(rowIndex);
-                    handleLoadMore(pageAmount, rowIndex, 'next');
-                  }
-                }}
-                sendMessage={sendMessage}
-                loadingMessage={message}
-                disabled={isNextButtonDisabled}
-                pagingButtonLabel={nextLabel}
-                buttonStyle="none"
-                bottomMargin0
-                data-test-next-paging-button
-                id={`${id || keyId}-next-paging-button`}
-              />
-            </div>
-          </CenteredContainer>
-        </div>
-      )}
-    </RowPositioner>
+          sendMessage={sendMessage}
+          loadingMessage={message}
+          disabled={isPrevButtonDisabled}
+          pagingButtonLabel={previousLabel}
+          buttonStyle="none"
+          bottomMargin0
+          data-test-prev-paging-button
+          id={`${id || keyId}-prev-paging-button`}
+        />
+        {!hidePageIndices && (
+          <div className={css.mclPrevNextPageInfoContainer}>
+            <div>{dataStartIndex}</div>&nbsp;-&nbsp;<div>{dataEndIndex}</div>
+          </div>
+        )}
+        <PagingButton
+          onClick={() => {
+            if (typeof pagingOffset !== 'undefined') {
+              setFocusIndex(0);
+              handleLoadMore(pageAmount, pagingOffset + pageAmount, 'next');
+            } else {
+              setFocusIndex(rowIndex);
+              handleLoadMore(pageAmount, rowIndex, 'next');
+            }
+          }}
+          sendMessage={sendMessage}
+          loadingMessage={message}
+          disabled={isNextButtonDisabled}
+          pagingButtonLabel={nextLabel}
+          buttonStyle="none"
+          bottomMargin0
+          data-test-next-paging-button
+          id={`${id || keyId}-next-paging-button`}
+        />
+      </div>
+    </div>
   );
 };
 

--- a/lib/MultiColumnList/tests/MultiColumnList-test.js
+++ b/lib/MultiColumnList/tests/MultiColumnList-test.js
@@ -793,18 +793,18 @@ describe('MultiColumnList', () => {
           await mcl.clickNextPagingButton();
         });
 
-        it('displays advanced starting index within pagination', () => HTMLInteractor('101'));
-        it('displays the proper advanced ending index within pagination', () => HTMLInteractor('200'));
-        it('scrolls back to top when new data received', () => mcl.has({ scrollTop: 0 }));
+        it('displays advanced starting index within pagination', async () => await HTMLInteractor('101').exists());
+        it('displays the proper advanced ending index within pagination', async () => await HTMLInteractor('200').exists());
+        it('scrolls back to top when new data received', async () => await mcl.has({ scrollTop: 0 }));
 
         describe('Reaching the totalCount disables the next button...', () => {
           beforeEach( async () => {
             await mcl.clickNextPagingButton();
           });
 
-          it('displays advanced starting index within pagination', () => HTMLInteractor('201'));
-          it('displays the proper advanced ending index within pagination', () => HTMLInteractor('250'));
-          it('disables the next button', () => mcl.find(ButtonInteractor('Next')).is({ disabled: true }));
+          it('displays advanced starting index within pagination', async () => await HTMLInteractor('201').exists());
+          it('displays the proper advanced ending index within pagination', async () =>  await HTMLInteractor('250').exists());
+          it('disables the next button', async () => await mcl.find(ButtonInteractor('Next')).is({ disabled: true }));
         });
 
         describe('clicking the previous pagination button', () => {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/register": "^7.0.0",
     "@bigtest/interactor": "0.7.2",
     "@folio/eslint-config-stripes": "^7.0.0",
-    "@folio/stripes-cli": "^3.0.0",
+    "@folio/stripes-cli": "https://github.com/folio-org/stripes-cli#STCLI-237",
     "@folio/stripes-testing": "^4.5.0",
     "@formatjs/cli": "^6.1.3",
     "@mdx-js/loader": "^1.6.22",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@folio/eslint-config-stripes": "^7.0.0",
     "@folio/stripes-cli": "^3.0.0",
     "@folio/stripes-testing": "^4.5.0",
-    "@formatjs/cli": "^6.0.4",
+    "@formatjs/cli": "^6.1.3",
     "@mdx-js/loader": "^1.6.22",
     "@storybook/addon-actions": "^6.3.6",
     "@storybook/addon-essentials": "^6.3.6",
@@ -84,7 +84,7 @@
     "postcss-url": "^10.1.3",
     "react": "^18.2",
     "react-dom": "^18.2",
-    "react-intl": "^5.8.0",
+    "react-intl": "^6.4.4",
     "react-redux": "^8.0.5",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
@@ -126,7 +126,7 @@
   },
   "peerDependencies": {
     "moment": "^2.29.0",
-    "react-intl": "^5.0.0",
+    "react-intl": "^6.4.4",
     "react-redux": "^8.0.5",
     "react-router-dom": "^5.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/register": "^7.0.0",
     "@bigtest/interactor": "0.7.2",
     "@folio/eslint-config-stripes": "^7.0.0",
-    "@folio/stripes-cli": "https://github.com/folio-org/stripes-cli#STCLI-237",
+    "@folio/stripes-cli": "^3.0.0",
     "@folio/stripes-testing": "^4.5.0",
     "@formatjs/cli": "^6.1.3",
     "@mdx-js/loader": "^1.6.22",


### PR DESCRIPTION
## Purpose
MCL is moved outside of the scroll container, so the mark-up no longer has to result to any tricks to be a row - and no more having to scroll in order to reach pagination actions!

## Approach
Since the Prev/Next pagination is no longer rendered within the `renderRows()` function, it isn't able to grab the `rowIndex` from that function's scope, so the value is stored in a variable that the `renderRows()` function now just returns as part of an object, so it gets passed to the pagination in the outer scope (JSX of the `render()` function)

Height of the pagination is measured via a ref, but defaults to 40px in case the ref is unavailable. This is used to affect the height of the scrollable container.

## Screenshot
![image](https://github.com/folio-org/stripes-components/assets/20704067/aee21e0c-7cbc-4b64-a867-f05c63a8a83c)
