### PR TITLE
STCOM-1222 Accessibility Issues - stripes components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Include pagination height in MCL container height calculation. Refs STCOM-1224.
 * Added `indexRef` and `inputRef` props to `<SearchField>`. Refs STCOM-1231.
 * Adjusted print styles of panes so that the last pane will print. Refs STCOM-1228, STCOM-1229.
+* Accessibility Issues - stripes components. Refs STCOM-1222.
 
 ## [12.0.0](https://github.com/folio-org/stripes-components/tree/v12.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v11.0.0...v12.0.0)

--- a/lib/MessageBanner/MessageBanner.module.css
+++ b/lib/MessageBanner/MessageBanner.module.css
@@ -19,7 +19,7 @@
   --message-banner-error-color: var(--error);
   --message-banner-error-border-color: var(--error);
   --message-banner-success-fill: var(--success-fill);
-  --message-banner-success-color: var(--success);
+  --message-banner-success-color: var(--color-text);
   --message-banner-success-border-color: var(--success);
   --message-banner-warning-fill: var(--warn-fill);
   --message-banner-warning-color: var(--warn);

--- a/lib/PaneHeader/PaneHeader.css
+++ b/lib/PaneHeader/PaneHeader.css
@@ -82,9 +82,9 @@
 
 /* Pane sub */
 .paneSub {
-  color: var(--color-text-p2);
+  color: var(--color-text);
   font-size: var(--font-size-small);
-  line-height: 1.2;
+  line-height: 1.5;
 }
 
 /* Pane button areas */


### PR DESCRIPTION
All changes agreed with **Kimie Kester** (check comment section of [STCOM-1222](https://issues.folio.org/browse/STCOM-1222))

After this PR is resolved, we will fix the following accessibility issues:

1. In Pane's subtitle, the contrast and line-height will be increased, which will make the text more readable
2. The text color in the MessageBanner component has been changed to increase contrast (previously it was green on green)

