### PR TITLE
STCOM-1202: Fix focus of first row and prevent multiple focus calls in MCLRenderer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * Add `pagingOffset` prop to `<MultiColumnList/>`. Resoves STCOM-1189.
 * Adjust scroll position to the top for non-sparse array. Resolves STCOM-1196.
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs STCOM-1198.
+* Fix focus of first row and prevent multiple focus calls in MCLRenderer. Fixes STCOM-1202.
 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -510,7 +510,7 @@ class MCLRenderer extends React.Component {
 
   componentDidUpdate(prevProps) {
     const { columnWidths, hasMargin, width, visibleColumns, contentData, pagingType, virtualize } = this.props;
-    const { columns, isSparse, columnWidths: stateColumnWidths, hasScrollbar: stateHasScrollbar } = this.state;
+    const { columns, isSparse, columnWidths: stateColumnWidths, hasScrollbar: stateHasScrollbar, loading } = this.state;
 
     let newState = {};
     let widthsToClear = [];
@@ -563,7 +563,13 @@ class MCLRenderer extends React.Component {
       }
     } else if (pagingType === pagingTypes.LOAD_MORE || pagingType === pagingTypes.PREV_NEXT) {
       // this.focusTargetIndex can be 0, so we need to check for undefined
-      if (this.focusTargetIndex !== undefined) {
+      // When `isSparse` is false, focus happens more than once and `handleRowFocus` fires multiple times,
+      // so we need to check for `null` as well.
+      // We wait for the loading to complete so that to have the correct `isSparse` state, since empty items are only
+      // added to the `contentData` array after new data has been loaded, which is how it works in stripes-connect.
+      // E.g. when we go from the first page to the second, `isSparse` will be false during loading,
+      // because dataKeys.length === contentData.length.
+      if (!isNil(this.focusTargetIndex) && !loading) {
         const { current } = this.scrollContainer;
         // When array is sparse focus index starts with this.focusTargetIndex
         // When array is non-sparse, set focusIndex to 0


### PR DESCRIPTION
## Purpose
1. Focus the first row after the pagination button is clicked ([screencast](https://github.com/folio-org/stripes-components/assets/77053927/bd73ab5c-0169-451e-8fe0-b390cdd41301)).
2. Focus happens more than once and `handleRowFocus` fires multiple times ([screencast](https://github.com/folio-org/stripes-components/assets/77053927/468c99bb-7616-4437-a909-625c98cf1962)).

## Approach
 1. We wait for the loading to complete so that to have the correct `isSparse` state, since empty items are only added to the `contentData` array after new data has been loaded, which is how it works in [stripes-connect](https://github.com/folio-org/stripes-connect/blob/8714d76a24af275527edc34a3e020f8fbd4d179e/RESTResource/reducer.js#L62). E.g. when we go from the first page to the second, `isSparse` will be false during loading, because `dataKeys.length === contentData.length`.
 2. Check if `this.focusTargetIndex` is `null`.





## Issue
[STCOM-1202](https://issues.folio.org/browse/STCOM-1202)

## Screencast

https://github.com/folio-org/stripes-components/assets/77053927/e7f5fb90-a2c7-4b59-84b4-c1b4690deb11

