### PR TITLE
STCOM-1320 Selection should maintain its value as far as redux-form is concerned.

### DIFF
--- a/lib/Selection/Selection.js
+++ b/lib/Selection/Selection.js
@@ -348,6 +348,7 @@ const Selection = ({
           onBlur={onBlur}
           onFocus={onFocus}
           name={name}
+          value={selectedItem?.value}
         >
           <span className="sr-only">{formatMessage({ id: 'stripes-components.selection.controlLabel' })}</span>
           <div className={css.singleValue} id={valueId}>{valueLabel}</div>

--- a/lib/Selection/tests/Selection-ReduxForm-test.js
+++ b/lib/Selection/tests/Selection-ReduxForm-test.js
@@ -12,7 +12,7 @@ import TestForm from '../../../tests/TestForm';
 
 import Selection from '../Selection';
 
-describe('Selection', () => {
+describe.only('Selection', () => {
   const selection = SelectionInteractor('testSelection');
   describe('coupled to redux-form', () => {
     beforeEach(async () => {
@@ -54,6 +54,8 @@ describe('Selection', () => {
         });
 
         it('displays redux-form validation', () => selection.has({ error: 'there\'s a problem!' }));
+
+        it('retains the selected value in the field', () => selection.has({ singleValue: 'Hello World' }));
       });
     });
   });

--- a/lib/Selection/tests/Selection-ReduxForm-test.js
+++ b/lib/Selection/tests/Selection-ReduxForm-test.js
@@ -12,7 +12,7 @@ import TestForm from '../../../tests/TestForm';
 
 import Selection from '../Selection';
 
-describe.only('Selection', () => {
+describe('Selection', () => {
   const selection = SelectionInteractor('testSelection');
   describe('coupled to redux-form', () => {
     beforeEach(async () => {


### PR DESCRIPTION
Prior to refactor, `Selection` provided no `onBlur` _event_ to its supplied handler: https://github.com/folio-org/stripes-components/blob/b55b8c0449490be4c91e050fa3b7e5aa8ada0ea7/lib/Selection/SingleSelect.js#L504

This is dishonest, but it got us by.

Love it or hate it, Redux Form/react-final form perform an under-the-hood change to the value when the element is blurred. This change event is even outside of the realm of the component's own 'onChange' handler. Adding the value to a `value` attribute on the rendered control keeps the blur event honest and allows the component to retain its value.

As per usual, tests are expanded slightly to address the case.