### PR TITLE
prop-type of searchableIndexes[] changed to to node

### DIFF
--- a/lib/SearchField/SearchField.js
+++ b/lib/SearchField/SearchField.js
@@ -60,7 +60,7 @@ const propTypes = {
   searchableIndexes: PropTypes.arrayOf(PropTypes.shape({
     disabled: PropTypes.bool,
     id: PropTypes.string,
-    label: PropTypes.string,
+    label: PropTypes.any,
     placeholder: PropTypes.string,
     value: PropTypes.string,
   })),

--- a/lib/SearchField/SearchField.js
+++ b/lib/SearchField/SearchField.js
@@ -60,7 +60,7 @@ const propTypes = {
   searchableIndexes: PropTypes.arrayOf(PropTypes.shape({
     disabled: PropTypes.bool,
     id: PropTypes.string,
-    label: PropTypes.any,
+    label: PropTypes.node,
     placeholder: PropTypes.string,
     value: PropTypes.string,
   })),


### PR DESCRIPTION
When this is provided as `<FormattedMessage>`, a prop-types warning is emitted on the console even though this works just fine. We should get rid of the false-positive complaint.