### PR TITLE
Update AdvancedSearch prop documentation

### DIFF
--- a/lib/AdvancedSearch/AdvancedSearch.js
+++ b/lib/AdvancedSearch/AdvancedSearch.js
@@ -10,7 +10,7 @@ import defaultRowFormatter from './utilities/defaultRowFormatter';
 import { ROW_COUNT } from './constants';
 
 const propTypes = {
-  children: PropTypes.func.isRequired,
+  children: PropTypes.func,
   defaultSearchOptionValue: PropTypes.string,
   firstRowInitialSearch: PropTypes.shape({
     option: PropTypes.string,

--- a/lib/AdvancedSearch/readme.md
+++ b/lib/AdvancedSearch/readme.md
@@ -131,7 +131,7 @@ onCancel | func | Callback fired when the user clicks the cancel button. | true
 defaultSearchOptionValue | string | One of the options in `searchOptions` that will be selected by default in all rows | false
 firstRowInitialSearch | object | Object with shape `{ query, option }` - will be used to populate first row with default values | false
 hasMatchSelection | boolean | Show/hide search match option dropdown | false
-hasQueryOption | boolean | Controls whether `Query` search option should be appended to search options list | true
+hasQueryOption | boolean | Controls whether `Query` search option should be appended to search options list | false
 rowFormatter | func | Function that will be used to combine boolean, query and search option of each row. Signature: `(searchOption, query, bool, comparator) => {...}`. Returned values will be used by `queryBuilder` to join them together. *Note:* no need to add `bool` to resulting string here - it will be added by `queryBuilder`. | false
 queryBuilder | func | Function that will be used to construct the search query. Signature: `(rows, rowFormatter) => {...}`. `rows` - array of shapes `{ query, searchOption, query }`, `rowFormatter` - the prop. Returned value will be passed as the first argument to `onSearch`. | false
 queryToRow | func | Function that will be used to parse a query string into a row object. | false

--- a/lib/AdvancedSearch/readme.md
+++ b/lib/AdvancedSearch/readme.md
@@ -130,7 +130,7 @@ onSearch | func | Callback fired when search is performed. Called with two argum
 onCancel | func | Callback fired when the user clicks the cancel button. | true
 defaultSearchOptionValue | string | One of the options in `searchOptions` that will be selected by default in all rows | false
 firstRowInitialSearch | object | Object with shape `{ query, option }` - will be used to populate first row with default values | false
-hasMatchSelection | boolean | Show/hide search match option dropdown | true
+hasMatchSelection | boolean | Show/hide search match option dropdown | false
 hasQueryOption | boolean | Controls whether `Query` search option should be appended to search options list | true
 rowFormatter | func | Function that will be used to combine boolean, query and search option of each row. Signature: `(searchOption, query, bool, comparator) => {...}`. Returned values will be used by `queryBuilder` to join them together. *Note:* no need to add `bool` to resulting string here - it will be added by `queryBuilder`. | false
 queryBuilder | func | Function that will be used to construct the search query. Signature: `(rows, rowFormatter) => {...}`. `rows` - array of shapes `{ query, searchOption, query }`, `rowFormatter` - the prop. Returned value will be passed as the first argument to `onSearch`. | false


### PR DESCRIPTION
- Children is not required (listed as optional in README and the code performs a ternary to fail-safe if it's missing)
- `hasMatchSelection` and `hasQueryOption` both have default props, so should be denoted as optional in the README