### PR TITLE
STCOM-1195: Bump '@folio/stripes-testing' from ^4.7.0 to ^4.9.0 (follow-up).

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@csstools/postcss-relative-color-syntax": "^2.0.7",
     "@folio/eslint-config-stripes": "^7.0.0",
     "@folio/stripes-cli": "^3.0.0",
-    "@folio/stripes-testing": "^4.7.0",
+    "@folio/stripes-testing": "^4.9.0",
     "@formatjs/cli": "^6.1.3",
     "@storybook/addon-actions": "^7.6.12",
     "@storybook/addon-essentials": "^7.6.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2346,7 +2346,7 @@
     element-is-visible "^1.0.0"
     minimist "^1.2.0"
 
-"@folio/stripes-testing@^4.7.0":
+"@folio/stripes-testing@^4.9.0":
   version "4.9.10900000036396"
   resolved "https://repository.folio.org/repository/npm-folioci/@folio/stripes-testing/-/stripes-testing-4.9.10900000036396.tgz#d439664b3bac42ce071f279934695950d81689e2"
   integrity sha512-pEdF7uUqx+nx5/2/DWCNeH3/Pee5Xs09/EPptc0IXLKYRoos39MB1g6O+VSAxSVn/FpZyH77iy+MFlImphLIQA==


### PR DESCRIPTION
## Description
Bump `@folio/stripes-testing` from `^4.7.0` to `^4.9.0` (follow-up). More [details.](https://github.com/folio-org/stripes-components/pull/2409#pullrequestreview-2532057330)

## Issues
[STCOM-1195](https://folio-org.atlassian.net/browse/STCOM-1195)