### PR TITLE
STCOM-1219 - ExpandAllButton not updating when accordions are expanded/collapsed by user.

### DIFF
--- a/lib/Accordion/ExpandAllButton.js
+++ b/lib/Accordion/ExpandAllButton.js
@@ -1,21 +1,19 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { flushSync } from 'react-dom';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import isEqual from 'lodash/isEqual';
-import memoizeOne from 'memoize-one';
 import expandAll from './expandCollapseAll';
 import Button from '../Button';
 import { withAccordionStatus } from './AccordionStatusContext';
 
 // returns true if more keys in status are set to false than true;
-const majorityCollapsed = memoizeOne((status) => {
+const majorityCollapsed = (status) => {
   const marjority = Object.keys(status).reduce(
     (accum, id) => (status[id] ? accum + 1 : accum - 1),
     0
   );
   return marjority < 0;
-}, isEqual);
+};
 
 const propTypes = {
   accordionStatus: PropTypes.object,
@@ -44,12 +42,11 @@ const ExpandAllButton = ({
   onToggle,
   setStatus,
 }) => {
+  const func = useMemo(majorityCollapsed(accordionStatus), Object.values(accordionStatus));
   const expandLabel = expandLabelProp ||
     <FormattedMessage id="stripes-components.expandAll" />;
   const collapseLabel = collapseLabelProp ||
     <FormattedMessage id="stripes-components.collapseAll" />;
-
-  const func = majorityCollapsed(accordionStatus);
 
   return (
     <Button


### PR DESCRIPTION
https://issues.folio.org/browse/STCOM-1219

Multiple modules experiencing the defect that the `ExpandAllButton` wouldn't update its text when accordions were manually expanded/collapsed.

The symptom appeared to be due to the `Object-is` comparison - it was always the same in-memory object, thus underlying values were always the same so the value returned was always the initially memoized value. I believe this was introduced when we updated `Accordion` for R18.

## Approach
remove imports for `lodash/isEqual` and `memoize-one`, add the import for `react`'s `useMemo` and memoize the value, passing the array of values from the status as the dependency array.