### PR TITLE
STCOM-1481 - Add ability to keep disabled buttons focusable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Provide `isLoading` prop for `<MetaSection>` components to reflect loading status. Refs STCOM-1467.
 * Expose the `dedupe` property for `<Callout>` to prevent duplicate callouts with the same message and type from being displayed. Refs STCOM-1469.
 * `<MultiSelection>` - add a new `filterProps` prop to control option filtering. Refs STCOM-1473.
+* Add focusable styles for disabled buttons via `aria-disabled` or 'disabled' className. Refs STCOM-1481.
 
 ## [13.0.0](https://github.com/folio-org/stripes-components/tree/v13.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.2.0...v13.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,16 +30,12 @@
 * Provide `isLoading` prop for `<MetaSection>` components to reflect loading status. Refs STCOM-1467.
 * Expose the `dedupe` property for `<Callout>` to prevent duplicate callouts with the same message and type from being displayed. Refs STCOM-1469.
 * `<MultiSelection>` - add a new `filterProps` prop to control option filtering. Refs STCOM-1473.
-<<<<<<< HEAD
 * `downshift` version locked to `v19.0.13` after `v19.2.0` release. Refs STCOM-1483.
 * Dependency correction: `react-intl` bumped to v7 in STCOM-1046, but we forgot to bump the peer. Refs STCOM-1485.
 * Fix: Prevent onClearField from being spread onto native textarea element. Refs STCOM-1486.
 * Allow `<Pane>` to receive focus when its children are non-interactive. Refs STCOM-1488.
 * Move `InteractionStyles`' CSS variables to top level `variables.css` to avoid duplication in the bundle. Refs STCOM-1490.
 * Add `aria-disabled` styling to `<Button>` - this provides a way to make 'disabled' buttons appear disabled while still being focusable/announced to screenreader users. Refs STCOM-1481.
-=======
-* Add focusable styles for disabled buttons via `aria-disabled` or 'disabled' className. Refs STCOM-1481.
->>>>>>> a5bca1db14987ff5461ef1c507543bfe90b3b418
 
 ## [13.0.0](https://github.com/folio-org/stripes-components/tree/v13.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.2.0...v13.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Fix: Prevent onClearField from being spread onto native textarea element. Refs STCOM-1486.
 * Allow `<Pane>` to receive focus when its children are non-interactive. Refs STCOM-1488.
 * Move `InteractionStyles`' CSS variables to top level `variables.css` to avoid duplication in the bundle. Refs STCOM-1490.
+* Add `aria-disabled` styling to `<Button>` - this provides a way to make 'disabled' buttons appear disabled while still being focusable/announced to screenreader users. Refs STCOM-1481.
 
 ## [13.0.0](https://github.com/folio-org/stripes-components/tree/v13.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.2.0...v13.0.0)

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -233,7 +233,7 @@
     padding-right: 0;
   }
 
-  &[disabled] {
+  &[disabled], &[aria-disabled="true"], &.disabled {
     background-color: #ccc;
     border-color: #ccc;
     color: var(--color-text);

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -239,7 +239,6 @@
     color: var(--color-text);
     transition: opacity ease-in-out 500ms;
     pointer-events: none;
-    opacity: 0.65;
   }
 
   &.mega {

--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -233,12 +233,13 @@
     padding-right: 0;
   }
 
-  &[disabled] {
+  &[disabled], &[aria-disabled="true"] {
     background-color: #ccc;
     border-color: #ccc;
     color: var(--color-text);
     transition: opacity ease-in-out 500ms;
     pointer-events: none;
+    opacity: 0.65;
   }
 
   &.mega {

--- a/lib/Button/readme.md
+++ b/lib/Button/readme.md
@@ -74,9 +74,25 @@ The `link` buttonStyle is useful for adding link buttons inside the text.
 </Button>
 ```
 
-### disabled, but focusable
+### `aria-disabled` disabled, but focusable
 
 Disabling a button takes it out of the accessibility tree, making the element non-focusable. For assistive technology, this is as if the button were removed entirely. 95% of the time, this happens in a situation
 when another reasonable focus-target is within proximity where focus can effectively be moved to. With the
 other 5% of cases, there's no focusable element in reasonable range. This is where using `aria-disabled=true` is
 useful, so that focus *can remain on the button itself without moving it far away from a reasonable focus order.
+
+Since the button is not formally `disabled`, it can still be triggered with a keypress. That said, click handlers will need to include
+a defensive conditional to check the `aria-disabled` attribute before executing the rest of the function, like the following example:
+
+```
+const handleClick = (event) => {
+  // Check if aria-disabled is explicitly set to "true"
+  if (event.currentTarget.getAttribute('aria-disabled') === 'true') {
+    event.preventDefault(); // Stop default browser actions
+    return;                 // Exit early to prevent custom logic execution
+  }
+
+  // Your custom click logic here...
+  console.log("Action performed!");
+};
+```

--- a/lib/Button/readme.md
+++ b/lib/Button/readme.md
@@ -33,6 +33,7 @@ role | string | Adds [role-attribute](https://www.w3.org/wiki/PF/XTech/HTML5/Rol
 children | node / array of nodes | Adds child node(s) to button |
 buttonRef | string | Adds ref-attribute |
 autoFocus | bool | If this prop is `true`, component will automatically focus on mount | |
+aria-disabled | bool | Renders button with disabled styles, button remains focusable.
 
 ## Styles
 
@@ -69,6 +70,13 @@ The `link` buttonStyle is useful for adding link buttons inside the text.
 
 ```
 <Button buttonStyle="link">
-     I'm a link button 
+     I'm a link button
 </Button>
 ```
+
+### disabled, but focusable
+
+Disabling a button takes it out of the accessibility tree, making the element non-focusable. For assistive technology, this is as if the button were removed entirely. 95% of the time, this happens in a situation
+when another reasonable focus-target is within proximity where focus can effectively be moved to. With the
+other 5% of cases, there's no focusable element in reasonable range. This is where using `aria-disabled=true` is
+useful, so that focus *can remain on the button itself without moving it far away from a reasonable focus order.

--- a/lib/Button/stories/general.js
+++ b/lib/Button/stories/general.js
@@ -9,5 +9,6 @@ export default () => (
     <Button buttonStyle="success">Success</Button>
     <Button buttonStyle="warning">Warning</Button>
     <Button disabled>Disabled</Button>
+    <Button aria-disabled="true">Disabled</Button>
   </div>
 );

--- a/lib/Button/stories/general.js
+++ b/lib/Button/stories/general.js
@@ -9,10 +9,6 @@ export default () => (
     <Button buttonStyle="success">Success</Button>
     <Button buttonStyle="warning">Warning</Button>
     <Button disabled>Disabled</Button>
-<<<<<<< HEAD
     <Button aria-disabled="true">Aria-Disabled (focusable)</Button>
-=======
-    <Button aria-disabled="true">Disabled</Button>
->>>>>>> a5bca1db14987ff5461ef1c507543bfe90b3b418
   </div>
 );

--- a/lib/Button/stories/general.js
+++ b/lib/Button/stories/general.js
@@ -9,5 +9,6 @@ export default () => (
     <Button buttonStyle="success">Success</Button>
     <Button buttonStyle="warning">Warning</Button>
     <Button disabled>Disabled</Button>
+    <Button aria-disabled="true">Aria-Disabled (focusable)</Button>
   </div>
 );

--- a/lib/sharedStyles/interactionStyles.css
+++ b/lib/sharedStyles/interactionStyles.css
@@ -38,6 +38,16 @@
 }
 
 /**
+ * Disabled state for elements that should still be focusable.
+ */
+.interactionStyles[aria-disabled="true"],
+.interactionStyles.disabled {
+  opacity: 0.65;
+  cursor: default;
+}
+
+
+/**
  * Focus/active pseudo element
  */
 .interactionStyles::before {


### PR DESCRIPTION
## [STCOM-1481](https://folio-org.atlassian.net/browse/STCOM-1481)

From readme of this PR:
> Disabling a button takes it out of the accessibility tree, making the element non-focusable. For assistive technology, this is as if the button were removed entirely. 95% of the time, this happens in a situation
when another reasonable focus-target is within proximity where focus can effectively be moved to. With the
other 5% of cases, there's no focusable element in reasonable range. This is where using `aria-disabled=true` is
useful, so that focus *can remain on the button itself without moving it far away from a reasonable focus order.

>Since the button is not formally `disabled`, it can still be triggered with a keypress. That said, click handlers will need to include
a defensive conditional to check the `aria-disabled` attribute before executing the rest of the function, like the following example:

```
const handleClick = (event) => {
  // Check if aria-disabled is explicitly set to "true"
  if (event.currentTarget.getAttribute('aria-disabled') === 'true') {
    event.preventDefault(); // Stop default browser actions
    return;                 // Exit early to prevent custom logic execution
  }

  // Your custom click logic here...
  console.log("Action performed!");
};
```

<img width="838" height="106" alt="image" src="https://github.com/user-attachments/assets/68d4d08a-5c98-488c-bfa0-d39c02cb9d52" />
