### PR TITLE
STCOM-1225 missing number spinner in datepicker.

### DIFF
--- a/lib/Datepicker/Calendar.css
+++ b/lib/Datepicker/Calendar.css
@@ -120,7 +120,9 @@
   padding: 4px;
 }
 
-.yearInput {
+input[type="number"].yearInput {
+  -moz-appearance: initial;
+  appearance: initial;
   border-style: dashed;
   border-width: 0 0 1px 0;
   min-width: 0;
@@ -130,7 +132,7 @@
 }
 
 input[type="number"].yearInput::-webkit-inner-spin-button {
-  appearance: initial;
+  appearance: auto;
   opacity: 1;
 }
 


### PR DESCRIPTION
Despite the original attempt, `appearance: initial;` did not work to display the spinner button on the datepicker's year input. This apparently computed to 'none'.
Changing to `appearance: auto;` resolved.