### PR TITLE
Modal: Use div[role=dialog] instead of dialog element

### DIFF
--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -190,7 +190,8 @@ const Modal = forwardRef((props, ref) => {
           className={css.backdrop}
           onClick={handleBackgroundClick}
         />
-        <dialog
+        <div
+          role="dialog"
           className={classNames(css.modalRoot, css[status])}
           ref={modalElem}
           onFocus={focusEntered}
@@ -263,7 +264,7 @@ const Modal = forwardRef((props, ref) => {
               )
             }
           </WrappingElement>
-        </dialog>
+        </div>
       </>
     ),
     refreshPortal()


### PR DESCRIPTION
Because jest/jsdom seems to want to mark all `<dialog>` elements as `display: 'none'` which doesn't allow interactors to find things, no way, no how unless `{visible: false}` is specified.