### PR TITLE
STCOM-1351 Scope `<CommandList>` to `document.body` by default rather that wrapping div.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * `<MultiColumnList>` components `<CellMeasurer>` and `<RowMeasurer>` updated to use refs vs `findDOMNode`. Refs STCOM-1343.
 * `<AccordionHeaders>` are wrapped with a div for use as a HotKeys ref. Refs STCOM-1343.
 * Use whole `dataOptions` array for memoization dependency rather that just `length` property. STCOM-1346.
+* Default the scope of `<CommandList>` to `document.body`. Remove internal wrapping div. Refs STCOM-1351.
 
 ## [12.1.0](https://github.com/folio-org/stripes-components/tree/v12.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.0.0...v12.1.0)

--- a/lib/Commander/CommandList.js
+++ b/lib/Commander/CommandList.js
@@ -4,6 +4,7 @@ import { HotKeys } from '../HotKeys';
 
 class CommandList extends Component {
   static propTypes = {
+    attach: PropTypes.oneOfType([PropTypes.element, PropTypes.object]),
     children: PropTypes.node,
     commands: PropTypes.arrayOf(
       PropTypes.shape({
@@ -15,11 +16,6 @@ class CommandList extends Component {
     ).isRequired,
     id: PropTypes.string,
   };
-
-  constructor(props) {
-    super(props);
-    this.shortcutRef = createRef(null);
-  }
 
   generateHotKeysProps() {
     const {
@@ -44,14 +40,13 @@ class CommandList extends Component {
   render() {
     const {
       children,
-      id
+      id,
+      attach
     } = this.props;
 
     return (
-      <HotKeys id={id} {...this.generateHotKeysProps()} attach={this.shortcutRef.current} noWrapper>
-        <div ref={this.shortcutRef}>
+      <HotKeys id={id} {...this.generateHotKeysProps()} attach={attach || document.body} noWrapper>
         {children}
-        </div>
       </HotKeys>
     );
   }


### PR DESCRIPTION
## [STCOM-1351](https://folio-org.atlassian.net/browse/STCOM-1351)

### Resolves the ugly [STCOM-1349](https://folio-org.atlassian.net/browse/STCOM-1349)

To refactor away from `findDOMNode` usage, `<CommandList>`'s internally rendered `<HotKeys>` instance has to be provided with an element or a ref to an element. This was originally implemented with a wrapping `<div>`, but this proved problematic when the element was nested as a flexbox child/within a paneset (See the ugly JIRA above).

This PR removes the offending wrapping div, resolving any style issues that would rise from it. Since `CommandList` is commonly used at the top level of an App, a default binding of `document.body` should be adequate to use. If this proves problematic, a ref to an existing element can be provided.
