### PR TITLE
STCOM-1297 Add 'dndProvided' prop for MCLRenderer to support DND placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Avoid deprecated `defaultProps` for functional components. Refs STCOM-1291.
 * Use user agent colors for native `<Select>` selected `<option>`s. Refs STCOM-1287.
 * Add a "Save & keep editing" translation. Refs STCOM-1296.
+* Add `dndProvided` prop to the `<MCLRenderer>` to render a placeholder for a draggable row. Refs STCOM-1297.
 
 ## [12.1.0](https://github.com/folio-org/stripes-components/tree/v12.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.0.0...v12.1.0)

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -198,6 +198,9 @@ class MCLRenderer extends React.Component {
     containerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     contentData: PropTypes.arrayOf(PropTypes.object),
     dataEndReached: PropTypes.bool,
+    dndProvided: PropTypes.shape({
+      placeholder: PropTypes.node,
+    }),
     formatter: PropTypes.object,
     getCellClass: PropTypes.func,
     getHeaderCellClass: PropTypes.func,
@@ -269,6 +272,7 @@ class MCLRenderer extends React.Component {
     columnWidths: {},
     contentData: [],
     dataEndReached: false,
+    dndProvided: {},
     formatter: {},
     hasMargin: false,
     hotKeys: { keyMap: {}, handlers: {} },
@@ -1843,6 +1847,7 @@ class MCLRenderer extends React.Component {
   render() {
     const {
       contentData,
+      dndProvided,
       getRowContainerClass,
       isEmptyMessage,
       totalCount,

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -1934,6 +1934,7 @@ class MCLRenderer extends React.Component {
                 ref={this.rowContainer}
               >
                 {renderedRows}
+                {dndProvided.placeholder}
               </div>
             </div>
             {

--- a/lib/MultiColumnList/readme.md
+++ b/lib/MultiColumnList/readme.md
@@ -81,6 +81,7 @@ Name | type | description | default | required
 `columnWidths` | object | Set custom column widths, e.g. {email: '150px'}. Component will automatically measure any columns that are unspecified. An object can be provided with `min` and `max` keys to set up a range - MCL will pick as close to the `min` as it can and none over the `max`.| |
 `contentData` | array of object | the list of objects to be displayed. | | required
 `dataEndReached` | bool | Used in conjuction with `pagingType="click"`, `dataEndReached` can be used if a suitable `totalCount` prop cannot be obtained. Setting this to `true` will render the "end-of-list" marker rather than the load button. | `false` |
+`dndProvided` | object | The `provided` object provided by the `<Droppable>` context contains a `placeholder` for the draggable element. Used for MCLs supporting Drag-n-Drop. | `{}` |
 `formatter`  | object mapping names to functions | see separate section | |
 `getCellClass` | func | Used to update or completely overwrite the visual styles for each column. The function passed to this prop will receive the current CSS class, row data and the column name as the parameters and the returned value will overwrite the default class – e.g. `(defaultClass, rowData, header) => ${defaultClass} ${myCustomClass}` | `undefined` |
 `getHeaderCellClass` | func | Used to update the visual styles for each column header. The function passed to this prop will receive the column name as the  parameter and the returned value will extend the default class – e.g. `header =>  ${myCustomClass}` | `undefined` |

--- a/lib/MultiColumnList/readme.md
+++ b/lib/MultiColumnList/readme.md
@@ -81,7 +81,7 @@ Name | type | description | default | required
 `columnWidths` | object | Set custom column widths, e.g. {email: '150px'}. Component will automatically measure any columns that are unspecified. An object can be provided with `min` and `max` keys to set up a range - MCL will pick as close to the `min` as it can and none over the `max`.| |
 `contentData` | array of object | the list of objects to be displayed. | | required
 `dataEndReached` | bool | Used in conjuction with `pagingType="click"`, `dataEndReached` can be used if a suitable `totalCount` prop cannot be obtained. Setting this to `true` will render the "end-of-list" marker rather than the load button. | `false` |
-`dndProvided` | object | The `provided` object provided by the `<Droppable>` context contains a `placeholder` for the draggable element. Used for MCLs supporting Drag-n-Drop. | `{}` |
+`dndProvided` | object | The `provided` object provided by the `<Droppable>` context contains a `placeholder` for the draggable row. Used for MCLs supporting Drag-n-Drop. | `{}` |
 `formatter`  | object mapping names to functions | see separate section | |
 `getCellClass` | func | Used to update or completely overwrite the visual styles for each column. The function passed to this prop will receive the current CSS class, row data and the column name as the parameters and the returned value will overwrite the default class – e.g. `(defaultClass, rowData, header) => ${defaultClass} ${myCustomClass}` | `undefined` |
 `getHeaderCellClass` | func | Used to update the visual styles for each column header. The function passed to this prop will receive the column name as the  parameter and the returned value will extend the default class – e.g. `header =>  ${myCustomClass}` | `undefined` |


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/STCOM-1297

Add `react-beautiful-dnd` placeholder support to enhance the drag-and-drop experience. The placeholder ensures that the layout remains stable and consistent during drag actions by temporarily occupying the space of the dragged element. This prevents content shifts or collapses, providing a smoother and more visually consistent user interface. Currently, the absence of a placeholder causes the list height to jump by the height of the dragged element, leading to a jarring user experience.

## Approach

FOLIO uses the `react-beautiful-dnd` library to implement DnD, which operates with `<Draggable>` and `<Droppable>` entities. The Droppable context provides the `provided` object as a render prop, which contains a placeholder for the draggable element. Passing this object as a prop and placing it directly after the list rows will solve the visualization problem with DnD.

## PoC

#### Without placeholder

https://github.com/folio-org/stripes-components/assets/88109087/dc43f935-2587-44ef-8d17-806be203217c

---

#### With placeholder

https://github.com/folio-org/stripes-components/assets/88109087/aac1b7c3-0cd9-42e9-85ef-a37fc1d67644

## Links
- TS type for `provided`: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-beautiful-dnd/v12/index.d.ts#L565
