### PR TITLE
Bump @svgr/webpack from 7.0.0 to 8.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * Fix focus of first row and prevent multiple focus calls in MCLRenderer. Fixes STCOM-1202.
 * Move prev/next pagination outside of MCL's scrollable div. Refs STCOM-1115.
 * Reset the `loading` state for the sparse array in `MCLRenderer`, not just the non-sparse. Fixes STCOM-1203.
+* Bump `@svgr/webpack` from `7.0.0` to `8.1.0`.
 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@storybook/builder-webpack5": "^6.3.12",
     "@storybook/manager-webpack5": "^6.3.12",
     "@storybook/react": "^6.3.6",
-    "@svgr/webpack": "^7.0.0",
+    "@svgr/webpack": "^8.1.0",
     "autoprefixer": "^10.4.13",
     "babel-loader": "^8.0.0",
     "babel-plugin-lodash": "^3.3.4",


### PR DESCRIPTION
This appears to be an update in name only. From what I can tell by looking at the release notes, the 7 to 8 bump is a side-effect of changes elsewhere in its monorepo, i.e. there are no actual changes here, but it would be nice to keep the version current in case of future development on the 8.x line.

This work must be done after folio-org/stripes-webpack/pull/122.