### PR TITLE
STCOM-1304 - Selection/MultiSelection bugfix

### DIFF
--- a/lib/MultiSelection/MultiSelectOptionsList.js
+++ b/lib/MultiSelection/MultiSelectOptionsList.js
@@ -49,7 +49,7 @@ const MultiSelectOptionsList = ({
         {renderedItems && renderedItems?.length === 0 &&
           <div className={css.multiSelectEmptyMessage}>{emptyMessage}</div>
         }
-        {asyncFiltering && !renderedItems && (<Icon icon="spinner-ellipsis" />)}
+        {asyncFiltering && renderedItems.length === 0 && (<Icon icon="spinner-ellipsis" />)}
       </div>
       <ul
         style={getListStyle(atSmallMedia, maxHeight)}

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -19,7 +19,6 @@ import DefaultOptionFormatter from '../Selection/DefaultOptionFormatter';
 
 import SRStatus from '../SRStatus';
 import TextFieldIcon from '../TextField/TextFieldIcon';
-import Icon from '../Icon';
 import sharedInputStylesHelper from '../sharedStyles/sharedInputStylesHelper';
 import formField from '../FormField';
 import Label from '../Label';
@@ -390,7 +389,7 @@ const MultiSelection = ({
       getInputProps={getInputProps}
       getDropdownProps={getDropdownProps}
       isOpen={isOpen}
-      placeholder={placeholder}
+      placeholder={selectedItems.length === 0 && placeholder}
       menuId={menuId}
       setFilterValue={setFilterValue}
       setFilterFocus={setFilterFocused}
@@ -410,7 +409,8 @@ const MultiSelection = ({
     onBlur,
     menuId,
     onFocus,
-    placeholder
+    placeholder,
+    selectedItems.length
   ]);
 
   const renderOptions = useCallback(() => options.renderedItems?.map((item, index) => (
@@ -439,6 +439,10 @@ const MultiSelection = ({
     options.renderedItems,
     selectedItems
   ]);
+
+  const getValueAsString = useCallback(() => {
+    return Array.isArray(selectedItems) ? selectedItems.map(itemToString).join(',') : '';
+  }, [selectedItems, itemToString]);
 
   const renderActions = useCallback(() => actions?.map((item, index) => {
     const { renderedItems, exactMatch } = options;
@@ -539,7 +543,7 @@ const MultiSelection = ({
               className={css.multiSelectValueInput}
               id={valueInputId}
               required={required}
-              value={Array.isArray(value) ? value.map(itemToString).join(',') : value}
+              value={getValueAsString(value)}
               onChange={noop}
               autoFocus={autoFocus}
               onFocus={onValueInputFocus}

--- a/lib/MultiSelection/tests/MultiSelection-test.js
+++ b/lib/MultiSelection/tests/MultiSelection-test.js
@@ -590,7 +590,7 @@ describe('testing actions', () => {
       await multiselection.select('actionItem');
     });
 
-    it('calls the action\'s onSelect function', () => converge(() => { if (!actionSelected) throw new Error ('MultiSelection - action should be executed'); }));
+    it('calls the action\'s onSelect function', () => converge(() => { if (!actionSelected) throw new Error('MultiSelection - action should be executed'); }));
   });
 });
 

--- a/lib/MultiSelection/tests/MultiSelection-test.js
+++ b/lib/MultiSelection/tests/MultiSelection-test.js
@@ -4,9 +4,9 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import {
   HTML,
-  MultiSelect as MultiSelectInteractor,
+  MultiSelect,
   MultiSelectMenu as MenuInteractor,
-  MultiSelectOption as OptionInteractor,
+  MultiSelectOption,
   Button,
   TextInput,
   Label,
@@ -19,6 +19,17 @@ import { Interactor } from '@bigtest/interactor';
 
 import { mountWithContext } from '../../../tests/helpers';
 import MultiSelection from '../MultiSelection';
+
+const MultiSelectInteractor = MultiSelect.extend('local multiselect')
+  .filters({
+    id: (el) => el.id,
+    ariaLabelledby: (el) => el.querySelector('[role=searchbox]').getAttribute('aria-labelledby'),
+  });
+
+const OptionInteractor = MultiSelectOption.extend('local multiselect option')
+  .filters({
+    cursored: (el) => el.className.includes('Cursor'),
+  });
 
 const LoadingInteractor = HTML.extend('loading')
   .selector('[class^=spinner-]')

--- a/lib/MultiSelection/tests/MultiSelection-test.js
+++ b/lib/MultiSelection/tests/MultiSelection-test.js
@@ -20,8 +20,11 @@ import { Interactor } from '@bigtest/interactor';
 import { mountWithContext } from '../../../tests/helpers';
 import MultiSelection from '../MultiSelection';
 
+const LoadingInteractor = HTML.extend('loading')
+  .selector('[class^=spinner-]')
+
 const menu = MenuInteractor();
-const hiddenInput = TextInput({ visible: false });
+const hiddenInput = TextInput({ className: including('multiSelectValueInput') });
 const emptyMessage = HTML.extend('empty message')
   .selector('[class^=multiSelectEmptyMessage-]');
 
@@ -77,35 +80,19 @@ describe('MultiSelect', () => {
 
   it('contains no axe errors - Multiselect', runAxeTest);
 
-  it('renders the control', () => {
-    multiselection.exists();
-  });
+  it('renders the control', () => multiselection.exists());
 
-  it('does not have a value', () => {
-    multiselection.has({ selectedCount: 0 });
-  });
+  it('does not have a value', () => multiselection.has({ selectedCount: 0 }));
 
-  it('renders the supplied id prop', () => {
-    multiselection.has({ id: testId });
-  });
+  it('renders the supplied id prop', () => multiselection.has({ id: testId }));
 
-  it('renders placeholder', () => {
-    multiselection.has({ placeholder: 'test multiselect' });
-  });
+  it('renders placeholder', () => multiselection.has({ placeholder: 'test multiselect' }));
 
   it('list is hidden by default', expectClosedMenu);
 
-  it('expand button has a true has-popup attribute', () => {
-    Button('open menu').has({ ariaHasPopup: true });
-  });
+  it('control\'s aria-labelledBy attribute is set', () => multiselection.has({ ariaLabelledby: including(`multi-value-status-${testId}`) }));
 
-  it('control\'s aria-labelledBy attribute is set', () => {
-    multiselection.has({ arialabelledBy: `multi-value-status-${testId}` });
-  });
-
-  it('should have empty hidden value', () => {
-    hiddenInput.has({ value: '' });
-  });
+  it('should have empty hidden value', () => hiddenInput.has({ value: '' }));
 
   describe('clicking the control', () => {
     beforeEach(async () => {
@@ -116,33 +103,22 @@ describe('MultiSelect', () => {
 
     it('contains no axe errors - Multiselect: open menu', runAxeTest);
 
-    it('focuses the filter input', () => {
-      multiselection.has({ focused: true });
-    });
+    it('focuses the filter input', () => multiselection.has({ focused: true }));
 
-    it(`list is rendered with ${listOptions.length} options`, () => {
-      menu.has({ optionCount: listOptions.length });
-    });
+    it(`list is rendered with ${listOptions.length} options`, () => menu.has({ optionCount: listOptions.length }));
 
     describe('clicking an option', () => {
       beforeEach(async () => {
         await multiselection.select('Option 2');
       });
 
-      it(`sets control value to ${listOptions[2].label}`, () => {
-        menu.has({ optionCount: 1 });
-        OptionInteractor(`${listOptions[2].label}`).exists();
-      });
+      it(`sets control value to ${listOptions[2].label}`, () => ValueChipInteractor(`${listOptions[2].label}`).exists());
 
       it('the list stays open', expectOpenMenu);
 
-      it('does not render placeholder', () => {
-        multiselection.has({ placeholder: '' });
-      });
+      it('does not render placeholder', () => multiselection.has({ placeholder: '' }));
 
-      it('sets correct value of hidden input value', () => {
-        hiddenInput.has({ value: listOptions[2].label });
-      });
+      it('sets correct value of hidden input value', () => hiddenInput.has({ value: listOptions[2].label }));
 
       it('calls the onChange handler supplying the selected object', async () => {
         await converge(() => {
@@ -176,8 +152,12 @@ describe('MultiSelect', () => {
         });
 
         it('removes the last selected item', () => {
-          multiselection.has({ selectedCount: 2 });
-          multiselection.has({ selected: [`${listOptions[2].label}`, `${listOptions[3].label}`] });
+          return Promise.all(
+            [
+              multiselection.has({ selectedCount: 2 }),
+              multiselection.has({ selected: [`${listOptions[2].label}`, `${listOptions[3].label}`] })
+            ]
+          );
         });
 
         it('calls the supplied onRemove handler, supplying the removed item.', () => {
@@ -221,17 +201,11 @@ describe('MultiSelect', () => {
         await multiselection.filter('sample');
       });
 
-      it('first option is cursored', () => {
-        OptionInteractor({ index: 0, cursored: true }).exists();
-      });
+      it('first option is cursored', () => OptionInteractor({ index: 0, cursored: true }).exists());
 
-      it('decreases list to 3 options', () => {
-        menu.has({ optionCount: 3 });
-      });
+      it('decreases list to 3 options', () => menu.has({ optionCount: 3 }));
 
-      it('does not display the empty message', () => {
-        emptyMessage().absent();
-      });
+      it('does not display the empty message', () => emptyMessage().absent());
 
       describe('clicking a filtered option', () => {
         beforeEach(async () => {
@@ -421,7 +395,6 @@ describe('MultiSelection, initial value', () => {
 
     it('sets the appropriate aria-activedescendant on the filter', () => {
       TextInput({ ariaActiveDescendent: OptionInteractor({ index: 2 }).id }).exists();
-      // expect(multiselection.filterActiveDescendant).to.equal(multiselection.options(2).id);
     });
 
     describe('Keyboard : up arrow with open menu navigates to previous option', () => {
@@ -643,13 +616,9 @@ describe('asyncFiltering', () => {
 
     it('opens the menu', expectOpenMenu);
 
-    it('displays loading icon (dataOptions is undefined)', () => {
-      menu.has({ loading: true });
-    });
+    it('displays loading icon (dataOptions is undefined)', () => LoadingInteractor().exists());
 
-    it('calls the supplied filter function', () => {
-      converge(() => filtered);
-    });
+    it('calls the supplied filter function', () => converge(() => filtered));
   });
 });
 
@@ -669,18 +638,14 @@ describe('when the menu is open on a small screen', () => {
     viewport.reset();
   });
 
-  it('should focus the input', () => {
-    multiselection.is({ focused: true });
-  });
+  it('should focus the input', () => multiselection.is({ focused: true }));
 
   describe('and the menu was closed', () => {
     beforeEach(async () => {
       await multiselection.toggle();
     });
 
-    it('should focus the control', () => {
-      Button().is({ focused: true });
-    });
+    it('should focus the control', () => Button().is({ focused: true }));
   });
 });
 
@@ -702,9 +667,7 @@ describe('when a MultiSelect is set as required and placed inside a <form>', () 
       await submit.click();
     });
 
-    it('should focus the filter field', () => {
-      multiselection.has({ focused: true });
-    });
+    it('should focus the filter field', () => multiselection.has({ focused: true }));
   });
 
   describe('on mobile', () => {
@@ -728,9 +691,7 @@ describe('when a MultiSelect is set as required and placed inside a <form>', () 
       viewport.reset();
     });
 
-    it('should focus the control field', () => {
-      Button().is({ focused: true });
-    });
+    it('should focus the control field', () => multiselection.is({ focused: true }));
   });
 
   describe('when supplying a showLoading prop', () => {
@@ -745,8 +706,6 @@ describe('when a MultiSelect is set as required and placed inside a <form>', () 
       );
     });
 
-    it('should display loading icon', () => {
-      menu.has({ loading: true });
-    });
+    it('should display loading icon', () => LoadingInteractor().exists());
   });
 });

--- a/lib/Selection/Selection.js
+++ b/lib/Selection/Selection.js
@@ -4,6 +4,7 @@ import { useIntl } from 'react-intl';
 import { useCombobox } from 'downshift';
 import classNames from 'classnames';
 import isEqual from 'lodash/isEqual';
+import formField from '../FormField';
 
 import {
   defaultItemToString,
@@ -118,7 +119,8 @@ const Selection = ({
   const [selectedItem, updateSelectedItem] = useState(value ? getSelectedObject(value, dataOptions) : null);
   const controlRef = useProvidedRefOrCreate(inputRef);
   const options = useMemo(
-    () => (asyncFilter ? dataOptions : onFilter(filterValue, dataOptions)),
+    () => (asyncFilter ? dataOptions :
+      filterValue ? onFilter(filterValue, dataOptions) : dataOptions),
     [asyncFilter, filterValue, dataOptions, onFilter]
   );
 
@@ -147,7 +149,7 @@ const Selection = ({
     }
   });
 
-  const valueLabel = selectedItem?.label || placeholder || '';
+  const valueLabel = defaultItemToString(selectedItem) || placeholder || '';
   const labelId = `sl-label-${testId}`;
   const valueId = `selected-${testId}-item`;
 
@@ -212,7 +214,7 @@ const Selection = ({
             })}
             className={getItemClass(item, reducedIndex, { selectedItem, highlightedIndex, dataOptions })}
           >
-            {formatter({ option: item, filterValue })}
+            {formatter({ option: item, searchTerm: filterValue })}
           </li>
         )
       }
@@ -221,7 +223,7 @@ const Selection = ({
           key={`${item.label}-heading-${i}`}
           className={css.groupLabel}
         >
-          {formatter({ option: item, filterValue })}
+          {formatter({ option: item, searchTerm: filterValue })}
         </li>
       );
     })
@@ -352,4 +354,12 @@ Selection.propTypes = {
   warning: PropTypes.node,
 }
 
-export default Selection;
+export default formField(
+  Selection,
+  ({ meta }) => ({
+    dirty: meta.dirty,
+    error: (meta.touched && meta.error ? meta.error : ''),
+    valid: meta.valid,
+    warning: (meta.touched ? parseMeta(meta, 'warning') : ''),
+  })
+);

--- a/lib/Selection/Selection.js
+++ b/lib/Selection/Selection.js
@@ -139,7 +139,7 @@ const Selection = ({
     itemToString: defaultItemToString,
     selectedItem,
     onSelectedItemChange: ({ selectedItem: newSelectedItem }) => {
-      if (onChange) onChange(defaultItemToString(newSelectedItem));
+      if (onChange) onChange(newSelectedItem.value);
       updateSelectedItem(newSelectedItem);
     },
     isItemDisabled(item) {

--- a/lib/Selection/utils.js
+++ b/lib/Selection/utils.js
@@ -72,7 +72,7 @@ export const ensureValuedOption = (index, dataOptions) => {
   return undefined;
 };
 
-export const defaultItemToString = (item) => item?.value;
+export const defaultItemToString = (item) => item?.label;
 
 // removes any option group headers, leaving only selectable options.
 export const reduceOptions = (dataOptions) => dataOptions?.reduce((options, op) => {

--- a/lib/Selection/utils.js
+++ b/lib/Selection/utils.js
@@ -72,7 +72,7 @@ export const ensureValuedOption = (index, dataOptions) => {
   return undefined;
 };
 
-export const defaultItemToString = (item) => item?.label;
+export const defaultItemToString = (item) => item?.value;
 
 // removes any option group headers, leaving only selectable options.
 export const reduceOptions = (dataOptions) => dataOptions?.reduce((options, op) => {


### PR DESCRIPTION
- Update `<MultiSelection>` tests/interactor
- Only execute filtering logic in `<Selection>` when the filter has a value - this caused a handful of issues with initial rendering of pages throwing errors - but it does appear there are some ui-modules that pass components directly to dataOption labels vs the strings that those components might render via `react-intl`
- Properly send `<Selection>` value string to its `onChange` handler.
- Wrap `<Selection>` in `formField` HOC so that it can conform to React-Final-Form's expectations.

Will open a corresponding PR in stripes-testing. ~These tests will not pass without it.~ Locally patching interactors to get this PR over the hump and hopefully fix the major functional issues.