### PR TITLE
STCOM-1512 - SessionConfirmationModal updating state within render.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Switch from `cloneDeep` in `<Callout>` component's state updates- a fix for potential stack overflows due to cloned react component trees 😬 . Refs STCOM-1508.
 * Update placeholder text color for Select to improve contrast. Refs STCOM-1491.
 * Update timezone data. Refs STCOM-1472.
+* bugfix - `<SessionConfirmationModal>` shouldn't call its `onConfirm` prop every render. Refs STCOM-1512.
 
 ## [13.1.0](https://github.com/folio-org/stripes-components/tree/v13.1.0) (2026-04-14)
 

--- a/lib/ConfirmationModal/SessionConfirmationModal.js
+++ b/lib/ConfirmationModal/SessionConfirmationModal.js
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useRef, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import uniqueId from 'lodash/uniqueId';
 import { useSessionStorage } from 'usehooks-ts'
@@ -13,19 +13,24 @@ const propTypes = {
   sessionKey: PropTypes.string,
 };
 
-const SessionConfirmationModal = ({ sessionKey, checkboxLabel, onConfirm, message, ...rest }) => {
+const SessionConfirmationModal = ({ sessionKey, checkboxLabel, onConfirm, open, message, ...rest }) => {
   const { formatMessage } = useIntl();
   const sessionKeyRef = useRef(sessionKey || uniqueId('confirmation-modal-'));
   const [suppressStorage, setSuppressStorage] = useSessionStorage(sessionKeyRef.current, false);
   const [suppress, setSuppress] = useState(false);
+
+  useEffect(() => {
+    if (suppressStorage && open) {
+      onConfirm();
+    }
+  }, [suppressStorage, open, onConfirm]);
 
   const handleSessionConfirm = useCallback(() => {
     onConfirm();
     if (suppress) {
       setSuppressStorage(suppress);
     }
-  }, [onConfirm, suppress, setSuppressStorage]
-  );
+  }, [onConfirm, suppress, setSuppressStorage]);
 
   const appendedMessage = (
     <>
@@ -34,25 +39,21 @@ const SessionConfirmationModal = ({ sessionKey, checkboxLabel, onConfirm, messag
         <Checkbox
           label={formatMessage({
             id: 'ConfirmationModal.suppressLabel',
-            defaultMessage: "Do not display this message again."
+            defaultMessage: 'Do not display this message again.'
           })}
           onChange={(e) => setSuppress(e.target.checked)}
         />
         <div className="margin-start-gutter">{formatMessage({
           id: 'ConfirmationModal.suppressMessage',
-          defaultMessage: "If checked, this message will be automatically confirmed for the rest of the session."
-        })}</div>
+          defaultMessage: 'If checked, this message will be automatically confirmed for the rest of the session.'
+        })}
+        </div>
       </Layout>
     </>
-  )
-
-  if (suppressStorage) {
-    onConfirm();
-    return null;
-  }
+  );
 
   return (
-    <ConfirmationModal {...rest} message={appendedMessage} onConfirm={handleSessionConfirm} />
+    <ConfirmationModal {...rest} open={open} message={appendedMessage} onConfirm={handleSessionConfirm} />
   )
 }
 

--- a/lib/ConfirmationModal/readme.md
+++ b/lib/ConfirmationModal/readme.md
@@ -65,7 +65,7 @@ const [ns] = useNameSpace();
   message="Description of the thing that needs confirming"
   onConfirm={this.handleSubmit}
   onCancel={this.hideConfirm}
-  storageKey = {`${ns}-mycomponent-confirm-modal`}
+  sessionKey = {`${ns}-mycomponent-confirm-modal`}
 />
 ```
 

--- a/lib/ConfirmationModal/stories/ConfirmationModalExample.js
+++ b/lib/ConfirmationModal/stories/ConfirmationModalExample.js
@@ -26,7 +26,7 @@ export default () => {
           heading="Please confirm this action"
           message="Here's a detailed message that explains what happens if you confirm this action."
           bodyTag="div"
-          onConfirm={() => { action('Confirmed'); setOpen(false); }}
+          onConfirm={() => { action('Confirmed'); console.log('onConfirm'); setOpen(false); }}
           onCancel={() => { action('Cancelled'); setOpen(false); }}
           cancelLabel="No, I will not confirm"
           confirmLabel="Okay, I will confirm this"


### PR DESCRIPTION
## [STCOM-1512](https://folio-org.atlassian.net/browse/STCOM-1512)

`sessionKey` not `storageKey` 🤦‍♂️

Well.. also we got other problems...
Since the `onConfirm()` is currently called in the body of the component, it will call every time external state is updated/ on EVERY re-render. 
This will need to be moved to a `useEffect` so that it will only be called both when the modal is suppressed and the open prop changes to true.

Also other nits with this code - consistent quotes.