### PR TITLE
STCOM-1348 Keyboard shortcut modal missing scrollbar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * AdvancedSearch - added a wrapping div to ref for a HotKeys ref. Refs STCOM-1343.
 * `<MultiColumnList>` components `<CellMeasurer>` and `<RowMeasurer>` updated to use refs vs `findDOMNode`. Refs STCOM-1343.
 * `<AccordionHeaders>` are wrapped with a div for use as a HotKeys ref. Refs STCOM-1343.
+* Remove inline styling from `<Modal>` content. Refs STCOM-1348.
 
 ## [12.1.0](https://github.com/folio-org/stripes-components/tree/v12.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.0.0...v12.1.0)

--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -246,7 +246,6 @@ const Modal = forwardRef((props, ref) => {
             <div
               className={getContentClass()}
               id={id && `${id}-content`}
-              style={{ overflow: 'hidden' }}
               ref={contentRef}
             >
               {/* so that aria-labels will still announce if aria-labelledby is also provided */}


### PR DESCRIPTION
## [STCOM-1348](https://folio-org.atlassian.net/browse/STCOM-1348)

During refactor of our modals, an inline style was added, hiding the overflow of the content div. This PR just removes that inline style. Tested with the `ui-plugin-find-users` modal as well as the applicable keyboard shortcuts modal.