### PR TITLE
STCOM-1421 Make `dayjs.contains` include start end end dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * `AuditLog` - Show current version for the newest card. Refs STCOM-1415.
 * CSS Support for printing of results list content. Refs STCOM-1417.
 * `AuditLog` - add `modalFieldChanges` to display field change in card modal window, make modal large, add totalVersions. Refs STCOM-1419.
+* Make `dayjs.contains` include start end end dates. Refs STCOM-1421.
 
 ## [13.0.0](https://github.com/folio-org/stripes-components/tree/v13.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.2.0...v13.0.0)

--- a/util/dateTimeUtils.js
+++ b/util/dateTimeUtils.js
@@ -13,7 +13,7 @@ import objectSupport from 'dayjs/plugin/objectSupport';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import isBetween from 'dayjs/plugin/isBetween';
-import availableLocales from 'dayjs/locale'
+import availableLocales from 'dayjs/locale';
 
 dayjs.extend(timezone);
 dayjs.extend(localeData);
@@ -89,6 +89,12 @@ export class DayRange {
       return this.isSame(candidate) ||
       (this.contains(candidate.start) && this.contains(candidate.end));
     } else {
+      /*
+        dayjs needs some additional configuration to include start and end dates
+        when checking if a date is in range.
+        For example, without `[]`, 01/01/2025 would NOT be considered included in 01/01/2025-12/31/2025 range
+        https://day.js.org/docs/en/plugin/is-between
+      */
       return dayjs(candidate).isBetween(this.start, this.end, 'day', '[]');
     }
   };

--- a/util/dateTimeUtils.js
+++ b/util/dateTimeUtils.js
@@ -89,7 +89,7 @@ export class DayRange {
       return this.isSame(candidate) ||
       (this.contains(candidate.start) && this.contains(candidate.end));
     } else {
-      return dayjs(candidate).isBetween(this.start, this.end);
+      return dayjs(candidate).isBetween(this.start, this.end, 'day', '[]');
     }
   };
 


### PR DESCRIPTION
## Description

`moment.contains` included start and end dates by default, so 01/01/2025 would be considered included in 01/01/2025-12/31/2025 range
`dayjs` needs some additional configuration to replicate this behaviour
https://day.js.org/docs/en/plugin/is-between

## Issues
[STCOM-1421](https://folio-org.atlassian.net/browse/STCOM-1421)