### PR TITLE
Fix timepicker tests

### DIFF
--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -202,7 +202,7 @@ describe('Timepicker', () => {
         />
       );
 
-      await timepicker.fillIn('05:00 P');
+      await timepicker.fillIn('5:00 P');
     });
 
     it('emits an event with the time accounting for timezone', () => HTML({ id: 'state-time', text: testTime }).exists());
@@ -227,7 +227,7 @@ describe('Timepicker', () => {
         />
       );
 
-      await timepicker.fillIn('04:20 P');
+      await timepicker.fillIn('4:20 P');
     });
 
     it('emits an event with the time accounting for timezone', () => HTML({ id: 'state-time', text: testTime }).exists());


### PR DESCRIPTION
Looks like moment got a bit more strict when handling single digit vs double digit parsing of time values, https://github.com/moment/moment/pull/5592

Tests, in this case, were testing with a value that didn't exactly match the format anyhow, so they were a bit unrealistic to start with.

If this causes more grief than this, we might have to consider locking to moment v2.29.4 :/
