### PR TITLE
STCOM-1327: Datepicker: outputBackendValue={false} causes crash on date entry.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-components
 
 ## 12.2.0 IN PROGRESS
+* Fix bug in Datepicker when outputBackendValue is set to false, and introduce formatInvalidDates bool. refs STCOM-1327
 * Add specific loading props to MCL to pass to Prev/Next pagination row, Refs STCOM-1305
 * Exclude invalid additional currencies. Refs STCOM-1274.
 * Validate ref in `Paneset` before dereferencing it. Refs STCOM-1235.

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -92,6 +92,7 @@ const propTypes = {
   dateFormat: PropTypes.string,
   disabled: PropTypes.bool,
   exclude: PropTypes.func,
+  formatInvalidDates: PropTypes.bool,
   hideOnChoose: PropTypes.bool,
   id: PropTypes.string,
   input: PropTypes.object,
@@ -135,6 +136,8 @@ const Datepicker = (
     disabled,
     dateFormat,
     exclude,
+    // Set formatInvalidDates to false to not format invalid date strings to '', allowing for validation in component
+    formatInvalidDates = true,
     hideOnChoose = true,
     id,
     intl,
@@ -166,7 +169,8 @@ const Datepicker = (
       valueProp, // value
       timeZoneProp || intl.timeZone, // timezone
       format, // uiFormat
-      getBackendDateStandard(backendDateStandard, true) // outputFormats
+      getBackendDateStandard(backendDateStandard, true), // outputFormats
+      formatInvalidDates,
     ) : null,
     formatted: typeof valueProp !== 'undefined' ? outputFormatter({
       backendDateStandard,
@@ -251,7 +255,7 @@ const Datepicker = (
     } else if (value !== datePair.dateString) {
       dates = {
         dateString: value,
-        formatted: ''
+        formatted: formatInvalidDates ? '' : value
       };
       updateDatePair(current => {
         const newDatePair = Object.assign(current, dates);

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -170,7 +170,6 @@ const Datepicker = (
       timeZoneProp || intl.timeZone, // timezone
       format, // uiFormat
       getBackendDateStandard(backendDateStandard, true), // outputFormats
-      formatInvalidDates,
     ) : null,
     formatted: typeof valueProp !== 'undefined' ? outputFormatter({
       backendDateStandard,

--- a/lib/Datepicker/Datepicker.js
+++ b/lib/Datepicker/Datepicker.js
@@ -121,7 +121,7 @@ const propTypes = {
 };
 
 const getBackendDateStandard = (standard, use) => {
-  if (!use) return undefined;
+  if (!use) return []; // This is spread later on, so return empty array instead of undefined
   if (standard === 'ISO8601') return ['YYYY-MM-DDTHH:mm:ss.sssZ', 'YYYY-MM-DDTHH:mm:ssZ'];
   if (standard === 'RFC2822') return ['ddd, DD MMM YYYY HH:mm:ss ZZ'];
   return [standard, 'YYYY-MM-DDTHH:mm:ss.sssZ', 'ddd, DD MMM YYYY HH:mm:ss ZZ'];

--- a/lib/Datepicker/readme.md
+++ b/lib/Datepicker/readme.md
@@ -15,6 +15,7 @@ Name | type | description | default | required
 `autoFocus` | bool | If this prop is `true`, component will automatically focus on mount | |
 `backendDateStandard` | string | parses to/from ISO 8601 standard, with Arabic (0-9) digits, by default before committing value. | "ISO 8601" | false
 `disabled` | bool | if true, field will be disabled for focus or entry. | false | false
+`formatInvalidDates` | bool | If set to true, the input value will be set directly to '' when an invalid date is entered. When set to false the value is left alone for validation purposes (which leaves the onus of preventing save or sanitising value on the implementing code) | true | false
 `id` | string | id for date field - used in the "id" attribute of the text input | | false
 `label` | string | visible field label | | false
 `locale` | string | Overrides the locale provided by context. | "en" | false


### PR DESCRIPTION
(Branch was misnamed)

Fixes issue where outputBackendValue={false} would cause crash on date entry.
Also introduces a `formatInvalidDates` boolean to avoid needing to replicate all of DatePicker's internal logic around date formatting/parsing just to be able to validate whether a date is valid or not externally.

This is an issue when a Date field is non-required, as the default behaviour will set the input value to '' when an invalid date is typed, which for a non-required field is a valid entry.