### PR TITLE
STCOM-1225 Spinner button hidden in datepicker calendar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add z-index of 1 to callout out to have it always render on top of sibling elements. Fixes STCOM-1217.
 * Make `<SearchField>` support input and textarea as an input field. Refs STCOM-1220.
 * Add support for new match option `containsAll` in `<AdvancedSearch>`. Refs STCOM-1223.
+* Ensure CSS visibility of datepicker's year input number spinner. Refs STCOM-1225.
 
 ## [12.0.0](https://github.com/folio-org/stripes-components/tree/v12.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v11.0.0...v12.0.0)

--- a/lib/Datepicker/Calendar.css
+++ b/lib/Datepicker/Calendar.css
@@ -130,6 +130,7 @@
 }
 
 input[type="number"].yearInput::-webkit-inner-spin-button {
+  appearance: initial;
   opacity: 1;
 }
 

--- a/lib/Datepicker/Calendar.css
+++ b/lib/Datepicker/Calendar.css
@@ -129,6 +129,10 @@
   width: 8em;
 }
 
+input[type="number"].yearInput::-webkit-inner-spin-button {
+  opacity: 1;
+}
+
 .daysOfWeek {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
We display the spinner on all `input[type="number"]` in our global styles. Recently I discovered some global styles (soon to be remedied in `ui-plugin-query-builder`). The changes in this pr isolate and specify to datepicker's year input so that it we can prevent this from happening again in the future.