### PR TITLE
STCOM-1216 provide correct Italian value for NL country code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * Correctly handle multiple `<Callout>` elements when they are manipulated quickly. Refs STCOM-1209.
 * Make Advanced search query boxes expandable. Fixes STCOM-1205.
 * Fix state mutation in `<AccordionSet>`. Add `onRegisterAccordion` and `onUnregisterAccordion` props. Refs STCOM-1210.
+* Italian locale: provide correct value for `NL` country code. Refs STCOM-1216
 
 ## [11.0.0](https://github.com/folio-org/stripes-components/tree/v11.0.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v10.3.0...v11.0.0)

--- a/translations/stripes-components/it_IT.json
+++ b/translations/stripes-components/it_IT.json
@@ -232,7 +232,7 @@
     "countries.NA": "Namibia",
     "countries.NR": "Nauru",
     "countries.NP": "Nepal",
-    "countries.NL": "Antille Olandesi",
+    "countries.NL": "Olanda",
     "countries.AN": "Antille Olandesi",
     "countries.NC": "Nuova Caledonia",
     "countries.NZ": "Nuova Zelanda",


### PR DESCRIPTION
The value for `NL` (Netherlands) in the Italian locale was incorrectly copied from `AN` (Netherlands Antilles).

Refs [STCOM-1216](https://issues.folio.org/browse/STCOM-1216)