### PR TITLE
STCOM-1240 Added support for clear icon in TextArea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Include pagination height in MCL container height calculation. Refs STCOM-1224.
 * Added `indexRef` and `inputRef` props to `<SearchField>`. Refs STCOM-1231.
 * Adjusted print styles of panes so that the last pane will print. Refs STCOM-1228, STCOM-1229.
+* Added support for clear icon in `<TextArea>`. Refs STCOM-1240.
 
 ## [12.0.0](https://github.com/folio-org/stripes-components/tree/v12.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v11.0.0...v12.0.0)

--- a/lib/SearchField/SearchField.js
+++ b/lib/SearchField/SearchField.js
@@ -160,14 +160,14 @@ const SearchField = (props) => {
       readOnly: loading || rest.readOnly,
       placeholder: inputPlaceholder,
       inputRef,
+      hasClearIcon: typeof onClear === 'function',
+      clearFieldId: clearSearchId,
+      onClearField: onClear,
     };
 
     const textFieldProps = {
       focusedClass: css.isFocused,
       inputClass: classNames(css.input, inputClass),
-      hasClearIcon: typeof onClear === 'function' && loading !== true,
-      onClearField: onClear,
-      clearFieldId: clearSearchId,
     };
     const textAreaProps = {
       rootClass: rest.className,

--- a/lib/TextArea/TextArea.css
+++ b/lib/TextArea/TextArea.css
@@ -20,3 +20,41 @@
   min-width: 100%;
   max-width: 100%;
 }
+
+.startControls,
+.endControls {
+  position: absolute;
+  right: 8px; /* leave some space for textarea's resize control */
+  bottom: 1px; /* makes the controls look more vertically centered in single line textareas */
+
+  pointer-events: none;
+  height: auto;
+  display: flex;
+  justify-content: flex-start;
+  align-items: stretch;
+  flex: 0;
+}
+
+.startControls {
+  justify-content: flex-start;
+  padding: 0 0 0 var(--input-horizontal-padding);
+}
+
+[dir="rtl"] .startControls {
+  padding: 0 var(--input-horizontal-padding) 0 0;
+}
+
+.endControls {
+  justify-content: flex-end;
+  padding: 0 var(--input-horizontal-padding) 0 0;
+}
+
+[dir="rtl"] .endControls {
+  padding: 0 0 0 var(--input-horizontal-padding);
+}
+
+.controlGroup {
+  pointer-events: all;
+  display: flex;
+  align-items: center;
+}

--- a/lib/TextArea/TextArea.js
+++ b/lib/TextArea/TextArea.js
@@ -1,12 +1,14 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import className from 'classnames';
+import { FormattedMessage } from 'react-intl';
 import uniqueId from 'lodash/uniqueId';
 import noop from 'lodash/noop';
 
 import Label from '../Label';
 import parseMeta from '../FormField/parseMeta';
 import formField from '../FormField';
+import TextFieldIcon from '../TextField/TextFieldIcon';
 import omitProps from '../../util/omitProps';
 import sharedInputStylesHelper from '../sharedStyles/sharedInputStylesHelper';
 
@@ -18,6 +20,10 @@ class TextArea extends Component {
     ariaLabel: PropTypes.string,
     ariaLabelledBy: PropTypes.string,
     autoFocus: PropTypes.bool,
+    /**
+     * Id to apply to clear field button.
+     */
+    clearFieldId: PropTypes.string,
     dirty: PropTypes.bool,
     disabled: PropTypes.bool,
     endControl: PropTypes.element,
@@ -30,6 +36,10 @@ class TextArea extends Component {
      * Will resize the textarea to be 100% of parent element's width
      */
     fullWidth: PropTypes.bool,
+    /**
+     * When set to false, will not show clear button.
+     */
+    hasClearIcon: PropTypes.bool,
     id: PropTypes.string,
     inputRef: PropTypes.oneOfType([
       PropTypes.func,
@@ -53,9 +63,21 @@ class TextArea extends Component {
     */
     noBorder: PropTypes.bool,
     /**
+     * Callback fired when the input is blurred.
+     */
+    onBlur: PropTypes.func,
+    /**
      * Event handler for text input. Required if a value is supplied.
      */
     onChange: PropTypes.func,
+    /**
+     * Callback fired when the input is cleared.
+     */
+    onClearField: PropTypes.func,
+    /**
+     * Callback fired when the input is focused.
+     */
+    onFocus: PropTypes.func,
     onKeyDown: PropTypes.func,
     /**
      * Event handler for submit. Will fire when `newLineOnShiftEnter` is true and user presses Enter key.
@@ -86,6 +108,9 @@ class TextArea extends Component {
     validStylesEnabled: false,
     onKeyDown: noop,
     onSubmitSearch: noop,
+    onBlur: noop,
+    onFocus: noop,
+    onClearField: noop,
     value: '',
   };
 
@@ -96,6 +121,7 @@ class TextArea extends Component {
     this.inputId = props.id ?? uniqueId('textarea-input-');
 
     this.state = {
+      focused: false,
       prevPropsValue: props.value,
       value: props.value,
     };
@@ -119,9 +145,15 @@ class TextArea extends Component {
   getRootStyle() {
     return className(
       css.textArea,
-      formStyles.inputGroup,
       this.props.rootClass,
       { [`${css.fullWidth}`]: this.props.fullWidth },
+    );
+  }
+
+  getInputGroupStyle() {
+    return className(
+      formStyles.inputGroup,
+      { [`${css.hasClearIcon}`]: this.props.hasClearIcon },
     );
   }
 
@@ -135,6 +167,35 @@ class TextArea extends Component {
       sharedInputStylesHelper(this.props),
       { [`${css.lockWidth}`]: this.props.lockWidth },
     );
+  }
+
+  onFocus = event => {
+    const { onFocus } = this.props;
+
+    if (!this.state.focused) {
+      this.setState({
+        focused: true
+      });
+
+      onFocus(event);
+    }
+  }
+
+  onBlur = event => {
+    const { onBlur } = this.props;
+    const { currentTarget, relatedTarget } = event;
+
+    if (!(relatedTarget && currentTarget.contains(relatedTarget))) {
+      // delay focus stay setting for a whole tick. This is intended to keep the clear button around long enough for its
+      // click event to fire on iOS devices.
+      this.resetFocusTO = setTimeout(() => {
+        this.setState({
+          focused: false
+        });
+      });
+
+      onBlur(event);
+    }
   }
 
   handleChange = (event) => {
@@ -188,6 +249,9 @@ class TextArea extends Component {
       valid,
       validStylesEnabled,
       warning,
+      hasClearIcon,
+      clearFieldId,
+      onClearField,
       ...rest
     } = this.props;
 
@@ -223,6 +287,39 @@ class TextArea extends Component {
       />
     );
 
+    let clearField = null;
+    let endControlElement;
+
+    if (hasClearIcon
+      && !loading
+      && this.state.focused
+      && this.state.value) {
+      clearField = (
+        <FormattedMessage id="stripes-components.clearThisField">
+          {([_ariaLabel]) => (
+            <TextFieldIcon
+              aria-label={ariaLabel}
+              icon="times-circle-solid"
+              id={clearFieldId || `clickable-${this.testId}-clear-field`}
+              onClick={onClearField}
+              tabIndex="-1"
+            />
+          )}
+        </FormattedMessage>
+      );
+    }
+
+    if ((!readOnly && clearField) || endControl) {
+      endControlElement = (
+        <div className={css.endControls}>
+          <div className={css.controlGroup} ref={this.endControl}>
+            {!readOnly && clearField}
+            {endControl}
+          </div>
+        </div>
+      );
+    }
+
     const warningElement = warning ?
       <div className={formStyles.feedbackWarning}>{warning}</div> : null;
 
@@ -242,10 +339,17 @@ class TextArea extends Component {
     return (
       <div className={this.getRootStyle()}>
         {labelElement}
-        {component}
-        <div role="alert">
-          {warningElement}
-          {errorElement}
+        <div
+          className={this.getInputGroupStyle()}
+          onFocus={this.onFocus}
+          onBlur={this.onBlur}
+        >
+          {component}
+          {endControlElement}
+          <div role="alert">
+            {warningElement}
+            {errorElement}
+          </div>
         </div>
       </div>
     );

--- a/lib/TextArea/tests/TextArea-test.js
+++ b/lib/TextArea/tests/TextArea-test.js
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 
 import { TextArea as Interactor, Label as LabelInteractor, runAxeTest, Keyboard } from '@folio/stripes-testing';
 
-import { mount } from '../../../tests/helpers';
+import { mountWithContext } from '../../../tests/helpers';
 import TextArea from '../TextArea';
 
 describe('TextArea', () => {
@@ -14,7 +14,7 @@ describe('TextArea', () => {
 
     describe('rendering a basic TextArea', async () => {
       beforeEach(async () => {
-        await mount(
+        await mountWithContext(
           <TextArea aria-label="test label" id="test" />
         );
       });
@@ -39,7 +39,7 @@ describe('TextArea', () => {
 
     describe('supplying an error', () => {
       beforeEach(async () => {
-        await mount(
+        await mountWithContext(
           <TextArea error="This is an error." />
         );
       });
@@ -49,7 +49,7 @@ describe('TextArea', () => {
 
     describe('supplying a warning', () => {
       beforeEach(async () => {
-        await mount(
+        await mountWithContext(
           <TextArea warning="This is a warning." />
         );
       });
@@ -62,7 +62,7 @@ describe('TextArea', () => {
     const textArea = Interactor('my test label');
 
     beforeEach(async () => {
-      await mount(
+      await mountWithContext(
         <TextArea label="my test label" id="myTestInput" />
       );
     });
@@ -81,7 +81,7 @@ describe('TextArea', () => {
     const value = 'Test value';
 
     beforeEach(async () => {
-      await mount(
+      await mountWithContext(
         <TextArea
           label="my test label"
           id="myTestInput"
@@ -98,7 +98,7 @@ describe('TextArea', () => {
     const textArea = Interactor();
 
     beforeEach(async () => {
-      await mount(
+      await mountWithContext(
         <TextArea ariaLabel="test areaLabel" />
       );
     });
@@ -112,7 +112,7 @@ describe('TextArea', () => {
     const textArea = Interactor();
 
     beforeEach(async () => {
-      await mount(
+      await mountWithContext(
         <TextArea ariaLabel="test label" value="test value" />
       );
     });
@@ -122,6 +122,34 @@ describe('TextArea', () => {
     it('applies the value to the textarea', () => textArea.has({ value: 'test value' }));
   });
 
+  describe('supplying hasClearIcon', () => {
+    const textArea = Interactor();
+    const onClearFieldSpy = sinon.spy();
+
+    beforeEach(async () => {
+      await mountWithContext(
+        <TextArea
+          ariaLabel="test label"
+          value="test value"
+          hasClearIcon
+          onClearField={onClearFieldSpy}
+        />
+      );
+
+      await textArea.focus();
+    });
+
+    it('should render the clear icon', () => textArea.has({ hasClearIcon: true }));
+
+    describe('when clear icon is clicked', () => {
+      beforeEach(async () => {
+        await textArea.clear();
+      });
+
+      it('should call onClearField', () => expect(onClearFieldSpy.callCount).to.equal(1));
+    });
+  })
+
   describe('supplying newLineOnShiftEnter', () => {
     const textArea = Interactor();
     const onSubmitSearchSpy = sinon.spy();
@@ -129,7 +157,7 @@ describe('TextArea', () => {
     beforeEach(async () => {
       onSubmitSearchSpy.resetHistory();
 
-      await mount(
+      await mountWithContext(
         <TextArea
           ariaLabel="test label"
           value="test value"


### PR DESCRIPTION
## Description
Added support for clear icon in `<TextArea>`
Checked the component in multiple apps and changes in component structure don't seem to affect visuals

## Screenshots
![image](https://github.com/folio-org/stripes-components/assets/19309423/5dd28115-60be-46b7-a1b0-ed09934cf755)
![image](https://github.com/folio-org/stripes-components/assets/19309423/8a48b16c-b1b5-402e-b7ac-43563271e2b9)
![image](https://github.com/folio-org/stripes-components/assets/19309423/c0f896e9-b175-430a-beff-5448ccc4b270)
![image](https://github.com/folio-org/stripes-components/assets/19309423/6cf35cd9-1f85-447e-8b3b-cecf3a72f6dc)

## Issues
[STCOM-1240](https://issues.folio.org/browse/STCOM-1240) 