### PR TITLE
STCOM-1270 - add component for rendering blocks of presentational HTML

### DIFF
--- a/lib/CleanHTML/CleanHTML.js
+++ b/lib/CleanHTML/CleanHTML.js
@@ -1,0 +1,95 @@
+import React, { useMemo, useRef, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import merge from 'lodash/merge';
+import sanitize from 'sanitize-html';
+
+// for presentational markup/formatting.
+const styledHTMLSettings = {
+  allowedStyles: {
+    '*': {
+      'color': [/^#(0x)?[0-9a-f]+$/i, /^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/, /^[a-z]+$/],
+      'text-align': [/^left$/, /^right$/, /^center$/],
+      'padding': [/^\d+(?:px|em|%)$/],
+      'font-size': [/^\d+(?:px|em|%)$/]
+    },
+  },
+  allowedAttributes: {
+    'p': ['style'],
+    'div': ['style'],
+    'a': ['style'],
+    'span': ['style']
+  }
+};
+
+// for rendering presentational SVG's. any embedded script tags are removed.
+const svgSettings =
+{
+  allowedTags: ['svg', 'rect', 'path', 'circle'],
+  allowedAttributes: {
+    'svg': ['width', 'height', 'style', 'viewBox'],
+    'rect': ['width', 'height', 'style', 'fill', 'stroke'],
+    'path': ['d', 'fill', 'stroke'],
+    'polygon': ['points', 'fill', 'stroke'],
+    'circle': ['cx', 'cy', 'r', 'fill', 'stroke']
+  },
+  parser: {
+    lowerCaseTags: false,
+    lowerCaseAttributeNames: false
+  },
+};
+
+/** Most props align with fields for sanitize-html's configuration.
+ * Documentation and a set of default values can be seen at
+ * https://github.com/apostrophecms/sanitize-html?tab=readme-ov-file#default-options */
+const propTypes = {
+  allowedAttributes: PropTypes.object,
+  allowedSchemes: PropTypes.arrayOf(PropTypes.string),
+  allowedSchemesAppliedToAttributes: PropTypes.arrayOf(PropTypes.string),
+  allowedSchemesByTag:  PropTypes.object,
+  allowedTags: PropTypes.arrayOf(PropTypes.string),
+  allowProtocolRelative: PropTypes.bool,
+  /** props that will be passed directly to the containing element... classnames, data-attributes, etc. */
+  containerProps: PropTypes.object,
+  disallowedTagsMode: PropTypes.string,
+  enforceHtmlBoundary: PropTypes.bool,
+  markup: PropTypes.string,
+  nonBooleanAttributes: PropTypes.arrayOf(PropTypes.string),
+  parseStyleAttributes: PropTypes.bool,
+  selfClosing: PropTypes.arrayOf(PropTypes.string),
+  /** merge default options in among all supplied props. defaults to true. */
+  useSanitizeDefault: PropTypes.bool,
+  /** use if SVG rendering is a requirement for the presentation. */
+  useSVG: PropTypes.bool,
+}
+
+const CleanHTML = ({
+  markup,
+  useSanitizeDefault = true,
+  useSVG,
+  containerProps,
+  ...sanitizeProps
+}) => {
+  const container = useRef();
+  const sanitizeParameters = JSON.stringify({ ...sanitizeProps })
+  const configuration = useMemo(() => {
+    const sanitizeParams = { useSanitizeDefault, ...sanitizeProps };
+    const base = useSanitizeDefault ? sanitize.defaults : {}
+    const parserSettings = useSVG ? svgSettings : {};
+    return merge(
+      base,
+      styledHTMLSettings,
+      { ...sanitizeParams },
+      parserSettings,
+    );
+  }, [sanitizeParameters, useSVG]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    container.current.innerHTML = sanitize(markup, configuration);
+  }, [markup, configuration]);
+
+  return <div ref={container} {...containerProps} />;
+}
+
+CleanHTML.propTypes = propTypes;
+
+export default CleanHTML;

--- a/lib/CleanHTML/stories/CleanHTML.stories.js
+++ b/lib/CleanHTML/stories/CleanHTML.stories.js
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import CleanHTML from '../CleanHTML';
+import TextArea from '../../TextArea';
+import Checkbox from '../../Checkbox';
+import Button from '../../Button';
+import Headline from '../../Headline';
+import bad from './bad.svg';
+
+/* eslint-disable max-len */
+
+const customSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="50">
+<path d="M28.4 27.5v-21c0-1.2-.8-2-2-2H22v-.6c0-1.2-.8-2-2-2s-2 .8-2 2v.4h-4v-.4c0-1.2-.8-2-2-2s-2 .8-2 2v.4H5.6c-1.2 0-2 .8-2 2v21c0 1.2.8 2 2 2h21c1 .2 1.8-.8 1.8-1.8zM10 8.5v.6c0 1.2.8 2 2 2s2-.8 2-2v-.6h4v.6c0 1.2.8 2 2 2s2-.8 2-2v-.6h2.6v4.4h-17V8.5H10zm-2.4 17v-8.8h17v8.6h-17v.2z"/>
+</svg>
+`;
+
+const xssSVG = `<p> open me in a new tab </p>
+<img src=${bad} onError="alert('xss')" />
+`
+const xssImg = '<img src="" onError="alert(\'xss\')" />';
+
+const styled = `<p style="color: red">This text is <strong>styled</strong></p>
+<div style="text-align: center"><strong>center</strong>-alignment</div>
+<div style="text-align: right; color: blue;"><strong>right<strong>-alignment</div>
+`;
+
+
+/**
+ * CleanHTML: Basic Usage
+ */
+
+export default {
+  title: 'CleanHTML',
+};
+
+export const BasicUsage = () => {
+  const [markup, updateMarkup] = useState(styled);
+  const [sanitize, updateSanitize] = useState(true);
+
+  return (
+    <>
+      <Headline>CleanHTML</Headline>
+      <p>The checkbox will enable/disable santization of markup input for presentation. Each of the buttons represent a preset value that illustrates a particular use-case.</p>
+      <Checkbox label="sanitize input" checked={sanitize} onChange={e => updateSanitize(e.target.checked)} />
+      <Button onClick={() => updateMarkup(styled)}>Styled content</Button>
+      <Button onClick={() => updateMarkup(customSVG)}>SVG</Button>
+      <Button onClick={() => updateMarkup(xssSVG)}>XSS SVG</Button>
+      <Button onClick={() => updateMarkup(xssImg)}>XSS img</Button>
+      <TextArea value={markup} onChange={(e) => updateMarkup(e.target.value)} rows="5" />
+      <div style={{ border: '1px solid #000', minHeight: '200px' }}>
+        <div>rendered mark-up:</div>
+        {sanitize ?
+          <CleanHTML markup={markup} useSVG /> :
+          <div dangerouslySetInnerHTML={{ __html: markup }} /> // eslint-disable-line react/no-danger
+        }
+
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
Adding `<CleanHTML>`  component as a centralized alternative for implementations that set `innerHTML` via refs of via `react`'s `dangerouslySetInnerHTML`.
https://github.com/folio-org/stripes-smart-components/blob/master/lib/Notes/NoteViewPage/components/NoteView/NoteView.js#L287-L290

## Approach
Make use of the `sanitize-html` library to clean potentially troublesome tags from content which requires no interactivity.

Storybook example depicted:
![image](https://github.com/folio-org/stripes-components/assets/20704067/6bd84f24-4606-4636-8fac-e39b8fa02071)
