### PR TITLE
STCOM-1238v2 - reduce 'focus()' calls within SelectList/Selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Fix `<FilterAccordionHeader>` does not have correct `aria-label` when `label` prop type is string. Fixes STCOM-1271.
 * Add `number-generator` icon. Refs STCOM-1269.
 * Accordions retain their z-index after being blurred, and assume the highest z-index when focus enters them. Refs STCOM-1238.
+* `<Selection>` should only move focus back to its control/trigger if focus within the list. Refs STCOM-1238.
 
 ## [12.0.5](https://github.com/folio-org/stripes-components/tree/v12.0.4) (2024-02-28)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.0.4...v12.0.5)

--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -81,7 +81,8 @@ const getHighestStackOrder = () => {
     // this will prevent duplicated highest z-index, since with matching z-index, the tag
     // that's ordered last will overlap.
     if (currentZ === acc) currentZ += 1;
-    return currentZ > acc ? currentZ : acc;
+    const high = currentZ > acc ? currentZ : acc;
+    return high;
   }, 2);
   return highest;
 }
@@ -137,12 +138,19 @@ const Accordion = (props) => {
   const handleFocusIn = () => {
     if (!focused) {
       updateFocused(true);
-      const highest = getHighestStackOrder();
-      if (zIndex !== highest) {
-        updateZIndex(highest);
-      }
+      updateZIndex((cur) => {
+        if(content.current.matches(':focus-within')) {
+          // we assign one greater than the highest z-index value.
+          const highest = getHighestStackOrder() + 1;
+          if (cur !== highest) {
+            return highest;
+          }
+        }
+        return cur;
+      });
     }
   }
+
 
   const handleFocusOut = () => {
     updateFocused(false);

--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -81,8 +81,7 @@ const getHighestStackOrder = () => {
     // this will prevent duplicated highest z-index, since with matching z-index, the tag
     // that's ordered last will overlap.
     if (currentZ === acc) currentZ += 1;
-    const high = currentZ > acc ? currentZ : acc;
-    return high;
+    return currentZ > acc ? currentZ : acc;
   }, 2);
   return highest;
 }

--- a/lib/Selection/SelectList.js
+++ b/lib/Selection/SelectList.js
@@ -111,6 +111,7 @@ class SelectList extends React.Component {
     // like a good overlay, send focus back to our trigger when we close...
     if (prevProps.visible && !this.props.visible) {
       if (this.props.controlRef.current) {
+        // we only need to send focus back to the control if focus is still within the list.
         if(this.container.current.matches(':focus-within')) {
           this.props.controlRef.current.focus();
         }

--- a/lib/Selection/SelectList.js
+++ b/lib/Selection/SelectList.js
@@ -111,7 +111,9 @@ class SelectList extends React.Component {
     // like a good overlay, send focus back to our trigger when we close...
     if (prevProps.visible && !this.props.visible) {
       if (this.props.controlRef.current) {
-        this.props.controlRef.current.focus();
+        if(this.container.current.matches(':focus-within')) {
+          this.props.controlRef.current.focus();
+        }
       }
     }
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/STCOM-1238

One culprit for z-index fighting in Orders is late-game calls to `focus()` - `<Selection>` code contains a late-game focus where the control of the list is always re-focused after the list is closed. This isn't always necessary - especially in cases where the user has intentionally focused somewhere else. When the control of one accordion A was open, and a control in a accordion B was clicked, accordion B's z-index logic would fire, giving it the highest value, but the control in accordion A would execute its `focus()` logic - causing the z-index logic to fire yet again and place Accordion A back at the top of the z-index stack so that it would overlap the control of Accordion B.
The fix here ensures that focus is only moved back to the control of `<Selection`>` if focus has not moved outside of the list control.

Additionally, prior to merging the previous fix, I removed the addition of 1 so that the z-index value would not grow too rapidly, but it turns out this addition was okay - adding 1 ensure uniqueness and that the value that's set will always be the highest of the accordion z-indices. This part of this logic should resolve the behavior we see in STCOM-1267.
