### PR TITLE
STCOM-1311 MultiSelection setting value prop after render should be reflected in component state.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 * Use `isEqual` to dedupe multiSelection values list rather that `===`. Refs STCOM-1311.
 * Set `<MultiSelection>`'s popper modifiers to avoid overlap with the control when rendered within an Editable list. Refs STCOM-1309.
 * Conform `<Selection>`'s internal state when value prop changes after initial render. Refs STCOM-1312.
+* Conform `<MultiSelection>`'s internal state when the value prop changes after the initial render. Refs STCOM-1311.
+* Make `<MultiSelection>` less strict about item removal via `itemToKey` setting (`downshift`). Refs STCOM-1311.
 
 ## [12.1.0](https://github.com/folio-org/stripes-components/tree/v12.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.0.0...v12.1.0)

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -486,8 +486,8 @@ const MultiSelection = ({
   }), [actionId, actions, filterValue, getItemProps, highlightedIndex, options, reset]);
 
   // check if value prop has changed from the outside and update state accordingly.
-  if (!awaitingChange.current && !isEqual(value, selectedItems)) {
-    setSelectedItems(value);
+  if (!awaitingChange.current && value && !isEqual(value, selectedItems)) {
+    setSelectedItems(value || []);
   }
 
   return (

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -113,6 +113,7 @@ const MultiSelection = ({
   const [atSmallMedia, setAtSmallMedia] = useState(window.matchMedia('(max-width: 640px)').matches);
   const [filterFocused, setFilterFocused] = useState(false);
   const [filterValue, setFilterValue] = useState('');
+  const awaitingChange = useRef(false);
   const container = useRef(null);
   const control = useRef(null);
   const input = useProvidedRefOrCreate(inputRef);
@@ -150,10 +151,13 @@ const MultiSelection = ({
     removeSelectedItem, // handler for removing the item from selected items
     addSelectedItem, // handler for adding the item from selected items
     selectedItems, // downshift manages this state.
+    setSelectedItems, // used only when the value changes from the outside of the component.
   } = useMultipleSelection({
     initialSelectedItems: value || [],
+    itemToKey: itemToString, // used by downshift's internal equality checker. itemToKey() === itemToKey
     onSelectedItemsChange(changes) {
       onChange(changes.selectedItems);
+      awaitingChange.current = false;
     },
     onStateChange({ selectedItems: newSelectedItems, type }) {
       switch (type) {
@@ -174,6 +178,16 @@ const MultiSelection = ({
           break;
       }
     },
+    stateReducer(state, actionAndChanges) {
+      const { changes, type } = actionAndChanges
+      switch (type) {
+        case useMultipleSelection.stateChangeTypes.FunctionRemoveSelectedItem:
+          awaitingChange.current = true;
+          return changes;
+        default:
+          return changes;
+      }
+    }
   });
 
   const {
@@ -233,6 +247,8 @@ const MultiSelection = ({
               isOpen: false, // keep the menu open after selection.
               highlightedIndex, // don't move highlight cursor back to top of list on selection.
             }
+          } else {
+            awaitingChange.current = true;
           }
           return {
             ...changes,
@@ -468,6 +484,11 @@ const MultiSelection = ({
       </SelectOption>
     );
   }), [actionId, actions, filterValue, getItemProps, highlightedIndex, options, reset]);
+
+  // check if value prop has changed from the outside and update state accordingly.
+  if (!awaitingChange.current && !isEqual(value, selectedItems)) {
+    setSelectedItems(value);
+  }
 
   return (
     <div

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -146,6 +146,13 @@ const MultiSelection = ({
     [asyncFiltering, filterValue, dataOptions, filter]
   );
 
+
+  // This component makes use of useMultiSelection and useCombobox hooks from downshift.
+  // useMultiSelection manages the list of selected items. It provides methods to add/remove affect that state.
+  // useCombobox manages the other state of other interactions with the component -
+  //    cursor position,
+  //    open/closed state of the menu
+  //    keyboard handlers/prop getters.
   const {
     getDropdownProps, // apply attributes to input or button trigger for dropdown
     removeSelectedItem, // handler for removing the item from selected items
@@ -154,7 +161,10 @@ const MultiSelection = ({
     setSelectedItems, // used only when the value changes from the outside of the component.
   } = useMultipleSelection({
     initialSelectedItems: value || [],
-    itemToKey: itemToString, // used by downshift's internal equality checker. itemToKey() === itemToKey
+    itemToKey: itemToString,  /* used by downshift's internal equality checker. We override it because it would default
+                                  a strict equals on objects which probably won't succeed. itemToString will
+                                  boil each object down to a string, so that the strict-equals will
+                                  have a better time succeeding.  */
     onSelectedItemsChange(changes) {
       onChange(changes.selectedItems);
       awaitingChange.current = false;
@@ -178,6 +188,11 @@ const MultiSelection = ({
           break;
       }
     },
+    // since we want the component to discern between internal changes
+    // and external changes in the selected item,
+    // we catch the internal changes with this function and flag the 'awaitingChange' ref to let
+    // state-syncing logic know the change happened internally, so we don't expect the value prop to sync until
+    // our `onChange` has been called...
     stateReducer(state, actionAndChanges) {
       const { changes, type } = actionAndChanges
       switch (type) {
@@ -228,6 +243,7 @@ const MultiSelection = ({
           break;
       }
     },
+    //
     stateReducer(state, actionAndChanges) {
       const { changes, type } = actionAndChanges
       switch (type) {

--- a/lib/MultiSelection/SelectOption.js
+++ b/lib/MultiSelection/SelectOption.js
@@ -17,6 +17,7 @@ const SelectOption = forwardRef((props, ref) => {
     children,
     isSelected,
     isActive, // eslint-disable-line
+    isDisabled, // eslint-disable-line
     optionItem,  // eslint-disable-line
     ...rest
   } = props;

--- a/lib/MultiSelection/tests/MultiSelection-test.js
+++ b/lib/MultiSelection/tests/MultiSelection-test.js
@@ -19,6 +19,7 @@ import { Interactor } from '@bigtest/interactor';
 
 import { mountWithContext } from '../../../tests/helpers';
 import MultiSelection from '../MultiSelection';
+import MultiSelectionHarness from './MultiSelectionHarness';
 
 const MultiSelectInteractor = MultiSelect.extend('local multiselect')
   .filters({
@@ -721,5 +722,33 @@ describe('when a MultiSelect is set as required and placed inside a <form>', () 
     });
 
     it('should display loading icon', () => LoadingInteractor().exists());
+  });
+
+  describe('Changing the value prop outside of render', () => {
+    const changeSpy = sinon.spy();
+    beforeEach(async () => {
+      await mountWithContext(
+        <MultiSelectionHarness
+          label="test multiselection"
+          initValue={[listOptions[2]]}
+          options={listOptions}
+          onChange={changeSpy}
+        />
+      );
+    });
+
+    it('renders initial value as provided', () => multiselection.has({ selected: ['Option 2']}));
+
+    describe('Reseting the value', () => {
+      beforeEach(async () => {
+        await Button('reset').click();
+      });
+
+      it('removes the value', () => multiselection.has({ selectedCount: 0 }))
+
+      it('calls the supplied change handler', () => {
+        expect(changeSpy.calledOnceWith([]));
+      })
+    });
   });
 });

--- a/lib/MultiSelection/tests/MultiSelectionHarness.js
+++ b/lib/MultiSelection/tests/MultiSelectionHarness.js
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+import MultiSelection from '../MultiSelection';
+import Button from '../../Button/Button';
+
+const MultiSelectionHarness = ({
+  initValue,
+  label,
+  options,
+  onChange = () => {},
+}) => {
+  const [fieldVal, setFieldVal] = useState(initValue);
+
+  return (
+    <>
+      <Button onClick={() => setFieldVal([])}>reset</Button>
+      <MultiSelection
+        label={label}
+        value={fieldVal}
+        dataOptions={options}
+        onChange={(val) => { setFieldVal(val); onChange(val) }}
+      />
+    </>
+  );
+}
+
+export default MultiSelectionHarness;


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/STCOM-1311

Round one of fixes addressed deduplication of selected items by using `isEqual` when determining if the chosen item is already selected or not, then it called downshift's own state management functions to handle addition or removal of the chosen item.

These problems (Multiselect not removing items, not resetting) ran a bit deeper.

Item removal was calling downshift's own 'removeSelectedItem', but the function within that was using strict equality against the result of a utility function (`itemToKey`) that needed to be overridden - otherwise it amounts to `object === object` which can be true but rarely and odd because all keys/values would be equal - so not intuitive for this. The override of `itemToKey` to use `itemToString` bakes the item down to a single string that strict equals is more likely to be affective with.

For the issue with affecting the value from outside of the component, the approach was to create a sentinel value so that the logic could differentiate between changes that happen outside of the component and changes that happened internally. Without it, having an empty value would always be different from the 'selectedItems' and always be reset before render so that no items could ever be selected or state couldn't change from its initial value.
