### PR TITLE
STCOM-1460 fix export of confirmation modal

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,10 @@ export { default as ErrorBoundary } from './lib/ErrorBoundary';
 
 
 /* structures */
-export { default as ConfirmationModal } from './lib/ConfirmationModal';
+export {
+  ConfirmationModal,
+  SessionConfirmationModal,
+} from './lib/ConfirmationModal';
 export { default as ErrorModal } from './lib/ErrorModal';
 export { default as InfoPopover } from './lib/InfoPopover';
 export { default as SearchField } from './lib/SearchField';


### PR DESCRIPTION
## Description
In https://github.com/folio-org/stripes-components/pull/2495 some exports have changed - `<ConfirmationModal>` used to be a default export, but became named
But the root index.js still referenced it as a default export, which caused build issues

## Issues
[STCOM-1460](https://folio-org.atlassian.net/browse/STCOM-1460)