### PR TITLE
STCOM-1525 Escape user input before building filter regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * bugfix - `<SessionConfirmationModal>` shouldn't call its `onConfirm` prop every render. Refs STCOM-1512.
 * `<Pane>` - add a new `actionMenuToggleProps` prop. Refs STCOM-1513.
 * `<Pane>` - remove focus outline from `<PaneHeader>`. Refs STCOM-1523.
+* bugfix - `<Selection>` - Escape regex metacharacters when filtering, so filtering by `*` (or other special characters) no longer throws.
 
 ## [13.1.0](https://github.com/folio-org/stripes-components/tree/v13.1.0) (2026-04-14)
 

--- a/lib/Selection/tests/Selection-test.js
+++ b/lib/Selection/tests/Selection-test.js
@@ -337,6 +337,16 @@ describe('Selection', () => {
           SelectionOptionInteractor('List is empty').exists();
         });
       });
+
+      describe('filtering by a regex special character', () => {
+        beforeEach(async () => {
+          await selection.filterOptions('*');
+        });
+
+        it('does not crash and displays the empty message', () => {
+          SelectionOptionInteractor('List is empty').exists();
+        });
+      });
     });
   });
 
@@ -590,6 +600,46 @@ describe('Selection', () => {
       it('renders option groups', () => SelectionGroupLabel('grouped').exists());
 
       it('renders expected number of items', () => SelectListInteractor().has({ optionCount: 5 }));
+    });
+  });
+
+  describe('filtering options containing special characters', () => {
+    const specialCharOptions = [
+      { value: 'star', label: '*Featured*' },
+      { value: 'cpp', label: 'C++ language' },
+      { value: 'plain', label: 'Plain option' },
+    ];
+
+    beforeEach(async () => {
+      await mountWithContext(
+        <SingleSelectionHarness
+          label="test selection"
+          options={specialCharOptions}
+        />
+      );
+      await selection.open();
+    });
+
+    describe('filtering by a leading special character', () => {
+      beforeEach(async () => {
+        await selection.filterOptions('*');
+      });
+
+      it('matches the special character literally', () => {
+        SelectListInteractor({ optionCount: 1 }).exists();
+        SelectionOptionInteractor('*Featured*').exists();
+      });
+    });
+
+    describe('filtering by a metacharacter mid-label', () => {
+      beforeEach(async () => {
+        await selection.filterOptions('C+');
+      });
+
+      it('matches the literal characters', () => {
+        SelectListInteractor({ optionCount: 1 }).exists();
+        SelectionOptionInteractor('C++ language').exists();
+      });
     });
   });
 

--- a/lib/Selection/utils.js
+++ b/lib/Selection/utils.js
@@ -3,10 +3,11 @@
  *   standard options are { value, label }
  *   grouped options are { label, options } where options contains standard options.
  */
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+}
+
 export const filterOptionList = (value, dataOptions = []) => {
-  function escapeRegExp(s) {
-    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  }
   const valueRE = new RegExp(`^${escapeRegExp(value)}`, 'i');
   const baseFilter = (o) => valueRE.test(o.label);
   // if items have an 'options' field, filter those items and return the dataOptions group with the

--- a/lib/Selection/utils.js
+++ b/lib/Selection/utils.js
@@ -4,7 +4,10 @@
  *   grouped options are { label, options } where options contains standard options.
  */
 export const filterOptionList = (value, dataOptions = []) => {
-  const valueRE = new RegExp(`^${value}`, 'i');
+  function escapeRegExp(s) {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+  const valueRE = new RegExp(`^${escapeRegExp(value)}`, 'i');
   const baseFilter = (o) => valueRE.test(o.label);
   // if items have an 'options' field, filter those items and return the dataOptions group with the
   // results inserted.


### PR DESCRIPTION
Summary: Filtering <Selection> by special characters such as * or [ causes outright errors or silently returns incorrect matches. Not cool, Selection. Not. Cool.

Expected behavior: 

When filtering options within the <Selection> component, characters typed into the field should match literally against each option:
”*” → “*Asterisk Test*
”+” → “Plus+test”

Actual behavior:

When inputting special regex characters (*, +, ., (, etc.), the component throws a SyntaxError: nothing to repeat