### PR TITLE
STCOM-1256: Show action buttons in correct color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Bug fix for Accordion content z-index rendering. Refs STCOM-1238.
 * Format aria attributes in `<Icon>`. Refs STCOM-1165.
 * Upgrade `stylelint` and fix errors. Refs STCOM-1087.
+* Show action buttons in correct color. Refs STCOM-1256.
 
 ## [12.0.0](https://github.com/folio-org/stripes-components/tree/v12.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v11.0.0...v12.0.0)

--- a/lib/sharedStyles/interactionStyles.css
+++ b/lib/sharedStyles/interactionStyles.css
@@ -26,7 +26,7 @@
 /**
  * Disabled state
  */
-.interactionStylesControl:disabled > .interactionStyles
+.interactionStylesControl:disabled > .interactionStyles,
 .interactionStyles:disabled {
   opacity: 0.65;
   cursor: default;


### PR DESCRIPTION
## Purpose
Show action buttons in correct color

## Refs
https://issues.folio.org/browse/STCOM-1256

## Approach
Revert removing comma that was removed by mistake in https://github.com/folio-org/stripes-components/pull/2212/files#diff-a346a5e30d164673f59d1283343c9ba1b507f01e94e09b325ad2ac4fffedc6e6L29