### PR TITLE
STCOM-1334: Modal - add 'open' attribute to dialog.

### DIFF
--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -191,6 +191,7 @@ const Modal = forwardRef((props, ref) => {
           onClick={handleBackgroundClick}
         />
         <dialog
+          open={open}
           className={classNames(css.modalRoot, css[status])}
           ref={modalElem}
           onFocus={focusEntered}


### PR DESCRIPTION
## Description
Currently, all tests that use `getByRole` to find elements in `Modal` fail (ui-quick-marc, ui-inventory,...). This is due to the lack of the `open` attribute on the `dialog` tag. The `open` property indicates whether the `dialog` is available for interaction.

