### PR TITLE
STCOM-1209 correctly handle multiple callouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * Reset the `loading` state for the sparse array in `MCLRenderer`, not just the non-sparse. Fixes STCOM-1203.
 * Bump `@svgr/webpack` from `7.0.0` to `8.1.0`.
 * Update/unbreak `expandAllSections` and `collapseAllSections` keyboard shortcuts to work with updated `<AccordionStatus>` code. Fixes STCOM-1207.
+* Correctly handle multiple `<Callout>` elements when they are manipulated quickly. Refs STCOM-1209.
 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)

--- a/lib/Callout/Callout.js
+++ b/lib/Callout/Callout.js
@@ -11,7 +11,7 @@ class Callout extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      callouts: [],
+      callouts: {},
     };
     this.timeouts = [];
 
@@ -44,7 +44,7 @@ class Callout extends React.Component {
     if (this._isMounted) {
       this.setState((curState) => {
         const newState = cloneDeep(curState);
-        newState.callouts.push(newCallout);
+        newState.callouts[newCallout.id] = newCallout;
         if (timeout !== 0) {
           this.timeouts.push(window.setTimeout(() => { this.removeCallout(newCallout.id); }, timeout));
         }
@@ -56,12 +56,11 @@ class Callout extends React.Component {
   }
 
   removeCallout(id) {
-    const toHide = findIndex(this.state.callouts, c => c.id === id);
-    if (toHide === -1) { return; }
+    if (!this.state.callouts[id]) { return; }
     if (this._isMounted) {
       this.setState((curState) => {
         const newState = cloneDeep(curState);
-        newState.callouts.splice(toHide, 1);
+        delete newState.callouts[id];
         return newState;
       });
     }
@@ -81,7 +80,7 @@ class Callout extends React.Component {
     return ReactDOM.createPortal(
       <div className={css.callout} data-test-callout>
         <TransitionGroup className={css.calloutContainer} aria-live="polite" aria-relevant="additions">
-          {this.state.callouts.map(calloutProps => (
+          {Object.values(this.state.callouts).map(calloutProps => (
             <CalloutElement key={calloutProps.id} transition="slide" {...calloutProps} data-test-callout-element />
           ))}
         </TransitionGroup>


### PR DESCRIPTION
Correctly handle callout-removal when multiple callouts are added in quick succession.

Previously, callouts were stored in an array in state and removal was handled by iterating through the list to find an item given its id and then removed via Array.splice on a cloned copy of state. When multiple callouts were added in quick succession, this could lead to the wrong callout being removed because of changes in the underlying state array.

Given callouts have a unique `id` property, storing them by `id` in an object/set, instead of on a list, allows them to be correctly and consistently manipulated.

h/t @usavkov-epam for precisely describing the problem, and proposing a solution, in [UIOR-1145](https://issues.folio.org/browse/UIOR-1145).

Refs [STCOM-1209](https://issues.folio.org/browse/STCOM-1209)