### PR TITLE
Use proper stripes-react-hotkeys version - 3.1.5 -> 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   },
   "dependencies": {
     "@csstools/postcss-global-data": "^2.1.1",
-    "@folio/stripes-react-hotkeys": "^3.1.5",
+    "@folio/stripes-react-hotkeys": "^3.1.0",
     "classnames": "^2.2.5",
     "currency-codes": "^2.1.0",
     "dayjs": "^1.11.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2325,7 +2325,7 @@
     webpack-bundle-analyzer "^4.4.2"
     yargs "^17.3.1"
 
-"@folio/stripes-react-hotkeys@^3.1.5":
+"@folio/stripes-react-hotkeys@^3.1.0":
   version "3.1.10990000000033"
   resolved "https://repository.folio.org/repository/npm-folioci/@folio/stripes-react-hotkeys/-/stripes-react-hotkeys-3.1.10990000000033.tgz#ca5e58a89cf9dbd1d9b5c1b7e5daf9c635289dc0"
   integrity sha512-IyMnHi0WJqdWQaNiNF/O+HtilF/OrIFdC58Ru539SnTFgfE1kMODmCAKKStfNravjGpazZrF7puJTSCP/X5sig==


### PR DESCRIPTION
When the dependencies were last updated, my fingers got lazy and only bumped the minor version rather than resetting the patch number.... chaos ensued in a platform build as the correct version wasn't able to be found :(