### PR TITLE
STCOM-1372 Use mutationobserver for focus management in repeatable field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Change `Repeatable field` focus behaviour. Refs STCOM-1341.
 * Fix `<Selection>` bug with option list closing when scrollbar is used. Refs STCOM-1371.
 * `<Selection>` - fix bug handling empty string options/values. Refs STCOM-1373.
+* `<RepeatableField>` - switch to MutationObserver to resolve focus-management issues. Refs STCOM-1372.
 
 ## [12.2.0](https://github.com/folio-org/stripes-components/tree/v12.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.1.0...v12.2.0)

--- a/lib/RepeatableField/RepeatableField.js
+++ b/lib/RepeatableField/RepeatableField.js
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
@@ -10,8 +10,6 @@ import EmptyMessage from '../EmptyMessage';
 import IconButton from '../IconButton';
 import { RepeatableFieldContent } from './RepeatableFieldContent';
 import css from './RepeatableField.css';
-import { useFocusedIndex } from './hooks/useFocusedIndex';
-import { useIsElementFocused } from './hooks/useIsElementFocused';
 import { getFirstFocusable } from '../../util/getFocusableElements';
 
 const RepeatableField = ({
@@ -33,8 +31,7 @@ const RepeatableField = ({
   const rootRef = useRef(null);
   const showDeleteBtn = typeof onRemove === 'function';
   const fieldsLength = fields.length;
-  const isSomeChildElementFocused = useIsElementFocused(rootRef);
-  const focusedIndex = useFocusedIndex(fieldsLength);
+  const [hasBeenFocused, setHasBeenFocused] = useState(false);
 
   // use mutation observers to handle focus-management since we only have internal state.
   useEffect(() => {
@@ -46,8 +43,12 @@ const RepeatableField = ({
         const removedNode = mutation.removedNodes?.[0];
         let rowElem;
         // Handle added node
-        if (rootRef.current.matches(':focus-within')) {
-          if (addedNode && addedNode.matches(`.${css.repeatableFieldItem}`)) {
+        // we check if the user has interacted with the component before handling this, otherwise focus could be
+        // unwantedly moved when a form is initialized.
+        if (hasBeenFocused) {
+          if (addedNode &&
+            addedNode.nodeType === 1 &&
+            addedNode.matches(`.${css.repeatableFieldItem}`)) {
             rowElem = getFirstFocusable(addedNode);
             rowElem?.focus();
           }
@@ -74,9 +75,7 @@ const RepeatableField = ({
     return () => {
       observer.disconnect();
     };
-  }, [])
-
-  const hasToBeFocused = (index) => isSomeChildElementFocused && focusedIndex === index;
+  }, [hasBeenFocused])
 
   return (
     <fieldset
@@ -84,6 +83,8 @@ const RepeatableField = ({
       id={id}
       data-test-repeatable-field
       className={classnames(css.repeatableField, { [css.hasMargin]: hasMargin }, className)}
+      tabIndex="-1"
+      onFocus={() => { setHasBeenFocused(true) }}
     >
       {legend && (
         <Headline
@@ -126,7 +127,6 @@ const RepeatableField = ({
             >
               <RepeatableFieldContent
                 rootRef={rootRef}
-                isFocused={hasToBeFocused(index)}
               >
                 {renderField(field, index, fields)}
               </RepeatableFieldContent>

--- a/lib/RepeatableField/RepeatableField.js
+++ b/lib/RepeatableField/RepeatableField.js
@@ -8,10 +8,10 @@ import Button from '../Button';
 import Headline from '../Headline';
 import EmptyMessage from '../EmptyMessage';
 import IconButton from '../IconButton';
-import { RepeatableFieldContent } from "./RepeatableFieldContent";
+import { RepeatableFieldContent } from './RepeatableFieldContent';
 import css from './RepeatableField.css';
-import { useFocusedIndex } from "./hooks/useFocusedIndex";
-import { useIsElementFocused } from "./hooks/useIsElementFocused";
+import { useFocusedIndex } from './hooks/useFocusedIndex';
+import { useIsElementFocused } from './hooks/useIsElementFocused';
 import { getFirstFocusable } from '../../util/getFocusableElements';
 
 const RepeatableField = ({
@@ -39,30 +39,26 @@ const RepeatableField = ({
   // use mutation observers to handle focus-management since we only have internal state.
   useEffect(() => {
     const observer = new MutationObserver(mutations => {
-      let rowElem;
-      // field additions - we only manage focus when focus is
-      // within the container...
-      if (rootRef.current.matches(':focus-within')) {
-        mutations.forEach((m) => {
-          if (m.type === 'childList') {
-            if (m.addedNodes?.length === 1) {
-              rowElem = m.addedNodes[0];
-              if (rowElem) {
-                getFirstFocusable(rowElem)?.focus();
-              }
-            }
+      mutations.forEach(mutation => {
+        if (mutation.type !== 'childList') return;
+
+        const addedNode = mutation.addedNodes?.[0];
+        const removedNode = mutation.removedNodes?.[0];
+        let rowElem;
+        // Handle added node
+        if (rootRef.current.matches(':focus-within')) {
+          if (addedNode && addedNode.matches(`.${css.repeatableFieldItem}`)) {
+            rowElem = getFirstFocusable(addedNode);
+            rowElem?.focus();
           }
-        });
-      }
-      // removals may or may not keep focus within the field list...
-      mutations.forEach((m) => {
-        if (m.type === 'childList') {
-          if (m.removedNodes.length === 1) {
-            rowElem = m.previousSibling;
-            if (rowElem) {
-              getFirstFocusable(rowElem)?.focus();
-            }
-          }
+        }
+
+        // Handle removed node
+        if (removedNode &&
+          mutation.previousSibling &&
+          mutation.previousSibling.matches(`.${css.repeatableFieldItem}`)) {
+          rowElem = getFirstFocusable(mutation.previousSibling);
+          rowElem?.focus();
         }
       });
     });

--- a/lib/RepeatableField/RepeatableField.js
+++ b/lib/RepeatableField/RepeatableField.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useEffect } from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
@@ -12,7 +12,7 @@ import { RepeatableFieldContent } from "./RepeatableFieldContent";
 import css from './RepeatableField.css';
 import { useFocusedIndex } from "./hooks/useFocusedIndex";
 import { useIsElementFocused } from "./hooks/useIsElementFocused";
-
+import { getFirstFocusable } from '../../util/getFocusableElements';
 
 const RepeatableField = ({
   canAdd = true,
@@ -35,6 +35,51 @@ const RepeatableField = ({
   const fieldsLength = fields.length;
   const isSomeChildElementFocused = useIsElementFocused(rootRef);
   const focusedIndex = useFocusedIndex(fieldsLength);
+
+  // use mutation observers to handle focus-management since we only have internal state.
+  useEffect(() => {
+    const observer = new MutationObserver(mutations => {
+      let rowElem;
+      // field additions - we only manage focus when focus is
+      // within the container...
+      if (rootRef.current.matches(':focus-within')) {
+        mutations.forEach((m) => {
+          if (m.type === 'childList') {
+            if (m.addedNodes?.length === 1) {
+              rowElem = m.addedNodes[0];
+              if (rowElem) {
+                getFirstFocusable(rowElem)?.focus();
+              }
+            }
+          }
+        });
+      }
+      // removals may or may not keep focus within the field list...
+      mutations.forEach((m) => {
+        if (m.type === 'childList') {
+          if (m.removedNodes.length === 1) {
+            rowElem = m.previousSibling;
+            if (rowElem) {
+              getFirstFocusable(rowElem)?.focus();
+            }
+          }
+        }
+      });
+    });
+
+    if (rootRef.current) {
+    // observe for item additions/removals from list.
+      observer.observe(rootRef.current, {
+        childList: true,
+        subtree: true,
+      });
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [])
+
   const hasToBeFocused = (index) => isSomeChildElementFocused && focusedIndex === index;
 
   return (

--- a/lib/RepeatableField/RepeatableField.js
+++ b/lib/RepeatableField/RepeatableField.js
@@ -47,8 +47,8 @@ const RepeatableField = ({
         // unwantedly moved when a form is initialized.
         if (hasBeenFocused) {
           if (addedNode &&
-            addedNode.nodeType === 1 &&
-            addedNode.matches(`.${css.repeatableFieldItem}`)) {
+            addedNode.nodeType === 1 && // looking for nodeType: element only... not attribute (2) or text (3)
+            addedNode.matches(`.${css.repeatableFieldItem}`)) { // only apply to repeatable field item addition removal
             rowElem = getFirstFocusable(addedNode);
             rowElem?.focus();
           }

--- a/lib/RepeatableField/RepeatableFieldContent.js
+++ b/lib/RepeatableField/RepeatableFieldContent.js
@@ -1,31 +1,17 @@
 import React, { useCallback } from "react";
 import PropTypes from "prop-types";
 
-import { getFirstFocusable } from "../../util/getFocusableElements";
-
 import css from "./RepeatableField.css";
 
-export const RepeatableFieldContent = ({ children, isFocused }) => {
-
-  const callbackRef = useCallback((node) => {
-    if (node && isFocused) {
-      const elem = getFirstFocusable(node, true, true);
-
-      elem?.focus();
-    }
-  }, [isFocused])
-
-  return (
-    <div className={css.repeatableFieldItemContent} ref={callbackRef}>
-      {children}
-    </div>
-  );
-}
+export const RepeatableFieldContent = ({ children }) => (
+  <div className={css.repeatableFieldItemContent}>
+    {children}
+  </div>
+);
 
 RepeatableFieldContent.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.func,
   ]).isRequired,
-  isFocused: PropTypes.bool.isRequired,
 }

--- a/lib/RepeatableField/RepeatableFieldContent.js
+++ b/lib/RepeatableField/RepeatableFieldContent.js
@@ -1,7 +1,7 @@
-import React, { useCallback } from "react";
-import PropTypes from "prop-types";
+import React from 'react';
+import PropTypes from 'prop-types';
 
-import css from "./RepeatableField.css";
+import css from './RepeatableField.css';
 
 export const RepeatableFieldContent = ({ children }) => (
   <div className={css.repeatableFieldItemContent}>


### PR DESCRIPTION
This is cited in a hanful of issues.... [STCOM-1372](https://folio-org.atlassian.net/browse/STCOM-1372) is the first. This solution uses a useEffect/MutationObserver combination for focus management in repeatable field.

Since state for RepeatableField is kept outside of the component, DOM state is the main way we have to control this behavior at the component level.

Pseudo-logic for this is as follows:
Manage focus only if the user has already interacted with the list (via `onFocus` handler)
When an item is added, move focus to the first focusable element within that item.
If items are removed from the list, focus the first focusable element within the item's previous sibling.