### PR TITLE
STCOM-1276 Contrast of links within default MessageBanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Avoid deprecated `defaultProps` for functional components. Refs STCOM-1291.
 * Use user agent colors for native `<Select>` selected `<option>`s. Refs STCOM-1287.
 * Add a "Save & keep editing" translation. Refs STCOM-1296.
+* Adjust styles for links within default `<MessageBanner>`. Refs STCOM-1276.
 
 ## [12.1.0](https://github.com/folio-org/stripes-components/tree/v12.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.0.0...v12.1.0)

--- a/lib/MessageBanner/MessageBanner.module.css
+++ b/lib/MessageBanner/MessageBanner.module.css
@@ -94,6 +94,25 @@
   & .dismissButton {
     color: #fff;
   }
+
+  & a {
+    color: #fff;
+    text-decoration: underline;
+
+    &:visited {
+      color: #ccc;
+      text-decoration-color: #ccc;
+    }
+
+    &:focus {
+      color: #fff;
+
+      &::before {
+        border: 1px solid #ccc;
+        z-index: auto;
+      }
+    }
+  }
 }
 
 .type-error {

--- a/lib/MessageBanner/stories/BasicUsage.js
+++ b/lib/MessageBanner/stories/BasicUsage.js
@@ -4,10 +4,11 @@
 
 import React from 'react';
 import MessageBanner from '../MessageBanner';
+import TextLink from '../../TextLink';
 
 const BasicUsage = () => (
   <div style={{ maxWidth: 850 }}>
-    <MessageBanner>Default</MessageBanner>
+    <MessageBanner>Default <TextLink href="https://www.google.com">Test link</TextLink></MessageBanner>
     <MessageBanner type="success">Success</MessageBanner>
     <MessageBanner type="error">Error</MessageBanner>
     <MessageBanner type="warning">Warning</MessageBanner>
@@ -16,7 +17,7 @@ const BasicUsage = () => (
       a egestas consequat, elit elit fringilla ligula, et luctus magna nunc et mauris. Praesent in felis
       mollis, congue tellus sed, faucibus arcu. Mauris iaculis quam eu elementum interdum. Donec nulla augue,
       scelerisque in scelerisque a, ultrices non arcu. Etiam vehicula convallis erat, ultricies pellentesque
-      est commodo vitae. Sed sed est ut odio laoreet lobortis tincidunt vel velit.
+      est commodo vitae. Sed sed est ut odio laoreet lobortis tincidunt vel velit. <TextLink href="https://www.google.com">Test link</TextLink>
     </MessageBanner>
     <MessageBanner type="error">
       <ul>


### PR DESCRIPTION
[STCOM-1276](https://folio-org.atlassian.net/browse/STCOM-1276)

After changes:
![image](https://github.com/folio-org/stripes-components/assets/20704067/42d98026-a986-4cbb-acd4-503b5daa361d)

focused:
![image](https://github.com/folio-org/stripes-components/assets/20704067/87961f98-80b1-4f23-92e0-f7ecbfd085e9)

