### PR TITLE
STCOM-1437 load dayjs' LocalizedFormat plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Display `Changed from - "true/false"` and `Changed to - "true/false"` values for boolean fields in AuditLogModal. Fixes STCOM-1427.
 * Restore onSelect support for AutoSuggest component. Refs STCOM-1426.
 * `AuditLog` - add `showSharedLabel` property to display "Shared" instead of "Original version" in the original card. Refs STCOM-1430.
+* Load dayjs' LocalizedFormat plugin to leverage localized formats. Refs STCOM-1437.
 
 ## 13.1.0 IN PROGRESS
 

--- a/util/dateTimeUtils.js
+++ b/util/dateTimeUtils.js
@@ -13,6 +13,7 @@ import objectSupport from 'dayjs/plugin/objectSupport';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import isBetween from 'dayjs/plugin/isBetween';
+import localizedFormat from 'dayjs/plugin/localizedFormat';
 import availableLocales from 'dayjs/locale';
 
 dayjs.extend(timezone);
@@ -27,6 +28,7 @@ dayjs.extend(customParseFormat);
 dayjs.extend(isSameOrBefore);
 dayjs.extend(isSameOrAfter);
 dayjs.extend(isBetween);
+dayjs.extend(localizedFormat);
 
 // export a pre-extended dayjs for consumption.
 export { dayjs };


### PR DESCRIPTION
[`dayjs` requires loading the `LocalizedFormat` plugin](https://day.js.org/docs/en/display/format#localized-formats) in order to use localized formats such as `L`, which [we use in
`getDayJSLocalizedFormat()`](https://github.com/folio-org/stripes-components/blob/71463007efee7f89dabbae2f3cb1951a00ab9812/util/dateTimeUtils.js#L145).

Refs [STCOM-1437](https://folio-org.atlassian.net/browse/STCOM-1437)