### PR TITLE
STCOM-1427: Display `Changed from - '-'` and `Changed to - 'false'` values for boolean fields in `AuditLogModal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-components
 
+## 13.0.3 IN PROGRESS
+
+* Display `Changed from - "-"` and `Changed to - "false"` values for boolean fields in AuditLogModal. Fixes STCOM-1427.
+
 ## 13.1.0 IN PROGRESS
 
 * Introduce `<AuditLog>` component. Refs STCOM-1412.

--- a/lib/AuditLog/AuditLogModal.js
+++ b/lib/AuditLog/AuditLogModal.js
@@ -46,6 +46,7 @@ const AuditLogModal = ({
       fieldName: item.fieldName,
       listItemFormatter: itemFormatter,
       fieldFormatter,
+      showFalsyValue: true
     }),
   };
 

--- a/lib/AuditLog/changedFieldsFormatter.js
+++ b/lib/AuditLog/changedFieldsFormatter.js
@@ -8,7 +8,10 @@ const changedFieldsFormatter = ({
   fieldValue,
   fieldName,
   listItemFormatter,
+  showFalsyValue,
 }) => {
+  if (fieldValue === false && showFalsyValue) return fieldValue.toString();
+
   if (!fieldValue) return <NoValue />;
 
   if (typeof fieldValue === 'object' && !Array.isArray(fieldValue)) {

--- a/lib/AuditLog/tests/AuditLogModal-test.js
+++ b/lib/AuditLog/tests/AuditLogModal-test.js
@@ -31,6 +31,8 @@ describe('AuditLogModal', () => {
   const fieldLabelsMap = {
     name1: 'Name 1',
     repeatable: 'Repeatable name',
+    booleanFieldAdd: 'Boolean field add',
+    booleanFieldModify: 'Boolean field modify',
   };
   const fieldFormatter = {
     repeatable: (value) => `Repeatable: ${value}`,
@@ -48,6 +50,16 @@ describe('AuditLogModal', () => {
     oldValue: {
       repeatable: 'old repeatable value',
     },
+  }, {
+    changeType: 'ADDED',
+    fieldName: 'booleanFieldAdd',
+    oldValue: false,
+    newValue: true,
+  }, {
+    changeType: 'MODIFIED',
+    fieldName: 'booleanFieldModify',
+    oldValue: true,
+    newValue: false,
   }];
   const actionsMap = {
     ADDED: 'ADDED',
@@ -101,6 +113,36 @@ describe('AuditLogModal', () => {
     });
     await mcl.find(MultiColumnListCell({ row: 1, columnIndex: 3 })).perform(el => {
       expect(el.textContent).to.equal('Repeatable: new repeatable value');
+    });
+  });
+
+  it('should render a boolean value when add', async () => {
+    await mcl.find(MultiColumnListCell({ row: 2, columnIndex: 0 })).perform(el => {
+      expect(el.textContent).to.equal('ADDED');
+    });
+    await mcl.find(MultiColumnListCell({ row: 2, columnIndex: 1 })).perform(el => {
+      expect(el.textContent).to.equal('Boolean field add');
+    });
+    await mcl.find(MultiColumnListCell({ row: 2, columnIndex: 2 })).perform(el => {
+      expect(el.textContent).to.equal('No value set-');
+    });
+    await mcl.find(MultiColumnListCell({ row: 2, columnIndex: 3 })).perform(el => {
+      expect(el.textContent).to.equal('true');
+    });
+  });
+
+  it('should render a boolean value when modify', async () => {
+    await mcl.find(MultiColumnListCell({ row: 3, columnIndex: 0 })).perform(el => {
+      expect(el.textContent).to.equal('MODIFIED');
+    });
+    await mcl.find(MultiColumnListCell({ row: 3, columnIndex: 1 })).perform(el => {
+      expect(el.textContent).to.equal('Boolean field modify');
+    });
+    await mcl.find(MultiColumnListCell({ row: 3, columnIndex: 2 })).perform(el => {
+      expect(el.textContent).to.equal('true');
+    });
+    await mcl.find(MultiColumnListCell({ row: 3, columnIndex: 3 })).perform(el => {
+      expect(el.textContent).to.equal('false');
     });
   });
 

--- a/lib/AuditLog/tests/AuditLogModal-test.js
+++ b/lib/AuditLog/tests/AuditLogModal-test.js
@@ -36,6 +36,8 @@ describe('AuditLogModal', () => {
   };
   const fieldFormatter = {
     repeatable: (value) => `Repeatable: ${value}`,
+    booleanFieldAdd: (value) => value.toString(),
+    booleanFieldModify: (value) => value.toString(),
   };
   const contentData = [{
     changeType: 'ADDED',


### PR DESCRIPTION
## Links
[STCOM-1427](https://folio-org.atlassian.net/browse/STCOM-1427)


* Currently `changedFieldsFormatter` displays all `false` values as `-`
* If we set the checkbox then we should display `Changed from - '-'` and `Changed to - 'true'`
* If we set the checkbox for the second time then we should display `Changed from - 'true'` and `Changed to - 'false'`

![image](https://github.com/user-attachments/assets/f4431a94-378d-4b32-81d6-7a37167eafb5)
