### PR TITLE
STCOM-1451 tests must reflect available language data

### DIFF
--- a/util/tests/languages-test.js
+++ b/util/tests/languages-test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 
 import languages, { formattedLanguageName, languageOptions, languageOptionsES } from '../languages';
 
-describe.only('language functions', () => {
+describe('language functions', () => {
   const langs = {
     'stripes-components.languages.tlh': 'Shiny happy Klingons holding hands',
     'stripes-components.languages.zul': 'Two letters match',


### PR DESCRIPTION
Update test to operate on entries that are part of the language-list in the current release. The original incarnation of the test modified a value that wasn't added until a later release, causing a false-failure.

Refs [STCOM-1452](https://folio-org.atlassian.net/browse/STCOM-1452)