### PR TITLE
STCOM-1354 add Kosovo to country list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Change `Repeatable field` focus behaviour. Refs STCOM-1341.
 * Fix `<Selection>` bug with option list closing when scrollbar is used. Refs STCOM-1371.
 * `<Selection>` - fix bug handling empty string options/values. Refs STCOM-1373.
+* Include Kosovo in the countries list. Refs STCOM-1354.
 
 ## [12.2.0](https://github.com/folio-org/stripes-components/tree/v12.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.1.0...v12.2.0)

--- a/translations/stripes-components/en.json
+++ b/translations/stripes-components/en.json
@@ -247,6 +247,7 @@
   "countries.KE": "Kenya",
   "countries.KI": "Kiribati",
   "countries.KR": "Korea",
+  "countries.XK": "Kosovo",
   "countries.KW": "Kuwait",
   "countries.KG": "Kyrgyzstan",
   "countries.LA": "Lao People\\'s Democratic Republic",

--- a/util/countries.js
+++ b/util/countries.js
@@ -242,6 +242,7 @@ const countries = [
   { alpha2: 'VN', alpha3: 'VNM', numeric: '704' },
   { alpha2: 'VI', alpha3: 'VIR', numeric: '850' },
   { alpha2: 'WF', alpha3: 'WLF', numeric: '876' },
+  { alpha2: 'XK', alpha3: 'XXK', numeric: '926' },
   { alpha2: 'EH', alpha3: 'ESH', numeric: '732' },
   { alpha2: 'YE', alpha3: 'YEM', numeric: '887' },
   { alpha2: 'ZM', alpha3: 'ZMB', numeric: '894' },


### PR DESCRIPTION
Add Kosovo to the list of countries and translations. Codes pulled from https://en.wikipedia.org/wiki/Country_codes:_J%E2%80%93K#_Kosovo.

Refs [STCOM-1354](https://folio-org.atlassian.net/browse/STCOM-1354)