### PR TITLE
STCOM-1311 User can select an item multiple times in MultiSelect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Add translation for `<MultiSelection>` dropdown trigger. Refs FAT-14783.
 * Apply correct widths for `<MultiSelectOptionsList>`. Refs STCOM-1308.
 * Pass the `isCursorAtEnd` property to the textarea props in the `SearchField` component. Refs STCOM-1307.
+* Use `isEqual` to dedupe multiSelection values list rather that `===`. Refs STCOM-1311.
 
 ## [12.1.0](https://github.com/folio-org/stripes-components/tree/v12.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.0.0...v12.1.0)

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -51,7 +51,7 @@ const getContainerWidth = (container) => { // eslint-disable-line consistent-ret
 // handleSelection - addition/removal of selected options, also ensures selected
 // options are deduped.
 const handleSelection = (selectedItem, selectedItems, removeSelectedItem, addSelectedItem, onAdd) => {
-  const selectedIndex = selectedItems.findIndex((item) => item === selectedItem);
+  const selectedIndex = selectedItems.findIndex((item) => isEqual(item, selectedItem));
   if (selectedIndex !== -1) {
     removeSelectedItem(selectedItem);
   } else {
@@ -127,7 +127,7 @@ const MultiSelection = ({
   const controlDescriptionId = useRef(`multi-describe-control-${uiId}`).current;
   const controlValueStatusId = useRef(`multi-value-status-${uiId}`).current;
   const ariaLabel = useRef(rest.ariaLabel || rest['aria-label']).current;
-  const labelId = useRef(`multiselect-label-id-${uiId}`).current;
+  const labelId = useRef(`${uiId}-label`).current;
   const label = useRef(labelProp || ariaLabel || rest['aria-label']).current;
   const actionId = useRef(`multiselect-action-${uiId}`).current;
   const menuId = useRef(`multiselect-option-list-${uiId}`).current;
@@ -217,6 +217,7 @@ const MultiSelection = ({
     stateReducer(state, actionAndChanges) {
       const { changes, type } = actionAndChanges
       switch (type) {
+        case useCombobox.stateChangeTypes.InputEvent:
         case useCombobox.stateChangeTypes.InputKeyDownEnter:
         case useCombobox.stateChangeTypes.ItemClick:
           if (changes?.selectedItem?.onSelect) {
@@ -479,7 +480,11 @@ const MultiSelection = ({
       <SRStatus ref={srStat} />
       {label &&
         <Label
-          {...getLabelProps({ required, id: labelId })}
+          {...getLabelProps({
+            required,
+            id: labelId,
+            htmlFor: filterId,
+          })}
           className={`${ariaLabel ? 'sr-only' : ''}`}
         >
           {label}

--- a/lib/MultiSelection/tests/MultiSelection-test.js
+++ b/lib/MultiSelection/tests/MultiSelection-test.js
@@ -212,7 +212,7 @@ describe('MultiSelect', () => {
 
     describe('filtering options', () => {
       beforeEach(async () => {
-        await multiselection.filter('sample');
+        await multiselection.fillIn('sample');
       });
 
       it('first option is cursored', () => OptionInteractor({ index: 0, cursored: true }).exists());


### PR DESCRIPTION
Not always, but some instances of multiselect are effected by this... all storybook examples work. The refactor of Multiselection used `===` to dedupe its selected items list. This code has been updated to use `isEqual` to check the values held within the object for equality.

Additionally, this PR changes the internally generate label id to match that used in testing, and reflects changes in the Multiselect interactor within the test suite. (`fillin === filter`)

I also discovered that `htmlFor` wasn't properly assigned in MultiSelect, so that is resolved. Clicking the label text will now focus the filter field.