### PR TITLE
STCOM-1451 correctly handle empty codes in formattedLanguageName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Show changes of multiple repeatable fields as 1 row in the `Card` on `Version history` pane. Fixes STCOM-1443.
 * Increase default `maxHeight` of `<MultiSelection>` to display the entirety of 6 options. Refs STCOM-1448.
 * `<AuditLog>` - change styling of "Current version" and "Changed" labels. Refs STCOM-1450.
+* Correctly handle empty language-codes in `formattedLanguageName()`. Refs STCOM-1451.
 
 ## [13.0.0](https://github.com/folio-org/stripes-components/tree/v13.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.2.0...v13.0.0)

--- a/util/tests/languages-test.js
+++ b/util/tests/languages-test.js
@@ -1,0 +1,103 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+
+import languages, { formattedLanguageName, languageOptions, languageOptionsES } from '../languages';
+
+describe('language functions', () => {
+  const langs = {
+    'stripes-components.languages.tlh': 'Shiny happy Klingons holding hands',
+    'stripes-components.languages.zul': 'Two letters match',
+    'stripes-components.languages.und': 'Undetermined',
+  };
+
+  const intl = {
+    formatMessage: ({ id }) => langs[id] ?? id,
+  }
+
+  describe('formattedLanguageName', () => {
+    describe('translates matched codes', () => {
+      it('translates three-letter codes', () => {
+        expect(formattedLanguageName('tlh', intl)).to.equal(langs['stripes-components.languages.tlh'])
+      });
+
+      it('translates two-letter codes', () => {
+        expect(formattedLanguageName('zu', intl)).to.equal(langs['stripes-components.languages.zul'])
+      });
+
+      it('falls back to English name if translated name is missing', () => {
+        const zxx = languages.find(i => i.alpha3 === 'zxx');
+        expect(formattedLanguageName('zxx', intl)).to.equal(zxx.name);
+      });
+    });
+
+    describe('returns undetermined given unmatched codes', () => {
+      it('code is null', () => {
+        expect(formattedLanguageName(null, intl)).to.equal(langs['stripes-components.languages.und']);
+      });
+      it('code is empty string', () => {
+        expect(formattedLanguageName('', intl)).to.equal(langs['stripes-components.languages.und']);
+      });
+      it('code is whitespace', () => {
+        expect(formattedLanguageName(' ', intl)).to.equal(langs['stripes-components.languages.und']);
+      });
+      it('code is unmatched', () => {
+        expect(formattedLanguageName('kirk', intl)).to.equal(langs['stripes-components.languages.und']);
+      });
+    });
+
+  });
+
+  describe('languageOptions', () => {
+    it('returns label/value tuples', () => {
+      const list = languageOptions(intl);
+      expect(list[0].label).not.to.equal(null);
+      expect(list[0].value).not.to.equal(null);
+    });
+
+    it('sorts the list alphabetically in the current locale', () => {
+      // atintl causes entries in atlangs to float to the top
+      const atlangs = {
+        'stripes-components.languages.zza': 'Zaza',
+      };
+      const atintl = {
+        formatMessage: ({ id }) => atlangs[id] ? `@${id}` : id,
+      }
+
+      // zintl causes entries in zlangs to sink to the bottom
+      const zlangs = {
+        'stripes-components.languages.9an': 'Angloromani',
+      };
+      const zintl = {
+        formatMessage: ({ id }) => zlangs[id] ? `ZZZ${id}` : id,
+      }
+
+      const atlist = languageOptions(atintl);
+      const zlist = languageOptions(zintl);
+
+      expect(atlist[0].value).to.equal('zza');
+      expect(zlist[zlist.length - 1].value).to.equal('9an')
+    });
+  });
+
+  describe('languageOptionsES', () => {
+    const input = [
+      { id: 'tlh', totalRecords: 271828 },
+      { id: 'missing', totalRecords: 0 },
+    ];
+
+    it('returns label/value/count tuples when totalRecords is non-zero', () => {
+      const list = languageOptionsES(intl, input);
+      const tlh = list.find(i => i.value === 'tlh');
+
+      expect(tlh.label).to.equal(langs['stripes-components.languages.tlh']);
+      expect(tlh.value).to.equal(input[0].id);
+      expect(tlh.count).to.equal(input[0].totalRecords);
+    });
+
+    it('omits entries where totalRecords is 0', () => {
+      const list = languageOptionsES(intl, input);
+      expect(list.length).to.equal(1);
+      expect(list.find(i => i.value === 'missing')).to.be.undefined;
+    });
+  });
+});


### PR DESCRIPTION
1. Return "undetermined" from `formattedLanguageName()` given an empty code. Previously, empty codes matched the first value in the languages table that lacked a two-character code. Whoops!
2. Correctly sort entries according to current locale in `languageOptions()`. The previous implementation used `lodash.sortBy`, an implementation that does not correctly handle localized data.

Refs [STCOM-1451](https://folio-org.atlassian.net/browse/STCOM-1451)