### PR TITLE
bump @folio/stripes-testing to 4.6.0 for new interactors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-components
 
+## 12.0.1
+
+* Bump `@folio/stripes-testing` to `v4.6.0` for new interactors.
+
 ## [12.0.0](https://github.com/folio-org/stripes-components/tree/v12.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v11.0.0...v12.0.0)
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@bigtest/interactor": "0.7.2",
     "@folio/eslint-config-stripes": "^7.0.0",
     "@folio/stripes-cli": "^3.0.0",
-    "@folio/stripes-testing": "^4.5.0",
+    "@folio/stripes-testing": "^4.6.0",
     "@formatjs/cli": "^6.1.3",
     "@mdx-js/loader": "^1.6.22",
     "@storybook/addon-actions": "^6.3.6",


### PR DESCRIPTION
At present, the `npm-build` job always installs dependencies from the `npm-folioci` repo, even when the build is taking place on a release branch named like `b12.0`. This is problematic because the PR merge will succeed, but the `npm-build-release` job that runs when the tag is applied will fail. I thought we had a Jira for this but cannot find it now.

Anyway, this should resolve several test failures in the v12.0.0 build-npm-release job:
```
FAILED TESTS:
  AdvancedSearch
    when resetting advanced search
      ✖ "before each" hook for "should clear rows"
        Chrome 117.0.0.0 (Linux x86_64)
      NoSuchElementError: did not find text field with label "Search for" within advanced search row with index 0
          at throwNoSuchElementError (/tmp/_karma_webpack_142962/commons.js:60996:15)
          at findMatchesNonEmpty (/tmp/_karma_webpack_142962/commons.js:61022:5)
          at resolveUnique (/tmp/_karma_webpack_142962/commons.js:61028:20)
          at Array.reduce (<anonymous>)
          at unsafeSyncResolveParent (/tmp/_karma_webpack_142962/commons.js:61052:30)
          at unsafeSyncResolveUnique (/tmp/_karma_webpack_142962/commons.js:61055:26)
          at /tmp/_karma_webpack_142962/commons.js:60383:99
          at converge (/tmp/_karma_webpack_142962/commons.js:60546:20)
          at converge.next (<anonymous>)
          at /tmp/_karma_webpack_142962/commons.js:59617:35

    when making some changes to rows and searching
      ✖ "before each" hook for "should call onSearch with corectly formatted data"
        Chrome 117.0.0.0 (Linux x86_64)
      NoSuchElementError: did not find text field with label "Search for" within advanced search row with index 0
          at throwNoSuchElementError (/tmp/_karma_webpack_142962/commons.js:60996:15)
          at findMatchesNonEmpty (/tmp/_karma_webpack_142962/commons.js:61022:5)
          at resolveUnique (/tmp/_karma_webpack_142962/commons.js:61028:20)
          at Array.reduce (<anonymous>)
          at unsafeSyncResolveParent (/tmp/_karma_webpack_142962/commons.js:61052:30)
          at unsafeSyncResolveUnique (/tmp/_karma_webpack_142962/commons.js:61055:26)
          at /tmp/_karma_webpack_142962/commons.js:60383:99
          at converge (/tmp/_karma_webpack_142962/commons.js:60546:20)
          at converge.next (<anonymous>)
          at /tmp/_karma_webpack_142962/commons.js:59617:35

    when searching with query in first row
      ✖ "before each" hook for "should call onSearch with corectly formatted data"
        Chrome 117.0.0.0 (Linux x86_64)
      Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.

    when search options has a dot in name and opening advanced search again
      ✖ "before each" hook for "should split it into several rows correctly"
        Chrome 117.0.0.0 (Linux x86_64)
      Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.

  MultiColumnList
    interactor API
      ✖ locate MCL by id
        Chrome 117.0.0.0 (Linux x86_64)
      NoSuchElementError: did not find multi column list "test-3-column-list", did you mean one of:

      ┃ multi column list ┃
      ┣━━━━━━━━━━━━━━━━━━━┫
      ┃ ⨯ ""              ┃
      ┃ ⨯ ""              ┃
          at throwNoSuchElementError (/tmp/_karma_webpack_142962/commons.js:60999:15)
          at findFirstMatch (/tmp/_karma_webpack_142962/commons.js:61011:5)
          at resolveFirst (/tmp/_karma_webpack_142962/commons.js:61040:12)
          at /tmp/_karma_webpack_142962/commons.js:60428:77
          at converge (/tmp/_karma_webpack_142962/commons.js:60546:20)
          at converge.next (<anonymous>)
          at /tmp/_karma_webpack_142962/commons.js:59617:35
          at /tmp/_karma_webpack_142962/commons.js:59590:24
          at Object.run (/tmp/_karma_webpack_142962/commons.js:59012:29)
          at resume (/tmp/_karma_webpack_142962/commons.js:59587:25)

      ✖ assigns id as appropriate
        Chrome 117.0.0.0 (Linux x86_64)
      NoSuchElementError: did not find multi column list with id "test-4-column-list", did you mean one of:

      ┃ id: "test-4-column-list" ┃
      ┣━━━━━━━━━━━━━━━━━━━━━━━━━━┫
      ┃ ⨯ ""                     ┃
      ┃ ⨯ ""                     ┃
          at throwNoSuchElementError (/tmp/_karma_webpack_142962/commons.js:60999:15)
          at findFirstMatch (/tmp/_karma_webpack_142962/commons.js:61011:5)
          at resolveFirst (/tmp/_karma_webpack_142962/commons.js:61040:12)
          at /tmp/_karma_webpack_142962/commons.js:60428:77
          at converge (/tmp/_karma_webpack_142962/commons.js:60546:20)
          at converge.next (<anonymous>)
          at /tmp/_karma_webpack_142962/commons.js:59617:35
          at /tmp/_karma_webpack_142962/commons.js:59590:24
          at Object.run (/tmp/_karma_webpack_142962/commons.js:59012:29)
          at resume (/tmp/_karma_webpack_142962/commons.js:59587:25)

      ✖ assigns aria rowcount as appropriate
        Chrome 117.0.0.0 (Linux x86_64)
      Error: interactor does not define a filter named "ariaRowCount"
          at get actual [as actual] (/tmp/_karma_webpack_142962/commons.js:60787:19)
          at get matches [as matches] (/tmp/_karma_webpack_142962/commons.js:60774:91)
          at get sortWeight [as sortWeight] (/tmp/_karma_webpack_142962/commons.js:60807:21)
          at /tmp/_karma_webpack_142962/commons.js:60751:54
          at Array.reduce (<anonymous>)
          at get sortWeight [as sortWeight] (/tmp/_karma_webpack_142962/commons.js:60751:27)
          at get sortWeight [as sortWeight] (/tmp/_karma_webpack_142962/commons.js:60706:120)
          at /tmp/_karma_webpack_142962/commons.js:60882:48
          at Array.sort (<anonymous>)
          at formatMatchesTable (/tmp/_karma_webpack_142962/commons.js:60882:31)

```