### PR TITLE
STCOM-1504: Pane support for disabled action menu and tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 
 * Supply Personal Data Disclosure form. Refs STCOM-1449.
+* `Pane`/`PaneHeader` - Add `actionMenuDisabled` and `actionMenuDisabledTooltip` props for rendering a disabled action menu with an optional tooltip. Refs STCOM-1504.
 
 ## [13.1.0](https://github.com/folio-org/stripes-components/tree/v13.1.0) (2026-04-14)
 

--- a/lib/Pane/Pane.js
+++ b/lib/Pane/Pane.js
@@ -11,6 +11,8 @@ import { FOCUSABLE_SELECTOR } from '../../util/getFocusableElements';
 const propTypes = {
   actionMenu: PropTypes.func,
   actionMenuAutoFocus: PropTypes.bool,
+  actionMenuDisabled: PropTypes.bool,
+  actionMenuDisabledTooltip: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   appIcon: PropTypes.oneOfType([PropTypes.object, PropTypes.element]),
   centerContent: PropTypes.bool,
   children: PropTypes.node,
@@ -221,6 +223,8 @@ class Pane extends React.Component {
     const {
       actionMenu,
       actionMenuAutoFocus, // eslint-disable-line no-unused-vars
+      actionMenuDisabled,
+      actionMenuDisabledTooltip,
       appIcon,
       children,
       centerContent,
@@ -262,6 +266,8 @@ class Pane extends React.Component {
           firstMenu,
           lastMenu,
           actionMenu,
+          actionMenuDisabled,
+          actionMenuDisabledTooltip,
           dismissible,
           onClose: this.handleClose,
           id: this.id

--- a/lib/Pane/readme.md
+++ b/lib/Pane/readme.md
@@ -74,6 +74,8 @@ To make a pane dismissible, simply supply the `dismissible` prop and a module-le
 Name | type | description | default | required
 --- | --- | --- | --- | ---
 actionMenu | func | Activates the action menu dropdown. Expects a function that returns a component or node. | undefined |
+actionMenuDisabled | bool | Disables the action menu trigger so it cannot be opened. | false |
+actionMenuDisabledTooltip | string or node | Tooltip content shown on hover/focus while the action menu is disabled. Ignored when `actionMenuDisabled` is `false`. | undefined |
 appIcon | element | Render an app icon in the PaneHeader by passing an `<AppIcon>` from stripes-core. |  | undefined
 defaultWidth | string percentage or `"fill"` | Tells the pane the percentage of the paneset that it should occupy. A string percentage (`"25%"`) will render a pane with a width of 25% of its containing element. The string `"fill"` will cause the pane to occupy any remaining space in the paneset after percentage-sized panes are accounted for. |  | &#10004;
 centerContent | bool | Wraps the content of the pane in a centered container. This can be useful when rendering forms or preview panes where you don't want the content to take up the entire width of a potentially very wide pane. | |

--- a/lib/PaneHeader/PaneHeader.js
+++ b/lib/PaneHeader/PaneHeader.js
@@ -9,6 +9,7 @@ import Dropdown from '../Dropdown';
 import DropdownMenu from '../DropdownMenu';
 import Icon from '../Icon';
 import Button from '../Button';
+import Tooltip from '../Tooltip';
 
 import css from './PaneHeader.css';
 
@@ -18,6 +19,8 @@ const PaneHeader = ({
   paneSub,
   appIcon,
   actionMenu,
+  actionMenuDisabled,
+  actionMenuDisabledTooltip,
   onClose,
   header,
   firstMenu,
@@ -84,15 +87,35 @@ const PaneHeader = ({
     </DropdownMenu>
   );
 
-  const renderActionMenu = () => (
-    <Dropdown
-      data-pane-header-actions-dropdown
-      key="action-menu-toggle"
-      hasPadding
-      renderTrigger={renderActionMenuToggle}
-      renderMenu={renderActionMenuContent}
-    />
-  );
+  const renderActionMenu = () => {
+    const dropdown = (
+      <Dropdown
+        data-pane-header-actions-dropdown
+        disabled={actionMenuDisabled}
+        hasPadding
+        renderTrigger={renderActionMenuToggle}
+        renderMenu={renderActionMenuContent}
+      />
+    );
+
+    if (actionMenuDisabled && actionMenuDisabledTooltip) {
+      return (
+        <Tooltip
+          key="action-menu-toggle"
+          id={`${_id}-action-menu-tooltip`}
+          text={actionMenuDisabledTooltip}
+        >
+          {({ ref, ariaIds }) => (
+            <div ref={ref} aria-describedby={ariaIds.text}>
+              {dropdown}
+            </div>
+          )}
+        </Tooltip>
+      );
+    }
+
+    return React.cloneElement(dropdown, { key: 'action-menu-toggle' });
+  };
 
   /**
    * App Icon
@@ -209,6 +232,8 @@ const PaneHeader = ({
 
 PaneHeader.propTypes = {
   actionMenu: PropTypes.func,
+  actionMenuDisabled: PropTypes.bool,
+  actionMenuDisabledTooltip: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   appIcon: PropTypes.oneOfType([PropTypes.object, PropTypes.element]),
   className: PropTypes.string,
   dismissible: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),

--- a/lib/PaneHeader/readme.md
+++ b/lib/PaneHeader/readme.md
@@ -123,6 +123,8 @@ const actionMenu = ({ onToggle }) => (
 Name | Type | Description | Default
 --- | --- | --- | ---
 actionMenu | func | Activates the action menu dropdown. Expects a function that returns a component or node. | undefined
+actionMenuDisabled | bool | Disables the action menu trigger so it cannot be opened. | false
+actionMenuDisabledTooltip | string or node | Tooltip content shown on hover/focus while the action menu is disabled. Ignored when `actionMenuDisabled` is `false`. | undefined
 appIcon | element | Render an app icon in the PaneHeader by passing an `<AppIcon>` from stripes-core. |  | undefined
 className | string | Adds a custom class name for the root element | |
 dismissible | bool or "last"| If true, pane will render a close (&times;) button in its firstMenu. If "last" is supplied, the button will render in the lastMenu. | false

--- a/lib/PaneHeader/tests/PaneHeader-test.js
+++ b/lib/PaneHeader/tests/PaneHeader-test.js
@@ -1,6 +1,13 @@
 import React from 'react';
 import { describe, beforeEach, it } from 'mocha';
-import { runAxeTest, HTML, IconButton as IconButtonInteractor, Dropdown as DropdownInteractor } from '@folio/stripes-testing';
+import {
+  runAxeTest,
+  HTML,
+  Button as ButtonInteractor,
+  IconButton as IconButtonInteractor,
+  Dropdown as DropdownInteractor,
+  Tooltip as TooltipInteractor,
+} from '@folio/stripes-testing';
 
 import { mountWithContext } from '../../../tests/helpers';
 import PaneHeader from '../PaneHeader';
@@ -88,6 +95,49 @@ describe('PaneHeader', () => {
     it('Should render an "Actions"-button', () => DropdownInteractor('Actions').exists());
 
     it('Should show the action menu dropdown on click', () => DropdownInteractor().is({ open: true }));
+  });
+
+  describe('When actionMenuDisabled is true', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <PaneHeader
+          actionMenu={() => <div>Action menu</div>}
+          actionMenuDisabled
+        />
+      );
+    });
+
+    it('Should mark the actions trigger as disabled', () => ButtonInteractor('Actions').is({ disabled: true }));
+  });
+
+  describe('When actionMenuDisabled is true and a tooltip is provided', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <PaneHeader
+          id="tooltip-test"
+          actionMenu={() => <div>Action menu</div>}
+          actionMenuDisabled
+          actionMenuDisabledTooltip="Close panel to enable actions."
+        />
+      );
+    });
+
+    it('Should describe the disabled trigger with the tooltip text', () => TooltipInteractor('Close panel to enable actions.', { proximity: true }).exists());
+  });
+
+  describe('When actionMenuDisabledTooltip is provided without actionMenuDisabled', () => {
+    beforeEach(async () => {
+      await mountWithContext(
+        <PaneHeader
+          actionMenu={() => <div>Action menu</div>}
+          actionMenuDisabledTooltip="Should not show on enabled menu."
+        />
+      );
+    });
+
+    it('Should not wrap the action menu in a tooltip', () => TooltipInteractor('Should not show on enabled menu.', { proximity: true }).absent());
+
+    it('Should keep the actions trigger enabled', () => ButtonInteractor('Actions').is({ disabled: false }));
   });
 
 


### PR DESCRIPTION
[STCOM-1504](https://folio-org.atlassian.net/browse/STCOM-1504)

### Summary

Adds `actionMenuDisabled` and `actionMenuDisabledTooltip` props to `Pane` and forwards them through `PaneHeader`. Lets consumers render the action-menu trigger in a disabled state with an optional tooltip explaining why, instead of replacing the real action menu with a per-consumer fake disabled `<Button>` workaround.

Originating discussion: [folio-org/ui-users#3035, comment 3190965080](https://github.com/folio-org/ui-users/pull/3035#discussion_r3190965080) (UIU-3388 review).

### Behaviour

- `actionMenuDisabled: bool`: disables the action-menu trigger so it cannot be opened.
- `actionMenuDisabledTooltip: string | <FormattedMessage>`: tooltip content shown on hover/focus while the menu is disabled. Ignored when `actionMenuDisabled` is `false`.
- The disabled trigger is wrapped in a `<Tooltip>` with `aria-describedby` linking to the tooltip text, so the explanation is reachable to screen-reader users.