### PR TITLE
FAT-14783 Fixes to align with interactor/automated tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 * Implement option grouping feature in `<Selection>`. Refs STCOM-1278.
 * Refactor `<Callout>` styles for Firefox compatibility.
 * Adjust focus styling for color contrast in main navigation. Refs STCOM-1301.
+* Wrap `<Selection>` value string in exclusive element. Apply `name` attribute to `<Selection>` control. Refs FAT-14783.
+* Correctly apply supplied `ariaLabelledby` prop in `<MultiSelection`>. Refs FAT-14783.
+* Add translation for `<MultiSelection>` dropdown trigger. Refs FAT-14783.
 
 ## [12.1.0](https://github.com/folio-org/stripes-components/tree/v12.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.0.0...v12.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Wrap `<Selection>` value string in exclusive element. Apply `name` attribute to `<Selection>` control. Refs FAT-14783.
 * Correctly apply supplied `ariaLabelledby` prop in `<MultiSelection`>. Refs FAT-14783.
 * Add translation for `<MultiSelection>` dropdown trigger. Refs FAT-14783.
+* Apply correct widths for `<MultiSelectOptionsList>`. Refs STCOM-1308.
 
 ## [12.1.0](https://github.com/folio-org/stripes-components/tree/v12.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.0.0...v12.1.0)

--- a/lib/MultiSelection/MultiSelectOptionsList.js
+++ b/lib/MultiSelection/MultiSelectOptionsList.js
@@ -6,8 +6,8 @@ import Icon from '../Icon';
 
 const getMenuStyle = (atSmallMedia, containerWidth) => {
   return atSmallMedia ?
-    { width: `${containerWidth}px` } :
-    { width: '100%' }
+    { width: '100%' } :
+    { width: `${containerWidth}px` }
 }
 
 const getListStyle = (atSmallMedia, maxHeight) => {

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -120,7 +120,7 @@ const MultiSelection = ({
   const srStat = useRef(null);
   const uiId = useProvidedIdOrCreate(id, 'multiselect-');
 
-  const ariaLabelledBy = useRef(rest['aria-labelledby'] || rest.ariaLabelledby).current;
+  const ariaLabelledBy = useRef(rest['aria-labelledby'] || rest.ariaLabelledby || rest.ariaLabelledBy).current;
   const valueLabelId = useRef(`multi-value-${uiId}`).current;
   const valueListId = useRef(`multi-values-list-${uiId}`).current;
   const valueDescriptionId = useRef(`multi-describe-action-${uiId}`).current;
@@ -559,7 +559,7 @@ const MultiSelection = ({
             type="button"
             {...getToggleButtonProps({
               ...getDropdownProps({
-                'aria-label': 'toggle menu',
+                'aria-label': formatMessage({ id: 'stripes-components.multiSelection.dropdownTriggerLabel' }),
                 'aria-controls': menuId,
                 // prevents the menu from immediately toggling
                 // closed (due to our custom click handler above).

--- a/lib/MultiSelection/tests/MultiSelection-test.js
+++ b/lib/MultiSelection/tests/MultiSelection-test.js
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import {
   HTML,
-  MultiSelect,
+  MultiSelect as MultiSelectInteractor,
   MultiSelectMenu as MenuInteractor,
   MultiSelectOption,
   Button,
@@ -19,12 +19,6 @@ import { Interactor } from '@bigtest/interactor';
 
 import { mountWithContext } from '../../../tests/helpers';
 import MultiSelection from '../MultiSelection';
-
-const MultiSelectInteractor = MultiSelect.extend('local multiselect')
-  .filters({
-    id: (el) => el.id,
-    ariaLabelledby: (el) => el.querySelector('[role=searchbox]').getAttribute('aria-labelledby'),
-  });
 
 const OptionInteractor = MultiSelectOption.extend('local multiselect option')
   .filters({
@@ -50,6 +44,7 @@ const ValueChipInteractor = HTML.extend('value chip')
     remove: ({ find }) => find(Button()).click()
   });
 
+const multiselectionAriaLabelledby = MultiSelectInteractor({ ariaLabelledby: 'test-label-id' });
 const multiselection = MultiSelectInteractor();
 
 const expectClosedMenu = () => {
@@ -85,29 +80,30 @@ describe('MultiSelect', () => {
         label="test multiselect"
         onRemove={onRemove}
         onChange={onChange}
+        ariaLabelledby="test-label-id"
       />
     );
   });
 
   it('contains no axe errors - Multiselect', runAxeTest);
 
-  it('renders the control', () => multiselection.exists());
+  it('renders the control', () => multiselectionAriaLabelledby.exists());
 
-  it('does not have a value', () => multiselection.has({ selectedCount: 0 }));
+  it('does not have a value', () => multiselectionAriaLabelledby.has({ selectedCount: 0 }));
 
-  it('renders the supplied id prop', () => multiselection.has({ id: testId }));
+  it('renders the supplied id prop', () => multiselectionAriaLabelledby.has({ id: testId }));
 
-  it('renders placeholder', () => multiselection.has({ placeholder: 'test multiselect' }));
+  it('renders placeholder', () => multiselectionAriaLabelledby.has({ placeholder: 'test multiselect' }));
 
   it('list is hidden by default', expectClosedMenu);
 
-  it('control\'s aria-labelledBy attribute is set', () => multiselection.has({ ariaLabelledby: including(`multi-value-status-${testId}`) }));
+  it('control\'s aria-labelledBy attribute is set', () => multiselectionAriaLabelledby.has({ ariaLabelledby: including('test-label-id') }));
 
   it('should have empty hidden value', () => hiddenInput.has({ value: '' }));
 
   describe('clicking the control', () => {
     beforeEach(async () => {
-      await multiselection.toggle();
+      await multiselectionAriaLabelledby.toggle();
     });
 
     it('opens the list', expectOpenMenu);
@@ -140,9 +136,11 @@ describe('MultiSelect', () => {
 
     describe('clicking multiple options', () => {
       beforeEach(async () => {
-        await multiselection.select(`${listOptions[2].label}`)
-        await multiselection.select(`${listOptions[3].label}`)
-        await multiselection.select(`${listOptions[4].label}`)
+        await multiselection.select([
+          `${listOptions[2].label}`,
+          `${listOptions[3].label}`,
+          `${listOptions[4].label}`
+        ])
       });
 
       it(`sets control value to ${listOptions[2].label}, ${listOptions[3].label}, ${listOptions[4].label}`, async () => {

--- a/lib/MultiSelection/tests/MultiSelection-test.js
+++ b/lib/MultiSelection/tests/MultiSelection-test.js
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import {
   HTML,
-  MultiSelect as MultiSelectInteractor,
+  MultiSelect,
   MultiSelectMenu as MenuInteractor,
   MultiSelectOption,
   Button,
@@ -19,6 +19,11 @@ import { Interactor } from '@bigtest/interactor';
 
 import { mountWithContext } from '../../../tests/helpers';
 import MultiSelection from '../MultiSelection';
+
+const MultiSelectInteractor = MultiSelect.extend('local multiselect')
+  .filters({
+    ariaLabelledby: (el) => el.querySelector('[role=combobox]').getAttribute('aria-labelledby'),
+  });
 
 const OptionInteractor = MultiSelectOption.extend('local multiselect option')
   .filters({

--- a/lib/Selection/Selection.js
+++ b/lib/Selection/Selection.js
@@ -105,6 +105,7 @@ const Selection = ({
   loading,
   loadingMessage,
   marginBottom0,
+  name,
   onFilter = filterOptionList,
   optionAlignment,
   popper,
@@ -302,9 +303,10 @@ const Selection = ({
           autoFocus={autofocus}
           onBlur={onBlur}
           onFocus={onFocus}
+          name={name}
         >
           <span className="sr-only">{formatMessage({ id: 'stripes-components.selection.controlLabel' })}</span>
-          {valueLabel}
+          <div className={css.singleValue} id={valueId}>{valueLabel}</div>
         </button>
         <div className={css.selectionEndControls}>
           <TextFieldIcon icon="triangle-down" />
@@ -349,6 +351,7 @@ Selection.propTypes = {
   loading: PropTypes.bool,
   loadingMessage: PropTypes.node,
   marginBottom0: PropTypes.bool,
+  name: PropTypes.string,
   onBlur: PropTypes.func,
   onChange: PropTypes.func,
   onFilter: PropTypes.func,

--- a/lib/Selection/tests/Selection-ReduxForm-test.js
+++ b/lib/Selection/tests/Selection-ReduxForm-test.js
@@ -46,7 +46,7 @@ describe('Selection', () => {
         await selection.choose('Hello World');
       });
 
-      it('sets the chosen label in the control field', () => selection.has({ value: 'Hello World' }));
+      it('sets the chosen label in the control field', () => selection.has({ singleValue: 'Hello World' }));
 
       describe('after using the control', () => {
         beforeEach(async () => {

--- a/lib/Selection/tests/Selection-ReduxForm-test.js
+++ b/lib/Selection/tests/Selection-ReduxForm-test.js
@@ -14,7 +14,6 @@ import Selection from '../Selection';
 
 describe('Selection', () => {
   const selection = SelectionInteractor('testSelection');
-
   describe('coupled to redux-form', () => {
     beforeEach(async () => {
       const validate = () => 'there\'s a problem!'
@@ -38,6 +37,8 @@ describe('Selection', () => {
 
     it('renders the control', () => selection.exists());
 
+    it('renders the name attribute', () => selection.has({ name: 'testField' }));
+
     it('focuses the button', () => Button({ focused: true }).exists());
 
     describe('using the control', () => {
@@ -45,7 +46,7 @@ describe('Selection', () => {
         await selection.choose('Hello World');
       });
 
-      it('sets the chosen label in the control field', () => selection.has({ value: 'Select controlHello World' }));
+      it('sets the chosen label in the control field', () => selection.has({ value: 'Hello World' }));
 
       describe('after using the control', () => {
         beforeEach(async () => {

--- a/lib/Selection/tests/Selection-test.js
+++ b/lib/Selection/tests/Selection-test.js
@@ -264,7 +264,7 @@ describe('Selection', () => {
       });
 
       it(`sets control value to ${listOptions[2].label}`, () => {
-        selection.has({ singleValue: 'Option 2' });
+        selection.has({ value: 'select controlOption 2' });
       });
 
       it('closes the list', expectClosedMenu);

--- a/lib/Selection/tests/Selection-test.js
+++ b/lib/Selection/tests/Selection-test.js
@@ -69,7 +69,7 @@ describe('Selection', () => {
     });
 
     it('does not have a value', () => {
-      selection.has({ value: '' });
+      selection.has({ singleValue: '' });
     });
 
     it('renders the supplied id prop', () => {
@@ -264,7 +264,7 @@ describe('Selection', () => {
       });
 
       it(`sets control value to ${listOptions[2].label}`, () => {
-        selection.has({ value: 'Option 2' });
+        selection.has({ singleValue: 'Option 2' });
       });
 
       it('closes the list', expectClosedMenu);
@@ -303,7 +303,7 @@ describe('Selection', () => {
         });
 
         it('sets the value appropriately', () => {
-          selection.has({ value: `${listOptions[5].label}` });
+          selection.has({ singleValue: `${listOptions[5].label}` });
         });
       });
 
@@ -331,7 +331,7 @@ describe('Selection', () => {
     });
 
     it("renders the appropriate option's label", () => {
-      selection.has({ value: listOptions[1].label });
+      selection.has({ singleValue: listOptions[1].label });
     });
 
     describe('Keyboard : letter press', () => {
@@ -342,7 +342,7 @@ describe('Selection', () => {
       });
 
       it('should set up the first filtered value', () => {
-        selection.has({ value: listOptions.find(o => o.value.startsWith('s')).label });
+        selection.has({ singleValue: listOptions.find(o => o.value.startsWith('s')).label });
       });
     });
 
@@ -355,7 +355,7 @@ describe('Selection', () => {
       it('opens the selection menu', expectOpenedMenu);
 
       it('selects the next option', () => {
-        selection.has({ value: listOptions[2].label });
+        selection.has({ singleValue: listOptions[2].label });
       });
     });
 
@@ -370,7 +370,7 @@ describe('Selection', () => {
       it('opens the selection menu', expectOpenedMenu);
 
       it('selects the previous option', () => {
-        selection.has({ value: listOptions[0].label });
+        selection.has({ singleValue: listOptions[0].label });
       });
     });
 
@@ -469,7 +469,7 @@ describe('Selection', () => {
             it('closes the option list', expectClosedMenu);
 
             it('sets the cursored option as the value', () => {
-              selection.has({ value: listOptions[4].label });
+              selection.has({ singleValue: listOptions[4].label });
             });
           });
         });
@@ -526,7 +526,7 @@ describe('Selection', () => {
       );
     });
 
-    it('has the intial value', () => selection.is({ value: 'Select controlOption 2' }));
+    it('has the intial value', () => selection.is({ singleValue: 'Option 2' }));
 
     describe('filtering all options from the list', () => {
       beforeEach(async () => {
@@ -541,7 +541,7 @@ describe('Selection', () => {
         });
 
         it('hides the list', () => selection.is({ open: false }));
-        it('has the intial value', () => selection.is({ value: 'Select controlOption 2' }));
+        it('has the intial value', () => selection.is({ singleValue: 'Option 2' }));
       });
     });
   });
@@ -558,7 +558,7 @@ describe('Selection', () => {
       await selection.open();
     });
 
-    it('sets provided value as visible value', () => selection.has({ value: 'Select controlSample 1' }));
+    it('sets provided value as visible value', () => selection.has({ singleValue: 'Sample 1' }));
 
     it('renders option groups', () => SelectionGroupLabel('grouped').exists());
     describe('filtering with grouped options', () => {

--- a/translations/stripes-components/en.json
+++ b/translations/stripes-components/en.json
@@ -110,6 +110,7 @@
   "selection.filterOptionsPlaceholder": "Filter options list",
   "selection.filterResultFeedback": "{length} items found, {label} selected",
   "selection.controlLabel": "Select control",
+  "multiSelection.dropdownTriggerLabel": "open menu",
   "multiSelection.defaultEmptyMessage": "No matching items found!",
   "multiSelection.filterPlaceholder": "filter option list",
   "multiSelection.controlDescription": "Contains a list of any selected values, followed by an autocomplete textfield for selecting additional values.",


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FAT-14783

With a handful of automated tests still failing, mark-up adjustments needed to be made for `<Selection>` and `<MultiSelection>`. Mostly these were omissions from the original rewrite of the component. Changes include:

- Wrapping `<Selection>`'s value in its own exclusive element.
- Applying the `name` attribute correctly within `<Selection>`
- Correctly labeling the dropdown trigger in in `<MultiSelection>`
- Correcting the implementation of `aria-labelledby` application in `<MultiSelection>`

Tests were updated to broaden their range of interactor usage.

This includes an additional bugfix cited in [STCOM-1308](https://folio-org.atlassian.net/browse/STCOM-1308) cited in the Automated tests issue. The fixed involved swapping the results on a conditional. By default the component was rendering its 100% wide version, as it should when rendering to small screens.