### PR TITLE
Fix Popper documentation consistency

### DIFF
--- a/lib/Popper/Popper.js
+++ b/lib/Popper/Popper.js
@@ -18,6 +18,8 @@ export const AVAILABLE_PLACEMENTS = [
   'right-start',
   'right-end',
   'auto',
+  'auto-start',
+  'auto-end',
 ];
 
 const [DEFAULT_PLACEMENT] = AVAILABLE_PLACEMENTS;

--- a/lib/Popper/readme.md
+++ b/lib/Popper/readme.md
@@ -26,4 +26,7 @@ placement | string | Overlay placement. Available values: `auto`, `top`, `bottom
 portal | node | When is provided, overlay renders inside provided portal. | | |
 anchorRef | object | Reference to anchor element |  | yes |
 children | component | Component to be passed as an overlay |  | yes |
-modifiers | object | A set of modifications for extending popper functionality. For more details, please, go to https://popper.js.org/popper-documentation.html#modifiers. | | |
+modifiers | object | A set of modifications for extending popper functionality. For more details, please, [see the Popper.js docs](https://popper.js.org/docs/v1/#modifiers). | | |
+hideIfClosed | boolean | Hides the overlay if the popper is closed (via `display: none`), rather than removing it from the DOM entirely | false | |
+overlayProps | object | Props to add to the `<div>` used as the overlay | `{}` | |
+overlayRef | ref | Grabs a reference for the overlay `<div>` | | |


### PR DESCRIPTION
There are several props available to the `Popper` component which were not documented in the README.

Additionally, the placements `auto-start` and `auto-end` were missing from the `AVAILABLE_PLACEMENTS` array, despite being valid (looks like I missed these in https://github.com/folio-org/stripes-components/pull/2004, whoops).