### PR TITLE
STCOM-1213 style: add disabled styling for Button component links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * Correctly handle multiple `<Callout>` elements when they are manipulated quickly. Refs STCOM-1209.
 * Make Advanced search query boxes expandable. Fixes STCOM-1205.
 * Fix state mutation in `<AccordionSet>`. Add `onRegisterAccordion` and `onUnregisterAccordion` props. Refs STCOM-1210.
+* Add disabled link styling for dropdown items for Button component. Refs STCOM-1212.
 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -297,6 +297,9 @@
   &[disabled] {
     background-color: transparent;
     border: 0;
+    color: var(--color-text);
+    opacity: 0.65;
+    pointer-events: none;
   }
 
   &:hover,


### PR DESCRIPTION
## Description
Add disabled button style for anchor tags(`a` & `<Link />`) when a `<Button />` component has `disabled` props and it is an anchor tag

Refs [STCOM-1213](https://issues.folio.org/browse/STCOM-1213)

## Approach
1. Add similar styling for `.dropdownItem` with `disabled` props

## Screenshots
![Screenshot 2023-10-10 at 11 53 29 AM](https://github.com/folio-org/stripes-components/assets/116072773/e0e61c39-6351-4e1a-a64b-9c7dd8e03250)
