### PR TITLE
STCOM-1304v2 - redux-form compatibility - Selection.

### DIFF
--- a/lib/Selection/Selection.js
+++ b/lib/Selection/Selection.js
@@ -5,6 +5,7 @@ import { useCombobox } from 'downshift';
 import classNames from 'classnames';
 import isEqual from 'lodash/isEqual';
 import formField from '../FormField';
+import parseMeta from '../FormField/parseMeta';
 
 import {
   defaultItemToString,
@@ -95,7 +96,9 @@ const Selection = ({
   formatter = DefaultOptionFormatter,
   id,
   inputRef,
+  onBlur,
   onChange,
+  onFocus,
   placeholder,
   label,
   listMaxHeight = '174px',
@@ -297,12 +300,18 @@ const Selection = ({
           })}
           className={getControlClass}
           autoFocus={autofocus}
+          onBlur={onBlur}
+          onFocus={onFocus}
         >
           <span className="sr-only">{formatMessage({ id: 'stripes-components.selection.controlLabel' })}</span>
           {valueLabel}
         </button>
         <div className={css.selectionEndControls}>
           <TextFieldIcon icon="triangle-down" />
+        </div>
+        <div role="alert">
+          {warning && <div className={`${formStyles.feedbackWarning}`}>{warning}</div>}
+          {error && <div className={`${formStyles.feedbackError}`}>{error}</div>}
         </div>
       </div>
       <SelectionOverlay
@@ -340,8 +349,10 @@ Selection.propTypes = {
   loading: PropTypes.bool,
   loadingMessage: PropTypes.node,
   marginBottom0: PropTypes.bool,
+  onBlur: PropTypes.func,
   onChange: PropTypes.func,
   onFilter: PropTypes.func,
+  onFocus: PropTypes.func,
   optionAlignment: PropTypes.string,
   placeholder: PropTypes.node,
   popper: PropTypes.object,

--- a/lib/Selection/tests/Selection-ReduxForm-test.js
+++ b/lib/Selection/tests/Selection-ReduxForm-test.js
@@ -1,7 +1,11 @@
 import React from 'react';
 import { describe, beforeEach, it } from 'mocha';
 import { Field } from 'redux-form';
-import { Selection as SelectionInteractor } from '@folio/stripes-testing';
+import {
+  Selection as SelectionInteractor,
+  Button,
+  TextInput,
+} from '@folio/stripes-testing';
 
 import { mountWithContext } from '../../../tests/helpers';
 import TestForm from '../../../tests/TestForm';
@@ -13,6 +17,7 @@ describe('Selection', () => {
 
   describe('coupled to redux-form', () => {
     beforeEach(async () => {
+      const validate = () => 'there\'s a problem!'
       await mountWithContext(
         <TestForm>
           <Field
@@ -20,15 +25,35 @@ describe('Selection', () => {
             name="testField"
             component={Selection}
             dataOptions={[
-              { value: 'test', label: 'Hello World' }
+              { value: 'test', label: 'Hello World' },
+              { value: 'test2', label: 'Hello World2' }
             ]}
+            validate={validate}
           />
+          <Field component="input" name="testText" />
         </TestForm>
       );
+      await selection.focus();
     });
 
-    it('renders the control', () => {
-      selection.exists();
+    it('renders the control', () => selection.exists());
+
+    it('focuses the button', () => Button({ focused: true }).exists());
+
+    describe('using the control', () => {
+      beforeEach(async () => {
+        await selection.choose('Hello World');
+      });
+
+      it('sets the chosen label in the control field', () => selection.has({ value: 'Select controlHello World' }));
+
+      describe('after using the control', () => {
+        beforeEach(async () => {
+          await TextInput().focus();
+        });
+
+        it('displays redux-form validation', () => selection.has({ error: 'there\'s a problem!' }));
+      });
     });
   });
 });


### PR DESCRIPTION
Selection needed to have `onBlur` and `onFocus` passed to its control in order to correctly validate/display validations methods, update `meta.touched` through `redux-form`.