### PR TITLE
Move changelog items from 13.0.3 to 13.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Change history for stripes-components
 
-## 13.0.3 IN PROGRESS
-
-* Display `Changed from - "true/false"` and `Changed to - "true/false"` values for boolean fields in AuditLogModal. Fixes STCOM-1427.
-* Restore onSelect support for AutoSuggest component. Refs STCOM-1426.
-* `AuditLog` - add `showSharedLabel` property to display "Shared" instead of "Original version" in the original card. Refs STCOM-1430.
-* Load dayjs' LocalizedFormat plugin to leverage localized formats. Refs STCOM-1437.
-* Remove tabIndex from `<MultiColumnList>`'s empty message wrapping element. Refs STCOM-1403.
-
 ## 13.1.0 IN PROGRESS
 
 * Introduce `<AuditLog>` component. Refs STCOM-1412.
@@ -18,6 +10,11 @@
 * Make `dayjs.contains` include start end end dates. Refs STCOM-1421.
 * Add loading indicator to `AuditLogPane` when data is initially loading. Refs STCOM-1422.
 * `AdvancedSearch` - replace `Cancel` button with `Reset all` in modal window. Refs STCOM-1424.
+* Display `Changed from - "true/false"` and `Changed to - "true/false"` values for boolean fields in AuditLogModal. Fixes STCOM-1427.
+* Restore onSelect support for AutoSuggest component. Refs STCOM-1426.
+* `AuditLog` - add `showSharedLabel` property to display "Shared" instead of "Original version" in the original card. Refs STCOM-1430.
+* Load dayjs' LocalizedFormat plugin to leverage localized formats. Refs STCOM-1437.
+* Remove tabIndex from `<MultiColumnList>`'s empty message wrapping element. Refs STCOM-1403.
 
 ## [13.0.0](https://github.com/folio-org/stripes-components/tree/v13.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.2.0...v13.0.0)


### PR DESCRIPTION
Multiple in-progress entries in the list - probably due to PR's spanning the version bump/merges of master... but confusing for incoming changes.

On master, they should all go to the latest version.. If any are for a previous, they would be cherry-picked/added to the necessary release branch.