### PR TITLE
STCOM-1346 Selection not reflecting changes in `dataOptions`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Apply `inert` attribute to header and siblings of `div#OverlayContainer` when modals are open. Refs STCOM-1334.
 * Expand focus trapping of modal to the `div#OverlayContainer` so that overlay components can function within `<Modal>` using the `usePortal` prop. Refs STCOM-1334.
 * Render string for `FilterGroups` clear button. Refs STCOM-1337.
+* Use whole `dataOptions` array for memoization dependency rather that just `length` property. STCOM-1346.
 
 ## [12.1.0](https://github.com/folio-org/stripes-components/tree/v12.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.0.0...v12.1.0)

--- a/lib/Selection/Selection.js
+++ b/lib/Selection/Selection.js
@@ -161,7 +161,7 @@ const Selection = ({
   // we need to skip over group headings since those can neither be selectable or cursored over.
   const reducedListItems = useMemo(
     () => { return hasGroups ? reduceOptionsRef(options) : options },
-    [options.length, hasGroups]
+    [options, hasGroups]
   )
 
   const {
@@ -281,7 +281,7 @@ const Selection = ({
   const optionsProcessing = false;
   const renderedOptions = useMemo(
     () => renderedOptionsFn(flattenedOptions),
-    [flattenedOptions.length, debouncedFilterValue]
+    [flattenedOptions, debouncedFilterValue]
   );
 
   // It doesn't need to update if *all of the things it uses change...


### PR DESCRIPTION
# [STCOM-1346](https://folio-org.atlassian.net/browse/STCOM-1346)

For cases where the supplied `dataOptions` are checked/could change their internal values after being provided, without the count itself changing, `<Selection>` is not updating.

Approach:
Pass the whole options array rather then only the length of the array as memoization dependency so that changes will be picked up.