### PR TITLE
STCOM-1524 MCL test flake - scroll less on a teeny grid in test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * bugfix - `<SessionConfirmationModal>` shouldn't call its `onConfirm` prop every render. Refs STCOM-1512.
 * `<Pane>` - add a new `actionMenuToggleProps` prop. Refs STCOM-1513.
 * `<Pane>` - remove focus outline from `<PaneHeader>`. Refs STCOM-1523.
+* Fix flaky test with virtualized `<MultiColumnList>`. Refs STCOM-1525.
 
 ## [13.1.0](https://github.com/folio-org/stripes-components/tree/v13.1.0) (2026-04-14)
 

--- a/lib/MultiColumnList/tests/MultiColumnList-test.js
+++ b/lib/MultiColumnList/tests/MultiColumnList-test.js
@@ -454,7 +454,7 @@ describe('MultiColumnList', () => {
 
         describe('adjusting to width change', () => {
           beforeEach(async () => {
-            await mcl.scrollBy({ direction: 'top', value: 600 });
+            await mcl.scrollBy({ direction: 'top', value: 400 });
           });
 
           describe('selecting another', () => {

--- a/lib/MultiColumnList/tests/MultiColumnList-test.js
+++ b/lib/MultiColumnList/tests/MultiColumnList-test.js
@@ -452,17 +452,18 @@ describe('MultiColumnList', () => {
 
         it('applies the selected class', () => mcl.find(CellInteractor({ row: 2, columnIndex: 1 })).is({ selected: true }));
 
-        describe('adjusting to width change', () => {
+        describe.only('adjusting to width change', () => {
           beforeEach(async () => {
-            await mcl.scrollBy({ direction: 'top', value: 400 });
+            await mcl.has({ width: 300 });
+            await mcl.scrollBy({ direction: 'top', value: 200 });
           });
 
           describe('selecting another', () => {
             beforeEach(async () => {
-              await mcl.click({ row: 11, columnIndex: 1 });
+              await mcl.click({ row: 24, columnIndex: 1 });
             });
 
-            it('applies the class to the updated selection', () => mcl.find(CellInteractor({ row: 11, columnIndex: 1 })).is({ selected: true }));
+            it('applies the class to the updated selection', () => mcl.find(CellInteractor({ row: 24, columnIndex: 1 })).is({ selected: true }));
           });
         });
       });

--- a/lib/MultiColumnList/tests/MultiColumnList-test.js
+++ b/lib/MultiColumnList/tests/MultiColumnList-test.js
@@ -452,7 +452,7 @@ describe('MultiColumnList', () => {
 
         it('applies the selected class', () => mcl.find(CellInteractor({ row: 2, columnIndex: 1 })).is({ selected: true }));
 
-        describe.only('adjusting to width change', () => {
+        describe('adjusting to width change', () => {
           beforeEach(async () => {
             await mcl.has({ width: 300 });
             await mcl.scrollBy({ direction: 'top', value: 200 });


### PR DESCRIPTION
The MCL in the test is virtualized - so it's getting rid of rows as you scroll. Scroll too far, and you've removed the very row you are trying to assert on or click.

Failing tests would shout something like 'I can't find MCL row 11'...
and the listing of almost-matching stuff starts at 14 or 15... scrolled too far.
How does one scroll on pixels that they cannot see? Are they any bigger or smaller because you CAN'T see them?

Locally, the test renders a teeny grid:
<img width="606" height="505" alt="image" src="https://github.com/user-attachments/assets/3d46e693-ba85-4a07-be57-0bbdcbc4c6ed" />

And you can't see it, but in a blink, the grid actually shrinks from a large width, which can cause the height of elements to shift as rows of text wrap, down to 300.

Row 2 is selected, the grid shrinks (scrolls as it tries to keep row 2 visible), scrolls more(the action `await mcl.scrollBy({ direction: 'top', value: 200 });`, select again (if possible - where our tests were failing before), assert the selected class is applied to the recently selected row.

So a few safety measures in the fix - 
- wait for the grid to shrink (`mcl.has({width: 300}`)
- scroll less
- select a row that's roughly in the middle of the visible list.