### PR TITLE
STCOM-1242: Use the default search option instead of an unsupported one in Advanced search.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Accessibility Issues - stripes components. Refs STCOM-1222.
 * Enable spinner on Datepicker year input. Refs STCOM-1225.
 * TextLink - underline showing up on nested spans with 'display: inline-flex'. Refs STCOM-1226.
+* Use the default search option instead of an unsupported one in Advanced search. Refs STCOM-1242.
 
 ## [12.0.0](https://github.com/folio-org/stripes-components/tree/v12.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v11.0.0...v12.0.0)

--- a/lib/AdvancedSearch/AdvancedSearch.js
+++ b/lib/AdvancedSearch/AdvancedSearch.js
@@ -64,6 +64,7 @@ const AdvancedSearch = ({
     rowFormatter,
     searchOptions,
     queryToRow,
+    hasQueryOption,
   });
 
   const renderRows = () => {

--- a/lib/AdvancedSearch/hooks/useAdvancedSearch/useAdvancedSearch.js
+++ b/lib/AdvancedSearch/hooks/useAdvancedSearch/useAdvancedSearch.js
@@ -33,6 +33,19 @@ const createInitialRowState = (firstRowInitialSearch, defaultSearchOptionValue) 
   }));
 };
 
+const replaceUnsupportedOptions = (row, searchOptions, defaultSearchOptionValue, hasQueryOption) => {
+  const hasSupportedSearchOption = searchOptions.some(option => option.value === row.searchOption);
+
+  if (hasQueryOption || hasSupportedSearchOption) {
+    return row;
+  }
+
+  return {
+    ...row,
+    searchOption: defaultSearchOptionValue,
+  };
+};
+
 const useAdvancedSearch = ({
   defaultSearchOptionValue,
   firstRowInitialSearch,
@@ -42,6 +55,7 @@ const useAdvancedSearch = ({
   rowFormatter = defaultRowFormatter,
   queryToRow = defaultQueryToRow,
   searchOptions = [],
+  hasQueryOption,
 }) => {
   const initialRowState = useMemo(() => {
     const initialRows = createInitialRowState(firstRowInitialSearch, defaultSearchOptionValue);
@@ -52,7 +66,12 @@ const useAdvancedSearch = ({
   const [rowState, setRowState] = useState(initialRowState);
   const [showEmptyFirstRowMessage, setShowEmptyFirstRowMessage] = useState(false);
   const [prevFirstRowInitialSearch, setPrevFirstRowInitialSearch] = useState(firstRowInitialSearch);
-  const filledRows = useMemo(() => filterFilledRows(splitQueryRows(rowState, queryToRow)), [rowState, queryToRow]);
+  const filledRows = useMemo(() => {
+    const rows = splitQueryRows(rowState, queryToRow)
+      .map(row => replaceUnsupportedOptions(row, searchOptions, defaultSearchOptionValue, hasQueryOption));
+
+    return filterFilledRows(rows)
+  }, [rowState, queryToRow, searchOptions, defaultSearchOptionValue, hasQueryOption]);
 
   const searchOptionsWithQuery = useMemo(() => (
     [{

--- a/lib/AdvancedSearch/tests/AdvancedSearch-test.js
+++ b/lib/AdvancedSearch/tests/AdvancedSearch-test.js
@@ -201,6 +201,24 @@ describe('AdvancedSearch', () => {
     });
   });
 
+  describe('when there is an unsupported search option', () => {
+    beforeEach(async () => {
+      await renderComponent({
+        hasQueryOption: false,
+        firstRowInitialSearch: {
+          query: 'test',
+          option: 'querySearch',
+        },
+      });
+
+      await advancedSearch.search();
+    });
+
+    it('should be replaced with the default one', () => {
+      expect(onSearchSpy.calledOnceWith('keyword==test')).to.be.true;
+    });
+  });
+
   describe('when searching with query in first row', () => {
     beforeEach(async () => {
       await RowInteractor({ index: 0 }).selectSearchOption(0, 'Query');


### PR DESCRIPTION
## Purpose
Use the default search option instead of an unsupported one in Advanced search.
## Issues
[STCOM-1242](https://issues.folio.org/browse/STCOM-1242)

## Screencast

https://github.com/folio-org/stripes-components/assets/77053927/ee8c4f8b-a8a8-4fb2-b312-29e257032de1

