### PR TITLE
STCOM - 1390 improve text contrast of disabled text, adjust calendar colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * `<AdvancedSearchRow>` - change `aria-label` for the input box to enter a search query and the Boolean operator dropdown. Refs STCOM-1195.
 * *BREAKING* Update `@csstools` postcss plugins to current versions in sync with `@folio/stripes-cli`. Refs STCOM-1404.
 * Paneset - deduplicate panes via `id` prior to registration. Refs STCOM-1386.
+* Calendar - improved color contrast of edge month days, as per WCAG standards. Changed hover bg color of edge/month days. Increased weight of day numbers overall. Refs STCOM-1390.
 
 ## [12.2.0](https://github.com/folio-org/stripes-components/tree/v12.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.1.0...v12.2.0)

--- a/lib/Datepicker/Calendar.css
+++ b/lib/Datepicker/Calendar.css
@@ -55,13 +55,18 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    font-weight: 600;
 
     &:hover {
-      background-color: #eee;
+      background-color: var(--color-focus-shadow);
     }
 
     &.muted {
       color: var(--color-fill-disabled);
+
+      &:hover {
+        background-color: #eee;
+      }
     }
 
     &.today {

--- a/lib/variables.css
+++ b/lib/variables.css
@@ -14,7 +14,7 @@
   --color-fill-table-row-even: rgba(0 0 0 / 3%);
   --color-fill-form-element: var(--color-fill);
   --color-fill-current: rgba(0 0 0 / 62%);
-  --color-fill-disabled: rgba(0 0 0 / 15%);
+  --color-fill-disabled: rgba(0 0 0 / 54%);
   --color-fill-hover: rgba(37 118 195 / 20%);
   --color-fill-focus: rgba(37 118 195 / 20%);
   --color-focus-shadow:  rgba(166 212 255 / 65%);


### PR DESCRIPTION
These particular changes targeted the calendar UI. The thickness of text was increased as well as colors of inactive days to improve contrast to acceptable levels (4.5:1 minimum).

Additionally, changed the hover bg for days during the month.

![dpupdatecolors](https://github.com/user-attachments/assets/1a5d7e30-ed1e-4aa6-8fae-134e27d87e72)
