### PR TITLE
STCOM-1335 add `StripesOverlayContext` to Modal, MCL... implement in Popper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Apply `inert` attribute to header and siblings of `div#OverlayContainer` when modals are open. Refs STCOM-1334.
 * Expand focus trapping of modal to the `div#OverlayContainer` so that overlay components can function within `<Modal>` using the `usePortal` prop. Refs STCOM-1334.
 * Render string for `FilterGroups` clear button. Refs STCOM-1337.
+* Add OverlayContext for Overlay-style components rendered within Modals and MCL's. Refs STCOM-1335.
 
 ## [12.1.0](https://github.com/folio-org/stripes-components/tree/v12.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.0.0...v12.1.0)

--- a/hooks/tests/useOverlayContainer-test.js
+++ b/hooks/tests/useOverlayContainer-test.js
@@ -1,0 +1,78 @@
+import {
+  describe,
+  beforeEach,
+  it,
+} from 'mocha';
+import { converge } from '@folio/stripes-testing';
+import getHookExecutionResult from '../../tests/helpers/getHookExecutionResult';
+import useOverlayContainer from '../useOverlayContainer';
+
+import { OVERLAY_CONTAINER_ID } from '../../util/consts';
+
+const Harness = ({ children }) => (
+  <div id="rootChild">
+    <div id="OverlayContainer" />
+    {children}
+  </div>
+);
+
+const HarnessWithout = ({ children }) => (
+  <div id="rootChild">
+    {children}
+  </div>
+);
+
+// lodash/isEqual does not work on comparing DOM nodes, so here we are....
+const domNodesEqual = (current, candidate) => {
+  if (current?.element?.tagName !== candidate?.element?.tagName) {
+    return false;
+  }
+
+  if (current?.element?.id !== candidate?.element?.id) {
+    return false;
+  }
+
+  return true;
+}
+
+describe('useOverlayContainer', () => {
+  const overlayElement = () => document.getElementById(OVERLAY_CONTAINER_ID);
+  let res;
+  beforeEach(() => {
+    res = null;
+  });
+
+  describe('withoutOverlay fallback to a child of root.', () => {
+    beforeEach(async () => {
+      await getHookExecutionResult(
+        useOverlayContainer,
+        [overlayElement()],
+        HarnessWithout,
+        (result) => { res = result.element },
+        domNodesEqual
+      );
+    });
+
+    it('should fallback to child of root element',
+      () => converge(() => {
+        if (res.parentNode?.id !== 'root') throw new Error(`expected child of root: ${res.id}`);
+      }));
+  });
+
+  describe('successfully resolving overlay container if it exists...', () => {
+    beforeEach(async () => {
+      await getHookExecutionResult(
+        useOverlayContainer,
+        [overlayElement()],
+        Harness,
+        (result) => { res = result.element },
+        domNodesEqual
+      );
+    });
+
+    it('div#OverlayContainer in place, it should return it',
+      () => converge(() => {
+        if (res.id !== OVERLAY_CONTAINER_ID) throw new Error(`expected element to fallback to body: ${res.id}`);
+      }));
+  });
+});

--- a/hooks/tests/useOverlayContainer-test.js
+++ b/hooks/tests/useOverlayContainer-test.js
@@ -110,6 +110,24 @@ describe('useOverlayContainer', () => {
       }));
   });
 
+  describe('falsy initial result...', () => {
+    beforeEach(async () => {
+      res = await getHookExecutionHarness(
+        useOverlayContainer,
+        [false],
+        Harness,
+        (result) => { res = result.element },
+        areDomNodesEqual
+      );
+      res.refresh();
+    });
+
+    it('div#OverlayContainer in place, it should return it',
+      () => converge(() => {
+        if (res !== false) throw new Error('should just return truthy value');
+      }));
+  });
+
   describe('refresh', () => {
     beforeEach(async () => {
       res = await getHookExecutionHarness(

--- a/hooks/tests/useOverlayContainer-test.js
+++ b/hooks/tests/useOverlayContainer-test.js
@@ -35,7 +35,7 @@ const areDomNodesEqual = (current, candidate) => {
   return true;
 }
 
-describe('useOverlayContainer', () => {
+describe.only('useOverlayContainer', () => {
   const overlayElement = () => document.getElementById(OVERLAY_CONTAINER_ID);
   let res;
   beforeEach(() => {
@@ -73,6 +73,41 @@ describe('useOverlayContainer', () => {
     it('div#OverlayContainer in place, it should return it',
       () => converge(() => {
         if (res.id !== OVERLAY_CONTAINER_ID) throw new Error(`expected element to fallback to body: ${res.id}`);
+      }));
+  });
+
+  describe('successfully initial null result...', () => {
+    beforeEach(async () => {
+      await getHookExecutionHarness(
+        useOverlayContainer,
+        [null],
+        Harness,
+        (result) => { res = result.element },
+        areDomNodesEqual
+      );
+    });
+
+    it('div#OverlayContainer in place, it should return it',
+      () => converge(() => {
+        if (res.id !== OVERLAY_CONTAINER_ID) throw new Error(`expected element to fallback to body: ${res.id}`);
+      }));
+  });
+
+  describe('refresh', () => {
+    beforeEach(async () => {
+      await getHookExecutionHarness(
+        useOverlayContainer,
+        [null],
+        Harness,
+        (result) => { res = result },
+        areDomNodesEqual
+      );
+      res.refresh();
+    });
+
+    it('div#OverlayContainer in place, it should return it',
+      () => converge(() => {
+        if (res.element.id !== OVERLAY_CONTAINER_ID) throw new Error(`expected element to fallback to body: ${res.id}`);
       }));
   });
 });

--- a/hooks/tests/useOverlayContainer-test.js
+++ b/hooks/tests/useOverlayContainer-test.js
@@ -22,17 +22,9 @@ const HarnessWithout = ({ children }) => (
   </div>
 );
 
-// lodash/isEqual does not work on comparing DOM nodes, so here we are....
+// We need to compare the `element` field of the result to discern difference on the re-render.
 const areDomNodesEqual = (current, candidate) => {
-  if (current?.element?.tagName !== candidate?.element?.tagName) {
-    return false;
-  }
-
-  if (current?.element?.id !== candidate?.element?.id) {
-    return false;
-  }
-
-  return true;
+  return current?.element === candidate?.element;
 }
 
 describe('useOverlayContainer', () => {

--- a/hooks/tests/useOverlayContainer-test.js
+++ b/hooks/tests/useOverlayContainer-test.js
@@ -93,9 +93,26 @@ describe('useOverlayContainer', () => {
       }));
   });
 
-  describe('refresh', () => {
+  describe('successfully initial result...', () => {
     beforeEach(async () => {
       await getHookExecutionHarness(
+        useOverlayContainer,
+        ['true'],
+        Harness,
+        (result) => { res = result.element },
+        areDomNodesEqual
+      );
+    });
+
+    it('div#OverlayContainer in place, it should return it',
+      () => converge(() => {
+        if (res !== 'true') throw new Error('should just return truthy value');
+      }));
+  });
+
+  describe('refresh', () => {
+    beforeEach(async () => {
+      res = await getHookExecutionHarness(
         useOverlayContainer,
         [null],
         Harness,

--- a/hooks/tests/useOverlayContainer-test.js
+++ b/hooks/tests/useOverlayContainer-test.js
@@ -35,7 +35,7 @@ const areDomNodesEqual = (current, candidate) => {
   return true;
 }
 
-describe.only('useOverlayContainer', () => {
+describe('useOverlayContainer', () => {
   const overlayElement = () => document.getElementById(OVERLAY_CONTAINER_ID);
   let res;
   beforeEach(() => {

--- a/hooks/tests/useOverlayContainer-test.js
+++ b/hooks/tests/useOverlayContainer-test.js
@@ -4,7 +4,7 @@ import {
   it,
 } from 'mocha';
 import { converge } from '@folio/stripes-testing';
-import getHookExecutionResult from '../../tests/helpers/getHookExecutionResult';
+import { getHookExecutionHarness } from '../../tests/helpers/getHookExecutionResult';
 import useOverlayContainer from '../useOverlayContainer';
 
 import { OVERLAY_CONTAINER_ID } from '../../util/consts';
@@ -23,7 +23,7 @@ const HarnessWithout = ({ children }) => (
 );
 
 // lodash/isEqual does not work on comparing DOM nodes, so here we are....
-const domNodesEqual = (current, candidate) => {
+const areDomNodesEqual = (current, candidate) => {
   if (current?.element?.tagName !== candidate?.element?.tagName) {
     return false;
   }
@@ -44,12 +44,12 @@ describe('useOverlayContainer', () => {
 
   describe('withoutOverlay fallback to a child of root.', () => {
     beforeEach(async () => {
-      await getHookExecutionResult(
+      await getHookExecutionHarness(
         useOverlayContainer,
         [overlayElement()],
         HarnessWithout,
         (result) => { res = result.element },
-        domNodesEqual
+        areDomNodesEqual
       );
     });
 
@@ -61,12 +61,12 @@ describe('useOverlayContainer', () => {
 
   describe('successfully resolving overlay container if it exists...', () => {
     beforeEach(async () => {
-      await getHookExecutionResult(
+      await getHookExecutionHarness(
         useOverlayContainer,
         [overlayElement()],
         Harness,
         (result) => { res = result.element },
-        domNodesEqual
+        areDomNodesEqual
       );
     });
 

--- a/hooks/tests/useOverlayContainer-test.js
+++ b/hooks/tests/useOverlayContainer-test.js
@@ -124,7 +124,7 @@ describe('useOverlayContainer', () => {
 
     it('div#OverlayContainer in place, it should return it',
       () => converge(() => {
-        if (res !== false) throw new Error('should just return truthy value');
+        if (res.element !== false) throw new Error('should just return false value');
       }));
   });
 

--- a/hooks/useOverlayContainer/index.js
+++ b/hooks/useOverlayContainer/index.js
@@ -1,0 +1,1 @@
+export { default } from './useOverlayContainer';

--- a/hooks/useOverlayContainer/useOverlayContainer.js
+++ b/hooks/useOverlayContainer/useOverlayContainer.js
@@ -3,7 +3,7 @@
 // in contextes where there may not be a div#OverlayContainer
 
 import { useState, useEffect } from 'react';
-import { OVERLAY_CONTAINER_ID } from './consts';
+import { OVERLAY_CONTAINER_ID } from '../../util/consts';
 
 const resolveElement = (ref) => {
   if (ref === null) {

--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -190,7 +190,8 @@ const Modal = forwardRef((props, ref) => {
           className={css.backdrop}
           onClick={handleBackgroundClick}
         />
-        <dialog
+        <div
+          role="dialog"
           className={classNames(css.modalRoot, css[status])}
           ref={modalElem}
           onFocus={focusEntered}
@@ -263,7 +264,7 @@ const Modal = forwardRef((props, ref) => {
               )
             }
           </WrappingElement>
-        </dialog>
+        </div>
       </>
     ),
     refreshPortal()

--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { Transition, TransitionGroup } from 'react-transition-group';
 import { uniqueId, noop } from 'lodash';
 import { getFirstFocusable } from '../../util/getFocusableElements';
-import useOverlayContainer from '../../util/useOverlayContainer';
+import useOverlayContainer from '../../hooks/useOverlayContainer';
 import WrappingElement from './WrappingElement';
 import { OVERLAY_CONTAINER_ID } from '../../util/consts';
 import IconButton from '../IconButton';

--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { Transition, TransitionGroup } from 'react-transition-group';
 import { uniqueId, noop } from 'lodash';
 import { getFirstFocusable } from '../../util/getFocusableElements';
-import useOverlayContainer from './useOverlayContainer';
+import useOverlayContainer from '../../util/useOverlayContainer';
 import WrappingElement from './WrappingElement';
 import { OVERLAY_CONTAINER_ID } from '../../util/consts';
 import IconButton from '../IconButton';

--- a/lib/Modal/WrappingElement.js
+++ b/lib/Modal/WrappingElement.js
@@ -8,6 +8,7 @@ import {
 import PropTypes from 'prop-types';
 import * as focusTrap from 'focus-trap';
 import { listen } from '../../util/listen';
+import StripesOverlayContext from '../../util/StripesOverlayContext';
 import { OVERLAY_CONTAINER_SELECTOR } from '../../util/consts';
 import calloutCSS from '../Callout/Callout.css';
 import overlayCSS from '../Popper/Popper.css';
@@ -154,9 +155,11 @@ const WrappingElement = forwardRef(({
       ref={wrappingElementRef}
       {...rest}
     >
-      {children}
+      <StripesOverlayContext.Provider value={{ usePortal: true }}>
+        {children}
+      </StripesOverlayContext.Provider>
     </WrappingElementComponent>
-  )
+  );
 });
 
 WrappingElement.propTypes = {

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -2033,7 +2033,8 @@ class MCLRenderer extends React.Component {
                   )
                 }
             </div>
-          </HotKeys>
+          </div>
+        </HotKeys>
       </StripesOverlayContext.Provider>
     );
   }

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -1956,83 +1956,62 @@ class MCLRenderer extends React.Component {
                 </div>
               </div>
               <div
-                tabIndex="0" // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
-                id={this.props.id}
-                ref={this.container}
-                role="grid"
-                aria-rowcount={this.getAccessibleRowCount()}
-                className={classnames({ [css.hasMargin]: hasMargin })}
-                data-total-count={totalCount}
+                className={css.mclScrollable}
+                style={this.getScrollableStyle()}
+                onScroll={this.handleScroll}
+                ref={this.scrollContainer}
+                {...getScrollableTabIndex(this.scrollContainer)}
               >
-                <div ref={this.headerContainer} className={css.mclHeaderContainer}>
-                  <div
-                    className={this.getHeaderStyle()}
-                    style={{ display: 'flex' }}
-                    ref={this.headerRow}
-                    role="row"
-                    aria-rowindex="1"
-                  >
-                    {renderedHeaders}
-                  </div>
-                </div>
                 <div
-                  className={css.mclScrollable}
-                  style={this.getScrollableStyle()}
-                  onScroll={this.handleScroll}
-                  ref={this.scrollContainer}
-                  {...getScrollableTabIndex(this.scrollContainer)}
+                  className={rowContainerClass}
+                  role="rowgroup"
+                  style={this.getRowContainerStyle()}
+                  ref={this.rowContainer}
                 >
-                  <div
-                    className={rowContainerClass}
-                    role="rowgroup"
-                    style={this.getRowContainerStyle()}
-                    ref={this.rowContainer}
-                  >
-                    {renderedRows}
-                    {dndProvided.placeholder}
-                  </div>
+                  {renderedRows}
+                  {dndProvided.placeholder}
                 </div>
-                {
-                  loading &&
-                  <div className={css.mclContentLoadingRow}>
-                    <div className={css.mclContentLoading}>
-                      <Icon icon="spinner-ellipsis" width="35px" />
-                    </div>
-                  </div>
-                }
               </div>
               {
-                  pagingType === pagingTypes.PREV_NEXT && (
-                    <PrevNextPaginationRow
-                      activeNext={this.getCanGoNext()}
-                      activePrevious={this.getCanGoPrevious()}
-                      dataEndReached={dataEndReached}
-                      handleLoadMore={this.handleLoadMore}
-                      id={id}
-                      key="mcl-prev-next-pagination-row"
-                      keyId={this.keyId}
-                      loading={loadingState}
-                      loadingNext={pagingCanGoNextLoading}
-                      loadingPrevious={pagingCanGoPreviousLoading}
-                      pageAmount={pageAmount}
-                      pagingButtonLabel={pagingButtonLabel}
-                      pagingButtonRef={this.pageButton}
-                      positionCache={this.positionCache}
-                      rowHeightCache={this.rowHeightCache}
-                      rowIndex={lastIndex}
-                      sendMessage={this.sendMessage}
-                      setFocusIndex={this.setFocusIndex}
-                      staticBody={staticBody}
-                      virtualize={virtualize}
-                      dataStartIndex={typeof pagingOffset !== 'undefined' ? pagingOffset + 1 : dataStartIndex + 1}
-                      dataEndIndex={typeof pagingOffset !== 'undefined' ? pagingOffset + dataEndIndex + 1 : dataEndIndex + 1} // eslint-disable-line
-                      hidePageIndices={hidePageIndices}
-                      pagingOffset={pagingOffset}
-                      containerRef={this.paginationContainer}
-                    />
-                  )
-                }
+                loading &&
+                <div className={css.mclContentLoadingRow}>
+                  <div className={css.mclContentLoading}>
+                    <Icon icon="spinner-ellipsis" width="35px" />
+                  </div>
+                </div>
+              }
             </div>
+            {
+                pagingType === pagingTypes.PREV_NEXT && (
+                  <PrevNextPaginationRow
+                    activeNext={this.getCanGoNext()}
+                    activePrevious={this.getCanGoPrevious()}
+                    dataEndReached={dataEndReached}
+                    handleLoadMore={this.handleLoadMore}
+                    id={id}
+                    key="mcl-prev-next-pagination-row"
+                    keyId={this.keyId}
+                    loading={loadingState}
+                    loadingNext={pagingCanGoNextLoading}
+                    loadingPrevious={pagingCanGoPreviousLoading}
+                    pageAmount={pageAmount}
+                    pagingButtonLabel={pagingButtonLabel}
+                    pagingButtonRef={this.pageButton}
+                    positionCache={this.positionCache}
+                    rowHeightCache={this.rowHeightCache}
+                    rowIndex={lastIndex}
+                    sendMessage={this.sendMessage}
+                    setFocusIndex={this.setFocusIndex}
+                    staticBody={staticBody}
+                    virtualize={virtualize}
+                    dataStartIndex={typeof pagingOffset !== 'undefined' ? pagingOffset + 1 : dataStartIndex + 1}
+                    dataEndIndex={typeof pagingOffset !== 'undefined' ? pagingOffset + dataEndIndex + 1 : dataEndIndex + 1} // eslint-disable-line
+                    hidePageIndices={hidePageIndices}
+                    pagingOffset={pagingOffset}
+                    containerRef={this.paginationContainer}
+                  />
+                )
+              }
           </div>
         </HotKeys>
       </StripesOverlayContext.Provider>

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -18,6 +18,7 @@ import memoizeOne from 'memoize-one';
 
 import Icon from '../Icon';
 import EmptyMessage from '../EmptyMessage';
+import StripesOverlayContext from '../../util/StripesOverlayContext';
 import { HotKeys } from '../HotKeys';
 import SRStatus from '../SRStatus';
 import css from './MCLRenderer.css';
@@ -1929,88 +1930,90 @@ class MCLRenderer extends React.Component {
       : css.mclRowContainer;
 
     return (
-      <HotKeys handlers={this.handlers} noWrapper>
-        <div className={css.mclContainer} style={this.getOuterElementStyle()}>
-          <SRStatus ref={this.status} />
-          <div
-            tabIndex="0" // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
-            id={this.props.id}
-            ref={this.container}
-            role="grid"
-            aria-rowcount={this.getAccessibleRowCount()}
-            className={classnames({ [css.hasMargin]: hasMargin })}
-            data-total-count={totalCount}
-          >
-            <div ref={this.headerContainer} className={css.mclHeaderContainer}>
-              <div
-                className={this.getHeaderStyle()}
-                style={{ display: 'flex' }}
-                ref={this.headerRow}
-                role="row"
-                aria-rowindex="1"
-              >
-                {renderedHeaders}
-              </div>
-            </div>
+      <StripesOverlayContext.Provider value={{ usePortal: true }}>
+        <HotKeys handlers={this.handlers} noWrapper>
+          <div className={css.mclContainer} style={this.getOuterElementStyle()}>
+            <SRStatus ref={this.status} />
             <div
-              className={css.mclScrollable}
-              style={this.getScrollableStyle()}
-              onScroll={this.handleScroll}
-              ref={this.scrollContainer}
-              {...getScrollableTabIndex(this.scrollContainer)}
+              tabIndex="0" // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
+              id={this.props.id}
+              ref={this.container}
+              role="grid"
+              aria-rowcount={this.getAccessibleRowCount()}
+              className={classnames({ [css.hasMargin]: hasMargin })}
+              data-total-count={totalCount}
             >
-              <div
-                className={rowContainerClass}
-                role="rowgroup"
-                style={this.getRowContainerStyle()}
-                ref={this.rowContainer}
-              >
-                {renderedRows}
-                {dndProvided.placeholder}
-              </div>
-            </div>
-            {
-              loading &&
-              <div className={css.mclContentLoadingRow}>
-                <div className={css.mclContentLoading}>
-                  <Icon icon="spinner-ellipsis" width="35px" />
+              <div ref={this.headerContainer} className={css.mclHeaderContainer}>
+                <div
+                  className={this.getHeaderStyle()}
+                  style={{ display: 'flex' }}
+                  ref={this.headerRow}
+                  role="row"
+                  aria-rowindex="1"
+                >
+                  {renderedHeaders}
                 </div>
               </div>
-            }
+              <div
+                className={css.mclScrollable}
+                style={this.getScrollableStyle()}
+                onScroll={this.handleScroll}
+                ref={this.scrollContainer}
+                {...getScrollableTabIndex(this.scrollContainer)}
+              >
+                <div
+                  className={rowContainerClass}
+                  role="rowgroup"
+                  style={this.getRowContainerStyle()}
+                  ref={this.rowContainer}
+                >
+                  {renderedRows}
+                  {dndProvided.placeholder}
+                </div>
+              </div>
+              {
+                loading &&
+                <div className={css.mclContentLoadingRow}>
+                  <div className={css.mclContentLoading}>
+                    <Icon icon="spinner-ellipsis" width="35px" />
+                  </div>
+                </div>
+              }
+            </div>
+            {
+                pagingType === pagingTypes.PREV_NEXT && (
+                  <PrevNextPaginationRow
+                    activeNext={this.getCanGoNext()}
+                    activePrevious={this.getCanGoPrevious()}
+                    dataEndReached={dataEndReached}
+                    handleLoadMore={this.handleLoadMore}
+                    id={id}
+                    key="mcl-prev-next-pagination-row"
+                    keyId={this.keyId}
+                    loading={loadingState}
+                    loadingNext={pagingCanGoNextLoading}
+                    loadingPrevious={pagingCanGoPreviousLoading}
+                    pageAmount={pageAmount}
+                    pagingButtonLabel={pagingButtonLabel}
+                    pagingButtonRef={this.pageButton}
+                    positionCache={this.positionCache}
+                    rowHeightCache={this.rowHeightCache}
+                    rowIndex={lastIndex}
+                    sendMessage={this.sendMessage}
+                    setFocusIndex={this.setFocusIndex}
+                    staticBody={staticBody}
+                    virtualize={virtualize}
+                    dataStartIndex={typeof pagingOffset !== 'undefined' ? pagingOffset + 1 : dataStartIndex + 1}
+                    dataEndIndex={typeof pagingOffset !== 'undefined' ? pagingOffset + dataEndIndex + 1 : dataEndIndex + 1} // eslint-disable-line
+                    hidePageIndices={hidePageIndices}
+                    pagingOffset={pagingOffset}
+                    containerRef={this.paginationContainer}
+                  />
+                )
+              }
           </div>
-          {
-              pagingType === pagingTypes.PREV_NEXT && (
-                <PrevNextPaginationRow
-                  activeNext={this.getCanGoNext()}
-                  activePrevious={this.getCanGoPrevious()}
-                  dataEndReached={dataEndReached}
-                  handleLoadMore={this.handleLoadMore}
-                  id={id}
-                  key="mcl-prev-next-pagination-row"
-                  keyId={this.keyId}
-                  loading={loadingState}
-                  loadingNext={pagingCanGoNextLoading}
-                  loadingPrevious={pagingCanGoPreviousLoading}
-                  pageAmount={pageAmount}
-                  pagingButtonLabel={pagingButtonLabel}
-                  pagingButtonRef={this.pageButton}
-                  positionCache={this.positionCache}
-                  rowHeightCache={this.rowHeightCache}
-                  rowIndex={lastIndex}
-                  sendMessage={this.sendMessage}
-                  setFocusIndex={this.setFocusIndex}
-                  staticBody={staticBody}
-                  virtualize={virtualize}
-                  dataStartIndex={typeof pagingOffset !== 'undefined' ? pagingOffset + 1 : dataStartIndex + 1}
-                  dataEndIndex={typeof pagingOffset !== 'undefined' ? pagingOffset + dataEndIndex + 1 : dataEndIndex + 1} // eslint-disable-line
-                  hidePageIndices={hidePageIndices}
-                  pagingOffset={pagingOffset}
-                  containerRef={this.paginationContainer}
-                />
-              )
-            }
-        </div>
-      </HotKeys>
+        </HotKeys>
+      </StripesOverlayContext.Provider>
     );
   }
 }

--- a/lib/Popper/Popper.js
+++ b/lib/Popper/Popper.js
@@ -1,10 +1,10 @@
-import React, { useContext, forwardRef, useRef } from 'react';
+import React, { useContext, forwardRef } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import PopperJS from 'popper.js';
 import css from './Popper.css';
 import { OVERLAY_CONTAINER_ID } from '../../util/consts';
-import useOverlayContainer from '../../util/useOverlayContainer';
+import useOverlayContainer from '../../hooks/useOverlayContainer';
 import StripesOverlayContext from '../../util/StripesOverlayContext';
 
 export const OVERLAY_MODIFIERS = {

--- a/lib/Popper/Popper.js
+++ b/lib/Popper/Popper.js
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { useContext, forwardRef, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import PopperJS from 'popper.js';
 import css from './Popper.css';
+import { OVERLAY_CONTAINER_ID } from '../../util/consts';
+import useOverlayContainer from '../../util/useOverlayContainer';
+import StripesOverlayContext from '../../util/StripesOverlayContext';
 
 export const OVERLAY_MODIFIERS = {
   flip: { boundariesElement: 'viewport', padding: 5 },
@@ -29,7 +32,22 @@ export const AVAILABLE_PLACEMENTS = [
 
 const [DEFAULT_PLACEMENT] = AVAILABLE_PLACEMENTS;
 
-export default class Popper extends React.Component {
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
+}
+
+export function withOverlayContext(WrappedComponent) {
+  const WithOverlayContext = forwardRef(({ portal, ...props }, ref) => { // eslint-disable-line react/prop-types
+    const { usePortal } = useContext(StripesOverlayContext);
+    const portalRef = useOverlayContainer(document.getElementById(OVERLAY_CONTAINER_ID));
+    return <WrappedComponent ref={ref} portal={usePortal ? portalRef.element : portal} {...props} />;
+  });
+  WithOverlayContext.displayName = `WithOverlayContext(${getDisplayName(WrappedComponent)})`;
+
+  return WithOverlayContext;
+}
+
+class Popper extends React.Component {
   static propTypes = {
     anchorRef: PropTypes.oneOfType([
       PropTypes.func,
@@ -161,3 +179,5 @@ export default class Popper extends React.Component {
     return null;
   }
 }
+
+export default withOverlayContext(Popper);

--- a/tests/helpers/getHookExecutionResult.js
+++ b/tests/helpers/getHookExecutionResult.js
@@ -3,6 +3,20 @@ import isEqual from 'lodash/isEqual';
 import noop from 'lodash/noop';
 import { mountWithContext } from '../helpers';
 
+
+const objectCompare = (current, candidate) => {
+  if (current === candidate) {
+    return true;
+  }
+
+  if (typeof current === 'object' && typeof candidate === 'object') {
+    return JSON.stringify(current) === JSON.stringify(candidate);
+  }
+
+  return false;
+};
+
+
 /**
  * getHookExecutionResult
  * Test a hook by returning its result in a promise.
@@ -13,7 +27,29 @@ import { mountWithContext } from '../helpers';
  *   returns and we need to wait for the component that calls the hook to mount and
  *   render.
  */
-const useHookExecutionResult = (hook, hookParams, comparator = isEqual) => {
+
+const getHookExecutionResult = (hook, hookArguments = []) => {
+  let result = {};
+  const TestComponent = () => {
+    const hookResult = Array.isArray(hookArguments)
+      ? hook(...hookArguments)
+      : hook(hookArguments);
+    switch (typeof hookResult) {
+      case 'function':
+      case 'string':
+        result = hookResult;
+        break;
+      default:
+        result = Object.assign(result, hookResult);
+    }
+
+    return <></>;
+  };
+
+  return mountWithContext(<TestComponent />).then(() => result);
+};
+
+const useHookExecutionResult = (hook, hookParams, comparator = objectCompare) => {
   const [result, updateResult] = useState(hook(...hookParams));
 
   const candidate = hook(...hookParams);
@@ -24,13 +60,26 @@ const useHookExecutionResult = (hook, hookParams, comparator = isEqual) => {
 };
 
 
-
-const getHookExecutionResult = (
+/**
+ * getHookExecutionHarness
+ * Test a hook by returning its result in a promise.
+ *
+ * @param {*} hook the hook to test
+ * @param {*} hookArguments arguments to pass to the hook
+ * @param {*} Wrapper React component/element to wrap rendered test component in.
+ * @param {*} checkEffect Function that will be called each update to result.
+ * @param {*} comparator Function to compare two values - a previous value and a potential candidate -
+ * for potentially re-rendering the text component/updating state.
+ * @returns hook's result, wrapped in a Promise, because that's what mountWithContext
+ *   returns and we need to wait for the component that calls the hook to mount and
+ *   render.
+ */
+export const getHookExecutionHarness = (
   hook,
   hookArguments = [],
   Wrapper = Fragment,
   checkEffect = noop,
-  comparator = isEqual
+  comparator = objectCompare
 ) => {
   let result = {};
   const TestComponent = () => {
@@ -47,17 +96,6 @@ const getHookExecutionResult = (
     }, [innerResult]);
 
     result = innerResult;
-    // const hookResult = Array.isArray(hookArguments)
-    //   ? hook(...hookArguments)
-    //   : hook(hookArguments);
-    // switch (typeof hookResult) {
-    //   case 'function':
-    //   case 'string':
-    //     result = hookResult;
-    //     break;
-    //   default:
-    //     result = Object.assign(result, hookResult);
-    // }
 
     return <></>;
   };

--- a/tests/helpers/getHookExecutionResult.js
+++ b/tests/helpers/getHookExecutionResult.js
@@ -3,20 +3,6 @@ import isEqual from 'lodash/isEqual';
 import noop from 'lodash/noop';
 import { mountWithContext } from '../helpers';
 
-
-const objectCompare = (current, candidate) => {
-  if (current === candidate) {
-    return true;
-  }
-
-  if (typeof current === 'object' && typeof candidate === 'object') {
-    return JSON.stringify(current) === JSON.stringify(candidate);
-  }
-
-  return false;
-};
-
-
 /**
  * getHookExecutionResult
  * Test a hook by returning its result in a promise.
@@ -49,7 +35,7 @@ const getHookExecutionResult = (hook, hookArguments = []) => {
   return mountWithContext(<TestComponent />).then(() => result);
 };
 
-const useHookExecutionResult = (hook, hookParams, comparator = objectCompare) => {
+const useHookExecutionResult = (hook, hookParams, comparator = isEqual) => {
   const [result, updateResult] = useState(hook(...hookParams));
 
   const candidate = hook(...hookParams);
@@ -79,7 +65,7 @@ export const getHookExecutionHarness = (
   hookArguments = [],
   Wrapper = Fragment,
   checkEffect = noop,
-  comparator = objectCompare
+  comparator = isEqual
 ) => {
   let result = {};
   const TestComponent = () => {

--- a/util/StripesOverlayContext.js
+++ b/util/StripesOverlayContext.js
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+
+const PortalContext = createContext({ usePortal: false });
+export default PortalContext;

--- a/util/useOverlayContainer.js
+++ b/util/useOverlayContainer.js
@@ -3,7 +3,7 @@
 // in contextes where there may not be a div#OverlayContainer
 
 import { useState, useEffect } from 'react';
-import { OVERLAY_CONTAINER_ID } from '../../util/consts';
+import { OVERLAY_CONTAINER_ID } from './consts';
 
 const resolveElement = (ref) => {
   if (ref === null) {
@@ -19,7 +19,7 @@ const resolveElement = (ref) => {
     return el;
   }
   return ref;
-}
+};
 
 export default (ref) => {
   const [element, setElement] = useState(resolveElement(ref));
@@ -39,10 +39,10 @@ export default (ref) => {
       const el = resolveElement(ref);
       if (!el) setElement(el);
     }
-  }
+  };
 
   return {
     element,
     refresh
-  }
+  };
 };


### PR DESCRIPTION
## [STCOM-1335](https://folio-org.atlassian.net/browse/STCOM-1335)

We've seen a common issue with 'Overlay' components (`Selection`, `Datepicker`, etc) where they end up overlapped by the boundaries of their scrollable containers. Common among these, a `usePortal` boolean prop can be used to render them into the centralized 'OverlayContainer' element, but it isn't always so ergonomic to add or to know when it should be added.

The functionality in this PR adds a context to common containers where overflow can be problematic: Modals and MCL's. The main implementation exists within the `Popper` component, which is consumed and used by all of the 'Overlay' components. When any of the 'Overlay' components are used within a Modal or an MCL, they will automatically behave as thought a `usePortal` prop is applied.

### Approach
Wrap `Popper` in an HOC (it's still a class-based component) that reads the `StripesOverlayContext`. When we do upgrade from the PopperJS library to `floating-ui`, we'll refactor to a functional version which will clean things up more.

Additonally, since the `useOverlayContainer` hook has a necessity across components, it's moved into the `hooks` folder now.