### PR TITLE
STCOM-139 - Popper - hide popper overlay when target element is scrolled outside of the view.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@
 * *BREAKING* Update `@csstools` postcss plugins to current versions in sync with `@folio/stripes-cli`. Refs STCOM-1404.
 * Paneset - deduplicate panes via `id` prior to registration. Refs STCOM-1386.
 * Calendar - improved color contrast of edge month days, as per WCAG standards. Changed hover bg color of edge/month days. Increased weight of day numbers overall. Refs STCOM-1390.
-
+* Popper - hide overlay if popper anchor is scrolled out of the view. Refs STCOM-1386.
+  
 ## [12.2.0](https://github.com/folio-org/stripes-components/tree/v12.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.1.0...v12.2.0)
 

--- a/lib/Popper/Popper.css
+++ b/lib/Popper/Popper.css
@@ -1,7 +1,7 @@
 .overlay {
   z-index: 9999;
 
-  /*  popper-appied element property when the 'anchor' element is hidden
+  /*  popper-applied element property when the 'anchor' element is hidden
       or scrolled out of the view. This rule effectively hides the overlay if the anchor
       element/dropdown/control is scrolled out of the view.
       'visibility: hidden' is used instead of 'display: none' so that coordinates can still

--- a/lib/Popper/Popper.css
+++ b/lib/Popper/Popper.css
@@ -1,3 +1,13 @@
 .overlay {
   z-index: 9999;
+
+  /*  popper-appied element property when the 'anchor' element is hidden
+      or scrolled out of the view. This rule effectively hides the overlay if the anchor
+      element/dropdown/control is scrolled out of the view.
+      'visibility: hidden' is used instead of 'display: none' so that coordinates can still
+      be accounted for by Popper.
+  */
+  &[x-out-of-boundaries] {
+    visibility: hidden;
+  }
 }


### PR DESCRIPTION

### Approach

Popper already adds an attribute (via its default set of modifiers) - the hiding outcome just has to be connected via CSS. If the anchoring element control is visible within the view, then the popper/overlay will be visible as well. If not, it disappears.


### Result
![hidePopup](https://github.com/user-attachments/assets/89b1198b-ad90-42fb-848e-60f7c657524f)
