### PR TITLE
STCOM-1204 add tests for id and rowcount to MCL tests.

### DIFF
--- a/lib/MultiColumnList/tests/MultiColumnList-test.js
+++ b/lib/MultiColumnList/tests/MultiColumnList-test.js
@@ -1272,4 +1272,36 @@ describe('MultiColumnList', () => {
       expect(convertToPixels(num, width)).to.equal(150);
     });
   });
+
+  describe('interactor API', () => {
+    beforeEach( async () => {
+      await mountWithContext(
+        <>
+          <MultiColumnList
+            contentData={bigWidthData}
+            columnWidths={{
+              status: { min: 24, max: 24 },
+              id: { max: 60 },
+              orderer: { min: 60, max: 80 },
+              sender: { min: 60, max: 80 },
+            }}
+            id={'test-4-column-list'}
+          />
+          <MultiColumnList
+            contentData={bigWidthLongData}
+            columnWidths={{
+              status: { min: 24, max: 24 },
+              id: { max: 60 },
+              sender: { min: 60, max: 80 },
+            }}
+            visibleColumns={['status', 'id', 'sender']}
+            id={'test-3-column-list'}
+          />
+        </>
+      );
+    });
+
+    it('assigns id as appropriate', () => Interactor({id: 'test-4-column-list'}).exists());
+    it('assigns aria rowcount as appropriate', () => Interactor({id: 'test-4-column-list', ariaRowCount: '31'}).exists());
+  });
 });

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@bigtest/interactor": "0.7.2",
     "@folio/eslint-config-stripes": "^7.0.0",
     "@folio/stripes-cli": "^3.0.0",
-    "@folio/stripes-testing": "https://github.com/folio-org/stripes-testing#UITEST-110",
+    "@folio/stripes-testing": "^4.5.0",
     "@formatjs/cli": "^6.1.3",
     "@mdx-js/loader": "^1.6.22",
     "@storybook/addon-actions": "^6.3.6",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@bigtest/interactor": "0.7.2",
     "@folio/eslint-config-stripes": "^7.0.0",
     "@folio/stripes-cli": "^3.0.0",
-    "@folio/stripes-testing": "^4.5.0",
+    "@folio/stripes-testing": "https://github.com/folio-org/stripes-testing#UITEST-110",
     "@formatjs/cli": "^6.1.3",
     "@mdx-js/loader": "^1.6.22",
     "@storybook/addon-actions": "^6.3.6",


### PR DESCRIPTION
Tests added to make use of interactor filters that were previously unused.