### PR TITLE
STCOM-1442 itemToView bug.

### DIFF
--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -662,7 +662,7 @@ class MCLRenderer extends React.Component {
       }
 
       if (!virtualize && columns.length === Object.keys(stateColumnWidths).length) {
-        this.scrollToItemToView();
+        // this.scrollToItemToView();
       }
 
       // update header row and check for vertical scrollbar...
@@ -806,9 +806,18 @@ class MCLRenderer extends React.Component {
       this.itemToViewIsStale === false
     ) {
       const itemElem = this.container.current.querySelector(item.selector);
+
       if (itemElem) {
         const offset = itemElem.offsetTop;
-        this.scrollContainer.current.scrollTop = offset - (item.localClientTop);
+        const itemRect = itemElem.getBoundingClientRect();
+        const mclRect = this.container.current?.getBoundingClientRect();
+        const currentClientTop = itemRect.top - mclRect.top;
+        const scrollOffset = currentClientTop - item.localClientTop;
+        this.scrollContainer.current.scrollTop += scrollOffset;
+        this.itemToView.localClientTop = currentClientTop;
+        if (this.props.onMarkPosition) {
+          this.props.onMarkPosition(this.itemToView);
+        }
       } else if (!virtualize) {
         this.itemToView = null;
         if (onMarkReset) {
@@ -990,7 +999,7 @@ class MCLRenderer extends React.Component {
     this.focusedRowIndex = rowIndex;
     const mclRect = this.container.current?.getBoundingClientRect();
     if (mclRect) {
-      const rowRect = e.target.getBoundingClientRect();
+      const rowRect = e.target.closest(`.${css.mclRow}`).getBoundingClientRect();
       this.itemToView = {
         selector: `[aria-rowindex="${rowIndex}"]`,
         localClientTop: rowRect.top - mclRect.top,
@@ -1881,6 +1890,24 @@ class MCLRenderer extends React.Component {
     return amount;
   };
 
+  handleMouseDown = (e) => {
+    console.log('mouse down handling!')
+    const containingRow = e.target.closest(`.${css.mclRowFormatterContainer}`);
+    const rowIndex = containingRow.getAttribute('aria-rowindex');
+    const mclRect = this.container.current?.getBoundingClientRect();
+    if (mclRect) {
+      const rowRect = containingRow.getBoundingClientRect();
+      this.itemToView = {
+        selector: `[aria-rowindex="${rowIndex}"]`,
+        localClientTop: rowRect.top - mclRect.top,
+      };
+      this.itemToViewIsStale = false;
+      if (this.props.onMarkPosition) {
+        this.props.onMarkPosition(this.itemToView);
+      }
+    }
+  }
+
   render() {
     const {
       contentData,
@@ -1966,6 +1993,7 @@ class MCLRenderer extends React.Component {
                 onScroll={this.handleScroll}
                 ref={this.scrollContainer}
                 {...getScrollableTabIndex(this.scrollContainer)}
+                onMouseDown={this.handleMouseDown}
               >
                 <div
                   className={rowContainerClass}

--- a/lib/MultiColumnList/stories/ItemToView.js
+++ b/lib/MultiColumnList/stories/ItemToView.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
+import Checkbox from '../../Checkbox';
 import MultiColumnList from '../MultiColumnList';
 import { syncGenerate } from './service';
 
@@ -39,6 +40,24 @@ export default class ItemToView extends React.Component {
     });
   }
 
+  handleCheckbox = (e,item) => {
+    this.setState(cur => {
+      const rowIndex = cur.data.findIndex(i => item.email === i.email);
+      const newData = cur.data;
+      newData[rowIndex].active = e.target.checked;
+      return {
+        ...cur,
+        data: newData,
+        selected: newData[rowIndex],
+        viewWidth: cur.viewWidth === '800px' ? '400px' : '800px',
+      };
+    })
+  }
+
+  formatter = {
+    active: (item) => <Checkbox onChange={(e) => this.handleCheckbox(e,item)} checked={item.active}/>
+  }
+
   render() {
     const {
       viewWidth,
@@ -54,7 +73,6 @@ export default class ItemToView extends React.Component {
           sortedColumn={this.state.sorted}
           sortDirection="ascending"
           selectedRow={this.state.selected}
-          onRowClick={this.onRowClick}
           onHeaderClick={this.onHeaderClick}
           columnWidths={this.columnWidths}
           itemToView={viewItem}
@@ -66,6 +84,7 @@ export default class ItemToView extends React.Component {
           visibleColumns={[
             'active', 'email', 'index'
           ]}
+          formatter={this.formatter}
           autosize
         />
       </div>


### PR DESCRIPTION
## WIP for [STCOM-1442](https://folio-org.atlassian.net/browse/STCOM-1442)

Cleanup needed... already improved behavior in the storybook item-to-view story.

## Approach thus far:
1) previous item capturing was done from `event.target` rather than 'item' aka 'row'. Sometimes `target` might be a `<Checkbox>` that's aligned middle, so measurements are different from expected.

2) previous item capturing happened on focus. While this is fine when a row is selected, it's awkward because it won't happen again while the row is focus - and interactions like checkbox checks and stuff can happen again in the focus state, so the item capture wouldn't be updated correctly.
