### PR TITLE
STCOM-1238 Accordion vs overlay z-index issues.

### DIFF
--- a/.storybook/stcom-webpack.config.js
+++ b/.storybook/stcom-webpack.config.js
@@ -12,6 +12,8 @@ const { babelOptions } = require('@folio/stripes-cli');
 const adjustedBabelOptions = Object.assign(babelOptions, { plugins: babelOptions.plugins.filter((p) => !p.includes('react-refresh')) });
 
 module.exports = async (config) => {
+
+  config.devtool="eval-cheap-source-map";
   // Replace Storybook's own CSS config
   // get index of their css loading rule...
   const cssRuleIndex = config.module.rules.findIndex(r => { const t = new RegExp(r.test); return t.test('m.css'); });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Accessible grouping for filter group checkboxes via `role="group"`. Refs STCOM-1192.
 * Fix `<FilterAccordionHeader>` does not have correct `aria-label` when `label` prop type is string. Fixes STCOM-1271.
 * Add `number-generator` icon. Refs STCOM-1269.
+* Accordions retain their z-index after being blurred, and assume the highest z-index when focus enters them. Refs STCOM-1238.
 
 ## [12.0.0](https://github.com/folio-org/stripes-components/tree/v12.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v11.0.0...v12.0.0)

--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -122,11 +122,13 @@ const Accordion = (props) => {
   }).current;
 
   const handleFocusIn = () => {
+    // only update the accordion z-index if it does not contain focus or if it's not
+    // already the highest z-index among other accordions.
     if (!focused) {
       updateFocused(true);
       const highest = getHighestStackOrder();
       if (zIndex !== highest) {
-        updateZIndex(highest + 1)
+        updateZIndex(highest)
       }
     }
   }

--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -64,12 +64,22 @@ function getWrapClass(open) {
   );
 }
 
+/* The z-index requirements for accordions:
+* Accordions should not overlap any overlays/dropdowns from previous/next accordions.
+* Accordions/overlays should not be overlapped if focus left the accordion or went to another pane...
+*
+*/
+
+// loops through other accordions rendered within the UI to find the highest z-index among them all.
 const getHighestStackOrder = () => {
   const accordions = Array.from(document.querySelectorAll(`.${css['content-wrap']}`));
   const highest = accordions?.reduce((acc, cur) => {
     let currentZ = getComputedStyle(cur).getPropertyValue('z-index');
+    // skip any that might have non-integer z-index settings.
     if (currentZ === 'auto' || currentZ === null) return acc;
     currentZ = parseInt(currentZ, 10);
+    // this will prevent duplicated highest z-index, since with matching z-index, the tag
+    // that's ordered last will overlap.
     if (currentZ === acc) currentZ += 1;
     return currentZ > acc ? currentZ : acc;
   }, 2);
@@ -121,9 +131,10 @@ const Accordion = (props) => {
     updateOpen(current => !current);
   }).current;
 
+  // Affecting z-index when accordions are focused within.
+  // We only update the accordion z-index if it does not contain focus _and_ if it's not
+  // already the highest z-index among other accordions.
   const handleFocusIn = () => {
-    // only update the accordion z-index if it does not contain focus or if it's not
-    // already the highest z-index among other accordions.
     if (!focused) {
       updateFocused(true);
       const highest = getHighestStackOrder();
@@ -153,6 +164,8 @@ const Accordion = (props) => {
     }
   }, [open]);
 
+  // At registration, accordions are assigned a z-index that, in most cases,
+  // will render in reverse order.
   useEffect(() => { // eslint-disable-line
     function registrationCallback(isRegistered) {
       updateRegistered(isRegistered);

--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -128,7 +128,7 @@ const Accordion = (props) => {
       updateFocused(true);
       const highest = getHighestStackOrder();
       if (zIndex !== highest) {
-        updateZIndex(highest)
+        updateZIndex(highest);
       }
     }
   }

--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -64,6 +64,18 @@ function getWrapClass(open) {
   );
 }
 
+const getHighestStackOrder = () => {
+  const accordions = Array.from(document.querySelectorAll(`.${css['content-wrap']}`));
+  const highest = accordions?.reduce((acc, cur) => {
+    let currentZ = getComputedStyle(cur).getPropertyValue('z-index');
+    if (currentZ === 'auto' || currentZ === null) return acc;
+    currentZ = parseInt(currentZ, 10);
+    if (currentZ === acc) currentZ += 1;
+    return currentZ > acc ? currentZ : acc;
+  }, 2);
+  return highest;
+}
+
 const Accordion = (props) => {
   const {
     accordionSet,
@@ -102,15 +114,26 @@ const Accordion = (props) => {
   const getRef = useRef(() => toggle.current).current;
   const [isOpen, updateOpen] = useState(open || !closedByDefault);
   const [registered, updateRegistered] = useState(!accordionSet);
-  const [stackOrder, updateStackOrder] = useState(1);
   const [zIndex, updateZIndex] = useState(1);
+  const [focused, updateFocused] = useState(false);
 
   const uncontrolledToggle = useRef(() => {
     updateOpen(current => !current);
   }).current;
 
-  const handleFocusIn = () => updateZIndex(accordionSet?.getNumberOfAccordions() || 2);
-  const handleFocusOut = () => updateZIndex(stackOrder);
+  const handleFocusIn = () => {
+    if (!focused) {
+      updateFocused(true);
+      const highest = getHighestStackOrder();
+      if (zIndex !== highest) {
+        updateZIndex(highest + 1)
+      }
+    }
+  }
+
+  const handleFocusOut = () => {
+    updateFocused(false);
+  }
 
   const onToggle = (toggleArgs) => {
     if (typeof open === 'undefined') {
@@ -133,7 +156,6 @@ const Accordion = (props) => {
       updateRegistered(isRegistered);
       if (accordionSet) {
         const defaultZIndex = accordionSet.getStackOrder(trackingId);
-        updateStackOrder(defaultZIndex);
         updateZIndex(defaultZIndex);
       }
     }


### PR DESCRIPTION
### Problem
Accordions with overlay components could have their overlays overlapped by other accordions due to z-index issues.

### Approach
What we've previously done...
Accordions content would overlap overlays/dropdowns from previous accordions... (render with reverse z-index order to accordion index)
fixed, but..
Accordions content would overlap overlays/dropdowns from the following accordions...(have the focused accordion assume highest zindex from the set)
fixed, but
Accordions/overlays would go back to being overlapped if focus left the accordion or went to another pane...

In this PR, when focus moves to the accordion, it will find/assume the highest z-index among other accordions. It will retain this same z-index after it is blurred. If an accordion already has the highest z-index among accordions, it will not update its own. The z-indexes do continue to grow, but only for the life of a view... if navigation happens or accordions leave the DOM, all z-indices will be reset upon return.

![accordionZResults](https://github.com/folio-org/stripes-components/assets/20704067/2e73fed2-233e-4051-bc11-2639722c72eb)

