### PR TITLE
STCOM-1513 remove destructuring of actionMenuToggleProps in Pane (follow-up)

### DIFF
--- a/lib/Pane/Pane.js
+++ b/lib/Pane/Pane.js
@@ -268,7 +268,7 @@ class Pane extends React.Component {
           dismissible,
           onClose: this.handleClose,
           id: this.id,
-          ...actionMenuToggleProps,
+          actionMenuToggleProps,
         }) : null}
         {subheader}
         <div


### PR DESCRIPTION
## Description
remove destructuring of `actionMenuToggleProps` in Pane. `<PaneHeader>` expects `actionMenuToggleProps` object, but `<Pane>` desctructures in when passing.

## Issues
[STCOM-1513](https://folio-org.atlassian.net/browse/STCOM-1513)