### PR TITLE
STCOM-1419: `AuditLog` - add `modalFieldChanges` to display field change in card modal window, make modal large, add `totalVersions`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * `AuditLog` - Add original version card. Refs STCOM-1416.
 * `AuditLog` - Show current version for the newest card. Refs STCOM-1415.
 * CSS Support for printing of results list content. Refs STCOM-1417.
+* `AuditLog` - add `modalFieldChanges` to display field change in card modal window, make modal large, add totalVersions. Refs STCOM-1419.
 
 ## [13.0.0](https://github.com/folio-org/stripes-components/tree/v13.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.2.0...v13.0.0)

--- a/lib/AuditLog/AuditLogCard.js
+++ b/lib/AuditLog/AuditLogCard.js
@@ -20,6 +20,7 @@ const AuditLogCard = ({
   isCurrentVersion,
   source,
   userName,
+  modalFieldChanges,
 }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -81,7 +82,7 @@ const AuditLogCard = ({
         </p>
       </Card>
       <AuditLogModal
-        contentData={fieldChanges}
+        contentData={modalFieldChanges || fieldChanges}
         open={isModalOpen}
         label={modalHeader}
         onClose={() => setIsModalOpen(false)}

--- a/lib/AuditLog/AuditLogModal.js
+++ b/lib/AuditLog/AuditLogModal.js
@@ -66,6 +66,7 @@ const AuditLogModal = ({
       onClose={onClose}
       footer={modalFooter}
       dismissible
+      size="large"
     >
       <MultiColumnList
         contentData={contentData}

--- a/lib/AuditLog/AuditLogPane.js
+++ b/lib/AuditLog/AuditLogPane.js
@@ -24,6 +24,7 @@ const AuditLogPane = ({
   isLoading,
   isLoadMoreVisible = true,
   onClose,
+  totalVersions,
   versions,
 }) => {
   const paneTitleRef = useRef(null);
@@ -65,6 +66,7 @@ const AuditLogPane = ({
       source,
       userName,
       fieldChanges,
+      modalFieldChanges,
     }, i) => {
       return (
         <AuditLogCard
@@ -79,6 +81,7 @@ const AuditLogPane = ({
           fieldFormatter={fieldFormatter}
           actionsMap={actionsMap}
           columnWidths={columnWidths}
+          modalFieldChanges={modalFieldChanges}
         />
       );
     });
@@ -92,7 +95,7 @@ const AuditLogPane = ({
       paneSub={(
         <FormattedMessage
           id="stripes-components.auditLog.pane.sub"
-          values={{ count: versions.length }}
+          values={{ count: totalVersions }}
         />
       )}
       dismissible
@@ -132,6 +135,7 @@ AuditLogPane.propTypes = {
   isLoading: PropTypes.bool,
   isLoadMoreVisible: PropTypes.bool,
   onClose: PropTypes.func,
+  totalVersions: PropTypes.number,
   versions: PropTypes.arrayOf(
     PropTypes.shape({
       eventDate: PropTypes.string,

--- a/lib/AuditLog/readme.md
+++ b/lib/AuditLog/readme.md
@@ -48,22 +48,24 @@ return (
     fieldLabelsMap={fieldLabelsMap}
     fieldFormatter={fieldFormatter}
     actionsMap={actionsMap}
+    totalVersions={totalRecords}
   />
 );
 ```
 
 ## Props
-Name | type | description                                                                       | default | required
---- | --- |-----------------------------------------------------------------------------------| --- | ---
-actionsMap | object | Maps change type value to user friendly action label                              | | false
-columnWidths | object | Sets custom column widths to modal window columns                                 | | false
+Name | type   | description                                                                           | default | required
+--- |--------|---------------------------------------------------------------------------------------| --- | ---
+actionsMap | object | Maps change type value to user friendly action label                                  | | false
+columnWidths | object | Sets custom column widths to modal window columns                                     | | false
 fieldFormatter | object | Formats changed field value in modal content, used to format oldValue/newValue fields | | false
-fieldLabelsMap | object | Maps changed field name to user friendly label                                    | | false
-handleLoadMore | func | Callback fired when the "Load more" button is clicked                             | | false
-isLoading | bool | Flag that indicates whether data is being loaded                                  | | false
-isLoadMoreVisible | bool | Flag that indicates whether "Load more" button visible or not                     | true | false
-onClose | func | Callback fired when the pane is closed using its dismiss button                   | | false
-versions | array | An array of objects containing version change details                             | | true
+fieldLabelsMap | object | Maps changed field name to user friendly label                                        | | false
+handleLoadMore | func   | Callback fired when the "Load more" button is clicked                                 | | false
+isLoading | bool   | Flag that indicates whether data is being loaded                                      | | false
+isLoadMoreVisible | bool   | Flag that indicates whether "Load more" button visible or not                         | true | false
+onClose | func   | Callback fired when the pane is closed using its dismiss button                       | | false
+totalVersions | number | Total number of versions                                                              | | false
+versions | array  | An array of objects containing version change details                                 | | true
 
 ## AuditLogCard
 AuditLogCard represents a single change event within AuditLogPane.
@@ -80,6 +82,7 @@ const versionCards = () => {
     source,
     userName,
     fieldChanges,
+    modalFieldChanges,
   }, i) => {
     return (
       <AuditLogCard
@@ -94,6 +97,7 @@ const versionCards = () => {
         fieldFormatter={fieldFormatter}
         actionsMap={actionsMap}
         columnWidths={columnWidths}
+        modalFieldChanges={modalFieldChanges}
       />
     );
   });
@@ -101,18 +105,19 @@ const versionCards = () => {
 ```
 
 ### Props
-Name | type   | description                                                                                | default | required
---- |--------|--------------------------------------------------------------------------------------------| --- | ---
-actionsMap | object | Maps change type value to user friendly action label                                       | | false
-columnWidths | object | Sets custom column widths to modal window columns                                          | | false
-date | string | The date of the change event                                                               | | true
-fieldChanges | array  | A list of changed fields                                                                   | | true
-fieldFormatter | object | Formats changed field value in modal content, used to format oldValue/newValue fields      | | false
-fieldLabelsMap | object | Maps changed field name to user friendly label                                             | | false
-isCurrentVersion | bool | The flag that indicates that a card represents the current version  | | false
-isOriginal | bool | The flag that indicates that a card represents the original version and has no field changes | | false
-source | string or node | The source of fields changes                                                               | | true
-userName | string | The name of the user who made the change                                                   | | true
+Name | type           | description                                                                                  | default | required
+--- |----------------|----------------------------------------------------------------------------------------------| --- | ---
+actionsMap | object         | Maps change type value to user friendly action label                                         | | false
+columnWidths | object         | Sets custom column widths to modal window columns                                            | | false
+date | string         | The date of the change event                                                                 | | true
+fieldChanges | array          | A list of changed fields                                                                     | | true
+fieldFormatter | object         | Formats changed field value in modal content, used to format oldValue/newValue fields        | | false
+fieldLabelsMap | object         | Maps changed field name to user friendly label                                               | | false
+isCurrentVersion | bool           | The flag that indicates that a card represents the current version                           | | false
+isOriginal | bool           | The flag that indicates that a card represents the original version and has no field changes | | false
+modalFieldChanges | array          | A list of changed fields for card modal window                                               | | false
+source | string or node | The source of fields changes                                                                 | | true
+userName | string         | The name of the user who made the change                                                     | | true
 
 ## AuditLogChangedFieldsList
 AuditLogChangedFieldsList renders a list of changed fields and "Changed" button within an AuditLogCard.

--- a/lib/AuditLog/tests/AuditLogPane-test.js
+++ b/lib/AuditLog/tests/AuditLogPane-test.js
@@ -9,6 +9,8 @@ import {
   Pane,
   Button,
   HTML,
+  including,
+  MultiColumnListCell,
 } from '@folio/stripes-testing';
 
 import { mountWithContext } from '../../../tests/helpers';
@@ -48,6 +50,12 @@ const mockVersions = [{
     newValue: 'newValue3',
     oldValue: 'oldValue3',
   }],
+  modalFieldChanges: [{
+    fieldName: 'fieldName4',
+    changeType: 'ADDED',
+    newValue: 'newValue4',
+    oldValue: 'oldValue4',
+  }],
   eventDate: '2025-03-21T16:18:49.201+00:00',
 }, {
   fieldChanges: [{
@@ -85,12 +93,15 @@ describe('AuditLogPane', () => {
 
   describe('should display loading pane if references are loading', () => {
     const loadMoreSpy = sinon.spy();
+    const totalVersions = 123;
+
     beforeEach(async () => {
       loadMoreSpy.resetHistory();
       await mountWithContext(
         <RenderAuditLogPane
           versions={mockVersions}
           handleLoadMore={loadMoreSpy}
+          totalVersions={totalVersions}
         />
       );
     });
@@ -111,5 +122,19 @@ describe('AuditLogPane', () => {
 
     it('should render current version', () => Button('Current version').exists());
     it('should render an ordinary version', () => Button('Changed').exists());
+    it('should display the total number of versions', () => HTML(including(totalVersions)).exists());
+  });
+
+  describe('when a modal window is open', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <RenderAuditLogPane
+          versions={mockVersions}
+        />
+      );
+      await Button('Current version').click();
+    });
+
+    it('should render field name from modalFieldChanges prop', () => MultiColumnListCell(including('fieldName4')).exists());
   });
 });


### PR DESCRIPTION
## Purpose
1. Card fields should be displayed grouped if the action and tag match. The "Field" prefix should only be on the card, not the modal.
2. Increase the size of the card modal.
3. The history pane header should display the total number of versions.

## Approach  
1. Use `modalFieldChanges` to display fields in the modal if they should be different from card fields.
2. `size="large"`
3. Use`totalVersions` for `AuditLogPane`.

## Issues
[STCOM-1419](https://folio-org.atlassian.net/browse/STCOM-1419)

## Screencasts

https://github.com/user-attachments/assets/8486c35c-7a54-461e-9b34-22faf92f4281

