### PR TITLE
STCOM-1228 Print styling of panes (users want to print the detail pane, but full screen display is printed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Ensure CSS visibility of datepicker's year input number spinner. Refs STCOM-1225.
 * Include pagination height in MCL container height calculation. Refs STCOM-1224.
 * Added `indexRef` and `inputRef` props to `<SearchField>`. Refs STCOM-1231.
+* Adjusted print styles of panes so that the last pane will print. Refs STCOM-1228, STCOM-1229.
 
 ## [12.0.0](https://github.com/folio-org/stripes-components/tree/v12.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v11.0.0...v12.0.0)

--- a/lib/Pane/Pane.css
+++ b/lib/Pane/Pane.css
@@ -17,7 +17,15 @@
   will-change: transform;
 
   @media print {
-    overflow: visible;
+    display: none;
+  }
+
+  &:nth-last-of-type(1) {
+    @media print {
+      overflow: visible;
+      display: block;
+      flex: 0 0 100vw !important;
+    }
   }
 }
 


### PR DESCRIPTION
Printing with a detail pane open should print only the detail pane, without printing the others. The before state is captured in the associated JIRAs.

### Approach

Adjusted the styles of panes to have only the last pane visible and at 100% width when the page is printed.
Used a combination of hiding panes in print mode, and displaying the last pane via a higher specificity pseudo-selector (`nth-last-of-type(1)`)
The `flex` property is `!important` in this case in order to override the inline `flex` styling that is applied to the element.

Two stories, https://issues.folio.org/browse/STCOM-1228 and https://issues.folio.org/browse/STCOM-1229 are covered by this...

After:
Inventory:
![image](https://github.com/folio-org/stripes-components/assets/20704067/6d02a641-a84f-4430-9ef4-8f475e4eed55)

Users:
![image](https://github.com/folio-org/stripes-components/assets/20704067/39bdc2bf-69f6-4d6e-8a13-4f990d1f63c2)
