### PR TITLE
STCOM-1337 properly render string for filterGroups' clear button aria-label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * Refactor Modals away from `react-overlays`. Refs STCOM-1334.
 * Apply `inert` attribute to header and siblings of `div#OverlayContainer` when modals are open. Refs STCOM-1334.
 * Expand focus trapping of modal to the `div#OverlayContainer` so that overlay components can function within `<Modal>` using the `usePortal` prop. Refs STCOM-1334.
+* Render string for `FilterGroups` clear button. Refs STCOM-1337.
 
 ## [12.1.0](https://github.com/folio-org/stripes-components/tree/v12.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.0.0...v12.1.0)

--- a/lib/Accordion/headers/FilterAccordionHeader.js
+++ b/lib/Accordion/headers/FilterAccordionHeader.js
@@ -50,6 +50,7 @@ const FilterAccordionHeader = ({
   const clearButtonVisible = displayClearButton && typeof onClearFilter === 'function';
   const labelPropsId = label?.props?.id;
   const labelText = labelPropsId ? formatMessage({ id: labelPropsId }) : label || '-';
+  const clearFilterSetLabel = formatMessage({ id: stripes-components.filterGroups.clearFilterSetLabel , values: { labelText }});
 
   return (
     <div className={css.headerWrapper}>
@@ -88,7 +89,7 @@ const FilterAccordionHeader = ({
           size="small"
           iconSize="small"
           icon="times-circle-solid"
-          aria-label={`Clear selected filters for "${label}"`}
+          aria-label={clearFilterSetLabel}
           onClick={handleClearButtonClick}
         /> : null
       }

--- a/lib/Accordion/headers/FilterAccordionHeader.js
+++ b/lib/Accordion/headers/FilterAccordionHeader.js
@@ -50,7 +50,10 @@ const FilterAccordionHeader = ({
   const clearButtonVisible = displayClearButton && typeof onClearFilter === 'function';
   const labelPropsId = label?.props?.id;
   const labelText = labelPropsId ? formatMessage({ id: labelPropsId }) : label || '-';
-  const clearFilterSetLabel = formatMessage({ id: stripes-components.filterGroups.clearFilterSetLabel , values: { labelText }});
+  const clearFilterSetLabel = formatMessage(
+    { id: 'stripes-components.filterGroups.clearFilterSetLabel' },
+    { labelText }
+  );
 
   return (
     <div className={css.headerWrapper}>

--- a/translations/stripes-components/en.json
+++ b/translations/stripes-components/en.json
@@ -20,6 +20,7 @@
   "advancedSearch.emptyFirstRowError": "Enter a query in the first search box",
   "expandAll": "Expand all",
   "collapseAll": "Collapse all",
+  "filterGroups.clearFilterSetLabel": "Clear selected filters for {labelText}",
   "goToPreviousYear": "Go to previous year",
   "goToPreviousMonth": "Go to previous month",
   "goToNextYear": "Go to next year",

--- a/translations/stripes-components/en.json
+++ b/translations/stripes-components/en.json
@@ -20,7 +20,7 @@
   "advancedSearch.emptyFirstRowError": "Enter a query in the first search box",
   "expandAll": "Expand all",
   "collapseAll": "Collapse all",
-  "filterGroups.clearFilterSetLabel": "Clear selected filters for {labelText}",
+  "filterGroups.clearFilterSetLabel": "Clear selected {labelText} filters",
   "goToPreviousYear": "Go to previous year",
   "goToPreviousMonth": "Go to previous month",
   "goToNextYear": "Go to next year",

--- a/translations/stripes-components/en_US.json
+++ b/translations/stripes-components/en_US.json
@@ -1,6 +1,7 @@
 {
     "expandAll": "Expand all",
     "collapseAll": "Collapse all",
+    "filterGroups.clearFilterSetLabel": "Clear selected filters for {labelText}",
     "goToPreviousYear": "Go to previous year",
     "goToPreviousMonth": "Go to previous month",
     "goToNextYear": "Go to next year",

--- a/translations/stripes-components/en_US.json
+++ b/translations/stripes-components/en_US.json
@@ -1,7 +1,7 @@
 {
     "expandAll": "Expand all",
     "collapseAll": "Collapse all",
-    "filterGroups.clearFilterSetLabel": "Clear selected filters for {labelText}",
+    "filterGroups.clearFilterSetLabel": "Clear selected {labelText} filters",
     "goToPreviousYear": "Go to previous year",
     "goToPreviousMonth": "Go to previous month",
     "goToNextYear": "Go to next year",


### PR DESCRIPTION
## [STCOM-1337](https://folio-org.atlassian.net/browse/STCOM-1337)

`FilterGroups` renders its heading fine, just doesn't provide a string to the tiny `clear` X button for resetting the filters for the group. This PR moves a static string to the translations and calculates the proper string before applying it to the button.

The logic within `filtergroups` was potentially allowing a raw component/an instance of  `<FormattedMessage>` through to the aria label. The new logic just generates a string to supply to the aria-label instead of passing the `<FormattedMessage>` directly. 

The old aria-label: "Clear selected filter for [Object object]'

The new aria-label: 'Clear selected Status filters'