### PR TITLE
Allow nodes for ConfirmationModal heading

### DIFF
--- a/lib/ConfirmationModal/ConfirmationModal.js
+++ b/lib/ConfirmationModal/ConfirmationModal.js
@@ -16,7 +16,7 @@ const propTypes = {
   cancelButtonStyle: PropTypes.string,
   cancelLabel: PropTypes.node,
   confirmLabel: PropTypes.node,
-  heading: PropTypes.string.isRequired,
+  heading: PropTypes.node.isRequired,
   id: PropTypes.string,
   isConfirmButtonDisabled: PropTypes.bool,
   message: PropTypes.oneOfType([

--- a/lib/ConfirmationModal/readme.md
+++ b/lib/ConfirmationModal/readme.md
@@ -38,7 +38,7 @@ handleSubmit() {
 
 Name | type | description | default | required
 --- | --- | --- | --- | ---
-heading | string | String to appear as the modal's H1 tag. Doubles as the modal's ARIA-label |  | &#10004;
+heading | node | String to appear as the modal's H1 tag |  | &#10004;
 message | node or array of nodes | Renderable content rendered within a `<p>` tag. |  |
 open | bool | Boolean reflecting modal's open/closed status |  | &#10004;
 cancelLabel | node | String to render on the Cancel action. | "Cancel" |


### PR DESCRIPTION
Fixes a regression in #2193. The documentation was incorrect: the `heading` is used as the `label` on our `<Modal>` component, but the `label` prop accepts nodes and is not used as part of the ARIA label in any way.