### PR TITLE
STCOM-1426 make AutoSuggest::defaultIncludeItem() null-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * `AuditLog` - add `modalFieldChanges` to display field change in card modal window, make modal large, add totalVersions. Refs STCOM-1419.
 * Make `dayjs.contains` include start end end dates. Refs STCOM-1421.
 * Add loading indicator to `AuditLogPane` when data is initially loading. Refs STCOM-1422.
+* Make `AutoSuggest::defaultIncludeItem()` null-safe. Refs STCOM-1426.
 
 ## [13.0.0](https://github.com/folio-org/stripes-components/tree/v13.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.2.0...v13.0.0)

--- a/lib/AutoSuggest/AutoSuggest.js
+++ b/lib/AutoSuggest/AutoSuggest.js
@@ -25,11 +25,11 @@ const getClass = ({
   { [css.selected]: isEqual(selectedItem, item) }
 ]);
 
-const defaultIncludeItem = (item, searchString) => item.value.includes(searchString);
-const defaultRender = item => (item ? item.value : '');
+export const defaultIncludeItem = (item, searchString) => !!item?.value?.includes(searchString);
+export const defaultRender = item => (item ? item.value : '');
 
-const getObjectFromValue = (value, valueKey, items) => {
-  return items.filter((o) => o[valueKey] === value)[0]
+export const getObjectFromValue = (value, valueKey, items) => {
+  return items.filter((o) => o[valueKey] === value)[0];
 }
 
 const AutoSuggest = ({

--- a/lib/AutoSuggest/tests/AutoSuggest-test.js
+++ b/lib/AutoSuggest/tests/AutoSuggest-test.js
@@ -36,7 +36,7 @@ const testItems = [
   },
 ];
 
-describe.only('AutoSuggest', () => {
+describe('AutoSuggest', () => {
   const autosuggest = Interactor('autoSuggestTest');
   const onChange = sinon.spy();
   describe('rendering', () => {

--- a/lib/AutoSuggest/tests/AutoSuggest-test.js
+++ b/lib/AutoSuggest/tests/AutoSuggest-test.js
@@ -1,10 +1,17 @@
 import React from 'react';
 import { describe, beforeEach, it } from 'mocha';
 import sinon from 'sinon';
+import { expect } from 'chai';
+
 import { AutoSuggest as Interactor, converge, runAxeTest, HTML } from '@folio/stripes-testing';
+
 import { RoledHTML } from '../../../tests/helpers/localInteractors';
 import { mountWithContext } from '../../../tests/helpers';
-import AutoSuggest from '../AutoSuggest';
+import AutoSuggest, {
+  defaultIncludeItem,
+  defaultRender,
+  getObjectFromValue
+} from '../AutoSuggest';
 
 const testItems = [
   {
@@ -29,7 +36,7 @@ const testItems = [
   },
 ];
 
-describe('AutoSuggest', () => {
+describe.only('AutoSuggest', () => {
   const autosuggest = Interactor('autoSuggestTest');
   const onChange = sinon.spy();
   describe('rendering', () => {
@@ -128,5 +135,66 @@ describe('AutoSuggest', () => {
     });
 
     it('renders menu to overlay element', () => HTML({ id: 'OverlayContainer' }).find(RoledHTML({ tagName:'UL' })).exists())
+  });
+
+  describe('defaultIncludeItem', () => {
+    describe('when item.value contains search string', () => {
+      it('returns true', () => {
+        // now you, too, will hear hoMEOWner in your head every time you read it
+        expect(defaultIncludeItem({ value: 'homeowner' }, 'meow')).to.be.true;
+      });
+    });
+
+    describe('when item.value does not contain search string', () => {
+      it('returns false', () => {
+        expect(defaultIncludeItem({ value: 'homeowner' }, 'woof')).to.be.false;
+      });
+    })
+
+    describe('when item.value is undefined', () => {
+      it('returns false', () => {
+        expect(defaultIncludeItem({ nothing: 'gourmet' }, 'toothpaste')).to.be.false;
+      });
+    });
+  });
+
+  describe('defaultRender', () => {
+    it('returns item\'s value attribute when item is non-empty', () => {
+      const value = 'monkeys';
+      expect(defaultRender({ value })).to.equal(value);
+    });
+
+    it('returns empty string when item is falsy', () => {
+      expect(defaultRender()).to.equal('');
+    });
+  });
+
+  describe('getObjectFromValue', () => {
+    it('returns first matching item', () => {
+      const key = 'key';
+      const val = 'rogue 1';
+      const i0 = { [key]: 'rogue 0' };
+      const i1 = { [key]: 'rogue 1' };
+      const i2 = { [key]: 'rogue 2' };
+
+      const items = [i0, i1, i2];
+      expect(getObjectFromValue(val, key, items)).to.deep.equal(i1);
+    });
+
+    it('returns undefined if there are no matches', () => {
+      const key = 'verghese';
+      const i0 = { [key]: 'cutting for stone' };
+      const i1 = { [key]: 'covenant of water' };
+
+      const items = [i0, i1];
+      expect(getObjectFromValue('little no horse', key, items)).to.be.undefined;
+      expect(getObjectFromValue('four winds', 'hannah', items)).to.be.undefined;
+    });
+
+    it('returns undefined if the list is empty', () => {
+      const key = 'does not';
+
+      expect(getObjectFromValue('matter', key, [])).to.be.undefined;
+    });
   });
 });


### PR DESCRIPTION
`defaultIncludeItem(haystack, needle)` assumes `haystack` is shaped like `{ value }` and returns true if the `value` attribute is a string containing `needle`.

The previous incarnation did not validate whether `haystack` or `haystack.value` were null, leading to NPEs if `haystack` was `null` or if it did not contain an attribute named `value`.

CC: @bbarnetteebsco

Refs [STCOM-1426](https://folio-org.atlassian.net/browse/STCOM-1426)