### PR TITLE
STCOM-1379 pin currency-codes to avoid unexpected dupes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Include Kosovo in the countries list. Refs STCOM-1354.
 * `<RepeatableField>` - switch to MutationObserver to resolve focus-management issues. Refs STCOM-1372.
 * Bump `stripes-react-hotkeys` to `v3.2.0` for compatibility with `findDOMNode()` changes. STCOM-1343.
+* Pin `currency-codes` to `v2.1.0` to avoid duplicate entries in `v2.2.0`. Refs STCOM-1379.
 
 ## [12.2.0](https://github.com/folio-org/stripes-components/tree/v12.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.1.0...v12.2.0)

--- a/lib/CurrencySelect/tests/CurrencySelect-test.js
+++ b/lib/CurrencySelect/tests/CurrencySelect-test.js
@@ -33,10 +33,26 @@ describe('CurrencySelect', () => {
 
   describe('utility functions', () => {
     const CURRENCY_COUNT = 159;
-    it('expects currency maps to contain the same element counts', () => {
+    it('expects currency maps to contain the same element counts (reduce by CODE)', () => {
       expect(Object.keys(currenciesByCode).length).to.equal(CURRENCY_COUNT);
+    });
+
+    // this test fails with currency-codes v2.2.0 which supplies duplicate
+    // entries for Bolívar Soberano. it isn't clear if this is intentional
+    // (and so this map-by-name function should never have been written) or
+    // accidental (names are unique in previous releases).
+    //
+    // if we unpin the dependency from v2.1.0 then we need to remove this function,
+    // a breaking change. leave comments at STCOM-1379.
+    it('expects currency maps to contain the same element counts (reduce by NAME)', () => {
       expect(Object.keys(currenciesByName).length).to.equal(CURRENCY_COUNT);
+    });
+
+    it('expects currency maps to contain the same element counts (reduce by NUMBER)', () => {
       expect(Object.keys(currenciesByNumber).length).to.equal(CURRENCY_COUNT);
+    });
+
+    it('expects currency maps to contain the same element counts', () => {
       expect(currenciesOptions.length).to.equal(CURRENCY_COUNT);
     });
 

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@csstools/postcss-global-data": "^2.1.1",
     "@folio/stripes-react-hotkeys": "^3.2.1",
     "classnames": "^2.2.5",
-    "currency-codes": "^2.1.0",
+    "currency-codes": "2.1.0",
     "dayjs": "^1.11.10",
     "downshift": "^9.0.4",
     "flexboxgrid2": "^7.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7540,7 +7540,7 @@ ctrlc-windows@^2.1.0:
   resolved "https://registry.yarnpkg.com/ctrlc-windows/-/ctrlc-windows-2.1.0.tgz#f2096a96ac1d03181e0ec808c2c8a67fdc20b300"
   integrity sha512-OrX5KI+K+2NMN91QIhYZdW7VDO2YsSdTZW494pA7Nvw/wBdU2hz+MGP006bR978zOTrG6Q8EIeJvLJmLqc6MsQ==
 
-currency-codes@^2.1.0:
+currency-codes@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/currency-codes/-/currency-codes-2.1.0.tgz#6d84a1b7fec70ecb9ef64e57bf60f4271899044c"
   integrity sha512-aASwFNP8VjZ0y0PWlSW7c9N/isYTLxK6OCbm7aVuQMk7dWO2zgup9KGiFQgeL9OGL5P/ulvCHcjQizmuEeZXtw==


### PR DESCRIPTION
Data that was uniquely keyed up through `v2.1.0` is not so in `v2.2.0` (there are multiple entries for the currency `Bolívar Soberano`). It is not clear if the uniqueness property was intentional or incidental (see https://github.com/freeall/currency-codes/issues/46).

Since we have tests that directly rely on the data we import, we should _always_ depend on a specific version in order to avoid this kind of problem, and so we can choose when to address it instead of being forced to address it whenever the third-party dependency happens to publish a new release.

Refs [STCOM-1379](https://folio-org.atlassian.net/browse/STCOM-1379)