### PR TITLE
STCOM-1277: Replace the 'Control' shortcut display with 'Ctrl' for Windows computers in 'KeyboardShortcutsModal'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Exclude invalid additional currencies. Refs STCOM-1274.
 * Validate ref in `Paneset` before dereferencing it. Refs STCOM-1235.
+* Replace the `Control` shortcut display with `Ctrl` for Windows computers in `KeyboardShortcutsModal`. Refs STCOM-1277.
 
 ## [12.1.0](https://github.com/folio-org/stripes-components/tree/v12.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.0.0...v12.1.0)

--- a/lib/KeyboardShortcutsModal/KeyboardShortcutsModal.js
+++ b/lib/KeyboardShortcutsModal/KeyboardShortcutsModal.js
@@ -33,7 +33,7 @@ function KeyboardShortcutsModal(props) {
     if (platform.includes('Mac')) {
       camelCasedShortcut = commandArray.join(' + ').replace('Mod', 'Cmd').replace('Alt', 'Option');
     } else {
-      camelCasedShortcut = commandArray.join(' + ').replace('Mod', 'Ctrl');
+      camelCasedShortcut = commandArray.join(' + ').replace(/Mod|Control/, 'Ctrl');
     }
 
     return {

--- a/lib/KeyboardShortcutsModal/tests/KeyboardShortcutsModal-test.js
+++ b/lib/KeyboardShortcutsModal/tests/KeyboardShortcutsModal-test.js
@@ -5,7 +5,7 @@
 import React from 'react';
 import { describe, beforeEach, it } from 'mocha';
 import sinon from 'sinon';
-import { converge, Modal } from '@folio/stripes-testing';
+import { converge, Modal, including, some } from '@folio/stripes-testing';
 
 import { mountWithContext } from '../../../tests/helpers';
 
@@ -15,6 +15,7 @@ import coreShortcuts from '../coreShortcuts';
 const KeyboardShortcutsModalInteractor = Modal.extend('keyboard shortcuts modal')
   .selector('[data-test-keyboard-shortcuts-modal]')
   .filters({
+    shortcuts: el => Array.from(el.querySelectorAll('[role="gridcell"]:nth-child(2)')).map(el => el.innerText),
     shortcutCount: (el) => el.querySelectorAll('div[data-row-index]').length
   });
 
@@ -28,6 +29,10 @@ describe('KeyboardShortcutsModal', () => {
     {
       label: 'Paste',
       shortcut: 'mod+v'
+    },
+    {
+      label: 'Move to the previous subfield',
+      shortcut: 'CONTROL+['
     }
   ];
   const onClose = sinon.spy();
@@ -52,4 +57,10 @@ describe('KeyboardShortcutsModal', () => {
     });
     it('Should call the onClose handler', () => converge(() => onClose.called));
   });
+
+  describe('When a platform is Windows', () => {
+    it('Should display `Ctrl` instead of `Control`', () => {
+      return kSM.has({ shortcuts: some(including('Ctrl + [')) });
+    })
+  })
 });


### PR DESCRIPTION
## Description
The `quick-marc` module has shortcuts `Ctrl + ]` and `Ctrl + [` for Windows computers and `Control + ]` and `Control + [` for MACs.  `KeyboardShortcutsModal` doesn't support changing the MAC `Control` key display for Windows computers. After this PR, it will replace `Control` with `Ctrl` for Windows computers and leave everything as is for MACs.

## Issues
[STCOM-1277](https://folio-org.atlassian.net/browse/STCOM-1277)
## Screenshots
For Windows
![image](https://github.com/folio-org/stripes-components/assets/77053927/6f9a8f1a-4029-4b95-a1df-fba1309ddc69)

For MAC
![image](https://github.com/folio-org/stripes-components/assets/77053927/33ce7dd4-2def-4fea-bb5b-f4d364914604)
