### PR TITLE
STCOM-1460 s/rehooks-ts/usehooks-ts/g

### DIFF
--- a/lib/ConfirmationModal/SessionConfirmationModal.js
+++ b/lib/ConfirmationModal/SessionConfirmationModal.js
@@ -1,7 +1,7 @@
 import { useCallback, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import uniqueId from 'lodash/uniqueId';
-import { useSessionStorage } from 'rehooks-ts'
+import { useSessionStorage } from 'usehooks-ts'
 import { useIntl } from 'react-intl';
 import ConfirmationModal, { ConfirmationModalPropTypes } from './ConfirmationModal';
 import Checkbox from '../Checkbox';

--- a/lib/ConfirmationModal/stories/ConfirmationModalExample.js
+++ b/lib/ConfirmationModal/stories/ConfirmationModalExample.js
@@ -4,7 +4,7 @@
 
 import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';
-import { useSessionStorage } from 'rehooks-ts'
+import { useSessionStorage } from 'usehooks-ts'
 import { ConfirmationModal, SessionConfirmationModal } from '..';
 import Button from '../../Button';
 import Checkbox

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "react-quill": "^2.0.0",
     "react-transition-group": "^4.4.5",
     "react-virtualized-auto-sizer": "^1.0.2",
-    "rehooks-ts": "^2.5.0",
+    "usehooks-ts": "^3.1.1",
     "tai-password-strength": "^1.1.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14139,7 +14139,7 @@ react-virtualized-auto-sizer@^1.0.2:
   resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.25.tgz#b13cbc528ac200be2bd1ffa40c8bb19bcc60ac3f"
   integrity sha512-YHsksEGDfsHbHuaBVDYwJmcktblcHGafz4ZVuYPQYuSHMUGjpwmUCrAOcvMSGMwwk1eFWj1M/1GwYpNPuyhaBg==
 
-react@^18.2, react@^18.3.1:
+react@^18.2:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
   integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
@@ -14337,13 +14337,6 @@ regjsparser@^0.12.0:
   integrity sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==
   dependencies:
     jsesc "~3.0.2"
-
-rehooks-ts@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/rehooks-ts/-/rehooks-ts-2.5.0.tgz#2582293d605d3d68102b000c0d6f626c1b954025"
-  integrity sha512-ircmAvW2XNAvLlFEURZAIk3wH3JrvTk+lDY3TJo9Tjw56YOdVSu5URd4WBXDtGok3+TS2/PWIa4t9y3GYfEKcQ==
-  dependencies:
-    react "^18.3.1"
 
 relateurl@^0.2.7:
   version "0.2.7"
@@ -16446,6 +16439,13 @@ use-sync-external-store@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz#adbc795d8eeb47029963016cefdf89dc799fcebc"
   integrity sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==
+
+usehooks-ts@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/usehooks-ts/-/usehooks-ts-3.1.1.tgz#0bb7f38f36f8219ee4509cc5e944ae610fb97656"
+  integrity sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA==
+  dependencies:
+    lodash.debounce "^4.0.8"
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
If we're lucky, updates #2495; replaces #2497

`rehooks-ts` blows up in CI in other repos when their tests that leverage stripes-components claim not to be able to find `rehooks-ts`. Maybe this is a jest hiccup tripped by the fact that `rehooks-ts` claims to export `dist/index.cjs`, a file that does not exist. So that's ... odd.

`usehooks-ts` appears to offer a hook that offers the same API. So that's ... convenient!

~@JohnC-80, I was hoping for a silver bullet here but, alas, didn't find one. With stripes-components pinned to this branch in other repos, I still see test failures, but not so many and none that relate to being unable to find the import. I don't know if that's better or worse :/~

Refs STCOM-1460