### PR TITLE
STCOM-1307: Pass the `isCursorAtEnd` property to the textarea props in the `SearchField` component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Implement option grouping feature in `<Selection>`. Refs STCOM-1278.
 * Refactor `<Callout>` styles for Firefox compatibility.
 * Adjust focus styling for color contrast in main navigation. Refs STCOM-1301.
+* Pass the `isCursorAtEnd` property to the textarea props in the `SearchField` component. Refs STCOM-1307.
 
 ## [12.1.0](https://github.com/folio-org/stripes-components/tree/v12.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.0.0...v12.1.0)

--- a/lib/SearchField/SearchField.js
+++ b/lib/SearchField/SearchField.js
@@ -96,6 +96,7 @@ const SearchField = (props) => {
     newLineOnShiftEnter = false,
     inputRef,
     indexRef,
+    isCursorAtEnd = false,
     ...rest
   } = props;
 
@@ -175,6 +176,7 @@ const SearchField = (props) => {
       onSubmitSearch,
       newLineOnShiftEnter,
       rows: TEXTAREA_DEFAULT_HEIGHT,
+      isCursorAtEnd,
     };
 
     return {


### PR DESCRIPTION
## Description:
Pass the `isCursorAtEnd` property to the textarea props in the `SearchField` component to have a cursor at the end of the entered search term.

## Issues
[STCOM-1307](https://folio-org.atlassian.net/browse/STCOM-1307)