### PR TITLE
Update ConfirmationModal prop types/documentation

### DIFF
--- a/lib/ConfirmationModal/ConfirmationModal.js
+++ b/lib/ConfirmationModal/ConfirmationModal.js
@@ -16,7 +16,7 @@ const propTypes = {
   cancelButtonStyle: PropTypes.string,
   cancelLabel: PropTypes.node,
   confirmLabel: PropTypes.node,
-  heading: PropTypes.node.isRequired,
+  heading: PropTypes.string.isRequired,
   id: PropTypes.string,
   isConfirmButtonDisabled: PropTypes.bool,
   message: PropTypes.oneOfType([

--- a/lib/ConfirmationModal/readme.md
+++ b/lib/ConfirmationModal/readme.md
@@ -38,7 +38,7 @@ handleSubmit() {
 
 Name | type | description | default | required
 --- | --- | --- | --- | ---
-heading | node | Content to appear as the modal's H1 tag. Doubles as the modal's ARIA-label |  | &#10004;
+heading | string | String to appear as the modal's H1 tag. Doubles as the modal's ARIA-label |  | &#10004;
 message | node or array of nodes | Renderable content rendered within a `<p>` tag. |  |
 open | bool | Boolean reflecting modal's open/closed status |  | &#10004;
 cancelLabel | node | String to render on the Cancel action. | "Cancel" |

--- a/lib/ConfirmationModal/readme.md
+++ b/lib/ConfirmationModal/readme.md
@@ -43,6 +43,8 @@ message | node or array of nodes | Renderable content rendered within a `<p>` ta
 open | bool | Boolean reflecting modal's open/closed status |  | &#10004;
 cancelLabel | node | String to render on the Cancel action. | "Cancel" |
 confirmLabel | node | String to render on the Submit action. | "Submit" |
+buttonStyle | [button style](https://github.com/folio-org/stripes-components/tree/master/lib/Button#colors) | Style of the Submit action button. | `primary` |
+cancelButtonStyle | [button style](https://github.com/folio-org/stripes-components/tree/master/lib/Button#colors) | Style of the Cancel action button. | `default` |
 onConfirm | func | Callback fired when the Submit button is clicked |  | &#10004;
 onCancel | func | Callback fired when the Cancel button is clicked |  | &#10004;
 bodyTag | string | String to set the HTML tag used to wrap the modal message | "p" |

--- a/lib/ConfirmationModal/readme.md
+++ b/lib/ConfirmationModal/readme.md
@@ -41,8 +41,8 @@ Name | type | description | default | required
 heading | string | String to appear as the modal's H1 tag. Doubles as the modal's ARIA-label |  | &#10004;
 message | node or array of nodes | Renderable content rendered within a `<p>` tag. |  |
 open | bool | Boolean reflecting modal's open/closed status |  | &#10004;
-cancelLabel | string | String to render on the Cancel action. | "Cancel" |
-confirmLabel | string | String to render on the Submit action. | "Submit" |
+cancelLabel | node | String to render on the Cancel action. | "Cancel" |
+confirmLabel | node | String to render on the Submit action. | "Submit" |
 onConfirm | func | Callback fired when the Submit button is clicked |  | &#10004;
 onCancel | func | Callback fired when the Cancel button is clicked |  | &#10004;
 bodyTag | string | String to set the HTML tag used to wrap the modal message | "p" |

--- a/lib/ConfirmationModal/readme.md
+++ b/lib/ConfirmationModal/readme.md
@@ -38,7 +38,7 @@ handleSubmit() {
 
 Name | type | description | default | required
 --- | --- | --- | --- | ---
-heading | string | String to appear as the modal's H1 tag. Doubles as the modal's ARIA-label |  | &#10004;
+heading | node | Content to appear as the modal's H1 tag. Doubles as the modal's ARIA-label |  | &#10004;
 message | node or array of nodes | Renderable content rendered within a `<p>` tag. |  |
 open | bool | Boolean reflecting modal's open/closed status |  | &#10004;
 cancelLabel | node | String to render on the Cancel action. | "Cancel" |


### PR DESCRIPTION
This fixes the following:
- button labels allow `node`s (via prop-types and the code itself defaults to `<FormattedMessage>` nodes), so the README must be updated
- `heading` is limited to a `string` since it's used as an aria-label; the prop-types must be updated
- `buttonStyle` and `cancelButtonStyle` were undocumented.