### PR TITLE
STCOM-1430: `AuditLog` - add `showSharedLabel` property to display `Shared` instead of `Original version` in the original card.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 13.0.3 IN PROGRESS
 
 * Display `Changed from - "-"` and `Changed to - "false"` values for boolean fields in AuditLogModal. Fixes STCOM-1427.
+* `AuditLog` - add `showSharedLabel` property to display "Shared" instead of "Original version" in the original card. Refs STCOM-1430.
 
 ## 13.1.0 IN PROGRESS
 

--- a/lib/AuditLog/AuditLogCard.js
+++ b/lib/AuditLog/AuditLogCard.js
@@ -18,6 +18,7 @@ const AuditLogCard = ({
   fieldLabelsMap,
   isOriginal,
   isCurrentVersion,
+  showSharedLabel,
   source,
   userName,
   modalFieldChanges,
@@ -46,7 +47,7 @@ const AuditLogCard = ({
     <b>
       <i>
         <FormattedMessage
-          id="stripes-components.auditLog.card.originalVersion"
+          id={`stripes-components.auditLog.card.${showSharedLabel ? 'shared' : 'originalVersion'}`}
         />
       </i>
     </b>
@@ -104,6 +105,8 @@ AuditLogCard.propTypes = {
   fieldLabelsMap: PropTypes.object,
   isCurrentVersion: PropTypes.bool,
   isOriginal: PropTypes.bool,
+  showSharedLabel: PropTypes.bool,
+  modalFieldChanges: PropTypes.arrayOf(PropTypes.object),
   source: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   userName: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
 };

--- a/lib/AuditLog/AuditLogPane.js
+++ b/lib/AuditLog/AuditLogPane.js
@@ -24,6 +24,7 @@ const AuditLogPane = ({
   isInitialLoading,
   isLoading,
   isLoadMoreVisible = true,
+  showSharedLabel = false,
   onClose,
   totalVersions,
   versions,
@@ -75,6 +76,7 @@ const AuditLogPane = ({
           date={eventDate}
           isCurrentVersion={i === 0}
           isOriginal={isOriginal}
+          showSharedLabel={showSharedLabel}
           source={source}
           userName={userName}
           fieldChanges={fieldChanges}
@@ -86,7 +88,7 @@ const AuditLogPane = ({
         />
       );
     });
-  }, [versions, fieldLabelsMap, fieldFormatter, actionsMap, columnWidths]);
+  }, [versions, fieldLabelsMap, fieldFormatter, actionsMap, columnWidths, showSharedLabel]);
 
   return (
     <Pane
@@ -142,6 +144,7 @@ AuditLogPane.propTypes = {
   isInitialLoading: PropTypes.bool,
   isLoading: PropTypes.bool,
   isLoadMoreVisible: PropTypes.bool,
+  showSharedLabel: PropTypes.bool,
   onClose: PropTypes.func,
   totalVersions: PropTypes.number,
   versions: PropTypes.arrayOf(
@@ -151,6 +154,7 @@ AuditLogPane.propTypes = {
       eventTs: PropTypes.number,
       fieldChanges: PropTypes.arrayOf(PropTypes.object),
       isOriginal: PropTypes.bool,
+      modalFieldChanges: PropTypes.arrayOf(PropTypes.object),
       source: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
       userName: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     })

--- a/lib/AuditLog/readme.md
+++ b/lib/AuditLog/readme.md
@@ -37,6 +37,7 @@ const handleLoadMore = () => console.log('Load more clicked');
 const isLoading = false;
 const isInitialLoading = false;
 const isLoadMoreVisible = true;
+const showSharedLabel = false;
 const actionsMap = { ADDED: formatMessage({ id: 'ui-inventory.versionHistory.action.added' }) };
 
 return (
@@ -47,6 +48,7 @@ return (
     handleLoadMore={handleLoadMore}
     isLoading={isLoading}
     isInitialLoading={isInitialLoading}
+    showSharedLabel={showSharedLabel}
     fieldLabelsMap={fieldLabelsMap}
     fieldFormatter={fieldFormatter}
     actionsMap={actionsMap}
@@ -57,18 +59,19 @@ return (
 
 ## Props
 Name | type   | description                                                                           | default | required
---- |--------|---------------------------------------------------------------------------------------| --- | ---
-actionsMap | object | Maps change type value to user friendly action label                                  | | false
-columnWidths | object | Sets custom column widths to modal window columns                                     | | false
-fieldFormatter | object | Formats changed field value in modal content, used to format oldValue/newValue fields | | false
-fieldLabelsMap | object | Maps changed field name to user friendly label                                        | | false
-handleLoadMore | func   | Callback fired when the "Load more" button is clicked                                 | | false
-isInitialLoading | bool   | Flag that indicates whether data is being loaded for the first time                   | | false
-isLoading | bool   | Flag that indicates whether data is being loaded                                      | | false
-isLoadMoreVisible | bool   | Flag that indicates whether "Load more" button visible or not                         | true | false
-onClose | func   | Callback fired when the pane is closed using its dismiss button                       | | false
-totalVersions | number | Total number of versions                                                              | | false
-versions | array  | An array of objects containing version change details                                 | | true
+--- |--------|---------------------------------------------------------------------------------------|---------| ---
+actionsMap | object | Maps change type value to user friendly action label                                  |         | false
+columnWidths | object | Sets custom column widths to modal window columns                                     |         | false
+fieldFormatter | object | Formats changed field value in modal content, used to format oldValue/newValue fields |         | false
+fieldLabelsMap | object | Maps changed field name to user friendly label                                        |         | false
+handleLoadMore | func   | Callback fired when the "Load more" button is clicked                                 |         | false
+isInitialLoading | bool   | Flag that indicates whether data is being loaded for the first time                   |         | false
+isLoading | bool   | Flag that indicates whether data is being loaded                                      |         | false
+isLoadMoreVisible | bool   | Flag that indicates whether "Load more" button visible or not                         | true    | false
+onClose | func   | Callback fired when the pane is closed using its dismiss button                       |         | false
+showSharedLabel | bool   | Flag indicating whether the original version should display "Shared" label       | false   | false
+totalVersions | number | Total number of versions                                                              |         | false
+versions | array  | An array of objects containing version change details                                 |         | true
 
 ## AuditLogCard
 AuditLogCard represents a single change event within AuditLogPane.
@@ -92,6 +95,7 @@ const versionCards = () => {
         key={eventId || i}
         isCurrentVersion={i === 0}
         isOriginal={isOriginal}
+        showSharedLabel={showSharedLabel}
         date={eventDate}
         source={source}
         userName={userName}
@@ -118,8 +122,10 @@ fieldFormatter | object         | Formats changed field value in modal content, 
 fieldLabelsMap | object         | Maps changed field name to user friendly label                                               | | false
 isCurrentVersion | bool           | The flag that indicates that a card represents the current version                           | | false
 isOriginal | bool           | The flag that indicates that a card represents the original version and has no field changes | | false
+ |            |   | | 
 modalFieldChanges | array          | A list of changed fields for card modal window                                               | | false
 source | string or node | The source of fields changes                                                                 | | true
+showSharedLabel | bool | Flag indicating whether the original version should display "Shared" label                      | | false
 userName | string         | The name of the user who made the change                                                     | | true
 
 ## AuditLogChangedFieldsList

--- a/lib/AuditLog/tests/AuditLogPane-test.js
+++ b/lib/AuditLog/tests/AuditLogPane-test.js
@@ -138,4 +138,18 @@ describe('AuditLogPane', () => {
 
     it('should render field name from modalFieldChanges prop', () => MultiColumnListCell(including('fieldName4')).exists());
   });
+
+  describe('when the showSharedLabel is true', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <RenderAuditLogPane
+          showSharedLabel
+          versions={mockVersions}
+        />
+      );
+    });
+
+    it('should display "Shared" instead of "Original version"', () => HTML('Shared').exists());
+    it('should not display "Original version"', () => HTML('Original version').absent());
+  });
 });

--- a/translations/stripes-components/en.json
+++ b/translations/stripes-components/en.json
@@ -55,6 +55,7 @@
   "auditLog.card.changed": "Changed",
   "auditLog.card.currentVersion": "Current version",
   "auditLog.card.originalVersion": "Original version",
+  "auditLog.card.shared": "Shared",
   "auditLog.modal.action": "Action",
   "auditLog.modal.field": "Field",
   "auditLog.modal.changedFrom": "Changed from",


### PR DESCRIPTION
## Purpose
Display "Shared" instead of "Original version" for the original card when the record was shared from a local one.

## Approach
Add the `showSharedLabel` property.

## Issues
[STCOM-1430](https://folio-org.atlassian.net/browse/STCOM-1430)

## Screenshots
![image](https://github.com/user-attachments/assets/72fca55f-641c-4928-ab49-14d5a329a35c)


