### PR TITLE
STCOM-1373 - Selection - blank options are not selectable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * Properly pass `readOnly` prop to `<RadioButton>`'s internally rendered `<Label>`. Refs STCOM-1367.
 * `TextArea` - move focus to the field after clearing the field by clicking on the `x` icon. Refs STCOM-1369.
 * Change `Repeatable field` focus behaviour. Refs STCOM-1341.
+* `<Selection>` - fix bug handling empty string options/values. Refs STCOM-1373.
 
 ## [12.1.0](https://github.com/folio-org/stripes-components/tree/v12.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.0.0...v12.1.0)

--- a/lib/Selection/Selection.js
+++ b/lib/Selection/Selection.js
@@ -44,7 +44,7 @@ const getControlWidth = (control) => {
 const getItemClass = (item, i, props) => {
   const { value } = item;
   const { selectedItem, highlightedIndex, dataOptions } = props;
-  if (!value) {
+  if (value === undefined) {
     return;
   }
 
@@ -260,7 +260,7 @@ const Selection = ({
     const rendered = [];
     for (let i = 0; i < data.length; i++) {
       const item = data[i]
-      if (item.value) {
+      if (item.value !== undefined) {
         const reducedIndex = reconcileReducedIndex(item, reducedListItems);
         rendered.push(
           <li

--- a/lib/Selection/stories/BasicUsage.js
+++ b/lib/Selection/stories/BasicUsage.js
@@ -14,6 +14,7 @@ const hugeOptionsList = syncGenerate(3000, 0, () => {
 
 // the dataOptions prop takes an array of objects with 'label' and 'value' keys
 const countriesOptions = [
+  { value: '', label: 'blank' },
   { value: 'AU', label: 'Australia' },
   { value: 'CN', label: 'China' },
   { value: 'DK', label: 'Denmark' },

--- a/lib/Selection/tests/Selection-test.js
+++ b/lib/Selection/tests/Selection-test.js
@@ -47,7 +47,8 @@ describe('Selection', () => {
     { value: 'test2', label: 'Option 2' },
     { value: 'sample0', label: 'Sample 0' },
     { value: 'invalid', label: 'Sample 1' },
-    { value: 'sample2', label: 'Sample 2' }
+    { value: 'sample2', label: 'Sample 2' },
+    { value: '', label: '' },
   ];
 
   const groupedOptions = [
@@ -280,6 +281,16 @@ describe('Selection', () => {
 
       it('focuses the control/trigger', () => {
         selection.has({ focused: true });
+      });
+
+      describe('clicking a "blank" option', () => {
+        beforeEach(async () => {
+          await selection.choose('');
+        });
+
+        it('sets control value to ""', () => {
+          selection.has({ value: 'select control' });
+        });
       });
     });
 
@@ -743,7 +754,7 @@ describe('Selection', () => {
     beforeEach(async () => {
       filterSpy.resetHistory();
       await mountWithContext(
-        <AsyncFilter filterSpy={filterSpy}/>
+        <AsyncFilter filterSpy={filterSpy} />
       );
     });
 
@@ -756,7 +767,7 @@ describe('Selection', () => {
         await asyncSelection.filterOptions('tes');
       });
 
-      it ('calls filter function only once (not for each letter)', async () => converge(() => { if (filterSpy.calledTwice) { throw new Error('Selection - onFilter should only be called once.'); }}));
+      it('calls filter function only once (not for each letter)', async () => converge(() => { if (filterSpy.calledTwice) { throw new Error('Selection - onFilter should only be called once.'); } }));
 
       it('displays spinner in optionsList', () => asyncSelectionList().is({ loading: true }));
 


### PR DESCRIPTION
## [STCOM-1373](https://folio-org.atlassian.net/browse/STCOM-1373)

Conditional rendering logic within Selection is currently implemented for truthy/false-y values - but false-y includes `''` empty strings, so empty string values/labels were improperly rendered, keeping them from being selected.

Approach: switched to checking for `undefined` rather than truthiness or falsey-ness.

Test added for selecting an empty string value.
