### PR TITLE
STCOM-1423 Unify pane border colors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Make `dayjs.contains` include start end end dates. Refs STCOM-1421.
 * Add loading indicator to `AuditLogPane` when data is initially loading. Refs STCOM-1422.
 * `AdvancedSearch` - replace `Cancel` button with `Reset all` in modal window. Refs STCOM-1424.
+* Unify horizontal and vertical border colors of `<Pane>`s. Refs STCOM-1423.
 
 ## [13.0.0](https://github.com/folio-org/stripes-components/tree/v13.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.2.0...v13.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * Make `dayjs.contains` include start end end dates. Refs STCOM-1421.
 * Add loading indicator to `AuditLogPane` when data is initially loading. Refs STCOM-1422.
 * `AdvancedSearch` - replace `Cancel` button with `Reset all` in modal window. Refs STCOM-1424.
-* Unify horizontal and vertical border colors of `<Pane>`s. Refs STCOM-1423.
+* Unify horizontal and vertical border colors of `<Pane>`s, as well as `NavListSection` heading border. Refs STCOM-1423.
 
 ## [13.0.0](https://github.com/folio-org/stripes-components/tree/v13.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.2.0...v13.0.0)

--- a/lib/NavListSection/NavListSection.css
+++ b/lib/NavListSection/NavListSection.css
@@ -4,7 +4,7 @@
   padding: 0 var(--gutter-static-two-thirds);
   display: flex;
   align-items: flex-end;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border-p2);
 }
 
 .label {

--- a/lib/Pane/Pane.css
+++ b/lib/Pane/Pane.css
@@ -2,7 +2,7 @@
 
 .pane {
   background: var(--bg);
-  border-right: 1px solid var(--color-border);
+  border-right: 1px solid var(--color-border-p2);
   height: 100%;
   max-height: calc(100vh - 44px);
   display: flex;


### PR DESCRIPTION
## [STCOM-1423](https://folio-org.atlassian.net/browse/STCOM-1423)

This PR makes the vertical borders of `<Panes>` match the horizontal borders.
Before:
![image](https://github.com/user-attachments/assets/782e6793-cedb-4954-8877-5f957290bc0d)

After:
![image](https://github.com/user-attachments/assets/52f11c81-0b8c-49bb-a6fc-f4803109e9a1)
