### PR TITLE
STCOM-1513  `<Pane>` - add a new `actionMenuToggleProps` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Switch from `cloneDeep` in `<Callout>` component's state updates- a fix for potential stack overflows due to cloned react component trees 😬 . Refs STCOM-1508.
 * Update placeholder text color for Select to improve contrast. Refs STCOM-1491.
 * Update timezone data. Refs STCOM-1472.
+* `<Pane>` - add a new `actionMenuToggleProps` prop. Refs STCOM-1513.
 
 ## [13.1.0](https://github.com/folio-org/stripes-components/tree/v13.1.0) (2026-04-14)
 

--- a/lib/Pane/Pane.js
+++ b/lib/Pane/Pane.js
@@ -11,6 +11,7 @@ import { FOCUSABLE_SELECTOR } from '../../util/getFocusableElements';
 const propTypes = {
   actionMenu: PropTypes.func,
   actionMenuAutoFocus: PropTypes.bool,
+  actionMenuToggleProps: PropTypes.object,
   appIcon: PropTypes.oneOfType([PropTypes.object, PropTypes.element]),
   centerContent: PropTypes.bool,
   children: PropTypes.node,
@@ -55,7 +56,8 @@ const defaultProps = {
   padContent: true,
   tagName: 'section',
   transition: 'none',
-  renderHeader: (props) => <PaneHeader {...props} />
+  renderHeader: (props) => <PaneHeader {...props} />,
+  actionMenuToggleProps: {},
 };
 
 class Pane extends React.Component {
@@ -241,6 +243,7 @@ class Pane extends React.Component {
       paneTitle,
       paneTitleRef,
       renderHeader,
+      actionMenuToggleProps,
       subheader,
       tagName: Element,
       transition, // eslint-disable-line no-unused-vars
@@ -264,7 +267,8 @@ class Pane extends React.Component {
           actionMenu,
           dismissible,
           onClose: this.handleClose,
-          id: this.id
+          id: this.id,
+          ...actionMenuToggleProps,
         }) : null}
         {subheader}
         <div

--- a/lib/Pane/readme.md
+++ b/lib/Pane/readme.md
@@ -74,6 +74,7 @@ To make a pane dismissible, simply supply the `dismissible` prop and a module-le
 Name | type | description | default | required
 --- | --- | --- | --- | ---
 actionMenu | func | Activates the action menu dropdown. Expects a function that returns a component or node. | undefined |
+actionMenuToggleProps | object | Props to pass to the action menu toggle element | |
 appIcon | element | Render an app icon in the PaneHeader by passing an `<AppIcon>` from stripes-core. |  | undefined
 defaultWidth | string percentage or `"fill"` | Tells the pane the percentage of the paneset that it should occupy. A string percentage (`"25%"`) will render a pane with a width of 25% of its containing element. The string `"fill"` will cause the pane to occupy any remaining space in the paneset after percentage-sized panes are accounted for. |  | &#10004;
 centerContent | bool | Wraps the content of the pane in a centered container. This can be useful when rendering forms or preview panes where you don't want the content to take up the entire width of a potentially very wide pane. | |

--- a/lib/PaneHeader/PaneHeader.js
+++ b/lib/PaneHeader/PaneHeader.js
@@ -18,6 +18,7 @@ const PaneHeader = ({
   paneSub,
   appIcon,
   actionMenu,
+  actionMenuToggleProps = {},
   onClose,
   header,
   firstMenu,
@@ -25,7 +26,8 @@ const PaneHeader = ({
   paneTitleAutoFocus,
   paneTitleRef,
   lastMenu,
-  id
+  id,
+  actionMenuToggleProps,
 }) => {
   const _id = `paneHeader${id}`;
   const hasActionMenu = useMemo(() => typeof actionMenu === 'function' && actionMenu({
@@ -68,6 +70,7 @@ const PaneHeader = ({
       onKeyDown={keyHandler}
       ref={triggerRef}
       type="button"
+      {...actionMenuToggleProps}
       {...getTriggerProps()}
       {...ariaProps}
     >
@@ -209,6 +212,7 @@ const PaneHeader = ({
 
 PaneHeader.propTypes = {
   actionMenu: PropTypes.func,
+  actionMenuToggleProps: PropTypes.object,
   appIcon: PropTypes.oneOfType([PropTypes.object, PropTypes.element]),
   className: PropTypes.string,
   dismissible: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),

--- a/lib/PaneHeader/PaneHeader.js
+++ b/lib/PaneHeader/PaneHeader.js
@@ -27,7 +27,6 @@ const PaneHeader = ({
   paneTitleRef,
   lastMenu,
   id,
-  actionMenuToggleProps,
 }) => {
   const _id = `paneHeader${id}`;
   const hasActionMenu = useMemo(() => typeof actionMenu === 'function' && actionMenu({

--- a/lib/PaneHeader/readme.md
+++ b/lib/PaneHeader/readme.md
@@ -123,6 +123,7 @@ const actionMenu = ({ onToggle }) => (
 Name | Type | Description | Default
 --- | --- | --- | ---
 actionMenu | func | Activates the action menu dropdown. Expects a function that returns a component or node. | undefined
+actionMenuToggleProps | object | Props to pass to the action menu toggle element | |
 appIcon | element | Render an app icon in the PaneHeader by passing an `<AppIcon>` from stripes-core. |  | undefined
 className | string | Adds a custom class name for the root element | |
 dismissible | bool or "last"| If true, pane will render a close (&times;) button in its firstMenu. If "last" is supplied, the button will render in the lastMenu. | false


### PR DESCRIPTION
## Description
Add a new `actionMenuToggleProps` prop to `<Pane>` and `<PaneHeader>` to be able to pass props to the action menu toggle element.

Required by https://github.com/folio-org/ui-marc-authorities/pull/508

## Issues
[STCOM-1513](https://folio-org.atlassian.net/browse/STCOM-1513)