### PR TITLE
STCOM-1000: Firefox: TextLink - underline not showing up on nested spans with 'display: inline-flex'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `hasMatchSelection` to `<AdvancedSearch>` to hide/show search match selection dropdown. Refs STCOM-1211.
 * Add z-index of 1 to callout out to have it always render on top of sibling elements. Fixes STCOM-1217.
+* Firefox: TextLink - underline not showing up on nested spans with 'display: inline-flex'. Refs STCOM-1000.
 
 ## [12.0.0](https://github.com/folio-org/stripes-components/tree/v12.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v11.0.0...v12.0.0)

--- a/lib/TextLink/stories/BasicUsage.js
+++ b/lib/TextLink/stories/BasicUsage.js
@@ -40,6 +40,13 @@ const BasicUsage = () => (
         </TextLink>
       )}
     </Tooltip>
+    <br /><br />
+    <div style={{ width: 300 }}>
+      <TextLink href="#some-hash">
+        <span style={{ display: 'inline-flex' }}>This will not be underlined (bug)</span>&nbsp;
+        <span>This will be underlined.</span>
+      </TextLink>
+    </div>
   </HashRouter>
 );
 


### PR DESCRIPTION
I have added changes in story book, since it's not a bug. 
<img width="1104" alt="Screenshot 2023-10-26 at 17 31 55" src="https://github.com/folio-org/stripes-components/assets/72550466/f438a8c4-d5e5-4e4f-aab6-e200e9eda4ce">
