### PR TITLE
STCOM-1283 remove postcss-plugins as per STRWEB 111

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,9 +1,9 @@
 import React, { Component, Fragment } from 'react';
-import { IntlProvider } from 'react-intl';
 import pkg from '../package.json';
 import { themes } from '@storybook/theming';
 import IntlWrap from './IntlWrap';
 import '../lib/global.css';
+import '../lib/variables.css';
 
 /**
  * React intl support

--- a/.storybook/stcom-webpack.config.js
+++ b/.storybook/stcom-webpack.config.js
@@ -38,12 +38,15 @@ module.exports = async (config) => {
         options: {
           postcssOptions: {
             plugins: [
+              // postcssGlobalData to import custom media queries so that those can be successfully resolve
+              require('@csstools/postcss-global-data')({
+                files: [
+                  path.resolve(__dirname , '../lib/variables.css')
+                ]
+              }),
               require('postcss-import'),
               require('autoprefixer'),
-              require('postcss-custom-properties')({ preserve: false, importFrom: './lib/variables.css', disableDeprecationNotice: true }),
-              require('postcss-nesting'),
               require('postcss-custom-media'),
-              require('postcss-media-minmax'),
               require('@csstools/postcss-relative-color-syntax'),
             ],
           },

--- a/lib/Accordion/Accordion.css
+++ b/lib/Accordion/Accordion.css
@@ -1,4 +1,3 @@
-@import '../variables.css';
 
 .accordion {
   width: 100%;

--- a/lib/AdvancedSearch/components/AdvancedSearchRow/AdvancedSearchRow.css
+++ b/lib/AdvancedSearch/components/AdvancedSearchRow/AdvancedSearchRow.css
@@ -1,4 +1,3 @@
-@import '../../../variables.css';
 
 .AdvancedSearchRow {
   display: block;

--- a/lib/AutoSuggest/AutoSuggest.css
+++ b/lib/AutoSuggest/AutoSuggest.css
@@ -1,4 +1,3 @@
-@import '../variables.css';
 
 .autoSuggest {
   position: relative;

--- a/lib/Avatar/Avatar.css
+++ b/lib/Avatar/Avatar.css
@@ -2,7 +2,7 @@
  * Avatar
  */
 
-@import "../variables";
+
 
 .avatar {
   background-color: var(--color-fill);

--- a/lib/Badge/Badge.css
+++ b/lib/Badge/Badge.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .badge {
   border-radius: 999px;

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 /**
 * Default styling

--- a/lib/ButtonGroup/ButtonGroup.css
+++ b/lib/ButtonGroup/ButtonGroup.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .buttonGroup {
   display: inline-flex;

--- a/lib/Callout/Callout.css
+++ b/lib/Callout/Callout.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .callout {
   position: fixed;

--- a/lib/Card/Card.css
+++ b/lib/Card/Card.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .card {
   width: 100%;

--- a/lib/Card/headers/DefaultCardHeader.css
+++ b/lib/Card/headers/DefaultCardHeader.css
@@ -1,4 +1,4 @@
-@import '../../variables.css';
+
 
 .header {
   background-color: var(--bg-hover);

--- a/lib/Checkbox/Checkbox.css
+++ b/lib/Checkbox/Checkbox.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 /* stylelint-disable no-descending-specificity */
 
 :root {

--- a/lib/ConflictDetectionBanner/ConflictDetectionBanner.css
+++ b/lib/ConflictDetectionBanner/ConflictDetectionBanner.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .container {
   margin-bottom: 10px;

--- a/lib/Datepicker/Calendar.css
+++ b/lib/Datepicker/Calendar.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .container {
   position: relative;

--- a/lib/Dropdown/Dropdown.css
+++ b/lib/Dropdown/Dropdown.css
@@ -1,4 +1,4 @@
-@import "../variables.css";
+
 
 .show {
   display: block;

--- a/lib/DropdownMenu/DropdownLayout.css
+++ b/lib/DropdownMenu/DropdownLayout.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .dropdownHeader {
   padding: 0 1rem;

--- a/lib/DropdownMenu/DropdownMenu.css
+++ b/lib/DropdownMenu/DropdownMenu.css
@@ -1,4 +1,4 @@
-@import "../variables.css";
+
 
 .DropdownMenu {
   top: 100%;

--- a/lib/Editor/Editor.css
+++ b/lib/Editor/Editor.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .editor {
   position: relative;

--- a/lib/EmptyMessage/EmptyMessage.css
+++ b/lib/EmptyMessage/EmptyMessage.css
@@ -2,7 +2,7 @@
  * <EmptyMessage />
  */
 
-@import "../variables";
+
 
 .emptyMessage {
   font-size: var(--font-size-medium);

--- a/lib/FilterControlGroup/FilterControlGroup.css
+++ b/lib/FilterControlGroup/FilterControlGroup.css
@@ -1,4 +1,4 @@
-@import "../variables";
+
 
 .filterList {
   margin: 0;

--- a/lib/FilterPaneSearch/FilterPaneSearch.css
+++ b/lib/FilterPaneSearch/FilterPaneSearch.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .headerSearchContainer {
   width: 100%;

--- a/lib/FocusLink/FocusLink.css
+++ b/lib/FocusLink/FocusLink.css
@@ -1,7 +1,7 @@
 /**
  * FocusLink
  */
-@import "../variables.css";
+
 
 .focusLink {
   outline: 0;

--- a/lib/FocusLink/stories/FocusLinkExample.css
+++ b/lib/FocusLink/stories/FocusLinkExample.css
@@ -2,7 +2,7 @@
  * FocusLink example css
  */
 
-@import "../../variables.css";
+
 
 .skippableArea {
   border: 1px solid var(--color-border-p2);

--- a/lib/Headline/Headline.css
+++ b/lib/Headline/Headline.css
@@ -2,7 +2,7 @@
  * Component: Headline
  */
 
-@import '../variables';
+
 
 /**
  * Root styling

--- a/lib/Highlighter/Highlighter.css
+++ b/lib/Highlighter/Highlighter.css
@@ -2,7 +2,7 @@
  * Highlighter
  */
 
-@import '../variables.css';
+
 
 .mark {
   background-color: var(--highlighter-fill);

--- a/lib/Icon/DotSpinner.css
+++ b/lib/Icon/DotSpinner.css
@@ -1,4 +1,4 @@
-@import "../variables";
+
 
 .spinner {
   display: flex;

--- a/lib/Icon/Icon.css
+++ b/lib/Icon/Icon.css
@@ -1,4 +1,4 @@
-@import "../variables";
+
 
 .icon {
   display: inline-flex;

--- a/lib/Icon/stories/style.css
+++ b/lib/Icon/stories/style.css
@@ -1,4 +1,4 @@
-@import '../../variables';
+
 
 .iconGrid {
   padding: 0;

--- a/lib/IconButton/IconButton.css
+++ b/lib/IconButton/IconButton.css
@@ -2,7 +2,7 @@
  * Pane Menu Icon
  */
 
-@import '../variables';
+
 
 .iconButton {
   composes: interactionStylesControl from "../sharedStyles/interactionStyles.css";

--- a/lib/InfoPopover/InfoPopover.css
+++ b/lib/InfoPopover/InfoPopover.css
@@ -2,7 +2,7 @@
  * InfoPopover
  */
 
-@import "../variables";
+
 
 .root {
   max-width: 300px;

--- a/lib/KeyValue/KeyValue.css
+++ b/lib/KeyValue/KeyValue.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .kvLabel {
   display: block;

--- a/lib/Label/Label.css
+++ b/lib/Label/Label.css
@@ -2,7 +2,7 @@
  * Label
  */
 
-@import "../variables";
+
 
 .label {
   display: flex;

--- a/lib/Label/components/Asterisk/Asterisk.css
+++ b/lib/Label/components/Asterisk/Asterisk.css
@@ -2,7 +2,7 @@
  * Asterisk
  */
 
-@import "../../../variables";
+
 
 .asterisk {
   color: var(--error);

--- a/lib/Layout/Layout.css
+++ b/lib/Layout/Layout.css
@@ -1,4 +1,4 @@
-@import "../variables";
+
 @import "./styles/padding";
 @import "./styles/margin";
 @import "./styles/flexbox";

--- a/lib/Layout/styles/width.css
+++ b/lib/Layout/styles/width.css
@@ -2,7 +2,7 @@
  * Sizing
  */
 
-@import "../../variables";
+
 
 .full {
   width: 100%;

--- a/lib/LayoutBox/LayoutBox.css
+++ b/lib/LayoutBox/LayoutBox.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .sectionBox {
   width: 100%;

--- a/lib/LayoutGrid/stories/LayoutGridExample.css
+++ b/lib/LayoutGrid/stories/LayoutGridExample.css
@@ -2,7 +2,7 @@
  * LayoutGrid example CSS
  */
 
-@import "../../variables";
+
 
 .headline:not(:first-child) {
   margin-top: 30px;

--- a/lib/LayoutHeader/LayoutHeader.css
+++ b/lib/LayoutHeader/LayoutHeader.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .sectionHeader {
   background-color: var(--bg-hover);

--- a/lib/List/List.css
+++ b/lib/List/List.css
@@ -1,4 +1,4 @@
-@import "../variables";
+
 
 .list {
   margin-bottom: 1rem;

--- a/lib/MenuSection/MenuSection.css
+++ b/lib/MenuSection/MenuSection.css
@@ -2,7 +2,7 @@
  * MenuSection Section
  */
 
-@import '../variables.css';
+
 
 /**
  * Apply margin on stacked menu sections

--- a/lib/MessageBanner/MessageBanner.module.css
+++ b/lib/MessageBanner/MessageBanner.module.css
@@ -2,7 +2,7 @@
  * MessageBanner
  */
 
-@import '../variables.css';
+
 
 :root {
   --message-banner-font-size: var(--font-size-medium);

--- a/lib/MetaSection/MetaSection.css
+++ b/lib/MetaSection/MetaSection.css
@@ -1,4 +1,4 @@
-@import '../variables';
+
 
 .metaSectionRoot {
   border-radius: var(--radius);

--- a/lib/Modal/Modal.css
+++ b/lib/Modal/Modal.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .modalRoot {
   position: absolute;

--- a/lib/ModalFooter/ModalFooter.css
+++ b/lib/ModalFooter/ModalFooter.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .modalFooterButtons {
   align-items: center;

--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 /* stylelint-disable no-descending-specificity */
 

--- a/lib/MultiSelection/MultiSelect.css
+++ b/lib/MultiSelection/MultiSelect.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .multiSelectContainer {
   width: 100%;

--- a/lib/NavListItem/NavListItem.css
+++ b/lib/NavListItem/NavListItem.css
@@ -2,7 +2,7 @@
  * NavListItem
  */
 
-@import '../variables.css';
+
 
 .NavListItem {
   composes: interactionStyles hasDot focusDotPositionStart from "../sharedStyles/interactionStyles.css";

--- a/lib/NavListSection/NavListSection.css
+++ b/lib/NavListSection/NavListSection.css
@@ -1,4 +1,4 @@
-@import "../variables";
+
 
 .header {
   padding: 0 var(--gutter-static-two-thirds);

--- a/lib/Pane/Pane.css
+++ b/lib/Pane/Pane.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .pane {
   background: var(--bg);

--- a/lib/PaneBackLink/PaneBackLink.css
+++ b/lib/PaneBackLink/PaneBackLink.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .paneBackLink {
   @media (--medium-up) {

--- a/lib/PaneCloseLink/PaneCloseLink.css
+++ b/lib/PaneCloseLink/PaneCloseLink.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .paneCloseLinkArrow,
 .paneCloseLinkX {

--- a/lib/PaneFooter/DefaultPaneFooter.css
+++ b/lib/PaneFooter/DefaultPaneFooter.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .paneFooterContent {
   max-width: var(--container-max-width);

--- a/lib/PaneFooter/PaneFooter.css
+++ b/lib/PaneFooter/PaneFooter.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .paneFooter {
   display: flex;

--- a/lib/PaneHeader/PaneHeader.css
+++ b/lib/PaneHeader/PaneHeader.css
@@ -1,4 +1,4 @@
-@import "../variables";
+
 
 .paneHeader {
   width: 100%;

--- a/lib/PaneHeaderIconButton/PaneHeaderIconButton.css
+++ b/lib/PaneHeaderIconButton/PaneHeaderIconButton.css
@@ -2,7 +2,7 @@
  * PaneHeaderIconButton
  */
 
-@import "../variables";
+
 
 .PaneHeaderIconButton {
   /* min-width: var(--control-min-size-touch); */

--- a/lib/PaneMenu/PaneMenu.css
+++ b/lib/PaneMenu/PaneMenu.css
@@ -1,4 +1,4 @@
-@import "../variables.css";
+
 
 .paneMenu {
   display: flex;

--- a/lib/PaneSubheader/PaneSubheader.css
+++ b/lib/PaneSubheader/PaneSubheader.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .subheader {
   padding: 8px var(--gutter);

--- a/lib/Paneset/Paneset.css
+++ b/lib/Paneset/Paneset.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .paneset {
   width: 100%;

--- a/lib/PasswordStrength/PasswordStrength.css
+++ b/lib/PasswordStrength/PasswordStrength.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .password-strength__label {
   font-size: var(--font-size-small);

--- a/lib/Popover/LegacyPopover/LegacyPopover.css
+++ b/lib/Popover/LegacyPopover/LegacyPopover.css
@@ -1,4 +1,4 @@
-@import "../../variables.css";
+
 
 .popoverTarget {
   position: static;

--- a/lib/Popover/Popover.css
+++ b/lib/Popover/Popover.css
@@ -1,4 +1,4 @@
-@import "../variables.css";
+
 
 .popover {
   display: inline-block;

--- a/lib/RadioButton/RadioButton.css
+++ b/lib/RadioButton/RadioButton.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 /* stylelint-disable no-descending-specificity */
 
 :root {

--- a/lib/RadioButtonGroup/RadioButtonGroup.css
+++ b/lib/RadioButtonGroup/RadioButtonGroup.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .groupRoot {
   margin-bottom: var(--control-margin-bottom);

--- a/lib/RepeatableField/RepeatableField.css
+++ b/lib/RepeatableField/RepeatableField.css
@@ -1,4 +1,4 @@
-@import "../variables.css";
+
 
 .repeatableField {
   padding: 0;

--- a/lib/SearchField/SearchField.css
+++ b/lib/SearchField/SearchField.css
@@ -2,7 +2,7 @@
  * SearchField
  */
 
-@import "../variables.css";
+
 
 /**
  * Has searchable indexes

--- a/lib/Select/Select.css
+++ b/lib/Select/Select.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 :root {
   --select-icon-width: 1.9rem;

--- a/lib/Selection/Selection.css
+++ b/lib/Selection/Selection.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .selectionRoot {
   position: relative;

--- a/lib/TextArea/TextArea.css
+++ b/lib/TextArea/TextArea.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .textArea {
   position: relative;

--- a/lib/TextField/TextField.css
+++ b/lib/TextField/TextField.css
@@ -1,4 +1,4 @@
-@import '../variables.css';
+
 
 .textField {
   position: relative;

--- a/lib/TextLink/TextLink.css
+++ b/lib/TextLink/TextLink.css
@@ -2,7 +2,7 @@
  * TextLink
  */
 
-@import '../variables.css';
+
 
 :root {
   --link-color-default: var(--color-link);

--- a/lib/Timepicker/TimeDropdown.css
+++ b/lib/Timepicker/TimeDropdown.css
@@ -1,4 +1,4 @@
-@import "../variables.css";
+
 
 .timepickerContainer {
   position: relative;

--- a/lib/Tooltip/Tooltip.css
+++ b/lib/Tooltip/Tooltip.css
@@ -2,7 +2,7 @@
  * Tooltip
  */
 
-@import "../variables";
+
 
 .tooltip {
   display: flex;

--- a/lib/global.css
+++ b/lib/global.css
@@ -1,6 +1,6 @@
 @import "fonts.css";
 @import "normalize.css";
-@import "variables";
+
 
 * {
   box-sizing: border-box;

--- a/lib/sharedStyles/focusWithinIndicator.css
+++ b/lib/sharedStyles/focusWithinIndicator.css
@@ -9,7 +9,7 @@
     }
 */
 
-@import "../variables";
+
 
 .focusWithinIndicator {
   &::after {

--- a/lib/sharedStyles/form.css
+++ b/lib/sharedStyles/form.css
@@ -2,7 +2,7 @@
  * Shared form styles
  */
 
-@import "../variables";
+
 
 /**
  * Input Group

--- a/lib/sharedStyles/interactionStyles.css
+++ b/lib/sharedStyles/interactionStyles.css
@@ -5,7 +5,7 @@
 
 /* stylelint-disable no-descending-specificity  */
 
-@import '../variables.css';
+
 
 :root {
   --focus-dot-offset-default: var(--gutter-static-one-third);

--- a/package.json
+++ b/package.json
@@ -77,15 +77,9 @@
     "mocha": "^10.2.0",
     "moment": "^2.29.0",
     "postcss": "^8.4.2",
-    "postcss-calc": "^9.0.1",
     "postcss-custom-media": "^9.0.1",
-    "postcss-custom-properties": "12.1.11",
     "postcss-import": "^15.0.1",
     "postcss-loader": "^7.0.2",
-    "postcss-media-minmax": "^5.0.0",
-    "postcss-nesting": "^11.2.2",
-    "postcss-syntax": "^0.36.2",
-    "postcss-url": "^10.1.3",
     "react": "^18.2",
     "react-dom": "^18.2",
     "react-intl": "^6.4.4",
@@ -102,6 +96,7 @@
     "stylelint-junit-formatter": "^0.2.2"
   },
   "dependencies": {
+    "@csstools/postcss-global-data": "^2.1.1",
     "@folio/stripes-react-hotkeys": "^3.0.5",
     "classnames": "^2.2.5",
     "currency-codes": "^2.1.0",

--- a/tests/Harness.js
+++ b/tests/Harness.js
@@ -6,6 +6,7 @@ import { Provider } from 'react-redux';
 import { createStore, combineReducers } from 'redux';
 
 import translations from '../translations/stripes-components/en';
+import "../lib/variables.css";
 
 const reducers = {
   form: formReducer,


### PR DESCRIPTION
This PR cleans up stripes-components' storybook webpack config as well as removes postcss-plugin dependencies as seen in https://github.com/folio-org/stripes-webpack/pull/142

Additionally, it removes imports of CSS variables across the repo, since those are no longer necessary - they are stripped out by `stripes-webpack` here-forward. The majority of the large number of files changed are simply removing the `@import '..variables.css'` or similar from CSS files.

An import of the CSS variables was also included within the test harness, as the entries (courtesy of `karma-webpack`) are not the same as our standard webpack config.

* This does require https://github.com/folio-org/stripes-webpack/pull/142 to be merged before tests will pass.