### PR TITLE
Update TextLink README

### DIFF
--- a/lib/TextLink/readme.md
+++ b/lib/TextLink/readme.md
@@ -2,35 +2,45 @@
 A replacement for the native `<a>` and the react-router-dom `<TextLink>`-component with a11y friendly interaction styles.
 
 ## Usage
-```js
-import { TextLink } from '@folio/stripes/components';
-
+```jsx
 <TextLink to="/users">
-  I'm an internal link
+  I am an internal link
 </TextLink>
+```
 
+```jsx
 <TextLink target="_blank" rel="noopener noreferrer" href="https://folio.org">
-  I'm an external link
+  I am an external link
+</TextLink>
+```
+
+```jsx
+<TextLink element="button" onClick={() => doSomething()}>
+  I am a button element!
 </TextLink>
 ```
 
 ## Props
 Name | Type | Description
 -- | -- | --
-children | node | The content of the component |
-to | string | The path to a page. This renders the react-router-dom `<Link>`-component internally. |
-href | string | The url for a web page. Renders a native `<a>`. Use the `to`-prop for routing. |
+children | node, func | The content of the component.  Function form takes the root className as an argument; see below
+className | string | Adds a class name to the component
+element | string, func | Uses a custom element via tag name or component
+to | string | The path to a page. This renders the react-router-dom `<Link>`-component internally.
+href | string | The url for a web page. Renders a native `<a>`. Use the `to`-prop for routing.
 
-The remaining props are passed onto the root element of the component. This component also supports passing a `ref` and 
-the ability to apply a root CSS class to the child element. Now, the TextLink component supports the object parameter 
-`className` and applying a root CSS class to the child element. This change was made to ensure correct inheritance of styles, 
-especially in cases where the children are inline elements with display: inline-flex, and the underline is not inherited.
-```js
+Additional props are passed onto the root element of the component. This component also supports passing a `ref` and 
+the ability to apply a root CSS class to the child element.
+
+To pass the root CSS class to the child element, pass a render function as the child. This change was made to ensure correct
+inheritance of styles,  especially in cases where the children are inline elements with `display: inline-flex`, and the
+underline is not inherited.
+```jsx
 // In the case that direct style application is required, a child function can be used.
 <TextLink to="/users" ref={yourRefCallback}>
   {({ className }) => (
     <span className={className}>
-      I'm an internal link with custom styles
+      I am an internal link with custom styles
     </span>
   )}
 </TextLink>


### PR DESCRIPTION
This adds a new example and a few missing props to the readme of `<TextLink>`