### PR TITLE
STCOM-1271 Fix `<FilterAccordionHeader>` does not have correct `aria-label` when `label` prop type is string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Upgrade storybook to v7. Refs STCOM-1176.
 * Fix bug with MCL not re-enabling paging buttons after more data was loaded. Refs STCOM-1262.
 * Accessible grouping for filter group checkboxes via `role="group"`. Refs STCOM-1192.
+* Fix `<FilterAccordionHeader>` does not have correct `aria-label` when `label` prop type is string. Fixes STCOM-1271.
 
 ## [12.0.0](https://github.com/folio-org/stripes-components/tree/v12.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v11.0.0...v12.0.0)

--- a/lib/Accordion/headers/FilterAccordionHeader.js
+++ b/lib/Accordion/headers/FilterAccordionHeader.js
@@ -71,7 +71,7 @@ class FilterAccordionHeader extends React.Component {
     } = this.props;
     const clearButtonVisible = displayClearButton && typeof onClearFilter === 'function';
     const labelPropsId = label?.props?.id;
-    const labelText = labelPropsId ? formatMessage({ id: labelPropsId }) : '-';
+    const labelText = labelPropsId ? formatMessage({ id: labelPropsId }) : label || '-';
 
     return (
       <div className={css.headerWrapper}>


### PR DESCRIPTION
## Description
Fix `<FilterAccordionHeader>` does not have correct `aria-label` when `label` prop type is string

## Issues
[STCOM-1271](https://folio-org.atlassian.net/browse/STCOM-1271)