### PR TITLE
STCOM-1224 Include pagination height in MCL container height calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Make `<SearchField>` support input and textarea as an input field. Refs STCOM-1220.
 * Add support for new match option `containsAll` in `<AdvancedSearch>`. Refs STCOM-1223.
 * Ensure CSS visibility of datepicker's year input number spinner. Refs STCOM-1225.
+* Include pagination height in MCL container height calculation. Refs STCOM-1224.
 
 ## [12.0.0](https://github.com/folio-org/stripes-components/tree/v12.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v11.0.0...v12.0.0)

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -1749,9 +1749,11 @@ class MCLRenderer extends React.Component {
     if (height !== undefined) {
       // if we have a totalCount, we can set size based on that... if not, the receivedRows count.
       const scrollBarHeight = 20;
+      const paginationHeight = pagingType === pagingTypes.PREV_NEXT ? this.paginationHeight : 0;
+
       newHeight = Math.max(
         ((pagingType !== pagingTypes.SCROLL ? receivedRows : totalCount || receivedRows) * minimumRowHeight),
-        (height - this.headerHeight - scrollBarHeight - this.paginationHeight)
+        (height - this.headerHeight - scrollBarHeight - paginationHeight)
       );
 
       const rowContainerStyles = {

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -1751,7 +1751,7 @@ class MCLRenderer extends React.Component {
       const scrollBarHeight = 20;
       newHeight = Math.max(
         ((pagingType !== pagingTypes.SCROLL ? receivedRows : totalCount || receivedRows) * minimumRowHeight),
-        (height - this.headerHeight - scrollBarHeight)
+        (height - this.headerHeight - scrollBarHeight - this.paginationHeight)
       );
 
       const rowContainerStyles = {


### PR DESCRIPTION
## Description
Subtract pagination row height from MCL row container to not show scrollbar when there are fewer rows than what can be displayed.

## Screenshots
![image](https://github.com/folio-org/stripes-components/assets/19309423/5203b157-85f5-4f71-b6ad-d60485e29b45)

## Issues
[STCOM-1224](https://issues.folio.org/browse/STCOM-1224)