### PR TITLE
STCOM-814 Leverage sourcemaps in ErrorBoundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * `<AuditLog>` - change styling of "Current version" and "Changed" labels. Refs STCOM-1450.
 * Correctly handle empty language-codes in `formattedLanguageName()`. Refs STCOM-1451.
 * Remove spacing from `<ButtonGroup>`. Refs STCOM-1458.
+* Use mapped stacktraces in `<ErrorBoundary>` when sourcemaps are present. Refs STCOM-814.
 
 ## [13.0.0](https://github.com/folio-org/stripes-components/tree/v13.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.2.0...v13.0.0)

--- a/lib/ErrorBoundary/ErrorBoundary.js
+++ b/lib/ErrorBoundary/ErrorBoundary.js
@@ -4,6 +4,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+
 import { ErrorMessage, ProductionError } from './components';
 import css from './ErrorBoundary.css';
 
@@ -32,24 +33,7 @@ export default class ErrorBoundary extends Component {
       this.props.onError(error, info);
     }
 
-    const { stack: errorStack } = error;
-    const { componentStack } = info;
-
-    const lines = `
-      ${errorStack.toString()}
-      ${componentStack.toString()}
-    `.split('\n')
-      // Remove empty lines
-      .filter(Boolean);
-
-    const stack = lines
-      // Remove the first line because it's the same as the error we get above
-      .splice(1, lines.length)
-      // Remove whitespace
-      .map(str => str.replace(/\s+/, ''))
-      .join('\n');
-
-    this.setState({ error: error.toString(), stack });
+    this.setState({ error: error.toString(), stack: error.stack });
   }
 
   renderError = () => {

--- a/lib/ErrorBoundary/ErrorBoundary.js
+++ b/lib/ErrorBoundary/ErrorBoundary.js
@@ -4,6 +4,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { mapStackTrace } from 'sourcemapped-stacktrace';
 
 import { ErrorMessage, ProductionError } from './components';
 import css from './ErrorBoundary.css';
@@ -58,6 +59,7 @@ export default class ErrorBoundary extends Component {
         stackTrace={stack}
         subTitle={subTitle}
         title={title}
+        mapStackTrace={mapStackTrace}
       />
     );
   }

--- a/lib/ErrorBoundary/components/ProductionError/ProductionError.js
+++ b/lib/ErrorBoundary/components/ProductionError/ProductionError.js
@@ -5,6 +5,8 @@
 import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { mapStackTrace } from 'sourcemapped-stacktrace';
+
 import css from './ProductionError.css';
 import Icon from '../../../Icon';
 import SRStatus from '../../../SRStatus';
@@ -25,10 +27,10 @@ const ProductionError = ({
   title,
 }) => {
   const intl = useIntl();
-  const copyRef = useRef(null);
   const srsRef = useRef(null);
   const [modalOpen, setModalOpen] = useState(false);
   const [errorCopied, setErrorCopied] = useState(false);
+  const [mappedStack, setMappedStack] = useState();
   const handleToggleModal = () => setModalOpen(!modalOpen);
 
   const handleReset = e => {
@@ -40,36 +42,34 @@ const ProductionError = ({
   };
 
   const handleCopyStack = () => {
-    const el = copyRef.current;
-    el.select();
-    el.setSelectionRange(0, 99999);
-    document.execCommand('copy');
-
     if (typeof onCopyError === 'function') {
-      onCopyError(el.defaultValue);
+      onCopyError(mappedStack);
+    } else {
+      navigator.clipboard.writeText(mappedStack)
+        .then(() => {
+          setErrorCopied(true);
+          srsRef.current.sendMessage(
+            intl.formatMessage({
+              id: 'stripes-components.ErrorBoundary.errorCopiedScreenReaderMessage'
+            })
+          );
+        });
     }
-
-    srsRef.current.sendMessage(
-      intl.formatMessage({
-        id: 'stripes-components.ErrorBoundary.errorCopiedScreenReaderMessage'
-      })
-    );
-    setErrorCopied(true);
   };
 
+  // mapStackTrace must be called within an effect to avoid infinite renders
   useEffect(() => {
-    let timeout;
-
-    if (errorCopied) {
-      timeout = setTimeout(() => {
-        setErrorCopied(false);
-      }, 1000);
-    }
-
-    return () => {
-      clearTimeout(timeout);
-    };
-  }, [errorCopied]);
+    mapStackTrace(
+      stackTrace,
+      (lines) => {
+        // lines will be an empty array if the sourcemap didn't load
+        setMappedStack(lines.length ? lines.join('\n') : stackTrace);
+      },
+      {
+        cacheGlobally: true,
+      }
+    );
+  }, [stackTrace]);
 
   return (
     <>
@@ -98,6 +98,7 @@ const ProductionError = ({
             className={css.viewDetailsButton}
             onClick={handleToggleModal}
             data-test-error-boundary-production-error-details-button
+            disabled={!mappedStack}
           >
             <FormattedMessage id="stripes-components.ErrorBoundary.detailsButtonLabel" />
           </TextLink>
@@ -111,63 +112,53 @@ const ProductionError = ({
       >
         {resetButtonLabel || <FormattedMessage id="stripes-components.ErrorBoundary.defaultButtonLabel" />}
       </Button>
-      <FormattedMessage id="stripes-components.ErrorBoundary.errorDetails">
-        {([modalLabel]) => (
-          <Modal
-            label={modalLabel}
-            aria-label={modalLabel}
-            dismissible
-            open={modalOpen}
-            onClose={handleToggleModal}
-            data-test-error-boundary-production-error-details-modal
-            closeOnBackgroundClick
-            contentClass={css.modalContent}
-            size="medium"
-            footer={
-              <ModalFooter>
-                <Button
-                  marginBottom0
-                  buttonStyle="primary"
-                  onClick={handleToggleModal}
-                >
-                  <FormattedMessage id="stripes-components.close" />
-                </Button>
-                <Button
-                  marginBottom0
-                  buttonStyle="default"
-                  onClick={handleCopyStack}
-                  disabled={errorCopied}
-                  data-test-error-boundary-production-error-copy-button
-                  aria-label={intl.formatMessage({ id: 'stripes-components.ErrorBoundary.copyErrorButtonAriaLabel' })}
-                >
-                  <Icon icon="clipboard">
-                    {errorCopied ?
-                      <FormattedMessage id="stripes-components.copied" /> :
-                      <FormattedMessage id="stripes-components.copy" />
-                    }
-                  </Icon>
-                </Button>
-              </ModalFooter>
-            }
-          >
-            <SRStatus ref={srsRef} />
-            <Headline size="medium">
-              <FormattedMessage id="stripes-components.ErrorBoundary.detailsDescription" />
-            </Headline>
-            <ErrorMessage
-              data-test-error-boundary-production-error-message
-              error={error}
-              stack={stackTrace}
-            />
-          </Modal>
-        )}
-      </FormattedMessage>
-      <textarea
-        defaultValue={`URL: ${window.location.href}\n\nError: ${error}\n\nStack: ${stackTrace}`}
-        ref={copyRef}
-        className="sr-only"
-        aria-hidden
-      />
+      <Modal
+        label={intl.formatMessage({ id: 'stripes-components.ErrorBoundary.errorDetails' })}
+        aria-label={intl.formatMessage({ id: 'stripes-components.ErrorBoundary.errorDetails' })}
+        dismissible
+        open={modalOpen}
+        onClose={handleToggleModal}
+        data-test-error-boundary-production-error-details-modal
+        closeOnBackgroundClick
+        contentClass={css.modalContent}
+        size="medium"
+        footer={
+          <ModalFooter>
+            <Button
+              marginBottom0
+              buttonStyle="primary"
+              onClick={handleToggleModal}
+            >
+              <FormattedMessage id="stripes-components.close" />
+            </Button>
+            <Button
+              marginBottom0
+              buttonStyle="default"
+              onClick={handleCopyStack}
+              disabled={errorCopied}
+              data-test-error-boundary-production-error-copy-button
+              aria-label={intl.formatMessage({ id: 'stripes-components.ErrorBoundary.copyErrorButtonAriaLabel' })}
+            >
+              <Icon icon="clipboard">
+                {errorCopied ?
+                  <FormattedMessage id="stripes-components.copied" /> :
+                  <FormattedMessage id="stripes-components.copy" />
+                }
+              </Icon>
+            </Button>
+          </ModalFooter>
+        }
+      >
+        <SRStatus ref={srsRef} />
+        <Headline size="medium">
+          <FormattedMessage id="stripes-components.ErrorBoundary.detailsDescription" />
+        </Headline>
+        <ErrorMessage
+          data-test-error-boundary-production-error-message
+          error={error}
+          stack={mappedStack}
+        />
+      </Modal>
     </>
   );
 };

--- a/lib/ErrorBoundary/components/ProductionError/ProductionError.js
+++ b/lib/ErrorBoundary/components/ProductionError/ProductionError.js
@@ -5,7 +5,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { mapStackTrace } from 'sourcemapped-stacktrace';
 
 import css from './ProductionError.css';
 import Icon from '../../../Icon';
@@ -25,6 +24,7 @@ const ProductionError = ({
   stackTrace,
   subTitle,
   title,
+  mapStackTrace,
 }) => {
   const intl = useIntl();
   const srsRef = useRef(null);
@@ -69,7 +69,7 @@ const ProductionError = ({
         cacheGlobally: true,
       }
     );
-  }, [stackTrace]);
+  }, [mapStackTrace, stackTrace]);
 
   return (
     <>
@@ -165,6 +165,7 @@ const ProductionError = ({
 
 ProductionError.propTypes = {
   error: PropTypes.string,
+  mapStackTrace: PropTypes.func,
   onCopyError: PropTypes.func,
   onReset: PropTypes.func,
   resetButtonLabel: PropTypes.node,

--- a/lib/ErrorBoundary/tests/ErrorBoundary-test.js
+++ b/lib/ErrorBoundary/tests/ErrorBoundary-test.js
@@ -4,6 +4,9 @@
 
 import React from 'react';
 import { describe, beforeEach, it } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
 import { Bigtest, Button, converge, including, Modal } from '@folio/stripes-testing';
 import { mountWithContext } from '../../../tests/helpers';
 import ErrorBoundary from '../ErrorBoundary';
@@ -122,12 +125,47 @@ describe('ErrorBoundary', () => {
 
       it('Renders the error message inside the modal', () => errorMessage.exists());
 
-      describe('When a user clicks the copy button', () => {
+      describe('When a user clicks the copy button (with callback)', () => {
         beforeEach(async () => {
           await detailsModal.clickCopyButton();
         });
 
         it('Should fire the onCopyError-callback', () => converge(() => copyCallbackFired));
+      });
+    });
+
+    describe('When a user clicks the "More details"-button', () => {
+      describe('When a user clicks the copy button (without callback)', () => {
+        const stackTrace = 'stacktrace';
+        const mapStackTrace = (_stack, callback, _options) => {
+          callback([stackTrace]);
+        };
+        const copySpy = sinon.spy();
+        const stub = sinon.stub(navigator.clipboard, 'writeText')
+          .callsFake((str) => Promise.resolve(copySpy(str)));
+
+        beforeEach(async () => {
+          await mountWithContext(
+            <ProductionError
+              error="Some error"
+              onReset={() => { resetCallbackFired = true; }}
+              resetButtonLabel="Go back"
+              stackTrace={stackTrace}
+              subTitle="Please go back"
+              title="Some error occurred"
+              mapStackTrace={mapStackTrace}
+            />
+          );
+
+          await converge(() => Bigtest.Button(including('details')).exists());
+          await productionError.clickDetailsButton();
+          await detailsModal.clickCopyButton();
+        });
+
+        it('The copy-button label changes, and it disables', () => Button(including('Copied')).is({ disabled: true }));
+        it('Stacktrace is copied to the clipboard', () => {
+          expect(stub.called).to.be.true;
+        });
       });
     });
   });

--- a/lib/ErrorBoundary/tests/ErrorBoundary-test.js
+++ b/lib/ErrorBoundary/tests/ErrorBoundary-test.js
@@ -74,15 +74,21 @@ describe('ErrorBoundary', () => {
     let copyCallbackFired = false;
 
     beforeEach(async () => {
+      const stackTrace = 'component stack';
+      const mapStackTrace = (_stack, callback, _options) => {
+        callback([stackTrace]);
+      };
+
       await mountWithContext(
         <ProductionError
           error="Some error"
           onReset={() => { resetCallbackFired = true; }}
           onCopyError={() => { copyCallbackFired = true; }}
           resetButtonLabel="Go back"
-          stackTrace="component stack"
+          stackTrace={stackTrace}
           subTitle="Please go back"
           title="Some error occurred"
+          mapStackTrace={mapStackTrace}
         />
       );
 
@@ -124,5 +130,59 @@ describe('ErrorBoundary', () => {
         it('Should fire the onCopyError-callback', () => converge(() => copyCallbackFired));
       });
     });
+  });
+
+  describe('Production error with a sourcemap', () => {
+    const mappedStackText = 'mapped stacktrace';
+    beforeEach(async () => {
+      const mapStackTrace = (_stack, callback, _options) => {
+        callback([mappedStackText]);
+      };
+
+      await mountWithContext(
+        <ProductionError
+          error="Some error"
+          resetButtonLabel="Go back"
+          stackTrace="component stack"
+          subTitle="Please go back"
+          title="Some error occurred"
+          mapStackTrace={mapStackTrace}
+        />
+      );
+
+      await converge(() => Bigtest.Button(including('details')).exists());
+      await productionError.clickDetailsButton();
+    });
+
+    const mappedStack = ErrorMessageInteractor(including(mappedStackText));
+
+    it('Renders the mapped stacktrace inside the modal', () => converge(() => mappedStack.exists()));
+  });
+
+  describe('Production error without a sourcemap', () => {
+    const stackTrace = 'raw stacktrace';
+    beforeEach(async () => {
+      const mapStackTrace = (_stack, callback, _options) => {
+        callback([]);
+      };
+
+      await mountWithContext(
+        <ProductionError
+          error="Some error"
+          resetButtonLabel="Go back"
+          stackTrace={stackTrace}
+          subTitle="Please go back"
+          title="Some error occurred"
+          mapStackTrace={mapStackTrace}
+        />
+      );
+
+      await converge(() => Bigtest.Button(including('details')).exists());
+      await productionError.clickDetailsButton();
+    });
+
+    const rawStack = ErrorMessageInteractor(including(stackTrace));
+
+    it('Renders the original stacktrace inside the modal', () => converge(() => rawStack.exists()));
   });
 });

--- a/lib/ErrorBoundary/tests/ErrorBoundary-test.js
+++ b/lib/ErrorBoundary/tests/ErrorBoundary-test.js
@@ -154,9 +154,7 @@ describe('ErrorBoundary', () => {
       await productionError.clickDetailsButton();
     });
 
-    const mappedStack = ErrorMessageInteractor(including(mappedStackText));
-
-    it('Renders the mapped stacktrace inside the modal', () => converge(() => mappedStack.exists()));
+    it('Renders the mapped stacktrace inside the modal', () => errorMessage.has({ stackTrace: mappedStackText }));
   });
 
   describe('Production error without a sourcemap', () => {
@@ -181,8 +179,6 @@ describe('ErrorBoundary', () => {
       await productionError.clickDetailsButton();
     });
 
-    const rawStack = ErrorMessageInteractor(including(stackTrace));
-
-    it('Renders the original stacktrace inside the modal', () => converge(() => rawStack.exists()));
+    it('Renders the original stacktrace inside the modal', () => errorMessage.has({ stackTrace }));
   });
 });

--- a/lib/ErrorBoundary/tests/ErrorBoundary-test.js
+++ b/lib/ErrorBoundary/tests/ErrorBoundary-test.js
@@ -85,6 +85,8 @@ describe('ErrorBoundary', () => {
           title="Some error occurred"
         />
       );
+
+      await converge(() => Bigtest.Button(including('details')).exists());
     });
 
     it('Renders the title', () => ProductionErrorInteractor('Some error occurred').exists());

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "react-quill": "^2.0.0",
     "react-transition-group": "^4.4.5",
     "react-virtualized-auto-sizer": "^1.0.2",
+    "sourcemapped-stacktrace": "^1.1.11",
     "tai-password-strength": "^1.1.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15079,6 +15079,11 @@ source-map-support@^0.5.16, source-map-support@^0.5.21, source-map-support@~0.5.
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
+source-map@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+  integrity sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==
+
 source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
@@ -15088,6 +15093,13 @@ source-map@^0.7.3, source-map@^0.7.4:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
   integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
+
+sourcemapped-stacktrace@^1.1.11:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/sourcemapped-stacktrace/-/sourcemapped-stacktrace-1.1.11.tgz#e2dede7fc148599c52a4f883276e527f8452657d"
+  integrity sha512-O0pcWjJqzQFVsisPlPXuNawJHHg9N9UgpJ/aDmvi9+vnS3x1C0NhwkVFzzZ1VN0Xo+bekyweoqYvBw5ZBKiNnQ==
+  dependencies:
+    source-map "0.5.6"
 
 space-separated-tokens@^1.0.0:
   version "1.1.5"
@@ -15265,7 +15277,16 @@ string-argv@0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -15357,7 +15378,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15370,6 +15391,13 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -16810,7 +16838,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -16823,6 +16851,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Summary

If a sourcemap can be loaded and parsed, show the mapped stacktrace instead of the original (pretty much useless) stacktrace. 

## Details

* March 2021: We merged #1512 even though the reporting wasn't great 😑 
* ... ~200 "Something went wrong" tickets are filed 😱 
* October 2024: Ugh, STCOM-1355, we should purge the useless reporting 😢 
* ... ~70 more "Something went wrong" tickets are filed 🙀 
* September 2025, [WOLFCon's "How do we figure out what the problem is?"](https://wolfcon2025.sched.com/event/25ldl/how-do-we-figure-out-what-the-problem-is) reminds me how annoying it is that we couldn't do better, which led to more searching, which led to https://github.com/novocaine/sourcemapped-stacktrace, which has been around since 2018 so I don't know why we didn't find it earlier, but we didn't, and then we did, and here we are. So even though STCOM-814 was closed as "Won't do" years ago, sometimes ya just gotta [do it anyway](https://www.youtube.com/watch?v=mEyrfFwf3rI) 🔥 .

### Before

<img width="745" height="517" alt="Screenshot 2025-09-23 at 9 52 28 AM" src="https://github.com/user-attachments/assets/6410655e-c905-45f9-85e9-e8e842a181f8" />

### After

<img width="736" height="499" alt="Screenshot 2025-09-23 at 9 51 40 AM" src="https://github.com/user-attachments/assets/ea19a319-5f04-41a6-962d-bfd3623a5d7b" />

Refs [STCOM-814](https://folio-org.atlassian.net/browse/STCOM-814), [STCOM-1355](https://folio-org.atlassian.net/browse/STCOM-1355)