### PR TITLE
STCOM-1424: `AdvancedSearch` - replace `Cancel` button with `Reset all` in modal window.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * `AuditLog` - add `modalFieldChanges` to display field change in card modal window, make modal large, add totalVersions. Refs STCOM-1419.
 * Make `dayjs.contains` include start end end dates. Refs STCOM-1421.
 * Add loading indicator to `AuditLogPane` when data is initially loading. Refs STCOM-1422.
+* `AdvancedSearch` - replace `Cancel` button with `Reset all` in modal window. Refs STCOM-1424.
 
 ## [13.0.0](https://github.com/folio-org/stripes-components/tree/v13.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.2.0...v13.0.0)

--- a/lib/AdvancedSearch/AdvancedSearch.js
+++ b/lib/AdvancedSearch/AdvancedSearch.js
@@ -56,6 +56,7 @@ const AdvancedSearch = ({
     searchOptionsWithQuery,
     showEmptyFirstRowMessage,
     activeQueryIndex,
+    isPristine,
   } = useAdvancedSearch({
     defaultSearchOptionValue,
     firstRowInitialSearch,
@@ -92,7 +93,9 @@ const AdvancedSearch = ({
       <AdvancedSearchModal
         open={open}
         searchOptions={searchOptionsWithQuery}
+        isPristine={isPristine}
         onCancel={handleCancel}
+        onResetAll={resetRows}
         onSearch={handleSearch}
       >
         {renderRows()}

--- a/lib/AdvancedSearch/components/AdvancedSearchModal/AdvancedSearchModal.js
+++ b/lib/AdvancedSearch/components/AdvancedSearchModal/AdvancedSearchModal.js
@@ -12,6 +12,8 @@ const propTypes = {
     PropTypes.node,
     PropTypes.string,
   ]).isRequired,
+  isPristine: PropTypes.bool.isRequired,
+  onResetAll: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
   onSearch: PropTypes.func.isRequired,
   open: PropTypes.bool.isRequired,
@@ -20,15 +22,17 @@ const propTypes = {
 const AdvancedSearchModal = ({
   open,
   children,
+  isPristine,
   onSearch,
   onCancel,
+  onResetAll,
 }) => {
   const shortcutsRef = useRef(null);
   const intl = useIntl();
   const modalTitle = intl.formatMessage({ id: 'stripes-components.advancedSearch.title' });
 
   const searchLabel = intl.formatMessage({ id: 'stripes-components.advancedSearch.footer.search' });
-  const cancelLabel = intl.formatMessage({ id: 'stripes-components.advancedSearch.footer.cancel' });
+  const resetAllLabel = intl.formatMessage({ id: 'stripes-components.advancedSearch.footer.resetAll' });
 
   const footer = useMemo(() => {
     return (
@@ -43,16 +47,17 @@ const AdvancedSearchModal = ({
           {searchLabel}
         </Button>
         <Button
-          data-test-advanced-search-button-cancel
-          onClick={onCancel}
+          data-test-advanced-search-button-resetAll
+          onClick={onResetAll}
           marginBottom0
-          aria-label={cancelLabel}
+          aria-label={resetAllLabel}
+          disabled={isPristine}
         >
-          {cancelLabel}
+          {resetAllLabel}
         </Button>
       </ModalFooter>
     );
-  }, [onSearch, onCancel, cancelLabel, searchLabel]);
+  }, [onSearch, onResetAll, resetAllLabel, searchLabel]);
 
   const hotKeys = useMemo(() => ({
     search: ['enter'],

--- a/lib/AdvancedSearch/components/AdvancedSearchModal/AdvancedSearchModal.js
+++ b/lib/AdvancedSearch/components/AdvancedSearchModal/AdvancedSearchModal.js
@@ -6,6 +6,7 @@ import { HotKeys } from '../../../HotKeys';
 import Modal from '../../../Modal';
 import ModalFooter from '../../../ModalFooter';
 import Button from '../../../Button';
+import Icon from '../../../Icon';
 
 const propTypes = {
   children: PropTypes.oneOfType([
@@ -52,8 +53,14 @@ const AdvancedSearchModal = ({
           marginBottom0
           aria-label={resetAllLabel}
           disabled={isPristine}
+          buttonStyle="none"
         >
-          {resetAllLabel}
+          <Icon 
+            size="small"
+            icon="times-circle-solid"
+          >
+            {resetAllLabel}
+          </Icon>
         </Button>
       </ModalFooter>
     );

--- a/lib/AdvancedSearch/hooks/tests/useAdvancedSearch-test.js
+++ b/lib/AdvancedSearch/hooks/tests/useAdvancedSearch-test.js
@@ -202,4 +202,10 @@ describe('useAdvancedSearch', () => {
       expect(hookResult.activeQueryIndex).to.equal(2);
     });
   });
+
+  it('should expose isPristine', async () => {
+    const hookResult = await getHookExecutionResult(useAdvancedSearch, {});
+
+    expect(hookResult.isPristine).to.equal(true);
+  });
 });

--- a/lib/AdvancedSearch/hooks/useAdvancedSearch/useAdvancedSearch.js
+++ b/lib/AdvancedSearch/hooks/useAdvancedSearch/useAdvancedSearch.js
@@ -79,6 +79,8 @@ const useAdvancedSearch = ({
     return filterFilledRows(rows)
   }, [rowState, queryToRow, searchOptions, defaultSearchOptionValue, hasQueryOption, open]);
 
+  const isPristine = useMemo(() => isEqual(rowState, initialRowState), [rowState, initialRowState]);
+
   const searchOptionsWithQuery = useMemo(() => (
     [{
       label: intl.formatMessage({ id: 'stripes-components.advancedSearch.searchOptions.query' }),
@@ -145,6 +147,7 @@ const useAdvancedSearch = ({
     filledRows,
     query: queryBuilder(filledRows, rowFormatter),
     activeQueryIndex,
+    isPristine,
   };
 };
 

--- a/lib/AdvancedSearch/tests/AdvancedSearch-test.js
+++ b/lib/AdvancedSearch/tests/AdvancedSearch-test.js
@@ -55,6 +55,7 @@ describe('AdvancedSearch', () => {
   const advancedSearch = new Interactor();
   const resetButton = ButtonInteractor('Reset');
   const searchButton = ButtonInteractor('Search');
+  const resetAllButton = ButtonInteractor('Reset all');
 
   const onSearchSpy = sinon.spy();
   const onCancelSpy = sinon.spy();
@@ -120,6 +121,8 @@ describe('AdvancedSearch', () => {
   it('should render component children', () => resetButton.is({ visible: true }));
 
   it('should render component children', () => searchButton.is({ visible: true }));
+
+  it('should render "Reset all" button', () => resetAllButton.is({ disabled: true }));
 
   it('should render component', () => advancedSearch.is({ visible: true }));
 
@@ -288,16 +291,6 @@ describe('AdvancedSearch', () => {
         expect(el.querySelector('[data-test-advanced-search-query]').value).to.equal('id0002');
         expect(el.querySelector('[data-test-advanced-search-option]').value).to.equal('identifiers.all');
       });
-    });
-  });
-
-  describe('when clicking cancel', () => {
-    beforeEach(async () => {
-      await advancedSearch.cancel();
-    });
-
-    it('should call onCancel', () => {
-      expect(onCancelSpy.calledOnce).to.be.true;
     });
   });
 

--- a/translations/stripes-components/en.json
+++ b/translations/stripes-components/en.json
@@ -11,7 +11,7 @@
   "advancedSearch.match.startsWith": "Starts with",
   "advancedSearch.match.containsAny": "Contains any",
   "advancedSearch.footer.search": "Search",
-  "advancedSearch.footer.cancel": "Cancel",
+  "advancedSearch.footer.resetAll": "Reset all",
   "advancedSearch.booleanLabel": "Select Boolean operator",
   "advancedSearch.fieldLabel": "Enter search term",
   "advancedSearch.match.label": "Match option",


### PR DESCRIPTION
## Purpose
Add the ability to reset Advanced search input from modal

## Approach
Expose the `isPristine` property that compares the initial state of rows with the current one and use it to enable the `Reset all` button. Use the existing `resetRows` function to reset all states.

## Refs
[STCOM-1424](https://folio-org.atlassian.net/browse/STCOM-1424)

## Screencasts


https://github.com/user-attachments/assets/04f0d79d-126c-4dba-9bfb-c6f487299ca9


