### PR TITLE
STCOM-1320 - Selection needs to conform its state when an item is selected. 

### DIFF
--- a/lib/Selection/Selection.js
+++ b/lib/Selection/Selection.js
@@ -190,7 +190,11 @@ const Selection = ({
     if (selectedItem !== null && selectedItem?.value === value) {
       awaitingChange.current = false;
     }
-  } else if (selectedItem !== null && selectedItem?.value !== value){
+  } else if ((
+    selectedItem !== null ||
+    // if we can find a valid dataOption to match the value (for dataOptions that have value: '')
+    getSelectedObject(value, dataOptions) !== null
+  ) && selectedItem?.value !== value) {
     // conform to post-mount value prop changes from outside of the component,
     // whether the changed value is something empty like '' or null;
     const newValue = getSelectedObject(value, dataOptions) || { value }

--- a/lib/Selection/tests/Selection-test.js
+++ b/lib/Selection/tests/Selection-test.js
@@ -602,7 +602,46 @@ describe('Selection', () => {
 
       it('removes the value', () => selection.has({ singleValue: '' }));
 
-      it('will not trigger a onChange', async () => converge(() => { if (changeSpy.called) throw new Error('expected change handler to be called once') }));
+      it('will not trigger a onChange', async () => converge(() => { if (changeSpy.called) throw new Error('expected change handler to not be called once') }));
+
+      describe('Setting the value outside of the component', () => {
+        beforeEach(async () => {
+          await Button('set value').click();
+        });
+
+        it('removes the value', () => selection.has({ singleValue: listOptions[1].label }));
+
+        it('will not trigger a onChange', async () => converge(() => { if (changeSpy.called) throw new Error('expected change handler to not be called once') }));
+      });
+    });
+  });
+
+  describe('Changing the value prop outside of render', () => {
+    const changeSpy = sinon.spy();
+    const harnessHandler = (fn, val) => {
+      changeSpy(val);
+      fn(val);
+    };
+    beforeEach(async () => {
+      changeSpy.resetHistory();
+      await mountWithContext(
+        <SingleSelectionHarness
+          label="test selection"
+          initValue=""
+          options={listOptions}
+          onChange={harnessHandler}
+        />
+      );
+    });
+
+    describe('Setting the value outside of the component', () => {
+      beforeEach(async () => {
+        await Button('set value').click();
+      });
+
+      it('removes the value', () => selection.has({ singleValue: listOptions[1].label }));
+
+      it('will not trigger a onChange', async () => converge(() => { if (changeSpy.called) throw new Error('expected change handler to not be called once') }));
     });
   });
 

--- a/lib/Selection/tests/SingleSelectionHarness.js
+++ b/lib/Selection/tests/SingleSelectionHarness.js
@@ -8,13 +8,15 @@ const SingleSelectionHarness = ({
   options: optionsProp,
   delayedOptions = [],
   onChange = (fn, val) => { fn(val) },
+  forcedValue,
 }) => {
   const [fieldVal, setFieldVal] = useState(initValue);
   const [options, updateOptions] = useState(optionsProp);
   const [increment, updateIncrement] = useState(0);
   return (
     <>
-      <Button onClick={() => setFieldVal('')}>reset</Button>
+      <Button onClick={() => { setFieldVal(''); updateOptions(optionsProp); }}>reset</Button>
+      <Button onClick={() => setFieldVal(forcedValue || optionsProp[1].value)}>set value</Button>
       <Button onClick={() => setTimeout(updateOptions(delayedOptions), 100)}>fillData</Button>
       <Button onClick={() => updateIncrement((cur) => cur + 1)}>{`update(${increment})`}</Button>;
       <Selection


### PR DESCRIPTION
Problem: Selection won't set update its internal value if if it has a non-null `selectedItem`.

Approach: append the conditional to support value changes if either the `selectedItem` is null *or* if the incoming `value` is a valid value by checking the outcome of `getSelectedObject`.