### PR TITLE
Stcom 1217

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 12.1.0 IN PROGRESS
 
 * Add `hasMatchSelection` to `<AdvancedSearch>` to hide/show search match selection dropdown. Refs STCOM-1211.
+* Add z-index of 1 to callout out to have it always render on top of sibling elements. Fixes STCOM-1217.
 
 ## [12.0.0](https://github.com/folio-org/stripes-components/tree/v12.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v11.0.0...v12.0.0)

--- a/lib/Callout/Callout.css
+++ b/lib/Callout/Callout.css
@@ -10,6 +10,7 @@
   height: 100%;
   pointer-events: none;
   padding: 1.5rem 1rem;
+  z-index: 1;
 }
 
 .calloutContainer {


### PR DESCRIPTION
If a modal triggering a callout is rendered after a callout, the modal's backdrop will overlap the callout, preventing it from being dismissed. Setting the `z-index` of callout to `1` resolves.

Before:
![image](https://github.com/folio-org/stripes-components/assets/20704067/fa2a72e8-85be-492d-a99d-1c60a2f1c519)

After: 
![image](https://github.com/folio-org/stripes-components/assets/20704067/e6875722-6b55-4cb9-8d1d-496abf07c5a4)
