### PR TITLE
STCOM-1343 bump stripes-react-hotkeys for compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * `<Selection>` - fix bug handling empty string options/values. Refs STCOM-1373.
 * Include Kosovo in the countries list. Refs STCOM-1354.
 * `<RepeatableField>` - switch to MutationObserver to resolve focus-management issues. Refs STCOM-1372.
+* Bump `stripes-react-hotkeys` to `v3.2.0` for compatibility with `findDOMNode()` changes. STCOM-1343.
 
 ## [12.2.0](https://github.com/folio-org/stripes-components/tree/v12.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.1.0...v12.2.0)

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   },
   "dependencies": {
     "@csstools/postcss-global-data": "^2.1.1",
-    "@folio/stripes-react-hotkeys": "^3.1.0",
+    "@folio/stripes-react-hotkeys": "^3.2.1",
     "classnames": "^2.2.5",
     "currency-codes": "^2.1.0",
     "dayjs": "^1.11.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2325,10 +2325,10 @@
     webpack-bundle-analyzer "^4.4.2"
     yargs "^17.3.1"
 
-"@folio/stripes-react-hotkeys@^3.1.0":
-  version "3.1.10990000000033"
-  resolved "https://repository.folio.org/repository/npm-folioci/@folio/stripes-react-hotkeys/-/stripes-react-hotkeys-3.1.10990000000033.tgz#ca5e58a89cf9dbd1d9b5c1b7e5daf9c635289dc0"
-  integrity sha512-IyMnHi0WJqdWQaNiNF/O+HtilF/OrIFdC58Ru539SnTFgfE1kMODmCAKKStfNravjGpazZrF7puJTSCP/X5sig==
+"@folio/stripes-react-hotkeys@^3.2.1":
+  version "3.2.10990000000048"
+  resolved "https://repository.folio.org/repository/npm-folioci/@folio/stripes-react-hotkeys/-/stripes-react-hotkeys-3.2.10990000000048.tgz#18b16fffbf9bbc278034308c667aff17a8b52291"
+  integrity sha512-XlYtrDhfxyGT6loiBLSaypld13mO2npsxDkr1JklltyczTU/krRQmmFj659N/Ck1s6sS2eBZc3hMx1WX9DKMQQ==
   dependencies:
     core-js "^3.0.0"
     keyboardjs "~2.5.1"


### PR DESCRIPTION
Bump `stripes-react-hotkeys` to `v3.2.1` for compatibility with the changes it made in STCOM-1285 to maintain compatibility.

Refs [STCOM-1343](https://folio-org.atlassian.net/browse/STCOM-1343)