### PR TITLE
STCOM-1367 - RadioButton - pass readOnly prop to internal Label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * Remove inline styling from `<Modal>` content. Refs STCOM-1348.
 * Use `<Selection>`'s formatter for rendering the selected value within the field and prevent overflow of text. Refs STCOM-1344.
 * Export `<StripesOverlayWrapper>` that will automatically apply the `usePortal` behavior to nested overlay components. Refs STCOM-1353.
+* Properly pass `readOnly` prop to `<RadioButton>`'s internally rendered `<Label>`. Refs STCOM-1367.
 
 ## [12.1.0](https://github.com/folio-org/stripes-components/tree/v12.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.0.0...v12.1.0)

--- a/lib/RadioButton/RadioButton.js
+++ b/lib/RadioButton/RadioButton.js
@@ -196,7 +196,7 @@ class RadioButton extends React.Component {
             required={required}
           />
           <span className={css.pseudoButton} />
-          <Label htmlFor={this.id} className={this.getLabelStyle()}>
+          <Label htmlFor={this.id} className={this.getLabelStyle()} readOnly={readOnly}>
             <span className={css.labelText}>
               {label}
               {required && <Asterisk />}


### PR DESCRIPTION
Instances where a user *can affect the read-only status of a radio button in the UI warrant a visible indication of the read-only state - the lock icon. The more common case is that a user cannot affect this status - in which case, rendering interactive controls should be avoided in the first place. Rendering of the lock icon is handled by our `<Label>` component - internally rendered by RadioButton.

![image](https://github.com/user-attachments/assets/18c905d3-af90-494c-b4a4-7c4d5ec2a2fa)

Looking at the history to this, the lock icon was displayed/not displayed without a great deal of reason provided. The change only happens now that we have a specific use-case for this feature. The lock icon apparently still exists in visual designs from `ux.folio.org`. Kimie has also included it in mock-ups.

 I'm for the existence of the icon, as it provides a good 'at-a-glance' discernment between other states of the radio button.