### PR TITLE
STCOM-1235 validate refs before dereferencing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 12.2.0 IN PROGRESS
 
 * Exclude invalid additional currencies. Refs STCOM-1274.
+* Validate ref in `Paneset` before dereferencing it. Refs STCOM-1235.
 
 ## [12.1.0](https://github.com/folio-org/stripes-components/tree/v12.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.0.0...v12.1.0)

--- a/lib/Paneset/insertByClientRect.js
+++ b/lib/Paneset/insertByClientRect.js
@@ -2,10 +2,14 @@
 import cloneDeep from 'lodash/cloneDeep';
 
 export default (prevArray, newItem) => {
-  const newClientRect = newItem.getRef().current.getBoundingClientRect();
-  const nextIndex = prevArray.findIndex((p) => {
-    return (p.getRef().current.getBoundingClientRect().left > newClientRect.left);
-  });
+  let nextIndex = -1;
+  if (newItem.getRef().current) {
+    const newClientRect = newItem.getRef().current.getBoundingClientRect();
+    nextIndex = prevArray.findIndex((p) => {
+      return (p.getRef().current.getBoundingClientRect().left > newClientRect.left);
+    });
+  }
+
   let newArray;
   if (nextIndex === -1) {
     newArray = [...prevArray, newItem];


### PR DESCRIPTION
Avoid an NPE in `Paneset` by null-checking a ref before dereferencing it.

Refs [STCOM-1235](https://folio-org.atlassian.net/browse/STCOM-1235)