### PR TITLE
STCOM-1211 Add `hasMatchSelection` to `<AdvancedSearch>` to hide/show search match selection dropdown.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * Correctly handle multiple `<Callout>` elements when they are manipulated quickly. Refs STCOM-1209.
 * Make Advanced search query boxes expandable. Fixes STCOM-1205.
 * Fix state mutation in `<AccordionSet>`. Add `onRegisterAccordion` and `onUnregisterAccordion` props. Refs STCOM-1210.
+* Add `hasMatchSelection` to `<AdvancedSearch>` to hide/show search match selection dropdown. Refs STCOM-1211.
 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)

--- a/lib/AdvancedSearch/AdvancedSearch.js
+++ b/lib/AdvancedSearch/AdvancedSearch.js
@@ -16,18 +16,19 @@ const propTypes = {
     option: PropTypes.string,
     query: PropTypes.string.isRequired,
   }),
+  hasMatchSelection: PropTypes.bool,
   hasQueryOption: PropTypes.bool,
   onCancel: PropTypes.func.isRequired,
   onSearch: PropTypes.func.isRequired,
   open: PropTypes.bool.isRequired,
   queryBuilder: PropTypes.func,
+  queryToRow: PropTypes.func,
   rowFormatter: PropTypes.func,
   searchOptions: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string,
     label: PropTypes.string.isRequired,
     value: PropTypes.string.isRequired,
   })).isRequired,
-  queryToRow: PropTypes.func,
 };
 
 const AdvancedSearch = ({
@@ -38,6 +39,7 @@ const AdvancedSearch = ({
   queryBuilder,
   rowFormatter,
   hasQueryOption,
+  hasMatchSelection,
   defaultSearchOptionValue,
   firstRowInitialSearch,
   queryToRow,
@@ -76,6 +78,7 @@ const AdvancedSearch = ({
           ? intl.formatMessage({ id: 'stripes-components.advancedSearch.emptyFirstRowError' })
           : null
         }
+        hasMatchSelection={hasMatchSelection}
       />
     ));
   };
@@ -102,6 +105,7 @@ AdvancedSearch.defaultProps = {
   rowFormatter: defaultRowFormatter,
   firstRowInitialSearch: null,
   hasQueryOption: true,
+  hasMatchSelection: true,
 };
 
 export default AdvancedSearch;

--- a/lib/AdvancedSearch/components/AdvancedSearchRow/AdvancedSearchRow.js
+++ b/lib/AdvancedSearch/components/AdvancedSearchRow/AdvancedSearchRow.js
@@ -21,6 +21,7 @@ import styles from './AdvancedSearchRow.css';
 
 const propTypes = {
   errorMessage: PropTypes.string,
+  hasMatchSelection: PropTypes.bool.isRequired,
   index: PropTypes.number.isRequired,
   onChange: PropTypes.func.isRequired,
   rowState: PropTypes.shape({
@@ -41,6 +42,7 @@ const AdvancedSearchRow = ({
   searchOptions,
   onChange,
   errorMessage,
+  hasMatchSelection,
 }) => {
   const intl = useIntl();
 
@@ -107,18 +109,20 @@ const AdvancedSearchRow = ({
           />
           <span className={styles.emptyRowErrorMessage}>{errorMessage}</span>
         </Col>
-        <Col xs={3}>
-          <Select
-            data-test-advanced-match
-            aria-label={intl.formatMessage({ id: 'stripes-components.advancedSearch.match.label' })}
-            onChange={(e) => onChange(index, FIELD_NAMES.MATCH, e.target.value)}
-            value={rowState[FIELD_NAMES.MATCH]}
-            dataOptions={matchOptions}
-            data-testid="advanced-match"
-            id={`advanced-match-${index}`}
-            required
-          />
-        </Col>
+        {hasMatchSelection && (
+          <Col xs={3}>
+            <Select
+              data-test-advanced-match
+              aria-label={intl.formatMessage({ id: 'stripes-components.advancedSearch.match.label' })}
+              onChange={(e) => onChange(index, FIELD_NAMES.MATCH, e.target.value)}
+              value={rowState[FIELD_NAMES.MATCH]}
+              dataOptions={matchOptions}
+              data-testid="advanced-match"
+              id={`advanced-match-${index}`}
+              required
+            />
+          </Col>
+        )}
         <Col xs className={styles.searchInLabelCol}>
           <FormattedMessage id="stripes-components.advancedSearch.searchIn" />
         </Col>

--- a/lib/AdvancedSearch/components/AdvancedSearchRow/AdvancedSearchRow.js
+++ b/lib/AdvancedSearch/components/AdvancedSearchRow/AdvancedSearchRow.js
@@ -112,13 +112,13 @@ const AdvancedSearchRow = ({
         {hasMatchSelection && (
           <Col xs={3}>
             <Select
-              data-test-advanced-match
+              data-test-advanced-search-match
               aria-label={intl.formatMessage({ id: 'stripes-components.advancedSearch.match.label' })}
               onChange={(e) => onChange(index, FIELD_NAMES.MATCH, e.target.value)}
               value={rowState[FIELD_NAMES.MATCH]}
               dataOptions={matchOptions}
-              data-testid="advanced-match"
-              id={`advanced-match-${index}`}
+              data-testid="advanced-search-match"
+              id={`advanced-search-match-${index}`}
               required
             />
           </Col>

--- a/lib/AdvancedSearch/readme.md
+++ b/lib/AdvancedSearch/readme.md
@@ -130,6 +130,7 @@ onSearch | func | Callback fired when search is performed. Called with two argum
 onCancel | func | Callback fired when the user clicks the cancel button. | true
 defaultSearchOptionValue | string | One of the options in `searchOptions` that will be selected by default in all rows | false
 firstRowInitialSearch | object | Object with shape `{ query, option }` - will be used to populate first row with default values | false
+hasMatchSelection | boolean | Show/hide search match option dropdown | true
 hasQueryOption | boolean | Controls whether `Query` search option should be appended to search options list | true
 rowFormatter | func | Function that will be used to combine boolean, query and search option of each row. Signature: `(searchOption, query, bool, comparator) => {...}`. Returned values will be used by `queryBuilder` to join them together. *Note:* no need to add `bool` to resulting string here - it will be added by `queryBuilder`. | false
 queryBuilder | func | Function that will be used to construct the search query. Signature: `(rows, rowFormatter) => {...}`. `rows` - array of shapes `{ query, searchOption, query }`, `rowFormatter` - the prop. Returned value will be passed as the first argument to `onSearch`. | false

--- a/lib/AdvancedSearch/tests/AdvancedSearch-test.js
+++ b/lib/AdvancedSearch/tests/AdvancedSearch-test.js
@@ -133,6 +133,16 @@ describe('AdvancedSearch', () => {
     }
   });
 
+  describe('when hasMatchSelection is false', () => {
+    beforeEach(async () => {
+      await renderComponent({
+        hasMatchSelection: false,
+      });
+    });
+
+    it('should not render match option selects', () => advancedSearch.has({ hasMatchSelect: false }));
+  });
+
   describe('when firstRowInitialSearch is passed', () => {
     beforeEach(async () => {
       await renderComponent({


### PR DESCRIPTION
## Description
Add `hasMatchSelection` to `<AdvancedSearch>` to hide/show search match selection dropdown.

## Screenshots

https://github.com/folio-org/stripes-components/assets/19309423/384fac79-3725-41d7-9422-5ba1d6172021


## Issues
[STCOM-1211](https://issues.folio.org/browse/STCOM-1211)

## Related PRs
https://github.com/folio-org/stripes-authority-components/pull/116
https://github.com/folio-org/stripes-testing/pull/1821