### PR TITLE
Replace momentJS with dayJS

### DIFF
--- a/hooks/useDynamicLocale/DynamicLocaleRenderer.js
+++ b/hooks/useDynamicLocale/DynamicLocaleRenderer.js
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import useDynamicLocale from './useDynamicLocale';
+
+const DynamicLocaleRenderer = ({ children, onLoaded }) => {
+  const { localeLoaded, isEnglishLang } = useDynamicLocale();
+  useEffect(() => {
+    if (localeLoaded) {
+      onLoaded({ isEnglishLang });
+    }
+  }, [localeLoaded, onLoaded, isEnglishLang]);
+  return localeLoaded ? children : null;
+};
+
+DynamicLocaleRenderer.propTypes = {
+  children: PropTypes.node,
+  onLoaded: PropTypes.func,
+};
+
+export default DynamicLocaleRenderer;

--- a/hooks/useDynamicLocale/index.js
+++ b/hooks/useDynamicLocale/index.js
@@ -1,0 +1,3 @@
+export { default as useDynamicLocale } from './useDynamicLocale';
+export { default as DynamicLocaleRenderer } from './DynamicLocaleRenderer';
+

--- a/hooks/useDynamicLocale/useDynamicLocale.js
+++ b/hooks/useDynamicLocale/useDynamicLocale.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import availableLocales from 'dayjs/locale';
+import { IntlContext } from 'react-intl';
+
+const isEnglishLang = (locale) => {
+  return /^en/.test(locale);
+};
+
+/**
+ * getDayJSLocaleToLoad -
+ * Function that returns an existing DayJS locale. Returns undefined if the static locale does not exist.
+ *
+ * @param {String} locale  - locale string ex : 'en-SE'
+ * @param {String} parentLocale - 2 character language of the locale...ex parentLocale of
+ */
+const getDayJSLocaleToLoad = (locale, parentLanguage) => {
+  /**
+     * Check for availability of locales - DayJS comes with a JSON list of available locales.
+     * We can check against that before attempting to load. We check for the full locale
+     * first, followed by the language if the full locale doesn't work.
+     */
+  let localeToLoad;
+  let available = availableLocales.findIndex(l => l.key === locale);
+  if (available !== -1) {
+    localeToLoad = locale;
+  } else {
+    available = availableLocales.findIndex(l => l.key === parentLanguage);
+    if (available !== -1) {
+      localeToLoad = parentLanguage;
+    } else {
+      // eslint-disable-next-line no-console
+      console.error(`${locale}/${parentLanguage} unavailable for DayJS`);
+    }
+  }
+  return localeToLoad;
+};
+
+/**
+ * useDynamicLocale -
+ * React hook that loads a DayJS locale, returns an
+ * @date 12/15/2023 - 1:58:58 PM
+ *
+ * @param {Object} hookParams
+ * @param {String} hookParams.locale - locale string ex : 'en-SE'
+ */
+const useDynamicLocale = ({ locale : localeProp } = {}) => {
+  const { locale: localeContext } = React.useContext(IntlContext);
+  const [localeLoaded, setLocaleLoaded] = React.useState(
+    localeProp ? isEnglishLang(localeProp) :
+      isEnglishLang(localeContext)
+  );
+  const [prevLocale, updatePrevLocale] = React.useState(localeProp || localeContext);
+  const locale = localeProp || localeContext;
+
+  React.useEffect(() => {
+    const parentLanguage = locale.split('-')[0];
+    const localeToLoad = getDayJSLocaleToLoad(locale, parentLanguage);
+    // don't load a dynamic locale if the dayjs locale is already set to it,
+    // or if it's already been loaded according to state...
+    if (!localeLoaded && dayjs.locale() !== localeToLoad) {
+      // check if locale is available
+      const available = availableLocales.findIndex(l => l.key === localeToLoad);
+      if (available !== -1) {
+        import(
+          /* webpackChunkName: "dayjs-locale-[request]" */
+          /* webpackExclude: /\.d\.ts$/ */
+          `dayjs/locale/${localeToLoad}`
+        ).then(() => {
+          dayjs.locale(localeToLoad);
+          setLocaleLoaded(true);
+        });
+      }
+    } else if (dayjs.locale() === localeToLoad) {
+      setLocaleLoaded(true);
+    } else if (localeToLoad === 'en') {
+      setLocaleLoaded(true);
+      dayjs.locale('en');
+    }
+  }, [localeLoaded, locale, prevLocale]);
+
+  if (locale !== prevLocale) {
+    updatePrevLocale(localeProp || localeContext);
+    setLocaleLoaded(localeProp ? isEnglishLang(localeProp) : isEnglishLang(localeContext));
+  }
+
+  return {
+    localeLoaded,
+    isEnglish: localeProp ? localeProp === 'en' : localeContext === 'en'
+  };
+};
+
+export default useDynamicLocale;

--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -9,7 +9,6 @@ import React from 'react';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import { isArray } from 'lodash';
-import moment from 'moment-timezone';
 import dayjs from 'dayjs';
 import isoWeek from 'dayjs/plugin/isoWeek';
 import weekOfYear from 'dayjs/plugin/weekOfYear';
@@ -59,8 +58,8 @@ function getCalendar(year, month, offset = 0) {
     if (weeks.indexOf(ref) < 0) {
       weeks.push(mo.week());
       const endClone = dayjs(mo);
-      rowStartArray.push(mo.weekday(offset));
-      rowEndArray.push(endClone.weekday(offset + 6).add(1, 'day'));
+      rowStartArray.push(mo.day(offset).toISOString());
+      rowEndArray.push(endClone.day(offset + 6).add(1, 'day'));
     }
   });
 
@@ -180,10 +179,10 @@ class Calendar extends React.Component {
     // Hopefully it will be implemented in browser Intl API soon..
     // but until then...
 
-    let dayOffset = 0;
-    let adjustedLocale = getAdjustedLocale(props.intl.locale || props.locale);
+    const adjustedLocale = getAdjustedLocale(props.intl.locale || props.locale);
 
-    dayOffset = adjustedLocale === 'en' ? 0 : getFirstWeekday(adjustedLocale);
+    this.weekDays = getWeekDays(props.intl);
+    const dayOffset = getFirstWeekday(adjustedLocale, this.weekDays);
 
     const base = dayjs(cursorDate);
     const month = base.month();
@@ -201,9 +200,8 @@ class Calendar extends React.Component {
       dayOffset
     };
 
-    this.weekDays = getWeekDays(props.intl);
     this.months = getMonths(props.intl);
-    this.firstWeekDay = getFirstWeekday(adjustedLocale);
+    this.firstWeekDay = getFirstWeekday(adjustedLocale, this.weekDays);
     this.firstField = props.firstFieldRef || React.createRef();
     this.calendarGrid = React.createRef();
   }
@@ -442,12 +440,12 @@ class Calendar extends React.Component {
     if (!isEnglish) {
       this.setState(cur => {
         const adjustedLocale = getAdjustedLocale(intl.locale || locale);
-        const dayOffset = getFirstWeekday(adjustedLocale)
+        const dayOffset = getFirstWeekday(adjustedLocale, this.weekDays);
         return {
-        calendar: getCalendar(cur.year, cur.month, dayOffset),
-        dayOffset: dayOffset
-      }
-    });
+          calendar: getCalendar(cur.year, cur.month, dayOffset),
+          dayOffset
+        };
+      });
     }
   }
 

--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -2,48 +2,70 @@
 * Display calendar UI for datepicker.
 * Sync the cursor to the selected date or default to today.
 * Month is rendered based on cursor date.
-* Handles date math via moment.
+* Handles date math via dayjs.
 */
 
 import React from 'react';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
-import Moment from 'moment';
-import { extendMoment } from 'moment-range';
+import { isArray } from 'lodash';
+import moment from 'moment-timezone';
+import dayjs from 'dayjs';
+import isoWeek from 'dayjs/plugin/isoWeek';
+import weekOfYear from 'dayjs/plugin/weekOfYear';
+import weekday from 'dayjs/plugin/weekday';
+import localeData from 'dayjs/plugin/localeData';
+import arraySupport from 'dayjs/plugin/arraySupport';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 import IconButton from '../IconButton';
 import MonthSelect from './MonthSelect';
-
+import DynamicLocaleRenderer from '../../hooks/useDynamicLocale/DynamicLocaleRenderer';
 import css from './Calendar.css';
 
 import staticFirstWeekday from './staticFirstWeekDay';
 import staticRegions from './staticLangCountryCodes';
 
-const moment = extendMoment(Moment);
+
+dayjs.extend(isoWeek);
+dayjs.extend(localeData);
+dayjs.extend(weekOfYear);
+dayjs.extend(weekday);
+dayjs.extend(arraySupport);
+dayjs.extend(customParseFormat);
+
+const getRange = (start, end) => {
+  const range = [];
+  let current = typeof start === 'string' ? dayjs(start) : start;
+  while (current.isBefore(end)) {
+    range.push(current.clone());
+    current = current.add(1, 'day');
+  }
+  return range;
+};
 
 function getCalendar(year, month, offset = 0) {
-  const startDate = moment([year, month]);
-  const firstDay = moment(startDate).startOf('month');
-  const endDay = moment(startDate).endOf('month');
-  const monthRange = moment.range(firstDay, endDay);
+  const startDate = dayjs([year, month]);
+  const firstDay = startDate.startOf('month');
+  const endDay = startDate.endOf('month');
+  const monthRange = getRange(firstDay, endDay);
 
   const weeks = [];
   const calendar = [];
   const rowStartArray = [];
   const rowEndArray = [];
 
-  const weekdays = Array.from(monthRange.by('days'));
-  weekdays.forEach((mo) => {
+  monthRange.forEach((mo) => {
     const ref = mo.week();
     if (weeks.indexOf(ref) < 0) {
       weeks.push(mo.week());
-      const endClone = moment(mo);
-      rowStartArray.push(mo.weekday(offset + 0));
-      rowEndArray.push(endClone.weekday(offset + 6));
+      const endClone = dayjs(mo);
+      rowStartArray.push(mo.weekday(offset));
+      rowEndArray.push(endClone.weekday(offset + 6).add(1, 'day'));
     }
   });
 
   for (let i = 0; i < weeks.length; i += 1) {
-    const weekRange = moment.range(rowStartArray[i], rowEndArray[i]);
+    const weekRange = getRange(rowStartArray[i], rowEndArray[i]);
     calendar.push(weekRange);
   }
 
@@ -87,8 +109,17 @@ function getFirstWeekday(locale) {
   return dayMap[firstDay];
 }
 
+function getAdjustedLocale(locale) {
+  let adjustedLocale = locale;
+  if (adjustedLocale.length === 2) {
+    const regionDefault = staticRegions[adjustedLocale];
+    adjustedLocale = `${adjustedLocale}-${regionDefault}`;
+  }
+  return adjustedLocale;
+}
+
 const propTypes = {
-  dateFormat: PropTypes.string,
+  dateFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   exclude: PropTypes.func,
   fillParent: PropTypes.bool,
   firstFieldRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
@@ -124,19 +155,22 @@ class Calendar extends React.Component {
   constructor(props) {
     super(props);
 
-    moment.locale(this.props.intl.locale || this.props.locale);
-
     const { selectedDate, dateFormat } = this.props;
 
-    this.selectedMoment = new moment(); // eslint-disable-line new-cap
+    this.selectedDate = dayjs();
     let cursorDate;
     if (!selectedDate) {
-      cursorDate = new moment(); // eslint-disable-line new-cap
-    } else if (moment(selectedDate, dateFormat, true).isValid()) {
-      this.selectedMoment = new moment(selectedDate, dateFormat, true); // eslint-disable-line new-cap
-      cursorDate = this.selectedMoment;
+      cursorDate = dayjs();
+    } else if (dayjs(selectedDate, dateFormat, true).isValid()) {
+      if (selectedDate.isMoment) {
+        this.selectedDate = dayjs(selectedDate.toISOString(), dateFormat, true);
+        console.warn('Calendar component passed a MomentJS object for selected date. Migration to Dayjs is required!')
+      } else {
+        this.selectedDate = dayjs(selectedDate, dateFormat, true);
+      }
+      cursorDate = this.selectedDate;
     } else { // no pre-selected date, datestring invalid, init as 'today'.
-      cursorDate = new moment(); // eslint-disable-line new-cap
+      cursorDate = dayjs();
     }
 
     // if the stripes locale has no region (only 2 letters), it needs to be normalized to a
@@ -147,20 +181,11 @@ class Calendar extends React.Component {
     // but until then...
 
     let dayOffset = 0;
-    let adjustedLocale = props.intl.locale || props.locale;
-    if (adjustedLocale.length === 2) {
-      const regionDefault = staticRegions[adjustedLocale];
-      adjustedLocale = `${adjustedLocale}-${regionDefault}`;
-    }
+    let adjustedLocale = getAdjustedLocale(props.intl.locale || props.locale);
 
-    // if moment doesn't have the requested locale from above (intl/stripes), it falls back to 'en'. If this
-    // is the case, we need to set an offset value for correct calendar day rendering -
-    // otherwise, the calendar columns will be off, resulting misaligned weekdays/calendar days.
-    if (moment.locale() === 'en') {
-      dayOffset = getFirstWeekday(adjustedLocale);
-    }
+    dayOffset = adjustedLocale === 'en' ? 0 : getFirstWeekday(adjustedLocale);
 
-    const base = new moment(cursorDate); // eslint-disable-line new-cap
+    const base = dayjs(cursorDate);
     const month = base.month();
     const year = base.year();
 
@@ -169,10 +194,10 @@ class Calendar extends React.Component {
 
     this.state = {
       cursorDate,
-      date: this.selectedMoment,
+      date: this.selectedDate,
       month,
       year,
-      calendar: getCalendar(year, month),
+      calendar: getCalendar(year, month, dayOffset),
       dayOffset
     };
 
@@ -190,8 +215,9 @@ class Calendar extends React.Component {
 
     // When the selected date has changed, update the state with it
     let stateUpdate;
-    if (nextProps.selectedDate !== prevState.selectedDate) {
-      const moDate = new moment(nextProps.selectedDate, nextProps.dateFormat, true); // eslint-disable-line new-cap
+    if (nextProps.selectedDate &&
+      nextProps.selectedDate !== prevState.selectedDate) {
+      const moDate = dayjs(nextProps.selectedDate, nextProps.dateFormat, true);
       if (moDate.isValid()) {
         if (moDate !== prevState.date) {
           // const moDate = moment(nextProps.selectedDate);
@@ -208,7 +234,7 @@ class Calendar extends React.Component {
           };
         }
       } else { // fix navigation issue on null or invalid date
-        const fallbackDate = new moment(); // eslint-disable-line new-cap
+        const fallbackDate = dayjs();
         const month = fallbackDate.month();
         const year = fallbackDate.year();
         stateUpdate = {
@@ -283,8 +309,8 @@ class Calendar extends React.Component {
 
   moveCursor = (op) => {
     const curDate = this.state.cursorDate;
-    op(curDate); // eslint-disable-line new-cap
-    this.updateCursorDate(curDate);
+    const newDate = op(curDate);
+    this.updateCursorDate(newDate);
   }
 
   focusTrap = {
@@ -305,8 +331,12 @@ class Calendar extends React.Component {
       }
       return newState;
     }, () => {
-      const { id, dateFormat } = this.props;
+      const { id, dateFormat: dateFormatProp } = this.props;
       const { cursorDate } = this.state;
+      let dateFormat = dateFormatProp;
+      if (isArray(dateFormatProp)) {
+        dateFormat = dateFormatProp[0];
+      }
       const cursorString = cursorDate.format(dateFormat);
       const nextButtonElem = document.getElementById(`datepicker-choose-date-button-${cursorString}-${id}`);
       nextButtonElem?.focus(); // eslint-disable-line no-unused-expressions
@@ -328,15 +358,19 @@ class Calendar extends React.Component {
   }
 
   isDateSelected = (day) => {
+    const {
+      dateFormat
+    } = this.props;
+    const format = isArray(dateFormat) ? dateFormat[0] : dateFormat;
     if (this.props.selectedDate) {
-      return day.format(this.props.dateFormat) ===
-        new moment(this.props.selectedDate, this.props.dateFormat, true) // eslint-disable-line new-cap
-          .format(this.props.dateFormat);
+      return day.format(format) ===
+        new dayjs(this.props.selectedDate, dateFormat, true) // eslint-disable-line new-cap
+          .format(format);
     }
     if (this.state.date) {
-      return day.format(this.props.dateFormat) ===
-        new moment(this.state.date, this.props.dateFormat, true) // eslint-disable-line new-cap
-          .format(this.props.dateFormat);
+      return day.format(format) ===
+        new dayjs(this.state.date, dateFormat, true) // eslint-disable-line new-cap
+          .format(format);
     }
     return false;
   }
@@ -357,10 +391,10 @@ class Calendar extends React.Component {
     this.setState(curState => {
       const { dayOffset } = curState;
       let cursorDate = '';
-      if (month === this.selectedMoment?.month()) {
-        cursorDate = this.selectedMoment;
+      if (month === this.selectedDate?.month()) {
+        cursorDate = this.selectedDate;
       } else {
-        cursorDate = new moment().month(month).date(1).year(curState.year); // eslint-disable-line new-cap
+        cursorDate = new dayjs().month(month).date(1).year(curState.year); // eslint-disable-line new-cap
       }
       return {
         month,
@@ -373,7 +407,7 @@ class Calendar extends React.Component {
   updateYear = (e) => {
     if (e.target.value) {
       const year = e.target.value;
-      if (new moment(year, 'YYYY', true).isValid()) { // eslint-disable-line new-cap
+      if (new dayjs(year, 'YYYY', true).isValid()) { // eslint-disable-line new-cap
         this.setState(curState => ({
           year,
           calendar: getCalendar(year, curState.month, curState.dayOffset),
@@ -403,6 +437,20 @@ class Calendar extends React.Component {
     });
   }
 
+  handleLocaleLoaded = ({ isEnglish }) => {
+    const { intl, locale } = this.props;
+    if (!isEnglish) {
+      this.setState(cur => {
+        const adjustedLocale = getAdjustedLocale(intl.locale || locale);
+        const dayOffset = getFirstWeekday(adjustedLocale)
+        return {
+        calendar: getCalendar(cur.year, cur.month, dayOffset),
+        dayOffset: dayOffset
+      }
+    });
+    }
+  }
+
   render() {
     const { id, rootRef, fillParent, trapFocus } = this.props;
 
@@ -412,16 +460,16 @@ class Calendar extends React.Component {
       (week) => {
         weekCount += 1;
         const dayList = [];
-        const weekDays = Array.from(week.by('days'));
-        weekDays.forEach((day) => { dayList.push(day); });
+        week.forEach((day) => { dayList.push(day); });
 
         const days = dayList.map(
           (day) => {
             const { month, cursorDate } = this.state;
-            const { intl, exclude, dateFormat } = this.props;
-            const dayMonth = day.month() + 1;
-            const isCurrentMonth = dayMonth === month + 1;
-            const isToday = day.isSame(moment(), 'day');
+            const { intl, exclude, dateFormat: dateFormatProp } = this.props;
+            const dateFormat = isArray(dateFormatProp) ? dateFormatProp[0] : dateFormatProp;
+            const dayMonth = day.month();
+            const isCurrentMonth = dayMonth === month;
+            const isToday = day.isSame(dayjs(), 'day');
             const isSelected = this.isDateSelected(day);
 
             const isCursored = day.isSame(cursorDate, 'day');
@@ -448,7 +496,8 @@ class Calendar extends React.Component {
             numericDay = numericDay.replace('MM', new Intl.NumberFormat(
               intl.locale,
               { minimumIntegerDigits: 2 }
-            ).format(dayMonth))
+              // JS months are a 0-based index, so for correctly ISO-parseable dates, 1 needs to be added.
+            ).format(dayMonth + 1))
               .replace('YYYY',
                 new Intl.NumberFormat(intl.locale,
                   { style: 'decimal', useGrouping: false })
@@ -512,112 +561,114 @@ class Calendar extends React.Component {
     }
 
     return (
-      // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
-      <div
-        role="application"
-        aria-roledescription={this.calendarRoledescription}
-        aria-label={this.calendarLabel}
-        className={`${css.calendar}${fillParent ? '' : ' ' + css.maxWidth}`}
-        id={`datepicker-calendar-container-${id}`}
-        ref={rootRef}
-        tabIndex="-1"
-        onFocus={this.props.onFocus}
-        onKeyDown={this.handleKeyDown}
-        data-test-calendar
-      >{/* eslint-disable jsx-a11y/no-noninteractive-tabindex */}
-        { trapFocus && <div
-          onFocus={this.focusTrap.toLast}
-          tabIndex="0"
-        />}
-        <div className={css.calendarInner}>
-          <div
-            className={css.calendarHeader}
-            data-test-calendar-header
-          >
-            <FormattedMessage id="stripes-components.goToPreviousYear">
-              { ([ariaLabel]) => (
-                <IconButton
-                  icon="chevron-double-left"
-                  tabIndex="-1"
-                  onClick={() => this.moveDate('subtract', 'year')}
-                  data-test-calendar-previous-year
-                  aria-label={ariaLabel}
-                />
-              )}
+      <DynamicLocaleRenderer onLoaded={this.handleLocaleLoaded}>
+        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+        <div
+          role="application"
+          aria-roledescription={this.calendarRoledescription}
+          aria-label={this.calendarLabel}
+          className={`${css.calendar}${fillParent ? '' : ' ' + css.maxWidth}`}
+          id={`datepicker-calendar-container-${id}`}
+          ref={rootRef}
+          tabIndex="-1"
+          onFocus={this.props.onFocus}
+          onKeyDown={this.handleKeyDown}
+          data-test-calendar
+        >{/* eslint-disable jsx-a11y/no-noninteractive-tabindex */}
+          {trapFocus && <div
+            onFocus={this.focusTrap.toLast}
+            tabIndex="0"
+          />}
+          <div className={css.calendarInner}>
+            <div
+              className={css.calendarHeader}
+              data-test-calendar-header
+            >
+              <FormattedMessage id="stripes-components.goToPreviousYear">
+                {([ariaLabel]) => (
+                  <IconButton
+                    icon="chevron-double-left"
+                    tabIndex="-1"
+                    onClick={() => this.moveDate('subtract', 'year')}
+                    data-test-calendar-previous-year
+                    aria-label={ariaLabel}
+                  />
+                )}
+              </FormattedMessage>
+              <FormattedMessage id="stripes-components.goToPreviousMonth">
+                {([ariaLabel]) => (
+                  <IconButton
+                    icon="caret-left"
+                    tabIndex="-1"
+                    onClick={() => this.moveDate('subtract', 'month')}
+                    data-test-calendar-previous-month
+                    aria-label={ariaLabel}
+                  />
+                )}
+              </FormattedMessage>
+              <FormattedMessage id="stripes-components.Datepicker.monthControl">
+                {([ariaLabel]) => (
+                  <MonthSelect
+                    autoFocus
+                    aria-label={ariaLabel}
+                    month={this.state.month}
+                    months={this.months}
+                    onChange={this.updateMonth}
+                    inputRef={this.firstField}
+                  />
+                )}
+              </FormattedMessage>
+              <FormattedMessage id="stripes-components.Datepicker.yearControl">
+                {([ariaLabel]) => (
+                  <input
+                    data-test-year-input
+                    aria-label={ariaLabel}
+                    className={css.yearInput}
+                    type="number"
+                    value={this.state.year}
+                    onChange={this.updateYear}
+                  />
+                )}
+              </FormattedMessage>
+              <FormattedMessage id="stripes-components.goToNextMonth">
+                {([ariaLabel]) => (
+                  <IconButton
+                    icon="caret-right"
+                    tabIndex="-1"
+                    onClick={() => this.moveDate('add', 'month')}
+                    data-test-calendar-next-month
+                    aria-label={ariaLabel}
+                  />
+                )}
+              </FormattedMessage>
+              <FormattedMessage id="stripes-components.goToNextYear">
+                {([ariaLabel]) => (
+                  <IconButton
+                    icon="chevron-double-right"
+                    tabIndex="-1"
+                    onClick={() => this.moveDate('add', 'year')}
+                    data-test-calendar-next-year
+                    aria-label={ariaLabel}
+                  />
+                )}
+              </FormattedMessage>
+            </div>
+            <ul className={css.daysOfWeek}>
+              {daysOfWeek}
+            </ul>
+            <FormattedMessage id="stripes-components.Datepicker.calendarDaysListDescription">
+              {([description]) => <div className="sr-only" id={`${id}-cal-description`}>{description}</div>}
             </FormattedMessage>
-            <FormattedMessage id="stripes-components.goToPreviousMonth">
-              { ([ariaLabel]) => (
-                <IconButton
-                  icon="caret-left"
-                  tabIndex="-1"
-                  onClick={() => this.moveDate('subtract', 'month')}
-                  data-test-calendar-previous-month
-                  aria-label={ariaLabel}
-                />
-              )}
-            </FormattedMessage>
-            <FormattedMessage id="stripes-components.Datepicker.monthControl">
-              { ([ariaLabel]) => (
-                <MonthSelect
-                  autoFocus
-                  aria-label={ariaLabel}
-                  month={this.state.month}
-                  months={this.months}
-                  onChange={this.updateMonth}
-                  inputRef={this.firstField}
-                />
-              )}
-            </FormattedMessage>
-            <FormattedMessage id="stripes-components.Datepicker.yearControl">
-              { ([ariaLabel]) => (
-                <input
-                  data-test-year-input
-                  aria-label={ariaLabel}
-                  className={css.yearInput}
-                  type="number"
-                  value={this.state.year}
-                  onChange={this.updateYear}
-                />
-              )}
-            </FormattedMessage>
-            <FormattedMessage id="stripes-components.goToNextMonth">
-              { ([ariaLabel]) => (
-                <IconButton
-                  icon="caret-right"
-                  tabIndex="-1"
-                  onClick={() => this.moveDate('add', 'month')}
-                  data-test-calendar-next-month
-                  aria-label={ariaLabel}
-                />
-              )}
-            </FormattedMessage>
-            <FormattedMessage id="stripes-components.goToNextYear">
-              { ([ariaLabel]) => (
-                <IconButton
-                  icon="chevron-double-right"
-                  tabIndex="-1"
-                  onClick={() => this.moveDate('add', 'year')}
-                  data-test-calendar-next-year
-                  aria-label={ariaLabel}
-                />
-              )}
-            </FormattedMessage>
+            <table role="presentation" ref={this.calendarGrid} onKeyDown={this.handleCalendarKeyDown}>
+              <tbody>
+                {weeks}
+              </tbody>
+            </table>
           </div>
-          <ul className={css.daysOfWeek}>
-            {daysOfWeek}
-          </ul>
-          <FormattedMessage id="stripes-components.Datepicker.calendarDaysListDescription">
-            { ([description]) => <div className="sr-only" id={`${id}-cal-description`}>{description}</div>}
-          </FormattedMessage>
-          <table role="presentation" ref={this.calendarGrid} onKeyDown={this.handleCalendarKeyDown}>
-            <tbody>
-              {weeks}
-            </tbody>
-          </table>
+          {trapFocus && <div onFocus={this.focusTrap.toStart} tabIndex="0" />}
+          {/* eslint-enable jsx-a11y/no-noninteractive-tabindex */}
         </div>
-        {trapFocus && <div onFocus={this.focusTrap.toStart} tabIndex="0" />}
-        {/* eslint-enable jsx-a11y/no-noninteractive-tabindex */}
-      </div>
+      </DynamicLocaleRenderer>
     );
   }
 }

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -1,7 +1,11 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
-import moment from 'moment-timezone';
+import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+import contains from 'dom-helpers/query/contains';
 import uniqueId from 'lodash/uniqueId';
 import pick from 'lodash/pick';
 import RootCloseWrapper from '../../util/RootCloseWrapper';
@@ -13,24 +17,32 @@ import TextField from '../TextField';
 import Calendar from './Calendar';
 import css from './Calendar.css';
 import { getLocaleDateFormat } from '../../util/dateTimeUtils';
+import { useDynamicLocale } from '../../hooks/useDynamicLocale';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.extend(customParseFormat);
 
 const pickDataProps = (props) => pick(props, (v, key) => key.indexOf('data-test') !== -1);
 
-// Controls the formatting from the value prop to what displays in the UI.
+const containsUTCOffset = (value) => {
+  const offsetRegex = /T[\d.:]+[+-][\d]+$/;
+  const offsetRE2 = /T[\d:]+[-+][\d:]+\d{2}$/; // sans milliseconds
+  return offsetRegex.test(value) || offsetRE2.test(value);
+};
+
+// Controls the formatting from the value prop to what displays in the text input.
 // need to judge the breakage factor in adopting a spread syntax for these parameters...
 const defaultParser = (value, timeZone, uiFormat, outputFormats) => {
   if (!value || value === '') { return value; }
-
-  const offsetRegex = /T[\d.:]+[+-][\d]+$/;
-  const offsetRE2 = /T[\d:]+[-+][\d:]+\d{2}$/; // sans milliseconds
-  let inputMoment;
-  // if date string contains a utc offset, we can parse it as utc time and convert it to selected timezone.
-  if (offsetRegex.test(value) || offsetRE2.test(value)) {
-    inputMoment = moment.tz(value, timeZone);
+  let inputDate;
+  if (containsUTCOffset(value)) {
+    inputDate = dayjs.utc(value).tz(timeZone);
   } else {
-    inputMoment = moment.tz(value, [uiFormat, ...outputFormats], timeZone);
+    inputDate = dayjs(value, [uiFormat, ...outputFormats]);
   }
-  const inputValue = inputMoment.format(uiFormat);
+
+  const inputValue = inputDate.format(uiFormat);
   return inputValue;
 };
 
@@ -55,10 +67,10 @@ const defaultParser = (value, timeZone, uiFormat, outputFormats) => {
  */
 export const defaultOutputFormatter = ({ backendDateStandard, value, uiFormat, outputFormats, timeZone }) => {
   if (!value || value === '') { return value; }
-  const parsed = new moment.tz(value, [uiFormat, ...outputFormats], timeZone); // eslint-disable-line
+  const parsed = dayjs.utc(value);
 
-  if (/8601/.test(backendDateStandard)) {
-    return parsed.toISOString();
+  if (parsed.isValid() && /8601/.test(backendDateStandard)) {
+    return parsed.locale('en').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]');
   }
 
   // Use `.locale('en')` before `.format(...)` to get Arabic/"Latn" numerals.
@@ -73,16 +85,16 @@ export const defaultOutputFormatter = ({ backendDateStandard, value, uiFormat, o
   // https://www.rfc-editor.org/rfc/rfc5646.html
 
   // for support of the RFC2822 format (rare thus far and support may soon be deprecated.)
-  if (/2822/.test(backendDateStandard)) {
+  if (parsed.isValid() && /2822/.test(backendDateStandard)) {
     const DATE_RFC2822 = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
-    return parsed.locale('en').format(DATE_RFC2822);
+    return dayjs.tz(value, timeZone).locale('en').format(DATE_RFC2822);
   }
 
   // if a localized string dateformat has been passed, normalize the date first...
   // otherwise, localized strings could be submitted to the backend.
-  const normalizedDate = moment.utc(value, [uiFormat, ...outputFormats]);
+  const normalizedDate = dayjs.utc(value, [uiFormat, ...outputFormats]);
 
-  return new moment(normalizedDate, 'YYYY-MM-DD').locale('en').format(backendDateStandard); // eslint-disable-line
+  return dayjs(normalizedDate, 'YYYY-MM-DD').locale('en').format(backendDateStandard); // eslint-disable-line
 };
 
 const propTypes = {
@@ -122,7 +134,7 @@ const propTypes = {
 
 const getBackendDateStandard = (standard, use) => {
   if (!use) return undefined;
-  if (standard === 'ISO8601') return ['YYYY-MM-DDTHH:mm:ss.sssZ', 'YYYY-MM-DDTHH:mm:ssZ'];
+  if (standard === 'ISO8601') return ['YYYY-MM-DDTHH:mm:ss.SSSZ', 'YYYY-MM-DDTHH:mm:ssZ'];
   if (standard === 'RFC2822') return ['ddd, DD MMM YYYY HH:mm:ss ZZ'];
   return [standard, 'YYYY-MM-DDTHH:mm:ss.sssZ', 'ddd, DD MMM YYYY HH:mm:ss ZZ'];
 };
@@ -186,6 +198,7 @@ const Datepicker = (
       outputFormats: getBackendDateStandard(backendDateStandard, true)
     }) : null
   });
+  const { localeLoaded } = useDynamicLocale({ locale });
   // since updating the Datepair object isn't quite enough to prompt a re-render when its only partially
   // updated, need to maintain a 2nd field containing only the displayed value.
   // this resolves issue with the clearIcon not showing up.
@@ -205,7 +218,10 @@ const Datepicker = (
 
   // handle value changes that originate outside of the component.
   useEffect(() => {
-    if (typeof valueProp !== 'undefined' && valueProp !== datePair.dateString && valueProp !== datePair.formatted) {
+    if (input.current
+      && typeof valueProp !== 'undefined'
+      && valueProp !== datePair.dateString
+      && valueProp !== datePair.formatted) {
       payload.current = Object.assign(payload.current, maybeUpdateValue(valueProp));
       nativeChangeField(input, false, payload.current.dateString);
     }
@@ -222,13 +238,20 @@ const Datepicker = (
       return blankDates;
     }
 
-    // use strict mode to check validity  - incomplete dates, anything not conforming to the format will be invalid
+    let valueMoment;
     const backendStandard = getBackendDateStandard(backendDateStandard, outputBackendValue);
-    const valueMoment = new moment(// eslint-disable-line new-cap
-      value,
-      [format, ...backendStandard], // pass array of possible formats ()
-      true
-    );
+
+    if (containsUTCOffset(value)) {
+      valueMoment = dayjs(value);
+    } else {
+      // use strict mode to check validity  - incomplete dates, anything not conforming to the format will be invalid
+      valueMoment = dayjs(
+        value,
+        [format, ...backendStandard], // pass array of possible formats ()
+        true
+      );
+    }
+
     const isValid = valueMoment.isValid();
 
     let dates;
@@ -258,7 +281,7 @@ const Datepicker = (
         return dates;
       }
       return {};
-    } else if (value !== datePair.dateString) {
+    } else if (value !== datePair.dateString) { // if the date's not valid, we just update the datestring...
       dates = {
         dateString: value,
         formatted: ''
@@ -374,7 +397,7 @@ const Datepicker = (
       <Calendar
         onSetDate={setFromCalendar}
         selectedDate={datePair.dateString}
-        dateFormat={format}
+        dateFormat={[format, ...getBackendDateStandard(backendDateStandard, true)]}
         firstFieldRef={calendarFirstField}
         onFocus={handleInternalFocus}
         onRequestClose={handleRequestClose}
@@ -423,7 +446,7 @@ const Datepicker = (
     );
   };
 
-  const content = (
+  const content = localeLoaded && (
     <div
       className={css.container}
       ref={container}
@@ -436,7 +459,7 @@ const Datepicker = (
         id={testId}
         readOnly={readOnly}
         disabled={disabled}
-        value={datePair.dateString}
+        value={datePair.dateString || ''}
         onChange={internalHandleChange}
         endControl={renderEndElement()}
         hasClearIcon={false}
@@ -451,7 +474,7 @@ const Datepicker = (
         data-test-datepicker-hidden-input
         type="text"
         hidden
-        value={datePair.formatted}
+        value={datePair.formatted || ''}
         onChange={onChangeFormatted}
         ref={hiddenInput}
       />

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -5,7 +5,6 @@ import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
-import contains from 'dom-helpers/query/contains';
 import uniqueId from 'lodash/uniqueId';
 import pick from 'lodash/pick';
 import RootCloseWrapper from '../../util/RootCloseWrapper';
@@ -22,6 +21,15 @@ import { useDynamicLocale } from '../../hooks/useDynamicLocale';
 dayjs.extend(utc);
 dayjs.extend(timezone);
 dayjs.extend(customParseFormat);
+
+// Due to some differentiating behavior between
+// passing a single formats vs an array of formats to Dayjs,
+// we're implementing this utility function...
+// We can probably remove this once https://github.com/iamkun/dayjs/pull/1914 is merged...
+const dateIsParseAble = (value, formats) => ({
+  isValid: formats.some((f) => dayjs.utc(value, f).isValid()),
+  validFormat: formats[formats.findIndex((f) => dayjs(value, f, true).isValid())]
+});
 
 const pickDataProps = (props) => pick(props, (v, key) => key.indexOf('data-test') !== -1);
 
@@ -67,11 +75,7 @@ const defaultParser = (value, timeZone, uiFormat, outputFormats) => {
  */
 export const defaultOutputFormatter = ({ backendDateStandard, value, uiFormat, outputFormats, timeZone }) => {
   if (!value || value === '') { return value; }
-  const parsed = dayjs.utc(value);
-
-  if (parsed.isValid() && /8601/.test(backendDateStandard)) {
-    return parsed.locale('en').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]');
-  }
+  const parsed = dateIsParseAble(value, [uiFormat, ...outputFormats]);
 
   // Use `.locale('en')` before `.format(...)` to get Arabic/"Latn" numerals.
   // otherwise, a locale like ar-SA or any locale with a "-u-nu-..." subtag
@@ -84,15 +88,22 @@ export const defaultOutputFormatter = ({ backendDateStandard, value, uiFormat, o
   // and about how the locale string may be parsed at
   // https://www.rfc-editor.org/rfc/rfc5646.html
 
+  if (parsed.isValid && /8601/.test(backendDateStandard)) {
+    if (timeZone.toLowerCase() === 'utc') {
+      return dayjs.utc(value, parsed.validFormat).locale('en').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]');
+    }
+    return dayjs.tz(value, parsed.validFormat, timeZone).locale('en').toISOString();
+  }
+
   // for support of the RFC2822 format (rare thus far and support may soon be deprecated.)
-  if (parsed.isValid() && /2822/.test(backendDateStandard)) {
+  if (parsed.isValid && /2822/.test(backendDateStandard)) {
     const DATE_RFC2822 = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
-    return dayjs.tz(value, timeZone).locale('en').format(DATE_RFC2822);
+    return dayjs.tz(value, parsed.validFormat, timeZone).locale('en').format(DATE_RFC2822);
   }
 
   // if a localized string dateformat has been passed, normalize the date first...
   // otherwise, localized strings could be submitted to the backend.
-  const normalizedDate = dayjs.utc(value, [uiFormat, ...outputFormats]);
+  const normalizedDate = dayjs.utc(value);
 
   return dayjs(normalizedDate, 'YYYY-MM-DD').locale('en').format(backendDateStandard); // eslint-disable-line
 };
@@ -134,7 +145,7 @@ const propTypes = {
 
 const getBackendDateStandard = (standard, use) => {
   if (!use) return undefined;
-  if (standard === 'ISO8601') return ['YYYY-MM-DDTHH:mm:ss.SSSZ', 'YYYY-MM-DDTHH:mm:ssZ'];
+  if (standard === 'ISO8601') return ['YYYY-MM-DDTHH:mm:ss.SSS[Z]', 'YYYY-MM-DDTHH:mm:ss[Z]'];
   if (standard === 'RFC2822') return ['ddd, DD MMM YYYY HH:mm:ss ZZ'];
   return [standard, 'YYYY-MM-DDTHH:mm:ss.sssZ', 'ddd, DD MMM YYYY HH:mm:ss ZZ'];
 };

--- a/lib/Datepicker/tests/Datepicker-test.js
+++ b/lib/Datepicker/tests/Datepicker-test.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { describe, beforeEach, afterEach, it } from 'mocha';
 import { expect } from 'chai';
-import moment from 'moment';
-import 'moment/locale/ar';
-import 'moment/locale/fr';
+import dayjs from 'dayjs';
+import 'dayjs/locale/ar';
+import 'dayjs/locale/fr';
 
 import {
   Datepicker as Interactor,
@@ -471,7 +471,7 @@ describe('Datepicker', () => {
   // the same test is below with a Latn locale (fr) instead of
   // an Arab one (ar) since that seems to be the deciding factor.
   describe.skip('defaultOutputFormatter converts non-Latn input to Latn-output', () => {
-    const arm = moment().locale('ar');
+    const arm = dayjs().locale('ar');
 
     let output;
     const value = arm.format('2021/07/11');
@@ -492,7 +492,7 @@ describe('Datepicker', () => {
 
   // see above; this doesn't really convert non-Latn to Latn
   describe('defaultOutputFormatter converts non-en input to Latn-output', () => {
-    const frm = moment().locale('fr');
+    const frm = dayjs().locale('fr');
 
     let output;
     const value = frm.format('2021/07/11');
@@ -512,7 +512,7 @@ describe('Datepicker', () => {
   });
 
   describe('defaultOutputFormatter provides RFC-2822 output', () => {
-    const frm = moment().locale('en');
+    const frm = dayjs().locale('en');
 
     let output;
     const value = frm.format('2021-07-12 14:15:16');
@@ -533,7 +533,7 @@ describe('Datepicker', () => {
   });
 
   describe('defaultOutputFormatter provides ISO-8601 output', () => {
-    const frm = moment().locale('en');
+    const frm = dayjs().locale('en');
 
     let output;
     const value = frm.format('2021-07-12T14:15:16+00:00');

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -1,7 +1,11 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
-import moment from 'moment-timezone';
+import dayjs from 'dayjs';
+import localeData from 'dayjs/plugin/localeData';
+import utc from 'dayjs/plugin/utc';
+import timeZone from 'dayjs/plugin/timezone';
+import objectSupport from 'dayjs/plugin/objectSupport';
 import { uniqueId } from 'lodash';
 import FormField from '../FormField';
 import TextField from '../TextField';
@@ -14,6 +18,10 @@ import parseMeta from '../FormField/parseMeta';
 import nativeChangeFieldValue from '../../util/nativeChangeFieldValue';
 import { getLocaleDateFormat } from '../../util/dateTimeUtils';
 
+dayjs.extend(localeData);
+dayjs.extend(utc);
+dayjs.extend(timeZone);
+dayjs.extend(objectSupport);
 // supplied a list of formats, moment will use the FIRST format in the list
 // that can be successfully parsed.
 const twelveHourFormats = ['h:mm A', 'h:mm ', 'h:mm', 'h'];
@@ -40,10 +48,10 @@ const defaultParser = (value, timezone, timeFormat, intl) => { // eslint-disable
     // moment.tz(value, 'HH:mm:ss.sssZ', timezone);
     // with expected format(s) as the 2nd parameter
 
-    const dateString = moment().format('YYYY-MM-DD');
-    time = moment.tz(`${dateString}T${value}`, timezone);
+    const dateString = dayjs().format('YYYY-MM-DD');
+    time = dayjs.tz(`${dateString}T${value}`, timezone);
   } else {
-    time = moment(value, timeFormat, timezone);
+    time = dayjs(value, timeFormat, timezone);
   }
 
   // entered value that's fewer characters than the expected format will pass through..
@@ -54,9 +62,9 @@ const defaultParser = (value, timezone, timeFormat, intl) => { // eslint-disable
 // Not all parameter keys may be used in this function, but they are provided as a convenience for
 // overrides to the props using this as default.
 const defaultOutputFormatter = ({ value, formats, timezone = 'utc', intl }) => { // eslint-disable-line no-unused-vars
-  let isoTime = moment.utc(value, formats);
+  let isoTime = dayjs.utc(value, formats);
   if (timezone !== 'utc') {
-    isoTime = moment.tz(value, formats, timezone);
+    isoTime = dayjs.tz(value, formats, timezone);
   }
   if (isoTime.isValid()) {
     isoTime = isoTime.toISOString();
@@ -168,7 +176,7 @@ const Timepicker = ({
     }
   }, [valueProp, maybeUpdateValue, timePair.timeString, timePair.formatted]);
 
-  moment.locale(locale || intl.locale);
+  dayjs.locale(locale || intl.locale);
 
   /*  maybeUpdateValue
   *   runs on all changes to the main input and value props to parse
@@ -192,10 +200,10 @@ const Timepicker = ({
     */
     const additionalTimeFormats = timeFormat.includes('A') ? twelveHourFormats : twentyFourHourFormats;
     if (containsUTCOffset(value)) {
-      valueTimeObject = moment.utc(value, [timeFormat, ...additionalTimeFormats]).local();
+      valueTimeObject = dayjs.utc(value, [timeFormat, ...additionalTimeFormats]).local();
     } else {
       // use strict mode to check validity  - incomplete dates, anything not conforming to the format will be invalid
-      valueTimeObject = moment(
+      valueTimeObject = dayjs(
         value,
         [timeFormat],
         true
@@ -295,7 +303,7 @@ const Timepicker = ({
   // setting the time in the input from the values in the time dropdown
   const handlePickTime = ({ hour, minute, period, dayPeriods }) => {
     const adjustedHour = dayPeriods ? convertTo24hr(hour, period, dayPeriods) : hour;
-    const displayTime = moment({ hour: adjustedHour, minute }).format(timeFormat);
+    const displayTime = dayjs({ hour: adjustedHour, minute }).format(timeFormat);
     nativeChangeFieldValue(input, true, displayTime);
     setShowDropdown(false);
   };

--- a/lib/Timepicker/Timepicker.js
+++ b/lib/Timepicker/Timepicker.js
@@ -22,10 +22,12 @@ dayjs.extend(localeData);
 dayjs.extend(utc);
 dayjs.extend(timeZone);
 dayjs.extend(objectSupport);
-// supplied a list of formats, moment will use the FIRST format in the list
+// supplied a list of formats,
+// dayjs - non-strict- will use the FIRST matching format in the list
+// dayjs - strict mode - will use the LONGEST matching format in the list
 // that can be successfully parsed.
-const twelveHourFormats = ['h:mm A', 'h:mm ', 'h:mm', 'h'];
-const twentyFourHourFormats = ['HH:mm', 'H:mm', 'H'];
+const twelveHourFormats = ['h:mm A'];
+const twentyFourHourFormats = ['HH:mm'];
 
 const containsUTCOffset = (value) => {
   const offsetRegex = /T[\d.:]+[+-][\d]+$/;
@@ -49,9 +51,14 @@ const defaultParser = (value, timezone, timeFormat, intl) => { // eslint-disable
     // with expected format(s) as the 2nd parameter
 
     const dateString = dayjs().format('YYYY-MM-DD');
-    time = dayjs.tz(`${dateString}T${value}`, timezone);
+    // time = dayjs.tz(`${dateString}T${value}`, timezone);
+    time = dayjs(`${dateString}T${value}`).tz(timezone);
   } else {
-    time = dayjs(value, timeFormat, timezone);
+    // input values of 0 or 0:0 will be denied by dayjs, so avoid passing those.
+    if ('00:00'.includes(value)) {
+      return value;
+    }
+    time = dayjs.tz(value, timeFormat, timezone);
   }
 
   // entered value that's fewer characters than the expected format will pass through..
@@ -62,9 +69,14 @@ const defaultParser = (value, timezone, timeFormat, intl) => { // eslint-disable
 // Not all parameter keys may be used in this function, but they are provided as a convenience for
 // overrides to the props using this as default.
 const defaultOutputFormatter = ({ value, formats, timezone = 'utc', intl }) => { // eslint-disable-line no-unused-vars
-  let isoTime = dayjs.utc(value, formats);
+  // input values of 0 or 0:0 will be denied by dayjs, so avoid passing those.
+  if ('00:00'.includes(value)) {
+    return ''
+  }
+  let isoTime = dayjs.utc(value, formats[0]);
   if (timezone !== 'utc') {
-    isoTime = dayjs.tz(value, formats, timezone);
+    // isoTime = dayjs.tz(value, formats, timezone);
+    isoTime = dayjs.tz(value, formats[0], timezone, true);
   }
   if (isoTime.isValid()) {
     isoTime = isoTime.toISOString();
@@ -205,7 +217,7 @@ const Timepicker = ({
       // use strict mode to check validity  - incomplete dates, anything not conforming to the format will be invalid
       valueTimeObject = dayjs(
         value,
-        [timeFormat],
+        [timeFormat, ...additionalTimeFormats],
         true
       );
     }

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -41,7 +41,7 @@ const isDST = function () {
   return new Date().getTimezoneOffset() < stdTimezoneOffset();
 }
 
-describe.only('Timepicker', () => {
+describe('Timepicker', () => {
   const timepicker = TimepickerInteractor();
   const timeDropdown = TimepickerDropdownInteractor();
 
@@ -205,7 +205,7 @@ describe.only('Timepicker', () => {
     });
   });
 
-  describe.only('selecting a time with timeZone prop (Los Angeles) (RFF)', () => {
+  describe('selecting a time with timeZone prop (Los Angeles) (RFF)', () => {
     const tz = 'America/Los_Angeles';
     const testTime = isDST() ? '00:00:00.000Z' : '01:00:00.000Z';
     let timeOutput = '';
@@ -220,7 +220,7 @@ describe.only('Timepicker', () => {
         />
       );
 
-      await timepicker.fillIn('05:00 P');
+      await timepicker.fillIn('5:00 PM');
     });
 
     it('emits an event with the time accounting for timezone', () => HTML({ id: 'state-time', text: testTime }).exists());
@@ -245,7 +245,7 @@ describe.only('Timepicker', () => {
         />
       );
 
-      await timepicker.fillIn('04:20 P');
+      await timepicker.fillIn('4:20 PM');
     });
 
     it('emits an event with the time accounting for timezone', () => HTML({ id: 'state-time', text: testTime }).exists());
@@ -258,7 +258,7 @@ describe.only('Timepicker', () => {
   describe('parsing a time with timeZone prop (Barbados) (RFF)', () => {
     const tz = 'America/Barbados';
     const testTime = isDST() ? '15:20:00.000Z' : '16:20:00.000Z';
-    const expectedTime = dayjs.tz(testTime, 'HH:mm:ss.sssZ', tz).format('h:mm A');
+    const expectedTime = dayjs(testTime, 'HH:mm:ss.sssZ').tz(tz).format('h:mm A');
     beforeEach(async () => {
       await mountWithContext(
         <TimepickerHarness

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import { describe, beforeEach, it } from 'mocha';
 import { expect } from 'chai';
-import moment from 'moment-timezone';
+// import moment from 'moment-timezone';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import localeData from 'dayjs/plugin/localeData';
+import timeZone from 'dayjs/plugin/timezone';
+
 import {
   runAxeTest,
   Button,
@@ -22,8 +27,21 @@ import {
   TimeDropdown as TimepickerDropdownInteractor
 } from './timepicker-interactor-bt';
 
+dayjs.extend(localeData);
+dayjs.extend(utc);
+dayjs.extend(timeZone);
 
-describe('Timepicker', () => {
+const stdTimezoneOffset = function () {
+  const jan = new Date(new Date().getFullYear(), 0, 1);
+  const jul = new Date(new Date().getFullYear(), 6, 1);
+  return Math.max(jan.getTimezoneOffset(), jul.getTimezoneOffset());
+}
+
+const isDST = function () {
+  return new Date().getTimezoneOffset() < stdTimezoneOffset();
+}
+
+describe.only('Timepicker', () => {
   const timepicker = TimepickerInteractor();
   const timeDropdown = TimepickerDropdownInteractor();
 
@@ -45,7 +63,7 @@ describe('Timepicker', () => {
     });
 
     it('displays the time dropdown', () => timeDropdown.exists());
-    it('displays the current time in the time dropdown', () => timeDropdown.has({ hour: parseInt(moment().format('h'), 10), minute: parseInt(moment().format('mm'), 10) }));
+    it('displays the current time in the time dropdown', () => timeDropdown.has({ hour: parseInt(dayjs().format('h'), 10), minute: parseInt(dayjs().format('mm'), 10) }));
   });
 
   describe('selecting a time', () => {
@@ -151,7 +169,7 @@ describe('Timepicker', () => {
 
   describe('parsing a value prop with a time offset (usually from backend)', () => {
     const testTime = '10:00:00.000Z';
-    const expectedTime = moment.utc(testTime, 'HH:mm:ss.sssZ').format('H:mm A');
+    const expectedTime = dayjs.utc(testTime, 'HH:mm:ss.sssZ').format('H:mm A');
     beforeEach(async () => {
       await mountWithContext(
         <Timepicker
@@ -166,7 +184,7 @@ describe('Timepicker', () => {
 
   describe('Application level behavior', () => {
     const initialTime = '10:00:00.000Z';
-    const expectedTime = moment.utc(initialTime, 'HH:mm:ss.sssZ').format('H:mm A');
+    const expectedTime = dayjs.utc(initialTime, 'HH:mm:ss.sssZ').format('H:mm A');
     beforeEach(async () => {
       await mountWithContext(
         <TimepickerHarness
@@ -187,9 +205,9 @@ describe('Timepicker', () => {
     });
   });
 
-  describe('selecting a time with timeZone prop (Los Angeles) (RFF)', () => {
+  describe.only('selecting a time with timeZone prop (Los Angeles) (RFF)', () => {
     const tz = 'America/Los_Angeles';
-    const testTime = moment().tz(tz).isDST() ? '00:00:00.000Z' : '01:00:00.000Z';
+    const testTime = isDST() ? '00:00:00.000Z' : '01:00:00.000Z';
     let timeOutput = '';
     beforeEach(async () => {
       timeOutput = '';
@@ -214,7 +232,7 @@ describe('Timepicker', () => {
 
   describe('selecting a time with timeZone prop (Barbados) (RFF)', () => {
     const tz = 'America/Barbados';
-    const testTime = moment().tz(tz).isDST() ? '19:20:00.000Z' : '20:20:00.000Z';
+    const testTime = isDST() ? '19:20:00.000Z' : '20:20:00.000Z';
     let timeOutput;
     beforeEach(async () => {
       timeOutput = '';
@@ -239,8 +257,8 @@ describe('Timepicker', () => {
 
   describe('parsing a time with timeZone prop (Barbados) (RFF)', () => {
     const tz = 'America/Barbados';
-    const testTime = moment().tz(tz).isDST() ? '15:20:00.000Z' : '16:20:00.000Z';
-    const expectedTime = moment.tz(testTime, 'HH:mm:ss.sssZ', tz).format('h:mm A');
+    const testTime = isDST() ? '15:20:00.000Z' : '16:20:00.000Z';
+    const expectedTime = dayjs.tz(testTime, 'HH:mm:ss.sssZ', tz).format('h:mm A');
     beforeEach(async () => {
       await mountWithContext(
         <TimepickerHarness
@@ -256,7 +274,7 @@ describe('Timepicker', () => {
   describe('parsing a time with timeZone prop (UTC) (RFF)', () => {
     const tz = 'UTC';
     const testTime = '15:20:00.000Z';
-    const expectedTime = moment.tz(testTime, 'HH:mm:ss.sssZ', tz).format('h:mm A');
+    const expectedTime = dayjs.tz(testTime, 'HH:mm:ss.sssZ', tz).format('h:mm A');
     beforeEach(async () => {
       await mountWithContext(
         <TimepickerHarness
@@ -271,7 +289,7 @@ describe('Timepicker', () => {
 
   describe('Timedropdown', () => {
     const initialTime = '10:00:00.000Z';
-    const expectedTime = moment.utc(initialTime, 'HH:mm:ss.sssZ').format('H:mm A');
+    const expectedTime = dayjs.utc(initialTime, 'HH:mm:ss.sssZ').format('H:mm A');
     beforeEach(async () => {
       await mountWithContext(
         <div>

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "@folio/stripes-react-hotkeys": "^3.0.5",
     "classnames": "^2.2.5",
     "currency-codes": "^2.1.0",
+    "dayjs": "^1.11.10",
     "downshift": "^2.0.16",
     "flexboxgrid2": "^7.2.0",
     "hoist-non-react-statics": "^3.1.0",


### PR DESCRIPTION
For many instances, `dayJS` is a drop-in replacement for `moment` . There are a handful of differences when dealing with time/timezones.

Most notably was a `dayjs` bug for the `utc` plugin when an array of possible formats are provided - the resulting datetime bakes in an offset. This is due to an issue that's surfaced in a [dayJS PR](https://github.com/iamkun/dayjs/pull/1914) - but this shouldn't affect most FOLIO usage at the app level, as that level tends to deal with dates or times exclusinvely in the ISO8601 format if not just a plain string. Further, it was easy enough to circumvent with a small utility method to check the array of intended formats individually.

Additionally was a local implementation of a dayjs range - simply just an array of dayjs objects vs the npm import `moment-range`. There is a [dayJS issue](https://github.com/iamkun/dayjs/issues/1162) for this with some ideas included.

