### PR TITLE
STCOM-1309 MultiSelection menu overlaps input when rendered within an Editable List.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Add translation for `<MultiSelection>` dropdown trigger. Refs FAT-14783.
 * Apply correct widths for `<MultiSelectOptionsList>`. Refs STCOM-1308.
 * Pass the `isCursorAtEnd` property to the textarea props in the `SearchField` component. Refs STCOM-1307.
+* Set `<MultiSelection>`'s popper modifiers to avoid overlap with the control when rendered within an Editable list. Refs STCOM-1309.
 
 ## [12.1.0](https://github.com/folio-org/stripes-components/tree/v12.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.0.0...v12.1.0)

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -90,7 +90,7 @@ const MultiSelection = ({
   marginBottom0,
   modifiers = {
     flip: { boundariesElement: 'viewport', padding: 5 },
-    preventOverflow: { boundariesElement: 'scrollParent', padding: 5 },
+    preventOverflow: { boundariesElement: 'viewport', padding: 5 },
   },
   noBorder,
   onAdd = noop,


### PR DESCRIPTION
Changed the default popper modifiers to use `viewport` for overflow avoidance rather than `scrollparent` - short list problems!

Before:
![image](https://github.com/folio-org/stripes-components/assets/20704067/bf5eff85-6eec-4db3-96ca-bf39309f72eb)

After:
![image](https://github.com/folio-org/stripes-components/assets/20704067/32a0fb32-3246-4081-92bb-cea5d33348bb)
