### PR TITLE
STCOM-1332 Selection should occupy the full width of its container.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * `<RepeatableField>` - switch to MutationObserver to resolve focus-management issues. Refs STCOM-1372.
 * Bump `stripes-react-hotkeys` to `v3.2.0` for compatibility with `findDOMNode()` changes. STCOM-1343.
 * Pin `currency-codes` to `v2.1.0` to avoid duplicate entries in `v2.2.0`. Refs STCOM-1379.
+* Wrap `<Selection>` in full-width div. Refs STCOM-1332.
 
 ## [12.2.0](https://github.com/folio-org/stripes-components/tree/v12.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.1.0...v12.2.0)

--- a/lib/Selection/Selection.css
+++ b/lib/Selection/Selection.css
@@ -2,6 +2,7 @@
 
 .selectionOuter {
   width: 100%;
+  position: relative;
 }
 
 .selectionRoot {

--- a/lib/Selection/Selection.css
+++ b/lib/Selection/Selection.css
@@ -1,5 +1,9 @@
 
 
+.selectionOuter {
+  width: 100%;
+}
+
 .selectionRoot {
   position: relative;
 }

--- a/lib/Selection/Selection.js
+++ b/lib/Selection/Selection.js
@@ -424,7 +424,7 @@ const Selection = ({
   /* eslint-enable react-hooks/exhaustive-deps */
 
   return (
-    <div>
+    <div className={css.selectionOuter}>
       {label && (
         <Label
           {...getLabelProps({


### PR DESCRIPTION
## [STCOM-1332](https://folio-org.atlassian.net/browse/STCOM-1332)

Prior to refactor, the outer element for selection had an inline style that set the width to `100%`  https://github.com/folio-org/stripes-components/blob/4b25bb96a529c2b75091a127232791bef244e3e8/lib/Selection/SingleSelect.js#L675-L678
This change re-applies that style as a CSS class.