### PR TITLE
STCOM-1385 Clear filter value after an action is chosen from MultiSelection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Wrap `<Selection>` in full-width div. Refs STCOM-1332.
 * Assign `<Modal>`'s exit key handler to Modal's element rather than `document`. refs STCOM-1382.
 * Wrap `<Card>`'s render output in `<StripesOverlayContext>` to facilitate ease with overlay components. Refs STCOM-1384.
+* Clear filter value after an action chosen from `MultiSelection` menu. Refs STCOM-1385.
 
 ## [12.2.0](https://github.com/folio-org/stripes-components/tree/v12.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.1.0...v12.2.0)

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -272,6 +272,7 @@ const MultiSelection = ({
               selectedItems,
               reset
             });
+            setFilterValue('');
             return {
               isOpen: false, // keep the menu open after selection.
               highlightedIndex, // don't move highlight cursor back to top of list on selection.

--- a/lib/MultiSelection/MultiSelection.js
+++ b/lib/MultiSelection/MultiSelection.js
@@ -256,7 +256,6 @@ const MultiSelection = ({
           break;
       }
     },
-    //
     stateReducer(state, actionAndChanges) {
       const { changes, type } = actionAndChanges
       switch (type) {
@@ -274,7 +273,7 @@ const MultiSelection = ({
             });
             setFilterValue('');
             return {
-              isOpen: false, // keep the menu open after selection.
+              isOpen: false, // close the menu.
               highlightedIndex, // don't move highlight cursor back to top of list on selection.
             }
           } else {

--- a/lib/MultiSelection/tests/MultiSelection-test.js
+++ b/lib/MultiSelection/tests/MultiSelection-test.js
@@ -610,6 +610,16 @@ describe('MultiSelect', () => {
 
       it('calls the action\'s onSelect function', () => converge(() => { if (!actionSelected) throw new Error('MultiSelection - action should be executed'); }));
     });
+
+    describe('clicking a filtered action', () => {
+      beforeEach(async () => {
+        await multiselection.filter('act');
+        await multiselection.select('actionItem');
+      });
+
+      it('calls the action\'s onSelect function', () => converge(() => { if (!actionSelected) throw new Error('MultiSelection - action should be executed'); }));
+      it('clears the filter value', () => multiselection.has({ filterValue: '' }));
+    });
   });
 
   describe('asyncFiltering', () => {


### PR DESCRIPTION
## [STCOM-1385](https://folio-org.atlassian.net/browse/STCOM-1385)

Known locations affected: Tags (linked in main JIRA), [Agreements->Settings ->Supplementary properties](https://folio-org.atlassian.net/browse/STSMACOM-877) (closed as duplicate)

### Approach
Multiselection needs to reset the filter value when an option's `onSelect` handler is called (actions API for Multiselection) Otherwise, the filter value will not be reset as it usually is through typical value selection logic.
