### PR TITLE
STCOM-1299 Support Optimistic Locking in Tags - allow disable and show loading indicator in `<MultiSelection>`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Use user agent colors for native `<Select>` selected `<option>`s. Refs STCOM-1287.
 * Add a "Save & keep editing" translation. Refs STCOM-1296.
 * Add `dndProvided` prop to the `<MCLRenderer>` to render a placeholder for a draggable row. Refs STCOM-1297.
+* Support Optimistic Locking in Tags - allow disable and show loading indicator in MultiSelect. Refs STCOM-1299.
 
 ## [12.1.0](https://github.com/folio-org/stripes-components/tree/v12.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.0.0...v12.1.0)

--- a/lib/MultiSelection/MultiSelect.css
+++ b/lib/MultiSelection/MultiSelect.css
@@ -119,6 +119,11 @@
   composes: selected from '../Selection/Selection.css';
 }
 
+.optionDisabled {
+  background-color: var(--color-fill-disabled);
+  pointer-events: none;
+}
+
 .optionCursor {
   background-color: var(--color-fill-hover);
   box-shadow: inset 0 0 0 3px var(--primary);

--- a/lib/MultiSelection/MultiSelectOptionsList.js
+++ b/lib/MultiSelection/MultiSelectOptionsList.js
@@ -126,7 +126,8 @@ class MultiSelectOptionsList extends React.Component {
       formatter,
       downshiftActions,
       useLegacy,
-      renderToOverlay
+      renderToOverlay,
+      disabled,
     } = this.props;
 
     const filterProps = {
@@ -169,6 +170,7 @@ class MultiSelectOptionsList extends React.Component {
               {...getItemProps({
                 item,
                 index,
+                isDisabled: disabled,
                 optionItem: item,
                 isActive: highlightedIndex === index,
                 isSelected: findIndex(selectedItems, (o) => isEqual(o, item)) !== -1,

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -20,6 +20,7 @@ import TextFieldIcon from '../TextField/TextFieldIcon';
 import sharedInputStylesHelper from '../sharedStyles/sharedInputStylesHelper';
 import formField from '../FormField';
 import Label from '../Label';
+import { Loading } from '../Loading';
 import parseMeta from '../FormField/parseMeta';
 
 import css from './MultiSelect.css';
@@ -56,6 +57,7 @@ class MultiSelection extends React.Component {
     filter: PropTypes.func,
     formatter: PropTypes.func,
     id: PropTypes.string,
+    inputRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     intl: PropTypes.shape({
       formatMessage: PropTypes.func
     }),
@@ -71,6 +73,7 @@ class MultiSelection extends React.Component {
     placeholder: PropTypes.string,
     renderToOverlay: PropTypes.bool,
     required: PropTypes.bool,
+    showLoading: PropTypes.bool,
     validationEnabled: PropTypes.bool,
     value: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.object),
@@ -94,6 +97,7 @@ class MultiSelection extends React.Component {
       flip: { boundariesElement: 'viewport', padding: 5 },
       preventOverflow: { boundariesElement: 'scrollParent', padding: 5 },
     },
+    showLoading: false,
   };
 
   constructor(props) {
@@ -134,6 +138,14 @@ class MultiSelection extends React.Component {
 
   componentWillUnmount() {
     window.removeEventListener('resize', this.dbResize);
+  }
+
+  setInputRef = (element) => {
+    this.input.current = element;
+
+    if (this.props.inputRef) {
+      this.props.inputRef.current = element;
+    }
   }
 
   getContainerWidth = () => { // eslint-disable-line consistent-return
@@ -311,6 +323,7 @@ class MultiSelection extends React.Component {
       modifiers,
       autoFocus,
       valueFormatter,
+      showLoading,
       ...rest
     } = this.props;
 
@@ -402,7 +415,7 @@ class MultiSelection extends React.Component {
               atSmallMedia,
               backspaceDeletes,
               getInputProps,
-              inputRef: this.input,
+              inputRef: this.setInputRef,
               internalChangeCallback,
               onBlur: this.handleFilterBlur,
               onFocus: this.handleFilterFocus,
@@ -434,6 +447,7 @@ class MultiSelection extends React.Component {
               id: `multiselect-option-list-${uiId}`,
               inputRef: this.input,
               isOpen,
+              disabled,
               getMenuProps,
               getItemProps,
               maxHeight,
@@ -518,6 +532,9 @@ class MultiSelection extends React.Component {
                       {this.renderInputOrPlaceholder(filterProps)}
                       {this.renderValueInput(inputProps)}
                     </div>
+                    {showLoading && (
+                      <Loading />
+                    )}
                     <button
                       className={css.multiSelectToggleButton}
                       type="button"

--- a/lib/MultiSelection/SelectOption.js
+++ b/lib/MultiSelection/SelectOption.js
@@ -9,6 +9,7 @@ const SelectOption = (props) => {
       css.multiSelectOption,
       { [`${css.optionCursor}`]: props.isActive },
       { [`${css.optionSelected}`]: props.isSelected },
+      { [`${css.optionDisabled}`]: props.isDisabled },
     );
   }
 
@@ -36,6 +37,7 @@ SelectOption.propTypes = {
   children: PropTypes.node,
   id: PropTypes.string,
   isActive: PropTypes.bool,
+  isDisabled: PropTypes.bool,
   isSelected: PropTypes.bool,
 };
 

--- a/lib/MultiSelection/readme.md
+++ b/lib/MultiSelection/readme.md
@@ -32,6 +32,7 @@ Name | type | description | default | required
 `filter` | func | a custom function used to filter candidate values for search filters. It must accept two arguments: a string containing the partial value typed by the user, and an array of candidate values. If `asyncFiltering` is not being used, it should return an object with the shape of `{ renderedItems: <array> }`, where the array is a list of the candidate values that match the partial value. The returned object can also include additional properties that can be used for conditional rendering of `action`s. | The default filter (the `filterOptions` function in [`MultiSelection.js`](MultiSelection.js)) works by left-anchored regular-expression matching on the items' `label` field |
 `formatter` | func | Render function that accepts an object with keys for the option and the current filter string. The function is called to display values in the options dropdown and in the selected values list if `valueFormatter` prop is missing. A default `formatter` is provided. | [DefaultOptionFormatter](../Selection/DefaultOptionFormatter.js) |
 `id` | string | Sets the `id` attribute for the control. Other interior id's are generated using this string as a prefix. | |
+`inputRef` | object/func | Reference to input element | |
 `itemToString` | `<string>`func | Function used to return a single string representation of its value. For example, option objects with a shape of `{label:<string>, value:<object>}` would use `item => (item ? item.label : '')` for their toString function. This is used to generate strings so that values can accurately be announced for screen readers. | `item => (item ? item.label : '')` |
 `label` | string | Used as the form label for the field. Appropriate label/field relationship for accessibility is automatically set up by the component. | |
 `maxHeight` | number | The maximum height of the options menu in pixels. This does not include the heigh of any validation messages that may also appear with the menu. | `168` |
@@ -41,6 +42,7 @@ Name | type | description | default | required
 `onRemove` | func | Event handler specifically called when an item is removed from the selection. The removed item is passed to the handler. | |
 `placeholder` | string | Rendered as a placeholder for the control when no value is present. | |
 `renderToOverlay` | bool | For use in situations where the dropdown may be cut off due to a containing dom element's `overflow: hidden/auto` css attribute. | false |
+`showLoading` | bool | Should render loading indicator on the field | |
 `value` | array | Array of selected objects. | |
 `valueFormatter` | func | Render function that accepts an object with keys for the option. The function is called to display values in the selected values list. If the prop is missing, `formatter` will be used instead. | |
 `ariaLabelledBy` | string | Used for applying an accessible label if no `label` prop is provided | |

--- a/lib/MultiSelection/tests/MultiSelection-test.js
+++ b/lib/MultiSelection/tests/MultiSelection-test.js
@@ -747,4 +747,21 @@ describe('MultiSelect', () => {
       });
     });
   });
+
+  describe('when supplying a showLoading prop', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <MultiSelectionHarness
+          id={testId}
+          dataOptions={listOptions}
+          aria-label="test aria selection"
+          showLoading
+        />
+      );
+    });
+
+    it('should display loading icon', () => {
+      menu.has({ loading: true });
+    });
+  });
 });


### PR DESCRIPTION
## Description
Instance records have Optimistic Locking so we need to prevent users from editing tags while Instance is being updated

Add `inputRef` and `showLoading` props to `<MultiSelection>`

## Screenshots

https://github.com/folio-org/stripes-components/assets/19309423/d9f0f116-1c8e-4ba9-ac93-9172199212ec

## Issues
[STCOM-1299](https://folio-org.atlassian.net/browse/STCOM-1299)