### PR TITLE
STCOM-1384 Wrap Card render output with StripesOverlayContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Pin `currency-codes` to `v2.1.0` to avoid duplicate entries in `v2.2.0`. Refs STCOM-1379.
 * Wrap `<Selection>` in full-width div. Refs STCOM-1332.
 * Assign `<Modal>`'s exit key handler to Modal's element rather than `document`. refs STCOM-1382.
+* Wrap `<Card>`'s render output in `<StripesOverlayContext>` to facilitate ease with overlay components. Refs STCOM-1384.
 
 ## [12.2.0](https://github.com/folio-org/stripes-components/tree/v12.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.1.0...v12.2.0)

--- a/lib/Card/Card.js
+++ b/lib/Card/Card.js
@@ -6,6 +6,7 @@ import omitProps from '../../util/omitProps';
 
 import css from './Card.css';
 import DefaultCardHeader from './headers/DefaultCardHeader';
+import StripesOverlayWrapper from '../../util/StripesOverlayWrapper';
 
 export default class Card extends React.Component {
   static propTypes = {
@@ -73,18 +74,20 @@ export default class Card extends React.Component {
     ]);
 
     return (
-      <div
-        className={this.getCardStyle()}
-        {...customProps}
-      >
-        <HeaderComponent {...this.props} />
+      <StripesOverlayWrapper>
         <div
-          data-test-card-body
-          className={`${css.body} ${bodyClass || ''}`}
+          className={this.getCardStyle()}
+          {...customProps}
         >
-          {children}
+          <HeaderComponent {...this.props} />
+          <div
+            data-test-card-body
+            className={`${css.body} ${bodyClass || ''}`}
+          >
+            {children}
+          </div>
         </div>
-      </div>
+      </StripesOverlayWrapper>
     );
   }
 }


### PR DESCRIPTION
## [STCOM-1384](https://folio-org.atlassian.net/browse/STCOM-1384)

Module-level bug featuring card: [STCOM-1381](https://folio-org.atlassian.net/browse/STCOM-1381)

As with the inclusion in `<Modal>` and `<MCL>`, `<Card>` is another container where including a `<StripesOverlayContext>` can be helpful. Card container styling is overflow: hidden so portal usage is necessary here.