### PR TITLE
ModalFooter documentation

### DIFF
--- a/lib/Modal/readme.md
+++ b/lib/Modal/readme.md
@@ -24,7 +24,7 @@ Name | type | description | default | required
 `children` | node | Content for the body of the modal. | | &#10004;
 `closeOnBackgroundClick` | bool | Modal can be dismissed by clicking the background overlay. | false |
 `contentClass` | string | Apply custom CSS classes to the content element | |
-`dismissible` | bool | If true, renders a close 'X' in the starting corner of the modal. | false |
+`dismissible` | bool | If true, renders a close 'X' in the starting corner of the modal and applies focus there. This prop should only be used with information-only modals that do not provide a 'Cancel' button. | false |
 `enforceFocus` | bool | If true, automatically attempts to regain focus when its children are clicked.  | true |
 `footer` | node | Footer content of the modal. Pass a single component or multiple components wrapped in a Fragment. | |
 `id` | string | Used in the "id" attribute of the modal div. | |

--- a/lib/ModalFooter/readme.md
+++ b/lib/ModalFooter/readme.md
@@ -28,6 +28,12 @@ const footer = (
 </Modal>
 ```
 
+Note the primary button is the first element in the example above, but the
+`row-reverse` rule in this components CSS reverses the display order. While this
+may seem counterintuitive, it is not without reason: providing the primary
+element first allows the default focus-handling `<Modal>` to be very simple,
+focusing on the first focusable element.
+
 ### Props
 Name | type | description | default | required
 --- | --- | --- | --- | ---

--- a/lib/ModalFooter/readme.md
+++ b/lib/ModalFooter/readme.md
@@ -29,9 +29,9 @@ const footer = (
 ```
 
 Note the primary button is the first element in the example above, but the
-`row-reverse` rule in this components CSS reverses the display order. While this
-may seem counterintuitive, it is not without reason: providing the primary
-element first allows the default focus-handling `<Modal>` to be very simple,
+`row-reverse` rule in this component's CSS reverses the display order. While
+this may seem counterintuitive, it is not without reason: providing the primary
+element first allows the default focus-handling in `<Modal>` to be very simple,
 focusing on the first focusable element.
 
 ### Props


### PR DESCRIPTION
Describe the useful-but-unusual way `<ModalFooter>` expects its children elements to be specified to simplify focus management:

> Note the primary button is the first element in the example above, but the
> `row-reverse` rule in this component's CSS reverses the display order. While this
> may seem counterintuitive, it is not without reason: providing the primary
> element first allows the default focus-handling `<Modal>` to be very simple,
> focusing on the first focusable element.