### PR TITLE
STCOM-1523 - Clear outline from PaneHeader for focus styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Update timezone data. Refs STCOM-1472.
 * bugfix - `<SessionConfirmationModal>` shouldn't call its `onConfirm` prop every render. Refs STCOM-1512.
 * `<Pane>` - add a new `actionMenuToggleProps` prop. Refs STCOM-1513.
+* `<Pane>` - remove focus outline from `<PaneHeader>`. Refs STCOM-1523.
 
 ## [13.1.0](https://github.com/folio-org/stripes-components/tree/v13.1.0) (2026-04-14)
 

--- a/lib/PaneHeader/PaneHeader.css
+++ b/lib/PaneHeader/PaneHeader.css
@@ -11,6 +11,7 @@
   padding: 0 var(--gutter-static);
   min-height: var(--control-min-size-touch);
   background-color: var(--color-fill);
+  outline: 0;
 
   & button {
     z-index: 2;


### PR DESCRIPTION
Focus of the PaneHeader specifically gets used in `stripes-core`'s `<Settings>` component. This is an aesthetic part of the fix at the [STCOR-1083 PR](https://github.com/folio-org/stripes-core/pull/1747).