### PR TITLE
STCOM-1424: Use empty rows state for `isPristine` and for resetting rows state; add clear icon for inputs; disable search button (follow-up PR).

### DIFF
--- a/lib/AdvancedSearch/components/AdvancedSearchModal/AdvancedSearchModal.js
+++ b/lib/AdvancedSearch/components/AdvancedSearchModal/AdvancedSearchModal.js
@@ -44,6 +44,7 @@ const AdvancedSearchModal = ({
           onClick={onSearch}
           marginBottom0
           aria-label={searchLabel}
+          disabled={isPristine}
         >
           {searchLabel}
         </Button>
@@ -55,7 +56,7 @@ const AdvancedSearchModal = ({
           disabled={isPristine}
           buttonStyle="none"
         >
-          <Icon 
+          <Icon
             size="small"
             icon="times-circle-solid"
           >
@@ -71,8 +72,12 @@ const AdvancedSearchModal = ({
   }), []);
 
   const handlers = useMemo(() => ({
-    search: onSearch,
-  }), [onSearch]);
+    search: (e) => {
+      if (!isPristine) {
+        onSearch(e);
+      }
+    },
+  }), [onSearch, isPristine]);
 
   return (
     <Modal

--- a/lib/AdvancedSearch/components/AdvancedSearchRow/AdvancedSearchRow.js
+++ b/lib/AdvancedSearch/components/AdvancedSearchRow/AdvancedSearchRow.js
@@ -89,6 +89,7 @@ const AdvancedSearchRow = ({
         <Col xs>
           <TextArea
             isCursorAtEnd
+            hasClearIcon
             rows={TEXTAREA_HEIGHT}
             data-test-advanced-search-query
             aria-label={intl.formatMessage({ id: 'stripes-components.advancedSearch.fieldLabel' })}

--- a/lib/AdvancedSearch/hooks/useAdvancedSearch/useAdvancedSearch.js
+++ b/lib/AdvancedSearch/hooks/useAdvancedSearch/useAdvancedSearch.js
@@ -102,8 +102,6 @@ const useAdvancedSearch = ({
 
   const resetRows = () => {
     resetActiveRow();
-    // reset previous state to trigger sync with external search field
-    setPrevFirstRowInitialSearch(null);
     setRowState(emptyRowsState);
   };
 
@@ -136,7 +134,7 @@ const useAdvancedSearch = ({
 
   // if the firstRowInitialSearch is updated, go ahead and update state
   // before the state is committed to the DOM...
-  // (sync external search field with advanced modal search fields)
+  // (sync the changed value of the external search field with the fields of the advanced search modal window)
   if (!open && !isEqual(firstRowInitialSearch, prevFirstRowInitialSearch)) {
     const splitRows = splitQueryRows(initialRowState, queryToRow);
     setPrevFirstRowInitialSearch(firstRowInitialSearch);

--- a/lib/AdvancedSearch/hooks/useAdvancedSearch/useAdvancedSearch.js
+++ b/lib/AdvancedSearch/hooks/useAdvancedSearch/useAdvancedSearch.js
@@ -135,7 +135,7 @@ const useAdvancedSearch = ({
   // if the firstRowInitialSearch is updated, go ahead and update state
   // before the state is committed to the DOM...
   // (sync the changed value of the external search field with the fields of the advanced search modal window)
-  if (!open && !isEqual(firstRowInitialSearch, prevFirstRowInitialSearch)) {
+  if (!isEqual(firstRowInitialSearch, prevFirstRowInitialSearch)) {
     const splitRows = splitQueryRows(initialRowState, queryToRow);
     setPrevFirstRowInitialSearch(firstRowInitialSearch);
     updateActiveRow(splitRows);

--- a/lib/AdvancedSearch/hooks/useAdvancedSearch/useAdvancedSearch.js
+++ b/lib/AdvancedSearch/hooks/useAdvancedSearch/useAdvancedSearch.js
@@ -5,6 +5,7 @@ import {
 } from 'react';
 import isEqual from 'lodash/isEqual';
 import noop from 'lodash/noop';
+import cloneDeep from 'lodash/cloneDeep';
 import { useIntl } from 'react-intl';
 
 import useActiveRow from '../useActiveQuery';
@@ -23,7 +24,9 @@ import {
 
 const createInitialRowState = (firstRowInitialSearch, defaultSearchOptionValue) => {
   return new Array(ROW_COUNT).fill(null).map((_, index) => ({
-    [FIELD_NAMES.BOOL]: BOOLEAN_OPERATORS.AND,
+    [FIELD_NAMES.BOOL]: index === 0
+      ? ''
+      : BOOLEAN_OPERATORS.AND,
     [FIELD_NAMES.QUERY]: index === 0
       ? firstRowInitialSearch?.query || ''
       : '',
@@ -63,6 +66,8 @@ const useAdvancedSearch = ({
   hasQueryOption,
   open,
 }) => {
+  const emptyRowsState = useMemo(() => createInitialRowState(null, defaultSearchOptionValue), [defaultSearchOptionValue]);
+
   const initialRowState = useMemo(() => {
     const initialRows = createInitialRowState(firstRowInitialSearch, defaultSearchOptionValue);
     return splitQueryRows(initialRows, queryToRow);
@@ -79,7 +84,7 @@ const useAdvancedSearch = ({
     return filterFilledRows(rows)
   }, [rowState, queryToRow, searchOptions, defaultSearchOptionValue, hasQueryOption, open]);
 
-  const isPristine = useMemo(() => isEqual(rowState, initialRowState), [rowState, initialRowState]);
+  const isPristine = useMemo(() => isEqual(rowState, emptyRowsState), [rowState, emptyRowsState]);
 
   const searchOptionsWithQuery = useMemo(() => (
     [{
@@ -97,12 +102,14 @@ const useAdvancedSearch = ({
 
   const resetRows = () => {
     resetActiveRow();
-    setRowState(createInitialRowState(firstRowInitialSearch, defaultSearchOptionValue));
+    // reset previous state to trigger sync with external search field
+    setPrevFirstRowInitialSearch(null);
+    setRowState(emptyRowsState);
   };
 
   const onChange = (rowIndex, key, value) => {
     setRowState((currentRowState) => {
-      const newRowState = [...currentRowState];
+      const newRowState = cloneDeep(currentRowState);
 
       newRowState[rowIndex][key] = value;
       changeActiveRow(rowIndex, key, newRowState);
@@ -129,7 +136,8 @@ const useAdvancedSearch = ({
 
   // if the firstRowInitialSearch is updated, go ahead and update state
   // before the state is committed to the DOM...
-  if (!isEqual(firstRowInitialSearch, prevFirstRowInitialSearch)) {
+  // (sync external search field with advanced modal search fields)
+  if (!open && !isEqual(firstRowInitialSearch, prevFirstRowInitialSearch)) {
     const splitRows = splitQueryRows(initialRowState, queryToRow);
     setPrevFirstRowInitialSearch(firstRowInitialSearch);
     updateActiveRow(splitRows);

--- a/lib/AdvancedSearch/tests/AdvancedSearch-test.js
+++ b/lib/AdvancedSearch/tests/AdvancedSearch-test.js
@@ -338,9 +338,7 @@ describe('AdvancedSearch', () => {
 
     describe('resetting from the outside', () => {
       beforeEach(async () => {
-        await closeModalIcon.click();
         await ButtonInteractor('Reset').click();
-        await advancedSearchButton.click();
       });
 
       it('renders updated query values', async () => {

--- a/lib/AdvancedSearch/tests/AdvancedSearch-test.js
+++ b/lib/AdvancedSearch/tests/AdvancedSearch-test.js
@@ -24,6 +24,7 @@ import { mountWithContext } from '../../../tests/helpers';
 import AdvancedSearch from '../AdvancedSearch';
 import {
   BOOLEAN_OPERATORS,
+  DEFAULT_SEARCH_OPTION,
   MATCH_OPTIONS,
 } from '../constants';
 import Button from '../../Button';
@@ -350,48 +351,55 @@ describe('AdvancedSearch', () => {
     })
   })
 
-  describe('resetting values in modal', () => {
+  describe('when hitting the reset button inside the modal window', () => {
     beforeEach(async () => {
       await mountWithContext(
         <Harness
           open
+          defaultSearchOptionValue={DEFAULT_SEARCH_OPTION}
           searchOptions={searchOptions}
-          firstRowInitialSearch={{ query: 'test query', option: 'keyword' }}
+          firstRowInitialSearch={{
+            query: 'contributor exactPhrase test or isbn startsWith test2',
+            option: 'advancedSearch',
+          }}
         />
       );
+
+      await resetAllButton.click();
     });
 
-    describe('when hitting the reset button inside the modal', () => {
+    it('should disable the "Reset all" button', () => resetAllButton.is({ disabled: true }));
+
+    it('should disable the "Search" button', () => searchButton.is({ disabled: true }));
+
+    it('should remove all values in modal', async () => {
+      for (let i = 0; i < ROW_COUNT; i++) {
+        await advancedSearch.find(RowInteractor({ index: i })).perform(el => {
+          if (i > 0) {
+            expect(el.querySelector('[data-test-advanced-search-bool]').value).to.equal(BOOLEAN_OPERATORS.AND);
+          }
+          expect(el.querySelector('[data-test-advanced-search-query]').value).to.equal('');
+          expect(el.querySelector('[data-test-advanced-search-match]').value).to.equal(MATCH_OPTIONS.CONTAINS_ALL);
+          expect(el.querySelector('[data-test-advanced-search-option]').value).to.equal(DEFAULT_SEARCH_OPTION);
+        });
+      }
+    });
+
+    describe('when reopening the modal', () => {
       beforeEach(async () => {
-        await resetAllButton.click();
+        await closeModalIcon.click();
+        await advancedSearchButton.click();
       });
 
-      it('should disable the "Reset all" button', () => resetAllButton.is({ disabled: true }));
-
-      it('should disable the "Search" button', () => searchButton.is({ disabled: true }));
-
-      it('should remove all values in modal', async () => {
+      it('should not have values outside the modal', async () => {
         await advancedSearch.find(RowInteractor({ index: 0 })).perform(el => {
           expect(el.querySelector('[data-test-advanced-search-query]').value).to.equal('');
         });
       });
 
-      describe('when reopening the modal', () => {
-        beforeEach(async () => {
-          await closeModalIcon.click();
-          await advancedSearchButton.click();
-        });
+      it('should render the "Reset all" button disabled', () => resetAllButton.is({ disabled: true }));
 
-        it('should have values outside the modal', async () => {
-          await advancedSearch.find(RowInteractor({ index: 0 })).perform(el => {
-            expect(el.querySelector('[data-test-advanced-search-query]').value).to.equal('test query');
-          });
-        });
-
-        it('should enable the "Reset all" button', () => resetAllButton.is({ disabled: false }));
-
-        it('should enable the "Search" button', () => searchButton.is({ disabled: false }));
-      });
+      it('should render the "Search" button disabled', () => searchButton.is({ disabled: true }));
     });
   });
 });

--- a/lib/AdvancedSearch/tests/AdvancedSearch-test.js
+++ b/lib/AdvancedSearch/tests/AdvancedSearch-test.js
@@ -16,6 +16,7 @@ import {
   AdvancedSearch as Interactor,
   AdvancedSearchRow as RowInteractor,
   Button as ButtonInteractor,
+  including,
 } from '@folio/stripes-testing';
 
 import { mountWithContext } from '../../../tests/helpers';
@@ -27,13 +28,25 @@ import {
 } from '../constants';
 import Button from '../../Button';
 
-const Harness = (props) => {
+const Harness = ({
+  open = false,
+  onCancel,
+  ...props
+}) => {
   const [initState, setInitState] = useState({ query: 'try', option: 'keyword' });
+  const [isOpen, setIsOpen] = useState(open);
+
   return (
     <>
       <Button onClick={() => { setInitState({ query: 'test', option: 'keyword' }) }}>Reset</Button>
+      <Button onClick={() => setIsOpen(true)}>Advanced search</Button>
       <AdvancedSearch
+        open={isOpen}
         firstRowInitialSearch={initState}
+        onCancel={() => {
+          setIsOpen(false);
+          onCancel?.();
+        }}
         {...props}
       >
         {({ resetRows }) => (
@@ -56,6 +69,8 @@ describe('AdvancedSearch', () => {
   const resetButton = ButtonInteractor('Reset');
   const searchButton = ButtonInteractor('Search');
   const resetAllButton = ButtonInteractor('Reset all');
+  const advancedSearchButton = ButtonInteractor('Advanced search');
+  const closeModalIcon = ButtonInteractor({ className: including('closeModal') });
 
   const onSearchSpy = sinon.spy();
   const onCancelSpy = sinon.spy();
@@ -120,7 +135,7 @@ describe('AdvancedSearch', () => {
 
   it('should render component children', () => resetButton.is({ visible: true }));
 
-  it('should render component children', () => searchButton.is({ visible: true }));
+  it('should render "Search" button', () => searchButton.is({ disabled: true }));
 
   it('should render "Reset all" button', () => resetAllButton.is({ disabled: true }));
 
@@ -170,6 +185,13 @@ describe('AdvancedSearch', () => {
         expect(queryField.selectionEnd).to.equal('Test query'.length);
         expect(document.activeElement === queryField).to.be.true;
       });
+    });
+
+    it('should display the clear icon inside the input field', () => {
+      const firstRow = advancedSearch.find(RowInteractor({ index: 0 }));
+      const clearIcon = firstRow.find(ButtonInteractor({ icon: 'times-circle-solid'}));
+
+      return clearIcon.exists();
     });
   });
 
@@ -315,7 +337,9 @@ describe('AdvancedSearch', () => {
 
     describe('resetting from the outside', () => {
       beforeEach(async () => {
+        await closeModalIcon.click();
         await ButtonInteractor('Reset').click();
+        await advancedSearchButton.click();
       });
 
       it('renders updated query values', async () => {
@@ -325,4 +349,49 @@ describe('AdvancedSearch', () => {
       });
     })
   })
+
+  describe('resetting values in modal', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <Harness
+          open
+          searchOptions={searchOptions}
+          firstRowInitialSearch={{ query: 'test query', option: 'keyword' }}
+        />
+      );
+    });
+
+    describe('when hitting the reset button inside the modal', () => {
+      beforeEach(async () => {
+        await resetAllButton.click();
+      });
+
+      it('should disable the "Reset all" button', () => resetAllButton.is({ disabled: true }));
+
+      it('should disable the "Search" button', () => searchButton.is({ disabled: true }));
+
+      it('should remove all values in modal', async () => {
+        await advancedSearch.find(RowInteractor({ index: 0 })).perform(el => {
+          expect(el.querySelector('[data-test-advanced-search-query]').value).to.equal('');
+        });
+      });
+
+      describe('when reopening the modal', () => {
+        beforeEach(async () => {
+          await closeModalIcon.click();
+          await advancedSearchButton.click();
+        });
+
+        it('should have values outside the modal', async () => {
+          await advancedSearch.find(RowInteractor({ index: 0 })).perform(el => {
+            expect(el.querySelector('[data-test-advanced-search-query]').value).to.equal('test query');
+          });
+        });
+
+        it('should enable the "Reset all" button', () => resetAllButton.is({ disabled: false }));
+
+        it('should enable the "Search" button', () => searchButton.is({ disabled: false }));
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Purpose
1. The `Reset all` and `Search` buttons should be disabled with no values/selections in the advanced search modal.
2. A clear icon should be added for text fields.

## Issues
[STCOM-1424](https://folio-org.atlassian.net/browse/STCOM-1424)

## Screencasts

https://github.com/user-attachments/assets/0de86b8f-8736-4bfb-b153-6cf08f86ace1

