### PR TITLE
STCOM-1451 correctly handle empty codes in formattedLanguageName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-components
 
+## 13.0.7 IN PROGRESS
+
+* Correctly handle empty language-codes in `formattedLanguageName()`. Refs STCOM-1451.
+
 ## [13.0.6](https://github.com/folio-org/stripes-components/tree/v13.0.6) (2025-05-06)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v13.0.5...v13.0.6)
 

--- a/util/languages.js
+++ b/util/languages.js
@@ -1,4 +1,4 @@
-import { find, sortBy } from 'lodash';
+import { find } from 'lodash';
 
 // This list is derived from the table provided at https://www.loc.gov/standards/iso639-2/ascii_8bits.html
 // It uses the ISO 639-2 standard. Not all language names have both a two-character and three-character
@@ -496,23 +496,50 @@ const languages = [
   { alpha3: 'zza', alpha2: '', name: 'Zaza; Dimili; Dimli; Kirdki; Kirmanjki; Zazaki' },
 ];
 
-// Given a two- or three-character language code, return a localized langugae name string
-// @intl is really useIntl(), which can't be invoked outside a functional component
+/**
+ * formattedLanguageName
+ * return a localized string given an ISO-639-2 language code.
+ *
+ * Prefer a three-letter code to a two-letter code. If a code matches but
+ * no translation value is present in the current locale, return the `name`
+ * attribute, an English-language value, directly from the translations table.
+ *
+ * Unmatched codes will be handled as `und`, the code for "undetermined".
+ *
+ * @param {string} code three- or two-letter language code
+ * @param {object} intl return value of useIntl
+ * @returns string
+ */
 export const formattedLanguageName = (code, intl) => {
-  const language = find(languages, entry => entry.alpha3 === code || entry.alpha2 === code);
-  if (language === undefined) {
-    return intl.formatMessage({ id: 'stripes-components.languages.und' });
-  }
-  const translationId = `stripes-components.languages.${language.alpha3}`;
-  const translatedName = intl.formatMessage({ id: translationId });
+  if (code && code.trim()) {
+    const language = find(languages, entry => entry.alpha3 === code || entry.alpha2 === code);
+    if (language) {
+      const translationId = `stripes-components.languages.${language.alpha3}`;
+      const translatedName = intl.formatMessage({ id: translationId });
 
-  if (translatedName !== translationId) return translatedName;
-  // If no translation is found, use the English name from the list above
-  else return language.name;
+      // intl returns the input id if no matching translation is present.
+      // if that happens, use the `name` value from the languages table
+      // rather than the id
+      if (translatedName !== translationId) {
+        return translatedName;
+      }
+
+      return language.name;
+    }
+  }
+
+  return intl.formatMessage({ id: 'stripes-components.languages.und' });
 };
 
-// Provide an array of label/value pairs for the language list, suitable as options
-// for a <Select> component.
+/**
+ * languageOptions
+ * Return an array of label/value pairs for the language list, suitable as
+ * options for a <Select> component, sorted by label, i.e. the localized
+ * value for each language.
+ *
+ * @param {object} intl return value of useIntl
+ * @returns
+ */
 export const languageOptions = intl => {
   const options = languages.map(l => (
     {
@@ -520,9 +547,24 @@ export const languageOptions = intl => {
       value: l.alpha3,
     }
   ));
-  return sortBy(options, ['label']);
+
+  return options.sort((a, b) => a.label.localeCompare(b.label));
 };
 
+/**
+ * languageOptionsES
+ * Given an array of entries shaped like { id, totalRecords } where the id
+ * corresponds to a language code, return an array of { label, value, count }
+ * objects where:
+ * * label is the localized value of the id
+ * * value is id
+ * * count is totalRecords
+ * Entries without a totalRecords attribute are omitted.
+ *
+ * @param {object} intl return value of useIntl
+ * @param {array} langs list of entries shaped like { id, totalRecords}
+ * @returns
+ */
 export const languageOptionsES = (intl, langs = []) => {
   return langs.reduce((accum, { id, totalRecords }) => {
     if (!totalRecords) return accum;

--- a/util/tests/languages-test.js
+++ b/util/tests/languages-test.js
@@ -65,7 +65,7 @@ describe('language functions', () => {
 
       // zintl causes entries in zlangs to sink to the bottom
       const zlangs = {
-        'stripes-components.languages.9an': 'Angloromani',
+        'stripes-components.languages.abk': 'Abkhazian',
       };
       const zintl = {
         formatMessage: ({ id }) => zlangs[id] ? `ZZZ${id}` : id,
@@ -75,7 +75,7 @@ describe('language functions', () => {
       const zlist = languageOptions(zintl);
 
       expect(atlist[0].value).to.equal('zza');
-      expect(zlist[zlist.length - 1].value).to.equal('9an')
+      expect(zlist[zlist.length - 1].value).to.equal('abk')
     });
   });
 

--- a/util/tests/languages-test.js
+++ b/util/tests/languages-test.js
@@ -1,0 +1,103 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+
+import languages, { formattedLanguageName, languageOptions, languageOptionsES } from '../languages';
+
+describe('language functions', () => {
+  const langs = {
+    'stripes-components.languages.tlh': 'Shiny happy Klingons holding hands',
+    'stripes-components.languages.zul': 'Two letters match',
+    'stripes-components.languages.und': 'Undetermined',
+  };
+
+  const intl = {
+    formatMessage: ({ id }) => langs[id] ?? id,
+  }
+
+  describe('formattedLanguageName', () => {
+    describe('translates matched codes', () => {
+      it('translates three-letter codes', () => {
+        expect(formattedLanguageName('tlh', intl)).to.equal(langs['stripes-components.languages.tlh'])
+      });
+
+      it('translates two-letter codes', () => {
+        expect(formattedLanguageName('zu', intl)).to.equal(langs['stripes-components.languages.zul'])
+      });
+
+      it('falls back to English name if translated name is missing', () => {
+        const zxx = languages.find(i => i.alpha3 === 'zxx');
+        expect(formattedLanguageName('zxx', intl)).to.equal(zxx.name);
+      });
+    });
+
+    describe('returns undetermined given unmatched codes', () => {
+      it('code is null', () => {
+        expect(formattedLanguageName(null, intl)).to.equal(langs['stripes-components.languages.und']);
+      });
+      it('code is empty string', () => {
+        expect(formattedLanguageName('', intl)).to.equal(langs['stripes-components.languages.und']);
+      });
+      it('code is whitespace', () => {
+        expect(formattedLanguageName(' ', intl)).to.equal(langs['stripes-components.languages.und']);
+      });
+      it('code is unmatched', () => {
+        expect(formattedLanguageName('kirk', intl)).to.equal(langs['stripes-components.languages.und']);
+      });
+    });
+
+  });
+
+  describe('languageOptions', () => {
+    it('returns label/value tuples', () => {
+      const list = languageOptions(intl);
+      expect(list[0].label).not.to.equal(null);
+      expect(list[0].value).not.to.equal(null);
+    });
+
+    it('sorts the list alphabetically in the current locale', () => {
+      // atintl causes entries in atlangs to float to the top
+      const atlangs = {
+        'stripes-components.languages.zza': 'Zaza',
+      };
+      const atintl = {
+        formatMessage: ({ id }) => atlangs[id] ? `@${id}` : id,
+      }
+
+      // zintl causes entries in zlangs to sink to the bottom
+      const zlangs = {
+        'stripes-components.languages.9an': 'Angloromani',
+      };
+      const zintl = {
+        formatMessage: ({ id }) => zlangs[id] ? `ZZZ${id}` : id,
+      }
+
+      const atlist = languageOptions(atintl);
+      const zlist = languageOptions(zintl);
+
+      expect(atlist[0].value).to.equal('zza');
+      expect(zlist[zlist.length - 1].value).to.equal('9an')
+    });
+  });
+
+  describe('languageOptionsES', () => {
+    const input = [
+      { id: 'tlh', totalRecords: 271828 },
+      { id: 'missing', totalRecords: 0 },
+    ];
+
+    it('returns label/value/count tuples when totalRecords is non-zero', () => {
+      const list = languageOptionsES(intl, input);
+      const tlh = list.find(i => i.value === 'tlh');
+
+      expect(tlh.label).to.equal(langs['stripes-components.languages.tlh']);
+      expect(tlh.value).to.equal(input[0].id);
+      expect(tlh.count).to.equal(input[0].totalRecords);
+    });
+
+    it('omits entries where totalRecords is 0', () => {
+      const list = languageOptionsES(intl, input);
+      expect(list.length).to.equal(1);
+      expect(list.find(i => i.value === 'missing')).to.be.undefined;
+    });
+  });
+});


### PR DESCRIPTION
1. Return "undetermined" from `formattedLanguageName()` given an empty
  code. Previously, empty codes matched the first value in the languages
  table that lacked a two-character code. Whoops!
2. Correctly sort entries according to current locale in
  `languageOptions()`. The previous implementation used `lodash.sortBy`,
  an implementation that does not correctly handle localized data.
3. Update test to operate on entries that are part of the language-list in
  the current release. The original incarnation of the test modified a
  value that wasn't added until a later release, causing a false-failure.

Refs [STCOM-1451](https://folio-org.atlassian.net/browse/STCOM-1451) (Sunflower backport: [STCOM-1453](https://folio-org.atlassian.net/browse/STCOM-1453))

(code changes cherry picked from commit c7d8b129164dd929a90a6c8ac16e5c62d33d7ee7)
(test changes cherry picked from commit a1e3c9b2cee68945af091ffe76a99ae5ca16b9f3)
