### PR TITLE
Changed how resize handles are suppressed when a modal Layer is open

### DIFF
--- a/lib/Paneset/PaneResizeContainer.js
+++ b/lib/Paneset/PaneResizeContainer.js
@@ -15,6 +15,9 @@ const PaneResizeContainer = ({ isRoot, children, onElementResize, parentElement,
   const [activeHandle, setActiveHandle] = useState(null);
   const [update, setUpdate] = useState(0); // eslint-disable-line no-unused-vars
   const [blocking, setBlocking] = useState(null);
+  // count active layer-based suspensions so nested/overlapping layers
+  // do not accidentally re-enable handles too early.
+  const layerSuspendCount = useRef(0);
   let container = useRef();
   if (resizeContainerRef) {
     container = resizeContainerRef;
@@ -23,6 +26,7 @@ const PaneResizeContainer = ({ isRoot, children, onElementResize, parentElement,
   const containerRect = useRef();
   const activeRef = useRef();
   const observer = useRef();
+  const hasOpenLayer = useRef(false);
 
   const observerCallback = useRef(
     (mutationList) => {
@@ -72,6 +76,11 @@ const PaneResizeContainer = ({ isRoot, children, onElementResize, parentElement,
     setUpdate(u => u + 1);
   }, []);
 
+  const checkOpenLayers = useCallback(() => {
+    hasOpenLayer.current = Boolean(document.querySelector('[class*="LayerRoot"]'));
+    setUpdate(u => u + 1);
+  }, []);
+
   // set up the mutation observer for overlapping element once we get a usable parentElement prop.
   useEffect(() => {
     if (isRoot) {
@@ -88,6 +97,22 @@ const PaneResizeContainer = ({ isRoot, children, onElementResize, parentElement,
       if (observer.current) observer.current.disconnect();
     };
   }, [parentElement, isRoot, observerCallback]);
+
+  useEffect(() => {
+    if (isRoot) {
+      // track Layer mount/unmount globally and hide resize handles whenever
+      // a Layer is present to avoid visual bleed-through above modal content.
+      const globalObserver = new MutationObserver(checkOpenLayers);
+      globalObserver.observe(document.body, { childList: true, subtree: true });
+      checkOpenLayers();
+
+      return () => {
+        globalObserver.disconnect();
+      };
+    }
+
+    return undefined;
+  }, [checkOpenLayers, isRoot]);
 
   useEffect(() => {
     if (isRoot) {
@@ -222,11 +247,20 @@ const PaneResizeContainer = ({ isRoot, children, onElementResize, parentElement,
   };
 
   const suspend = () => {
-    setBlocking({ setByLayer: true });
+    layerSuspendCount.current += 1;
+    setBlocking(cur => cur || { setByLayer: true });
   };
 
   const resume = () => {
-    setBlocking(null);
+    layerSuspendCount.current = Math.max(layerSuspendCount.current - 1, 0);
+
+    setBlocking(cur => {
+      if (layerSuspendCount.current > 0) {
+        return cur || { setByLayer: true };
+      }
+
+      return cur?.setByLayer ? null : cur;
+    });
   };
 
   if (isRoot) {
@@ -239,7 +273,7 @@ const PaneResizeContainer = ({ isRoot, children, onElementResize, parentElement,
           ref={container}
           className={css.container}
         >
-          {!blocking && renderHandles()}
+          {!blocking && !hasOpenLayer.current && renderHandles()}
           <PaneResizeCursor visible={dragging} activeId={activeHandle} xpos={cursorX} />
         </div>
       </>


### PR DESCRIPTION
## Problem
Resizer overlay remained visible when it should have been suppressed during an active Layer.

## Approach
- Added a `hasOpenLayer` ref that tracks whether any Layer exists in DOM: `document.querySelector('[class*="LayerRoot"]')`
- Added `checkOpenLayers()` callback to refresh that flag.
- Added a `MutationObserver` on `document.body` (childList + subtree) so this flag updates whenever layers are mounted/unmounted.
- Updated handle rendering condition.
- So now resize handles are hidden not only by the existing local blocking/suspend mechanism, but also whenever a Layer is open globally.