### PR TITLE
CSP2 - cherry-pick mcl fix from master/STCOM-1262

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for stripes-components
 
+## In-progress
+
+* MCL loading bugfix - Refs STCOM-1262.
+
+
 ## [12.0.4](https://github.com/folio-org/stripes-components/tree/v12.0.4) (2023-11-10)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.0.3...v12.0.4)
 

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -435,10 +435,12 @@ class MCLRenderer extends React.Component {
 
     const checkValue = parseInt(Object.keys(contentData).length, 10);
 
-    if (newState.isSparse && receivedRows !== checkValue) {
+    if (receivedRows !== checkValue) {
       newState.receivedRows = checkValue;
       newState.loading = false;
+    }
 
+    if (newState.isSparse && receivedRows !== checkValue) {
       // for paging via slice-at-a-time sparse arrays (and prev/next pagination);
       if (!virtualize) {
         const contentDataIndices = Object.keys(contentData);

--- a/lib/MultiColumnList/stories/service.js
+++ b/lib/MultiColumnList/stories/service.js
@@ -14,6 +14,8 @@ export function syncGenerate(n, start = 0, generator) {
         date: faker.date.past().toString(),
         email: faker.internet.email(),
         status: faker.random.boolean(),
+        phone: faker.phone.phoneNumber(),
+        name: faker.name.findName(),
       });
     }
     i++;

--- a/lib/MultiColumnList/tests/MCLHarness.js
+++ b/lib/MultiColumnList/tests/MCLHarness.js
@@ -4,6 +4,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import MultiColumnList from '../MultiColumnList';
 import Button from '../../Button';
 import { generate } from './generate';
+import { asyncGenerate, syncGenerate } from '../stories/service';
 
 
 class MCLHarness extends React.Component {
@@ -15,7 +16,7 @@ class MCLHarness extends React.Component {
     super(props);
 
     this.state = {
-      data: props.initialData || generate(30),
+      data: props.initialData || syncGenerate(30),
       height: 400,
       selected: {},
       displayGrid: props.displayGrid,
@@ -36,9 +37,18 @@ class MCLHarness extends React.Component {
     this.onNeedMore();
   }
 
-  onNeedMore() {
+  async onNeedMore() {
+    const { onNeedMoreSpy, asyncPaging } = this.props;
+    if (onNeedMoreSpy) onNeedMoreSpy();
+    let newData;
+    if (asyncPaging) {
+      newData = await asyncGenerate(30, null, 500);
+    } else {
+      newData = await Promise.resolve(syncGenerate(30));
+    }
+
     this.setState(curState => ({
-      data: [...curState.data, ...generate(30)]
+      data: [...curState.data, ...newData]
     }));
   }
 
@@ -102,7 +112,7 @@ class MCLHarness extends React.Component {
 
   render() {
     const { displayGrid, placeMarker } = this.state;
-    const { initialData, ...rest } = this.props; // eslint-disable-line no-unused-vars
+    const { initialData, onNeedMoreSpy, asyncPaging, ...rest } = this.props; // eslint-disable-line no-unused-vars
     return (
       <div>
         <Button data-test-display-grid onClick={this.displayGrid}>show grid</Button>

--- a/lib/MultiColumnList/tests/MultiColumnList-test.js
+++ b/lib/MultiColumnList/tests/MultiColumnList-test.js
@@ -454,7 +454,7 @@ describe('MultiColumnList', () => {
 
         describe('adjusting to width change', () => {
           beforeEach(async () => {
-            await mcl.scrollBy({ direction: 'top', value: 500 });
+            await mcl.scrollBy({ direction: 'top', value: 600 });
           });
 
           describe('selecting another', () => {
@@ -688,17 +688,18 @@ describe('MultiColumnList', () => {
 
   describe('using the pagingType prop', () => {
     const loadMore = ButtonInteractor('Load more');
+
     let pagingNeedMore;
     beforeEach(async () => {
       pagingNeedMore = sinon.fake();
       await mountWithContext(
-        <MultiColumnList contentData={data3} onNeedMoreData={pagingNeedMore} pagingType="click" />
+        <MCLHarness initialData={data5} asyncPaging onNeedMoreSpy={pagingNeedMore} pagingType="click" />
       );
     });
 
     it('click paging type has no axe errors', runAxeTest);
 
-    it('renders the paging button', () => loadMore.is({ visible: true }));
+    it('renders the paging button', () => loadMore.exists());
 
     describe('clicking the paging button', () => {
       beforeEach(async () => {
@@ -708,10 +709,21 @@ describe('MultiColumnList', () => {
       it('calls the onNeedMoreData handler', () => {
         expect(pagingNeedMore.calledOnce).to.be.true;
       });
+
+      it('disables the Load more button', () => loadMore.is({ disabled: true }));
+
+      describe('after loading data...', () => {
+        beforeEach(async () => {
+          await mcl.has({ rowCount: 28 });
+          await mcl.scrollBy({ direction: 'top', value: 815 });
+        });
+
+        it('re-enables Load more button when loading is finished', () => loadMore.is({ disabled: false }));
+      })
     });
   });
 
-  describe.skip('prev-next paging', () => {
+  describe('prev-next paging', () => {
     let needMoreHandler;
     beforeEach(async () => {
       needMoreHandler = sinon.fake();
@@ -771,7 +783,7 @@ describe('MultiColumnList', () => {
     it('disables the Previous button', () => ButtonInteractor('Previous').is({ disabled: true }));
   });
 
-  describe.skip('pagingOffset prop', () => {
+  describe('pagingOffset prop', () => {
     let needMoreHandler;
     let handleScroll;
     beforeEach(async () => {
@@ -788,37 +800,37 @@ describe('MultiColumnList', () => {
     it('displays the proper ending index within pagination', () => HTMLInteractor('100').exists());
     it('scrolls down 500 px', () => mcl.has({ scrollTop: 500 }));
 
-      describe('clicking the next pagination button', () => {
-        beforeEach( async () => {
+    describe('clicking the next pagination button', () => {
+      beforeEach(async () => {
+        await mcl.clickNextPagingButton();
+      });
+
+      it('displays advanced starting index within pagination', () => HTMLInteractor('101').exists());
+      it('displays the proper advanced ending index within pagination', () => HTMLInteractor('200').exists());
+      it('scrolls back to top when new data received', () => mcl.has({ scrollTop: 0 }));
+
+      describe('Reaching the totalCount disables the next button...', () => {
+        beforeEach(async () => {
           await mcl.clickNextPagingButton();
         });
 
-        it('displays advanced starting index within pagination', async () => await HTMLInteractor('101').exists());
-        it('displays the proper advanced ending index within pagination', async () => await HTMLInteractor('200').exists());
-        it('scrolls back to top when new data received', async () => await mcl.has({ scrollTop: 0 }));
+        it('displays advanced starting index within pagination', () => HTMLInteractor('201').exists());
+        it('displays the proper advanced ending index within pagination', () => HTMLInteractor('250').exists());
+        it('disables the next button', () => mcl.find(ButtonInteractor('Next')).is({ disabled: true }));
+      });
 
-        describe('Reaching the totalCount disables the next button...', () => {
-          beforeEach( async () => {
-            await mcl.clickNextPagingButton();
-          });
-
-          it('displays advanced starting index within pagination', async () => await HTMLInteractor('201').exists());
-          it('displays the proper advanced ending index within pagination', async () =>  await HTMLInteractor('250').exists());
-          it('disables the next button', async () => await mcl.find(ButtonInteractor('Next')).is({ disabled: true }));
+      describe('clicking the previous pagination button', () => {
+        beforeEach(async () => {
+          await mcl.scrollBy({ direction: 'top', value: 500 });
+          await mcl.clickPreviousPagingButton();
         });
 
-        describe('clicking the previous pagination button', () => {
-          beforeEach( async () => {
-            await mcl.scrollBy({ direction: 'top', value: 500 });
-            await mcl.clickPreviousPagingButton();
-          });
-
-          it('displays advanced starting index within pagination', () => HTMLInteractor('1'));
-          it('displays the proper advanced ending index within pagination', () => HTMLInteractor('100'));
-          it('scrolls back to top when new data received', () => mcl.has({ scrollTop: 0 }));
-        });
+        it('displays advanced starting index within pagination', () => HTMLInteractor('1'));
+        it('displays the proper advanced ending index within pagination', () => HTMLInteractor('100'));
+        it('scrolls back to top when new data received', () => mcl.has({ scrollTop: 0 }));
       });
     });
+  });
 
   describe('mark position functionality', () => {
     let markPositionInspector;
@@ -918,6 +930,7 @@ describe('MultiColumnList', () => {
     describe('adding data roles to overflow the grid', () => {
       beforeEach(async () => {
         await Button('loadData').click();
+        await mcl.has({ rowCount: 33 })
       });
 
       it('detects vertical scrollbar', () => {

--- a/lib/Timepicker/tests/Timepicker-test.js
+++ b/lib/Timepicker/tests/Timepicker-test.js
@@ -202,7 +202,7 @@ describe('Timepicker', () => {
         />
       );
 
-      await timepicker.fillIn('05:00 P');
+      await timepicker.fillIn('5:00 P');
     });
 
     it('emits an event with the time accounting for timezone', () => HTML({ id: 'state-time', text: testTime }).exists());
@@ -227,7 +227,7 @@ describe('Timepicker', () => {
         />
       );
 
-      await timepicker.fillIn('04:20 P');
+      await timepicker.fillIn('4:20 P');
     });
 
     it('emits an event with the time accounting for timezone', () => HTML({ id: 'state-time', text: testTime }).exists());


### PR DESCRIPTION
This PR resolves an issue with MCL not restoring it's loading state to false with non-sparse `contentData`. It cherry picks from changes merged to master in https://github.com/folio-org/stripes-components/pull/2223 

As well as an update for the Timepicker tests  (remove leading 0's on time strings - who types those anyway?) from https://github.com/folio-org/stripes-components/pull/2201 in order for those to pass.