### PR TITLE
STCOM-1426 Restore onSelect support for AutoSuggest component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 13.0.3 IN PROGRESS
 
 * Display `Changed from - "-"` and `Changed to - "false"` values for boolean fields in AuditLogModal. Fixes STCOM-1427.
+* Restore onSelect support for AutoSuggest component. Refs STCOM-1426.
 
 ## 13.1.0 IN PROGRESS
 

--- a/lib/AutoSuggest/AutoSuggest.css
+++ b/lib/AutoSuggest/AutoSuggest.css
@@ -15,6 +15,7 @@
   border-radius: var(--radius);
   box-shadow: var(--shadow);
   font-size: var(--font-size-medium);
+  pointer-events: all;
 }
 
 .textFieldDiv {

--- a/lib/AutoSuggest/AutoSuggest.js
+++ b/lib/AutoSuggest/AutoSuggest.js
@@ -29,7 +29,7 @@ const defaultIncludeItem = (item, searchString) => item.value.includes(searchStr
 const defaultRender = item => (item ? item.value : '');
 
 const getObjectFromValue = (value, valueKey, items) => {
-  return items.filter((o) => o[valueKey] === value)[0]
+  return items.filter((o) => o[valueKey] === value)[0];
 }
 
 const AutoSuggest = ({
@@ -75,11 +75,13 @@ const AutoSuggest = ({
     id: testId,
     items: filteredItems,
     itemToString: renderValue,
-    onChange: selectedValue => onChange(selectedValue[valueKey]),
-    onInputValueChange: ({ inputValue: newValue }) => { onChange(newValue); setFilterValue(newValue); },
+    onInputValueChange: ({ inputValue: newValue }) => {
+      onChange(newValue);
+      setFilterValue(newValue);
+    },
     selectedItem: getObjectFromValue(value, valueKey, items),
+    onSelectedItemChange: ({ selectedItem }) => onSelect(selectedItem),
     inputValue: filterValue,
-    onSelect,
     initialInputValue: filterValue,
   });
 

--- a/lib/AutoSuggest/AutoSuggest.js
+++ b/lib/AutoSuggest/AutoSuggest.js
@@ -80,7 +80,7 @@ const AutoSuggest = ({
       setFilterValue(newValue);
     },
     selectedItem: getObjectFromValue(value, valueKey, items),
-    onSelectedItemChange: ({ selectedItem }) => onSelect(selectedItem),
+    onSelectedItemChange: ({ selectedItem: selected }) => onSelect(selected),
     inputValue: filterValue,
     initialInputValue: filterValue,
   });


### PR DESCRIPTION
purpose: https://folio-org.atlassian.net/browse/STCOM-1426

description: `useCombobox` doesn't support onSelect option (that was supported by previous AutoSuggest implementation), instead they have `onSelectedItemChange` https://github.com/downshift-js/downshift/blob/master/src/hooks/useCombobox/README.md#onselecteditemchange

The downshift upgrade for AutoSuggest switched from a component implementation to the `useCombobox` hook from `downshift` - The API change - as mentioned is covered in this change and kept the `onSelect` API intact. Additionally, I was unable to click on the option in the dropdown with the mouse - this is due to the way our `div#OverlayContainer` is setup when the dropdown is rendered it via React portal. Any element rendered directly there needs `pointer-events: all` to allow for mouse hovers/clicks to function.