### PR TITLE
STCOM-1238 Accordions - apply content  z-index in reverse-registration order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * TextLink - underline showing up on nested spans with 'display: inline-flex'. Refs STCOM-1226.
 * Use the default search option instead of an unsupported one in Advanced search. Refs STCOM-1242.
 * Added support for clear icon in `<TextArea>`. Refs STCOM-1240.
+* Bug fix for Accordion content z-index rendering. Refs STCOM-1238.
 
 ## [12.0.0](https://github.com/folio-org/stripes-components/tree/v12.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v11.0.0...v12.0.0)

--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -9,7 +9,6 @@ import {
 import { DefaultAccordionHeader } from './headers';
 import css from './Accordion.css';
 import { HotKeys } from '../HotKeys';
-import useClickOutside from '../../hooks/useClickOutside';
 import { withAccordionSet } from './AccordionSetContext';
 import omitProps from '../../util/omitProps';
 
@@ -102,8 +101,8 @@ const Accordion = (props) => {
 
   const getRef = useRef(() => toggle.current).current;
   const [isOpen, updateOpen] = useState(open || !closedByDefault);
-  const [focused, updateFocus] = useState(false);
-  const [registered, updateRegistered] = useState(!Boolean(accordionSet));
+  const [registered, updateRegistered] = useState(!accordionSet);
+  const [stackOrder, updateStackOrder] = useState(1);
 
   const uncontrolledToggle = useRef(() => {
     updateOpen(current => !current);
@@ -126,21 +125,20 @@ const Accordion = (props) => {
   }, [open]);
 
   useEffect(() => { // eslint-disable-line
+    function registrationCallback(isRegistered) {
+      updateRegistered(isRegistered);
+      if (accordionSet) {
+        updateStackOrder(accordionSet.getStackOrder(trackingId));
+      }
+    }
+
     if (accordionSet) {
-      accordionSet.registerAccordion(getRef, trackingId, closedByDefault, updateRegistered);
+      accordionSet.registerAccordion(getRef, trackingId, closedByDefault, registrationCallback);
       return () => {
         accordionSet.unregisterAccordion(trackingId);
       };
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const handleFocus = () => updateFocus(true);
-
-  // use click outside instead of blur
-  // blur has issues with clicking on scroll bars, where event's target is
-  // the whole document instead of the scrollable content. because of this we can't
-  // use blur to determine whether user clicked inside the accordion component tree
-  useClickOutside(content, (e, isOutside) => updateFocus(!isOutside));
 
   const accordionHeaderProps = Object.assign({}, omitProps(props, ['contentHeight']), {
     contentId,
@@ -168,14 +166,13 @@ const Accordion = (props) => {
       >
         {headerElement}
       </HotKeys>
-      <div className={getWrapClass(isOpen)} style={{ zIndex: focused ? '2' : '1' }}>
+      <div className={getWrapClass(isOpen)} style={{ zIndex: stackOrder }}>
         <div
           role="region"
           className={getContentClass(isOpen)}
           ref={setContentRef}
           id={contentId}
           aria-labelledby={labelId}
-          onFocus={handleFocus}
           style={contentHeight ? { height: contentHeight } : null}
           data-test-accordion-wrapper
         >

--- a/lib/Accordion/AccordionSet.js
+++ b/lib/Accordion/AccordionSet.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import indexOf from 'lodash/indexOf';
 import omit from 'lodash/omit';
 import noop from 'lodash/noop';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { Provider as AccProvider } from './AccordionSetContext';
 import AccordionStatus from './AccordionStatus';
@@ -59,6 +60,8 @@ class AccordionSet extends React.Component {
     };
 
     this.innerStatus = React.createRef();
+    this.stackedOrder = React.createRef();
+    this.stackedOrder.current = [];
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -97,6 +100,12 @@ class AccordionSet extends React.Component {
 
   focusLastAccordion() {
     this.state.accordionList[this.state.accordionList.length - 1].getRef().focus();
+  }
+
+  getStackOrder = (id) => {
+    const { accordionList } = this.state;
+    const index = accordionList.findIndex(a => a.id === id);
+    return accordionList.length - index;
   }
 
   registerAccordion = (getRef, id, closedByDefault = false, confirm) => {
@@ -187,7 +196,8 @@ class AccordionSet extends React.Component {
                   unregisterAccordion: this.unregisterAccordion,
                   handleToggle: onToggleProp || onToggle,
                   toggleKeyHandlers: this.toggleKeyHandlers,
-                  toggleKeyMap: this.toggleKeyMap
+                  toggleKeyMap: this.toggleKeyMap,
+                  getStackOrder: this.getStackOrder,
                 }
               }}
             >

--- a/lib/Accordion/AccordionSet.js
+++ b/lib/Accordion/AccordionSet.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import indexOf from 'lodash/indexOf';
 import omit from 'lodash/omit';
 import noop from 'lodash/noop';
-import cloneDeep from 'lodash/cloneDeep';
 
 import { Provider as AccProvider } from './AccordionSetContext';
 import AccordionStatus from './AccordionStatus';
@@ -60,8 +59,6 @@ class AccordionSet extends React.Component {
     };
 
     this.innerStatus = React.createRef();
-    this.stackedOrder = React.createRef();
-    this.stackedOrder.current = [];
   }
 
   componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
### Problem 
Toggling accordions with open overlay components can cause z-index fighting of content and subsequent accordion headers.

### Approach
Render the content of accordions with stepping z-index - top accordion gets the highest and the last gets a z-index of 1. This keeps the content rendered in front of headers and content from subsequent accordions.

Accordions do *usually get registered in `BoundingClientRect.top` order with standard registration - but if any similar problem does re-appear, we can apply some more intensive sorting logic on the accordions.

Bonus points - we lose some state tracking/updating with the 'focus' events, which were inadequate for maintaining a dynamic z-index.

Before:
![accordion-z-fix-before](https://github.com/folio-org/stripes-components/assets/20704067/598441d0-d06f-42ed-9e9f-ae60dcdf47fa)


After:
![accordion-z-fix-after](https://github.com/folio-org/stripes-components/assets/20704067/db4324e8-22ed-4063-8301-c5c74ab8b63e)
