### PR TITLE
STCOM-1501 - Add id attribute to Layer div.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Allow `<Pane>` to receive focus when its children are non-interactive. Refs STCOM-1488.
 * Move `InteractionStyles`' CSS variables to top level `variables.css` to avoid duplication in the bundle. Refs STCOM-1490.
 * Wrap `<Editor>`'s internals in an HTML sanitizer. Refs STCOM-1489.
+* Add `id` prop to `<Layer>` - generate id's internally for layer rendering/tracking and necessary suspension of paneset resize handles. Refs STCOM-1501.
 
 ## [13.0.0](https://github.com/folio-org/stripes-components/tree/v13.0.0) (2025-02-24)
 [Full Changelog](https://github.com/folio-org/stripes-components/compare/v12.2.0...v13.0.0)

--- a/lib/Layer/Layer.js
+++ b/lib/Layer/Layer.js
@@ -6,6 +6,7 @@ import React from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import componentOrElement from 'prop-types-extra/lib/componentOrElement';
+import uniqueId from 'lodash/uniqueId';
 import trapFocus from '../../util/trapFocus';
 import css from './Layer.css';
 import { withPaneset } from '../Paneset/PanesetContext';
@@ -23,6 +24,7 @@ class Layer extends React.Component {
     container: componentOrElement,
     contentLabel: PropTypes.string,
     enforceFocus: PropTypes.bool,
+    id: PropTypes.string,
     inRootSet: PropTypes.bool,
     isOpen: PropTypes.bool.isRequired,
     paneset: PropTypes.shape({
@@ -41,8 +43,8 @@ class Layer extends React.Component {
   static defaultProps = {
     enforceFocus: true,
     autoFocus: true,
-    afterOpen: () => {},
-    afterClose: () => {},
+    afterOpen: () => { },
+    afterClose: () => { },
   }
 
   constructor(props) {
@@ -53,6 +55,7 @@ class Layer extends React.Component {
     this.maybeEnforceFocus = this.maybeEnforceFocus.bind(this);
     this.handleOpen = this.handleOpen.bind(this);
     this.handleClose = this.handleClose.bind(this);
+    this.rootId = uniqueId('layer-root-');
   }
 
   componentDidMount() {
@@ -130,6 +133,7 @@ class Layer extends React.Component {
       isOpen,
       children,
       contentLabel,
+      id,
     } = this.props;
 
     if (!this.layerContainer) {
@@ -146,6 +150,7 @@ class Layer extends React.Component {
             tabIndex="-1"
             ref={this.contentRef}
             aria-label={contentLabel}
+            id={id || this.rootId}
           >
             {children}
           </div>

--- a/lib/Layer/readme.md
+++ b/lib/Layer/readme.md
@@ -28,7 +28,8 @@ Name | type | description | default | required
 `afterClose` | func | Callback for after the `<Layer>` has closed. Handle focus management for accessible code here! | `()=>{}` |
 `afterOpen` | func | Callback for after the `<Layer>` has opened. | `()=>{}` |
 `enforceFocus` | bool | Whether or not the modal should trap focus within itself (best for accessibility) | `true` |
-`inRootSet` | bool | if no `container` prop is provided, `<Layer>` will render into the root of its parent paneset. `InRootSet` pushes further by rendering the layer to the top-most paneset in the tree. Consider using this if your `<Layer>` is used within a nested paneset. Modules' settings have this structure. | | 
+`id` | string | Sets an `id` attribute on the generated div. Will apply a generated unique id if not set. | |
+`inRootSet` | bool | if no `container` prop is provided, `<Layer>` will render into the root of its parent paneset. `InRootSet` pushes further by rendering the layer to the top-most paneset in the tree. Consider using this if your `<Layer>` is used within a nested paneset. Modules' settings have this structure. | |
 
 ### A11y practices
 The `<Layer>` is very similar to a modal dialog and focus management should be accounted for accordingly. When opened, focus will move to the rendered content div (unless a child element has already assumed focus via `autoFocus` or some other means.) Focus should be managed appropriately by the application when the `<Layer>` is closed. The `afterClose` prop can be used for this.

--- a/lib/Paneset/PaneResizeContainer.js
+++ b/lib/Paneset/PaneResizeContainer.js
@@ -51,7 +51,7 @@ const PaneResizeContainer = ({ isRoot, children, onElementResize, parentElement,
             // if we have a blocking node, check if it's been removed in this mutation batch so that
             // the resizer can be unblocked by setting blocker to null.
             if (typeof curBlocker === 'object') {
-              if (Array.from(m.removedNodes).find((n) => {
+              if (Array.from(m.removedNodes).some((n) => {
                 const candidate = {
                   id: n.id,
                   class: n.className,

--- a/lib/Paneset/PaneResizeContainer.js
+++ b/lib/Paneset/PaneResizeContainer.js
@@ -30,7 +30,8 @@ const PaneResizeContainer = ({ isRoot, children, onElementResize, parentElement,
         let blocker = curBlocker;
         mutationList.forEach((m) => {
           if (m.type === 'childList') {
-            // check against full container bounds
+            // check added elements against full container bounds.
+            // a fully blocking element will have its attributes added as the blocker on the state.
             const blockingNode = Array.from(m.addedNodes).find((n) => {
               const newBox = n?.getBoundingClientRect();
               return (
@@ -47,9 +48,10 @@ const PaneResizeContainer = ({ isRoot, children, onElementResize, parentElement,
               };
             }
 
+            // if we have a blocking node, check if it's been removed in this mutation batch so that
+            // the resizer can be unblocked by setting blocker to null.
             if (typeof curBlocker === 'object') {
-              if (Array.from(m.removedNodes).find((n) => { // eslint-disable-line consistent-return
-                // we look for the removal of a node matching the blocker...
+              if (Array.from(m.removedNodes).find((n) => {
                 const candidate = {
                   id: n.id,
                   class: n.className,


### PR DESCRIPTION
## [STCOM-1501](https://folio-org.atlassian.net/browse/STCOM-1501)
## [UIDATIMP-1750](https://folio-org.atlassian.net/browse/UIDATIMP-1750)

A Tale of two Layers - 
So prior to this, Layer had no id... When the panesetResizeContainer would try and see if a removed node matched the blocker, two separate layers would look the same, since their id, classname, style was "", "LayerRoot---* "" - no discernable difference, so it would think that the Layer for the detail was being removed as the Edit Layer was being added.


