### PR TITLE
STCOM-1416: AuditLog: Add original version card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 13.1.0 IN PROGRESS
 
 * Introduce `<AuditLog>` component. Refs STCOM-1412.
+* `AuditLog` - Add original version card. Refs STCOM-1416.
 
 ## [13.0.0](https://github.com/folio-org/stripes-components/tree/v13.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.2.0...v13.0.0)

--- a/lib/AuditLog/AuditLogCard.css
+++ b/lib/AuditLog/AuditLogCard.css
@@ -1,5 +1,6 @@
 .card p {
     margin: 0;
+    line-height: var(--line-height);
 }
 
 .card button {

--- a/lib/AuditLog/AuditLogCard.js
+++ b/lib/AuditLog/AuditLogCard.js
@@ -16,6 +16,7 @@ const AuditLogCard = ({
   fieldChanges,
   fieldFormatter,
   fieldLabelsMap,
+  isOriginal,
   source,
   userName,
 }) => {
@@ -39,6 +40,14 @@ const AuditLogCard = ({
       />
     </>
   );
+  const originalVersionLabel = (
+    <b>
+      <FormattedMessage
+        id="stripes-components.versionHistory.card.originalVersion"
+        tagName="em"
+      />
+    </b>
+  );
 
   const onChangeButtonClick = () => {
     setIsModalOpen(true);
@@ -54,12 +63,15 @@ const AuditLogCard = ({
         roundedBorder
       >
         {fieldChangesSource}
-        <AuditLogChangedFieldsList
-          actionsMap={actionsMap}
-          fieldChanges={fieldChanges}
-          fieldLabelsMap={fieldLabelsMap}
-          onChangeButtonClick={onChangeButtonClick}
-        />
+        {isOriginal && <p>{originalVersionLabel}</p>}
+        <p>
+          <AuditLogChangedFieldsList
+            actionsMap={actionsMap}
+            fieldChanges={fieldChanges}
+            fieldLabelsMap={fieldLabelsMap}
+            onChangeButtonClick={onChangeButtonClick}
+          />
+        </p>
       </Card>
       <AuditLogModal
         contentData={fieldChanges}
@@ -82,8 +94,9 @@ AuditLogCard.propTypes = {
   fieldChanges: PropTypes.arrayOf(PropTypes.object).isRequired,
   fieldFormatter: PropTypes.object,
   fieldLabelsMap: PropTypes.object,
-  source: PropTypes.oneOf([PropTypes.string, PropTypes.node]).isRequired,
-  userName: PropTypes.oneOf([PropTypes.string, PropTypes.node]).isRequired,
+  isOriginal: PropTypes.bool,
+  source: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  userName: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
 };
 
 export default AuditLogCard;

--- a/lib/AuditLog/AuditLogChangedFieldsList.js
+++ b/lib/AuditLog/AuditLogChangedFieldsList.js
@@ -10,7 +10,7 @@ const AuditLogChangedFieldsList = ({
   fieldLabelsMap,
   onChangeButtonClick,
 }) => {
-  if (!fieldChanges) return '';
+  if (!fieldChanges?.length) return '';
 
   const itemFormatter = (item, i) => {
     const {
@@ -26,7 +26,7 @@ const AuditLogChangedFieldsList = ({
   };
 
   return (
-    <div>
+    <>
       <Button
         buttonStyle="link"
         onClick={onChangeButtonClick}
@@ -42,7 +42,7 @@ const AuditLogChangedFieldsList = ({
         listStyle="bullets"
         marginBottom0
       />
-    </div>
+    </>
   );
 };
 

--- a/lib/AuditLog/AuditLogPane.js
+++ b/lib/AuditLog/AuditLogPane.js
@@ -59,6 +59,7 @@ const AuditLogPane = ({
 
   const versionCards = useMemo(() => {
     return versions.map(({
+      isOriginal,
       eventId,
       eventDate,
       source,
@@ -69,6 +70,7 @@ const AuditLogPane = ({
         <AuditLogCard
           key={eventId || i}
           date={eventDate}
+          isOriginal={isOriginal}
           source={source}
           userName={userName}
           fieldChanges={fieldChanges}
@@ -133,8 +135,11 @@ AuditLogPane.propTypes = {
     PropTypes.shape({
       eventDate: PropTypes.string,
       eventId: PropTypes.string,
+      eventTs: PropTypes.number,
       fieldChanges: PropTypes.arrayOf(PropTypes.object),
-      source: PropTypes.object,
+      isOriginal: PropTypes.bool,
+      source: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+      userName: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     })
   ).isRequired,
 };

--- a/lib/AuditLog/readme.md
+++ b/lib/AuditLog/readme.md
@@ -74,6 +74,7 @@ import { AuditLogCard } from '@folio/stripes/components';
 
 const versionCards = () => {
   return versions.map(({
+    isOriginal,
     eventId,
     eventDate,
     source,
@@ -83,6 +84,7 @@ const versionCards = () => {
     return (
       <AuditLogCard
         key={eventId || i}
+        isOriginal={isOriginal}
         date={eventDate}
         source={source}
         userName={userName}
@@ -98,16 +100,17 @@ const versionCards = () => {
 ```
 
 ### Props
-Name | type   | description                                                                          | default | required
---- |--------|--------------------------------------------------------------------------------------| --- | ---
-actionsMap | object | Maps change type value to user friendly action label                                 | | false
-columnWidths | object | Sets custom column widths to modal window columns                                    | | false
-date | string | The date of the change event                                                         | | true
-fieldChanges | array  | A list of changed fields                                                             | | true
-fieldFormatter | object | Formats changed field value in modal content, used to format oldValue/newValue fields | | false
-fieldLabelsMap | object | Maps changed field name to user friendly label                                       | | false
-source | string or node | The source of fields changes                                                         | | true
-userName | string | The name of the user who made the change | | true
+Name | type   | description                                                                                  | default | required
+--- |--------|----------------------------------------------------------------------------------------------| --- | ---
+actionsMap | object | Maps change type value to user friendly action label                                         | | false
+columnWidths | object | Sets custom column widths to modal window columns                                            | | false
+date | string | The date of the change event                                                                 | | true
+fieldChanges | array  | A list of changed fields                                                                     | | true
+fieldFormatter | object | Formats changed field value in modal content, used to format oldValue/newValue fields        | | false
+fieldLabelsMap | object | Maps changed field name to user friendly label                                               | | false
+isOriginal | bool | The flag that indicates that a card represents the original version and has no field changes | | false
+source | string or node | The source of fields changes                                                                 | | true
+userName | string | The name of the user who made the change                                                     | | true
 
 ## AuditLogChangedFieldsList
 AuditLogChangedFieldsList renders a list of changed fields and "Changed" button within an AuditLogCard.

--- a/lib/AuditLog/stories/BasicUsage.js
+++ b/lib/AuditLog/stories/BasicUsage.js
@@ -17,6 +17,7 @@ export default () => {
     }],
     eventId: '4ff9b7db-cb62-42fa-b52d-708cda1ba666',
     eventTs: 1740744042183,
+    isOriginal: false,
   }];
   const fieldLabelsMap = {
     administrativeNotes: intl.formatMessage({ id: 'ui-inventory.administrativeNotes' }),
@@ -38,7 +39,7 @@ export default () => {
     <AuditLogPane
       versions={versions}
       onClose={onClose}
-      isLoadMoreVisible={true}
+      isLoadMoreVisible
       handleLoadMore={handleLoadMore}
       isLoading={false}
       fieldLabelsMap={fieldLabelsMap}

--- a/translations/stripes-components/en.json
+++ b/translations/stripes-components/en.json
@@ -53,6 +53,7 @@
   "versionHistory.pane.sub": "{count, plural, one {# version} other {# versions}}",
   "versionHistory.pane.loadingLabel": "Loading",
   "versionHistory.card.changed": "Changed",
+  "versionHistory.card.originalVersion": "Original version",
   "versionHistory.modal.action": "Action",
   "versionHistory.modal.field": "Field",
   "versionHistory.modal.changedFrom": "Changed from",


### PR DESCRIPTION
## Purpose
When a card has action 'CREATE' and no field level changes info then it is required to show it, but with `Original version` label

## Approach
- Added `isOriginal` prop to `AuditLogCard`, get it from the `versions` list
- Updated `readme`
- Wrapped text content inside cards in `p` tag and apply styles

## Refs
https://folio-org.atlassian.net/browse/STCOM-1416

## Screenshot
<img width="748" alt="Screenshot 2025-03-06 at 13 31 43" src="https://github.com/user-attachments/assets/1739c944-9782-436c-9e14-1d1ef94e3f13" />
