### PR TITLE
STCOM-1422: Add loading indicator to `AuditLogPane` when data is initially loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * `AuditLog` - Show current version for the newest card. Refs STCOM-1415.
 * CSS Support for printing of results list content. Refs STCOM-1417.
 * `AuditLog` - add `modalFieldChanges` to display field change in card modal window, make modal large, add totalVersions. Refs STCOM-1419.
+* Add loading indicator to `AuditLogPane` when data is initially loading. Refs STCOM-1422.
 
 ## [13.0.0](https://github.com/folio-org/stripes-components/tree/v13.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.2.0...v13.0.0)

--- a/lib/AuditLog/AuditLogPane.js
+++ b/lib/AuditLog/AuditLogPane.js
@@ -21,6 +21,7 @@ const AuditLogPane = ({
   fieldFormatter,
   fieldLabelsMap,
   handleLoadMore,
+  isInitialLoading,
   isLoading,
   isLoadMoreVisible = true,
   onClose,
@@ -101,26 +102,32 @@ const AuditLogPane = ({
       dismissible
       onClose={onClose}
     >
-      <div
-        ref={cardsContainerRef}
-      >
-        {versionCards}
-      </div>
-      {isLoadMoreVisible && (
-        <Button
-          onClick={onLoadMoreClick}
-          fullWidth
-        >
-          {!isLoading && <FormattedMessage id="stripes-components.mcl.loadMore" />}
-          {isLoading && (
-            <>
-              <Loading size="medium" useCurrentColor />
-              <span className="sr-only">
-                <FormattedMessage id="stripes-components.auditLog.pane.loadingLabel" />
-              </span>
-            </>
+      {isInitialLoading ? (
+        <Loading />
+      ) : (
+        <>
+          <div
+            ref={cardsContainerRef}
+          >
+            {versionCards}
+          </div>
+          {isLoadMoreVisible && (
+            <Button
+              onClick={onLoadMoreClick}
+              fullWidth
+            >
+              {!isLoading && <FormattedMessage id="stripes-components.mcl.loadMore" />}
+              {isLoading && (
+                <>
+                  <Loading size="medium" useCurrentColor />
+                  <span className="sr-only">
+                    <FormattedMessage id="stripes-components.auditLog.pane.loadingLabel" />
+                  </span>
+                </>
+              )}
+            </Button>
           )}
-        </Button>
+        </>
       )}
     </Pane>
   );
@@ -132,6 +139,7 @@ AuditLogPane.propTypes = {
   fieldFormatter: PropTypes.object,
   fieldLabelsMap: PropTypes.object,
   handleLoadMore: PropTypes.func,
+  isInitialLoading: PropTypes.bool,
   isLoading: PropTypes.bool,
   isLoadMoreVisible: PropTypes.bool,
   onClose: PropTypes.func,

--- a/lib/AuditLog/readme.md
+++ b/lib/AuditLog/readme.md
@@ -35,6 +35,7 @@ const fieldFormatter = {
 const handleClose = () => console.log('Pane closed');
 const handleLoadMore = () => console.log('Load more clicked');
 const isLoading = false;
+const isInitialLoading = false;
 const isLoadMoreVisible = true;
 const actionsMap = { ADDED: formatMessage({ id: 'ui-inventory.versionHistory.action.added' }) };
 
@@ -45,6 +46,7 @@ return (
     isLoadMoreVisible={isLoadMoreVisible}
     handleLoadMore={handleLoadMore}
     isLoading={isLoading}
+    isInitialLoading={isInitialLoading}
     fieldLabelsMap={fieldLabelsMap}
     fieldFormatter={fieldFormatter}
     actionsMap={actionsMap}
@@ -61,6 +63,7 @@ columnWidths | object | Sets custom column widths to modal window columns       
 fieldFormatter | object | Formats changed field value in modal content, used to format oldValue/newValue fields | | false
 fieldLabelsMap | object | Maps changed field name to user friendly label                                        | | false
 handleLoadMore | func   | Callback fired when the "Load more" button is clicked                                 | | false
+isInitialLoading | bool   | Flag that indicates whether data is being loaded for the first time                   | | false
 isLoading | bool   | Flag that indicates whether data is being loaded                                      | | false
 isLoadMoreVisible | bool   | Flag that indicates whether "Load more" button visible or not                         | true | false
 onClose | func   | Callback fired when the pane is closed using its dismiss button                       | | false

--- a/lib/AuditLog/tests/AuditLogPane-test.js
+++ b/lib/AuditLog/tests/AuditLogPane-test.js
@@ -18,6 +18,8 @@ import Harness from '../../../tests/Harness';
 
 import AuditLogPane from '../AuditLogPane';
 
+const LoadingInteractor = HTML.extend('loading').selector('[class^=spinner-]')
+
 const fieldLabelsMap = {
   contributors: 'Contributors',
   statusId: 'Status id',
@@ -80,16 +82,15 @@ describe('AuditLogPane', () => {
     defaultProps.onClose.resetHistory();
   });
 
-  describe('should display loading pane if references are loading', () => {
+  describe('should display loading pane if references are loading for the first time', () => {
     beforeEach(async () => {
-      await mountWithContext(<RenderAuditLogPane isLoading />);
+      await mountWithContext(<RenderAuditLogPane isInitialLoading />);
     });
 
     it('should display loading pane if versions are loading', () => Pane({ title: 'Version history' }).exists());
-    it('should display loading button', () => Button('Loading').exists());
+    it('should display loading indicator', () => LoadingInteractor().exists());
     it('should display without a11y errors - loading', () => runAxeTest());
   });
-
 
   describe('should display loading pane if references are loading', () => {
     const loadMoreSpy = sinon.spy();


### PR DESCRIPTION
When `versions` data is initially loading - display `Loading` component in `AuditLogPane` component, otherwise display `Loading` as a label of `Load more` button when it it clicked.