### PR TITLE
STCOM-1489 Adding `dompurify` dependency, wrapping Editor with it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Fix: Prevent onClearField from being spread onto native textarea element. Refs STCOM-1486.
 * Allow `<Pane>` to receive focus when its children are non-interactive. Refs STCOM-1488.
 * Move `InteractionStyles`' CSS variables to top level `variables.css` to avoid duplication in the bundle. Refs STCOM-1490.
+* Wrap `<Editor>`'s internals in an HTML sanitizer. Refs STCOM-1489.
 
 ## [13.0.0](https://github.com/folio-org/stripes-components/tree/v13.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.2.0...v13.0.0)

--- a/lib/Editor/Editor.js
+++ b/lib/Editor/Editor.js
@@ -28,13 +28,15 @@ const defaultSanitizeConfig = {
 };
 
 const sanitize = (value, config = defaultSanitizeConfig) => {
-  // Preserve original HTML when DOMPurify reports no actual removals.
   let resultValue = DOMPurify.sanitize(value, config);
 
   if (value !== resultValue) {
-    const removed = DOMPurify.removed.map((item) => item.attribute?.name || item.element?.outerHTML);
+    const removed = DOMPurify.removed.map((item) => item.attribute?.name || item.element?.outerHTML) || [];
 
-    if (removed && removed.length === 0) {
+    // Preserve original HTML when DOMPurify reports no actual removals.
+    // This addresses cases where DOMPurify may have reversed the order of attributes.
+    // If the editor picks up a change in its value, it will shift the cursor to the beginning of the text.
+    if (removed.length === 0) {
       resultValue = value;
     }
   }

--- a/lib/Editor/Editor.js
+++ b/lib/Editor/Editor.js
@@ -31,12 +31,10 @@ const sanitize = (value, config = baseSanitizeConfig) => {
   let resultValue = DOMPurify.sanitize(value, config);
 
   if (value !== resultValue) {
-    const removed = DOMPurify.removed.filter((item) => item.attribute?.name || item.element?.outerHTML);
-
     // Preserve original HTML when DOMPurify reports no actual removals.
     // This addresses cases where DOMPurify may have reversed the order of attributes.
     // If the editor picks up a change in its value, it will shift the cursor to the beginning of the text.
-    if (removed.length === 0) {
+    if (DOMPurify.removed.length === 0) {
       resultValue = value;
     }
   }

--- a/lib/Editor/Editor.js
+++ b/lib/Editor/Editor.js
@@ -23,15 +23,15 @@ const defaultModulesConfig = {
 
 // this default config allows <a> tags with target and rel attributes,
 // which the editor itself generates.
-const defaultSanitizeConfig = {
+const baseSanitizeConfig = {
   ADD_ATTR: ['target', 'rel'],
 };
 
-const sanitize = (value, config = defaultSanitizeConfig) => {
+const sanitize = (value, config = baseSanitizeConfig) => {
   let resultValue = DOMPurify.sanitize(value, config);
 
   if (value !== resultValue) {
-    const removed = DOMPurify.removed.map((item) => item.attribute?.name || item.element?.outerHTML) || [];
+    const removed = DOMPurify.removed.filter((item) => item.attribute?.name || item.element?.outerHTML);
 
     // Preserve original HTML when DOMPurify reports no actual removals.
     // This addresses cases where DOMPurify may have reversed the order of attributes.
@@ -127,14 +127,14 @@ class Editor extends Component {
 
   getSanitizeConfig() {
     const { sanitizeConfig } = this.props;
-    const customAttrs = sanitizeConfig && Array.isArray(sanitizeConfig.ADD_ATTR)
+    const customAttrs = sanitizeConfig && Array.isArray(sanitizeConfig?.ADD_ATTR)
       ? sanitizeConfig.ADD_ATTR
       : [];
 
     return {
-      ...defaultSanitizeConfig,
+      ...baseSanitizeConfig,
       ...sanitizeConfig,
-      ADD_ATTR: [...new Set([...defaultSanitizeConfig.ADD_ATTR, ...customAttrs])],
+      ADD_ATTR: [...new Set([...baseSanitizeConfig.ADD_ATTR, ...customAttrs])],
     };
   }
 

--- a/lib/Editor/Editor.js
+++ b/lib/Editor/Editor.js
@@ -21,6 +21,8 @@ const defaultModulesConfig = {
   },
 };
 
+// this default config allows <a> tags with target and rel attributes,
+// which the editor itself generates.
 const defaultSanitizeConfig = {
   ADD_ATTR: ['target', 'rel'],
 };
@@ -134,6 +136,7 @@ class Editor extends Component {
     };
   }
 
+  // carry through all of the params that the basic onChange handler of React-quill receives.
   onChange = (value, delta, source, editor) => {
     const { onChange } = this.props;
     const sanitizeConfig = this.getSanitizeConfig();

--- a/lib/Editor/Editor.js
+++ b/lib/Editor/Editor.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import className from 'classnames';
 import ReactQuill from 'react-quill';
+import DOMPurify from 'dompurify';
 import merge from 'lodash/merge';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import '!style-loader!css-loader!react-quill/dist/quill.snow.css';
@@ -18,6 +19,25 @@ const defaultModulesConfig = {
   clipboard: {
     matchVisual: false,
   },
+};
+
+const defaultSanitizeConfig = {
+  ADD_ATTR: ['target', 'rel'],
+};
+
+const sanitize = (value, config = defaultSanitizeConfig) => {
+  // Preserve original HTML when DOMPurify reports no actual removals.
+  let resultValue = DOMPurify.sanitize(value, config);
+
+  if (value !== resultValue) {
+    const removed = DOMPurify.removed.map((item) => item.attribute?.name || item.element?.outerHTML);
+
+    if (removed && removed.length === 0) {
+      resultValue = value;
+    }
+  }
+
+  return resultValue;
 };
 
 class Editor extends Component {
@@ -46,6 +66,7 @@ class Editor extends Component {
     preserveWhitespace: PropTypes.bool,
     readOnly: PropTypes.bool,
     required: PropTypes.bool,
+    sanitizeConfig: PropTypes.object,
     style: PropTypes.object,
     tabIndex: PropTypes.number,
     valid: PropTypes.bool,
@@ -62,6 +83,7 @@ class Editor extends Component {
     readOnly: false,
     disableEditorTab: true,
     modules: {},
+    sanitizeConfig: {},
   };
 
   constructor(props) {
@@ -99,6 +121,28 @@ class Editor extends Component {
     );
   }
 
+  getSanitizeConfig() {
+    const { sanitizeConfig } = this.props;
+    const customAttrs = sanitizeConfig && Array.isArray(sanitizeConfig.ADD_ATTR)
+      ? sanitizeConfig.ADD_ATTR
+      : [];
+
+    return {
+      ...defaultSanitizeConfig,
+      ...sanitizeConfig,
+      ADD_ATTR: [...new Set([...defaultSanitizeConfig.ADD_ATTR, ...customAttrs])],
+    };
+  }
+
+  onChange = (value, delta, source, editor) => {
+    const { onChange } = this.props;
+    const sanitizeConfig = this.getSanitizeConfig();
+
+    if (onChange) {
+      onChange(sanitize(value, sanitizeConfig), delta, source, editor);
+    }
+  };
+
   render() {
     const {
       error,
@@ -110,6 +154,12 @@ class Editor extends Component {
       formats,
       ...restProps
     } = this.props;
+    const sanitizeConfig = this.getSanitizeConfig();
+
+    const inputValue = typeof restProps.value === 'string' ? sanitize(restProps.value, sanitizeConfig) : restProps.value;
+    const inputDefaultValue = typeof restProps.defaultValue === 'string'
+      ? sanitize(restProps.defaultValue, sanitizeConfig)
+      : restProps.defaultValue;
 
     const component = (
       <ReactQuill
@@ -118,11 +168,18 @@ class Editor extends Component {
         formats={formats}
         ref={editorRef}
         readOnly={readOnly}
+        value={inputValue}
+        defaultValue={inputDefaultValue}
+        onChange={this.onChange}
         theme="snow"
         {...omitProps(restProps, [
           'validationEnabled',
           'validStylesEnabled',
           'modules',
+          'onChange',
+          'defaultValue',
+          'sanitizeConfig',
+          'value',
         ])}
       />
     );

--- a/lib/Editor/readme.md
+++ b/lib/Editor/readme.md
@@ -34,6 +34,7 @@ Name | type | description | default | required
 `placeholder` | string | The default value for the empty editor. | |
 `modules` | object | An object specifying which modules are enabled, and their configuration. The editor toolbar is a commonly customized module. See the http://quilljs.com/docs/modules/ | |
 `formats` | array | An array of formats to be enabled during editing. All implemented formats are enabled by default. See http://quilljs.com/docs/formats/ for a list of availible formats. | |
+`sanitizeConfig` | object | Optional DOMPurify configuration used when sanitizing incoming `value`/`defaultValue` and outgoing `onChange` HTML. Merged with default `ADD_ATTR: ['target', 'rel']`. | |
 `inputRef` | object or func | Supplies a ref to the rendered `<Editor>` | |
 `tabIndex` | number | The order in which the editor becomes focused, among other controls in the page, during keyboard navigation. | |
 `disableEditorTab` | bool | Disable editor tab handling to improve accessibility. | true |
@@ -46,12 +47,35 @@ Name | type | description | default | required
 Name | type | description | default | required
 --- | --- | --- | --- | ---
 `onBlur` | func | Called when the editor loses focus. It will receive the selection range it had right before losing focus. | |
-`onChange` | func | Called back with the new contents of the editor after change. | |
+`onChange` | func | Called back with sanitized HTML contents of the editor after change. | |
 `onChangeSelection` | func |  Called back with the new selected range, or null when unfocused.  | |
 `onFocus` | func | Called when the editor becomes focused. It will receive the new selection range | |
 `onKeyPress` | func | Called after a key has been pressed and released. | |
 `onKeyDown` | func | Called after a key has been pressed, but before it is released. | |
 `onKeyUp` | func | Called after a key has been released. | |
+
+## Input/Output Sanitization
+The editor sanitizes HTML with `dompurify` in both directions:
+
+- Incoming values: `value` and `defaultValue` are sanitized before being passed to the internal ReactQuill component.
+- Outgoing values: the first argument passed to `onChange` is sanitized HTML.
+
+By default, anchor attributes `target` and `rel` are allowed to support links such as:
+
+```
+<a href="https://example.com" target="_blank" rel="noopener noreferrer">Example</a>
+```
+
+You can provide additional DOMPurify options with `sanitizeConfig`:
+
+```
+<Editor
+  sanitizeConfig={{
+    ADD_TAGS: ['custom-tag'],
+    ADD_ATTR: ['data-test-id'],
+  }}
+/>
+```
 
 ## Validation Props
 Name | type | description | default | required

--- a/lib/Editor/stories/BasicUsage.js
+++ b/lib/Editor/stories/BasicUsage.js
@@ -1,45 +1,51 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Editor from '../Editor';
 import modules from './EditorModules';
 import formats from './EditorFormats';
 
 
-const BasicUsage = () => (
-  <div>
-    <Editor
-      label="field with custom toolbar"
-      placeholder="Placeholder Text"
-      modules={modules}
-      formats={formats}
-    />
-    <Editor
-      value="This field is read only"
-      label="Read only field"
-      readOnly
-    />
-    <Editor
-      value="This field is required"
-      label="Required field"
-      required
-    />
-    <Editor
-      validStylesEnabled
-      valid
-      dirty
-      label="Field with validation success"
-    />
-    <Editor
-      value="Wrong value.."
-      error="Here is an error message"
-      label="Field with a validation error"
-    />
-    <Editor
-      value="Not entirely valid value.."
-      warning="Here is a warning"
-      dirty
-      label="Field with validation warning"
-    />
-  </div>
-);
+const BasicUsage = () => {
+  const [editorValue, setEditorValue] = useState('');
+
+  return (
+    <div>
+      <Editor
+        label="field with custom toolbar"
+        placeholder="Placeholder Text"
+        modules={modules}
+        formats={formats}
+        value={editorValue}
+        onChange={setEditorValue}
+      />
+      <Editor
+        value="This field is read only"
+        label="Read only field"
+        readOnly
+      />
+      <Editor
+        value="This field is required"
+        label="Required field"
+        required
+      />
+      <Editor
+        validStylesEnabled
+        valid
+        dirty
+        label="Field with validation success"
+      />
+      <Editor
+        value="Wrong value.."
+        error="Here is an error message"
+        label="Field with a validation error"
+      />
+      <Editor
+        value="Not entirely valid value.."
+        warning="Here is a warning"
+        dirty
+        label="Field with validation warning"
+      />
+    </div>
+  );
+};
 
 export default BasicUsage;

--- a/lib/Editor/tests/Editor.js
+++ b/lib/Editor/tests/Editor.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import { describe, beforeEach, it } from 'mocha';
+import sinon from 'sinon';
 
-import { runAxeTest, Bigtest, including } from '@folio/stripes-testing';
+import { runAxeTest, Bigtest, including, converge } from '@folio/stripes-testing';
 import { mount } from '../../../tests/helpers';
 import Editor from '../Editor';
 
@@ -81,5 +82,105 @@ describe('Editor', () => {
     });
 
     it('renders an error element', () => editor.has({ error: 'This is an error.' }));
+  });
+
+  describe('sanitization', () => {
+    describe('sanitizing input values', () => {
+      let editorRef;
+
+      beforeEach(async () => {
+        editorRef = React.createRef();
+
+        await mount(
+          <Editor
+            editorRef={editorRef}
+            value={'<p>text</p><img src=x onerror=alert(1) />'}
+            defaultValue={'<p>default</p><img src=y onerror=alert(2) />'}
+          />
+        );
+
+        await converge(() => {
+          if (!editorRef.current) throw new Error('Expected editorRef to be available');
+        });
+      });
+
+      it('sanitizes value before passing to ReactQuill', async () => {
+        await converge(() => {
+          if (editorRef.current.props.value.includes('onerror')) {
+            throw new Error('Expected value to be sanitized');
+          }
+        });
+      });
+
+      it('sanitizes defaultValue before passing to ReactQuill', async () => {
+        await converge(() => {
+          if (editorRef.current.props.defaultValue.includes('onerror')) {
+            throw new Error('Expected defaultValue to be sanitized');
+          }
+        });
+      });
+
+      it('allows anchor target and rel attributes by default', async () => {
+        const anchorRef = React.createRef();
+
+        await mount(
+          <Editor
+            editorRef={anchorRef}
+            value={'<p><a href="https://example.com" target="_blank" rel="noopener noreferrer">link</a></p>'}
+          />
+        );
+
+        await converge(() => {
+          if (!anchorRef.current) {
+            throw new Error('Expected editorRef to be available');
+          }
+
+          if (!anchorRef.current.props.value.includes('target="_blank"')) {
+            throw new Error('Expected target attribute to be preserved');
+          }
+
+          if (!anchorRef.current.props.value.includes('rel="noopener noreferrer"')) {
+            throw new Error('Expected rel attribute to be preserved');
+          }
+        });
+      });
+    });
+
+    describe('sanitizing output values', () => {
+      let editorRef;
+      let onChange;
+
+      beforeEach(async () => {
+        editorRef = React.createRef();
+        onChange = sinon.spy();
+
+        await mount(
+          <Editor
+            editorRef={editorRef}
+            onChange={onChange}
+          />
+        );
+
+        await converge(() => {
+          if (!editorRef.current) throw new Error('Expected editorRef to be available');
+        });
+      });
+
+      it('sanitizes changed html before calling onChange', async () => {
+        const dirtyValue = '<p>updated</p><img src=z onerror=alert(3) />';
+
+        editorRef.current.props.onChange(dirtyValue);
+
+        await converge(() => {
+          if (!onChange.calledOnce) {
+            throw new Error('Expected onChange to be called once');
+          }
+
+          if (onChange.firstCall.args[0].includes('onerror')) {
+            throw new Error('Expected changed value to be sanitized');
+          }
+        });
+      });
+    });
   });
 });

--- a/lib/Editor/tests/Editor.js
+++ b/lib/Editor/tests/Editor.js
@@ -18,6 +18,14 @@ const EditorInteractor = Bigtest.HTML.extend('Editor')
 
 describe('Editor', () => {
   const editor = EditorInteractor();
+  const builtInMarkupSamples = [
+    '<p><strong>bold</strong> <em>italic</em> <u>underline</u> <s>strike</s></p>',
+    '<blockquote>quoted text</blockquote>',
+    '<h1>Heading One</h1><h2>Heading Two</h2><p>body text</p>',
+    '<ol><li>ordered item</li><li class="ql-indent-1">indented ordered item</li></ol>',
+    '<ul><li>bulleted item</li><li class="ql-indent-2">indented bulleted item</li></ul>',
+    '<p><a href="https://example.com" target="_blank" rel="noopener noreferrer">link text</a></p>',
+  ];
 
   describe('rendering a basic Editor', async () => {
     beforeEach(async () => {
@@ -85,6 +93,70 @@ describe('Editor', () => {
   });
 
   describe('sanitization', () => {
+    describe('preserving default editor markup', () => {
+      it('does not alter built-in markup in value/defaultValue', async () => {
+        for (const sample of builtInMarkupSamples) {
+          const editorRef = React.createRef();
+
+          await mount(
+            <Editor
+              editorRef={editorRef}
+              value={sample}
+              defaultValue={sample}
+            />
+          );
+
+          await converge(() => {
+            if (!editorRef.current) {
+              throw new Error('Expected editorRef to be available');
+            }
+
+            if (editorRef.current.props.value !== sample) {
+              throw new Error(`Expected value markup to be unchanged: ${sample}`);
+            }
+
+            if (editorRef.current.props.defaultValue !== sample) {
+              throw new Error(`Expected defaultValue markup to be unchanged: ${sample}`);
+            }
+          });
+        }
+      });
+
+      it('does not alter built-in markup in onChange', async () => {
+        const editorRef = React.createRef();
+        const onChange = sinon.spy();
+
+        await mount(
+          <Editor
+            editorRef={editorRef}
+            onChange={onChange}
+          />
+        );
+
+        await converge(() => {
+          if (!editorRef.current) {
+            throw new Error('Expected editorRef to be available');
+          }
+        });
+
+        for (const sample of builtInMarkupSamples) {
+          onChange.resetHistory();
+
+          editorRef.current.props.onChange(sample);
+
+          await converge(() => {
+            if (!onChange.calledOnce) {
+              throw new Error('Expected onChange to be called once');
+            }
+
+            if (onChange.firstCall.args[0] !== sample) {
+              throw new Error(`Expected changed markup to be unchanged: ${sample}`);
+            }
+          });
+        }
+      });
+    });
+
     describe('sanitizing input values', () => {
       let editorRef;
 

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "classnames": "^2.2.5",
     "currency-codes": "2.1.0",
     "dayjs": "^1.11.10",
-    "dompurify": "^3.1.3",
+    "dompurify": "^3.3.3",
     "downshift": "9.0.13",
     "flexboxgrid2": "^7.2.0",
     "focus-trap": "^7.5.4",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "classnames": "^2.2.5",
     "currency-codes": "2.1.0",
     "dayjs": "^1.11.10",
+    "dompurify": "^3.1.3",
     "downshift": "9.0.13",
     "flexboxgrid2": "^7.2.0",
     "focus-trap": "^7.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7687,7 +7687,7 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@^3.1.3:
+dompurify@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.3.tgz#680cae8af3e61320ddf3666a3bc843f7b291b2b6"
   integrity sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4628,6 +4628,11 @@
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.10.tgz#277a542aff6776d8a9b15f2ac682a663e3e94bbd"
   integrity sha512-TC0dmN0K8YcWEAEfiPi5gJP14eJe30TTGjkvek3iM/1NdHHsdCA/Td6GvNndMOo/iSnIsZ4HuuhrYPDAmbxzww==
 
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
 "@types/unist@^2", "@types/unist@^2.0.0":
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.11.tgz#11af57b127e32487774841f7a4e54eab166d03c4"
@@ -7681,6 +7686,13 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
   dependencies:
     domelementtype "^2.3.0"
+
+dompurify@^3.1.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.3.tgz#680cae8af3e61320ddf3666a3bc843f7b291b2b6"
+  integrity sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 domutils@^2.5.2, domutils@^2.8.0:
   version "2.8.0"


### PR DESCRIPTION
## [STCOM-1489](https://folio-org.atlassian.net/browse/STCOM-1489)

Short of actually picking/implementing a new WYSIWYG editor, our security fallback would be to sanitize whatever content goes in and comes out of it and not EVEN to trust a thing that holds the sole purpose of editing some mark-up under the guise of a mini word-processor in a browser.

All editor functionality is retained, with links behaving as they should with the default `santizeConfig`. In case other `formats` are added, sanitization can be adjusted - although we see very little actual use of this component.

Tests added.