### PR TITLE
Release v12.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-components
 
-## In-progress
+## [12.0.5](https://github.com/folio-org/stripes-components/tree/v12.0.4) (2024-02-28)
+[Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.0.4...v12.0.5)
 
 * MCL loading bugfix - Refs STCOM-1262.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-components",
-  "version": "12.0.4",
+  "version": "12.0.5",
   "description": "Component library for building Stripes applications.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-components",


### PR DESCRIPTION
Includes: 

* MCL loading bugfix - Refs [STCOM-1262](https://folio-org.atlassian.net/browse/STCOM-1262).