### PR TITLE
STCOM-1377: Allow user to choose default value in Selection component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * `<Selection>` - fix bug handling empty string options/values. Refs STCOM-1373.
 * Include Kosovo in the countries list. Refs STCOM-1354.
 * `<RepeatableField>` - switch to MutationObserver to resolve focus-management issues. Refs STCOM-1372.
+* Allow user to choose default value in `Selection` component. Fixes STCOM-1377.
 
 ## [12.2.0](https://github.com/folio-org/stripes-components/tree/v12.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.1.0...v12.2.0)

--- a/lib/Selection/Selection.js
+++ b/lib/Selection/Selection.js
@@ -121,6 +121,7 @@ const Selection = ({
   valid,
   value,
   warning,
+  allowSetDefaultValue = false,
   ...rest
 }) => {
   const { formatMessage } = useIntl();
@@ -279,6 +280,7 @@ const Selection = ({
           <li
             key={`${item.label}-heading-${i}`}
             className={css.groupLabel}
+            {...(allowSetDefaultValue && getItemProps({ index: i }))}
           >
             {formatter({ option: item, searchTerm: filterValue })}
           </li>
@@ -489,6 +491,7 @@ const Selection = ({
 };
 
 Selection.propTypes = {
+  allowSetDefaultValue: PropTypes.bool,
   asyncFilter: PropTypes.bool,
   autofocus: PropTypes.bool,
   dataOptions: PropTypes.arrayOf(PropTypes.object),

--- a/lib/Selection/readme.md
+++ b/lib/Selection/readme.md
@@ -65,6 +65,7 @@ customFormatter = ({ option, searchTerm }) => {
 ## Props
 Name | type | description | default | required
 --- | --- | --- | --- | ---
+`allowSetDefaultValue` | bool | If `true`, default value can be selected from the options list
 `asyncFilter` | bool | Set to `true` if your `onFilter` function makes a request for updated `dataOptions` rather than filter the `dataOptions` directly on the front-end. | `false` | false
 `dataOptions` | array of objects | Array of objects with `label` and `value` keys. The labels are visible to the users in the options list, the values are not. | | &#10004;
 `id` | string | Sets the `id` html attribute on the control | |

--- a/lib/Selection/tests/Selection-test.js
+++ b/lib/Selection/tests/Selection-test.js
@@ -283,6 +283,30 @@ describe('Selection', () => {
       });
     });
 
+    describe('clicking a default option', () => {
+      beforeEach(async () => {
+        await mountWithContext(
+          <SingleSelectionHarness
+            label="test selection"
+            initValue="test2"
+            options={[{ label: 'Default value', value: '' }, ...listOptions]}
+          />
+        );
+
+        await selection.choose('Default value');
+      });
+
+      it('sets control value to empty string', () => {
+        selection.has({ value: '' });
+      });
+
+      it('closes the list', expectClosedMenu);
+
+      it('focuses the control/trigger', () => {
+        selection.has({ focused: true });
+      });
+    });
+
     describe('filtering options', () => {
       beforeEach(async () => {
         await selection.filterOptions('Sample');
@@ -743,7 +767,7 @@ describe('Selection', () => {
     beforeEach(async () => {
       filterSpy.resetHistory();
       await mountWithContext(
-        <AsyncFilter filterSpy={filterSpy}/>
+        <AsyncFilter filterSpy={filterSpy} />
       );
     });
 
@@ -756,7 +780,7 @@ describe('Selection', () => {
         await asyncSelection.filterOptions('tes');
       });
 
-      it ('calls filter function only once (not for each letter)', async () => converge(() => { if (filterSpy.calledTwice) { throw new Error('Selection - onFilter should only be called once.'); }}));
+      it('calls filter function only once (not for each letter)', async () => converge(() => { if (filterSpy.calledTwice) { throw new Error('Selection - onFilter should only be called once.'); } }));
 
       it('displays spinner in optionsList', () => asyncSelectionList().is({ loading: true }));
 


### PR DESCRIPTION
* Allow user to choose default value in `Selection` component.
* Currently it’s not possible to reset the value in `Selection` component, and select the default option: **Select…**.
* Added `allowSetDefaultValue` property, which allows user to select default value.

## Links
[STCOM-1377](https://folio-org.atlassian.net/browse/STCOM-1377)
[UIIN-3090](https://folio-org.atlassian.net/browse/UIIN-3090)

## Screenshots
