### PR TITLE
STCOM-1203: Reset the loading state for the sparse array in MCLRenderer, not just the non-sparse.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs STCOM-1198.
 * Add `current` for `selectList` and `container` refs due to removal of dom-helpers dependency. Refs STCOM-1199.
 * Fix focus of first row and prevent multiple focus calls in MCLRenderer. Fixes STCOM-1202.
+* Reset the `loading` state for the sparse array in `MCLRenderer`, not just the non-sparse. Fixes STCOM-1203.
 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -560,6 +560,7 @@ class MCLRenderer extends React.Component {
         newState.loading = false;
       } else {
         newState.firstIndex = parseInt(Object.keys(contentData)[0], 10) || 0;
+        newState.loading = false;
       }
     } else if (pagingType === pagingTypes.LOAD_MORE || pagingType === pagingTypes.PREV_NEXT) {
       // this.focusTargetIndex can be 0, so we need to check for undefined


### PR DESCRIPTION
## Purpose
Reset the loading state for the sparse array in MCLRenderer, not just the non-sparse. It currently [disables the Next](https://github.com/folio-org/stripes-components/assets/77053927/dd680d5a-e948-4419-b2fb-4eefa7f7bf49) button.

## Issue
[STCOM-1203](https://issues.folio.org/browse/STCOM-1203)

## Screencast


https://github.com/folio-org/stripes-components/assets/77053927/72c6009d-74d0-4c52-a8cc-f8d5bfeab52d








