### PR TITLE
STCOM-1284 BUG- form control highlights not rendering.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Exclude invalid additional currencies. Refs STCOM-1274.
 * Validate ref in `Paneset` before dereferencing it. Refs STCOM-1235.
+* Resolve bug with form control validation styles not rendering. Adjusted order of nested selectors. Refs STCOM-1284.
 
 ## [12.1.0](https://github.com/folio-org/stripes-components/tree/v12.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.0.0...v12.1.0)

--- a/lib/sharedStyles/form.css
+++ b/lib/sharedStyles/form.css
@@ -27,10 +27,6 @@
   display: flex;
   align-items: center;
 
-  &::-ms-clear {
-    display: none;
-  }
-
   &:focus,
   &.isFocused {
     border: 1px solid var(--primary);
@@ -81,6 +77,10 @@
 
   &.isChanged {
     background-color: oklch(from var(--primary) l c h / 20%);
+  }
+
+  &::-ms-clear {
+    display: none;
   }
 }
 


### PR DESCRIPTION
Problem
Form control styles for `:focus`, and validation feedback are not showing up in the UI. Recently the postcss-nesting plugin was removed from our CSS pipeline, which caused the problem to reveal itself. 

## Approach
`form.css` contained a nested **prefixed** pseudo-element selector for getting rid of the native 'clear X' that Microsoft Edge renders within text inputs. Moving this nested pseudo-selector to the end of the child declarations resolved the issue. Native `clear X`'s are still hidden as well.

Before:

![image](https://github.com/folio-org/stripes-components/assets/20704067/c9ad2a8d-e952-439c-9443-76fb4600f821)

After 
![image](https://github.com/folio-org/stripes-components/assets/20704067/54d60cd6-ead7-4df0-ab70-95e381f88c1c)
