### PR TITLE
Bump babel-loader to ^9.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * Fix focus of first row and prevent multiple focus calls in MCLRenderer. Fixes STCOM-1202.
 * Move prev/next pagination outside of MCL's scrollable div. Refs STCOM-1115.
 * Reset the `loading` state for the sparse array in `MCLRenderer`, not just the non-sparse. Fixes STCOM-1203.
+* Bump `babel-loader` from `^8.0.0` to `^9.1.3`.
 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@storybook/react": "^6.3.6",
     "@svgr/webpack": "^7.0.0",
     "autoprefixer": "^10.4.13",
-    "babel-loader": "^8.0.0",
+    "babel-loader": "^9.1.3",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-remove-jsx-attributes": "^0.0.2",
     "chai": "^4.1.2",


### PR DESCRIPTION
Bump `babel-loader` from `^8.0.0` to `^9.1.3`. The breaking changes appear to be limited to dropping support for old versions of babel and Node.js. This needs to be done after folio-org/stripes-webpack/pull/123.