### PR TITLE
STCOM-1382 Assign modal escape key handler to modal element rather than document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Bump `stripes-react-hotkeys` to `v3.2.0` for compatibility with `findDOMNode()` changes. STCOM-1343.
 * Pin `currency-codes` to `v2.1.0` to avoid duplicate entries in `v2.2.0`. Refs STCOM-1379.
 * Wrap `<Selection>` in full-width div. Refs STCOM-1332.
+* Assign `<Modal>`'s exit key handler to Modal's element rather than `document`. refs STCOM-1382.
 
 ## [12.2.0](https://github.com/folio-org/stripes-components/tree/v12.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.1.0...v12.2.0)

--- a/lib/Modal/WrappingElement.js
+++ b/lib/Modal/WrappingElement.js
@@ -123,7 +123,7 @@ const WrappingElement = forwardRef(({
         focusTrapRef.current.activate();
         ATTrap.apply();
       }
-      keyDownHandlerRef.current = listen(document, 'keydown', keyDownHandler);
+      keyDownHandlerRef.current = listen(modalElementRef.current, 'keydown', keyDownHandler);
       focusHandlerRef.current = listen(document, 'focus', enforceFocusTimeout, true);
       onOpen();
     }


### PR DESCRIPTION
## [STCOM-1382](https://folio-org.atlassian.net/browse/STCOM-1382)

See [UIQM-732](https://folio-org.atlassian.net/browse/UIQM-732) for the module-level bug.

Modal hangs its escape key listener on the `document` rather than one of its owned elements. this can be problematic if an app has a `escape` shortcut key that's set up the same way. See the UI-QuickMarc bug for details. TLDR: `escape` key in dirty form should trigger the confirmation modal, but instead it opens the modal and immediately closes it, exiting the form without any confirmation.