### PR TITLE
STCOM-1529 avoid initially focusing the close 'X' in Modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * `<Pane>` - remove focus outline from `<PaneHeader>`. Refs STCOM-1523.
 * bugfix - `<Selection>` - Escape regex metacharacters when filtering, so filtering by `*` (or other special characters) no longer throws. Refs STCOM-
 * Fix flaky test with virtualized `<MultiColumnList>`. Refs STCOM-1525.
+* `<Modal>` no longer focuses the close 'X' on initial open. Refs STCOM-1529.
 
 ## [13.1.0](https://github.com/folio-org/stripes-components/tree/v13.1.0) (2026-04-14)
 

--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -235,6 +235,7 @@ const Modal = forwardRef((props, ref) => {
                           id={id && `${id}-close-button`}
                           onClick={onClose}
                           aria-label={intlLabel}
+                          data-focus-exclude
                           icon="times"
                         />
                       )}
@@ -250,9 +251,9 @@ const Modal = forwardRef((props, ref) => {
             >
               {/* so that aria-labels will still announce if aria-labelledby is also provided */}
               {((ariaLabel || rest['aria-label']) && (ariaLabelledBy || rest['aria-labelledby']))
-              && (
-                <div className="sr-only">{ariaLabel || rest['aria-label']}</div>
-              )}
+                && (
+                  <div className="sr-only">{ariaLabel || rest['aria-label']}</div>
+                )}
               {children}
             </div>
             {

--- a/lib/Modal/tests/Modal-test.js
+++ b/lib/Modal/tests/Modal-test.js
@@ -4,7 +4,7 @@
 
 import React, { useState } from 'react';
 import { describe, beforeEach, it } from 'mocha';
-import { Modal as ModalInteractor, Button as ButtonInteractor, converge, including, Keyboard } from '@folio/stripes-testing';
+import { Modal as ModalInteractor, Button as ButtonInteractor, IconButton as IconButtonInteractor, converge, including, Keyboard } from '@folio/stripes-testing';
 
 import { RoledHTML } from '../../../tests/helpers/localInteractors';
 import { mountWithContext } from '../../../tests/helpers';
@@ -197,5 +197,8 @@ describe('useAssistiveTechTrap tests', () => {
       it('no elements have inert', () => RoledHTML({ inert: true }).absent());
       it('focuses trigger element', () => ButtonInteractor('Open Modal').is({ focused: true }));
     })
+
+    it('focuses first focusable content element, not the close button', () => ButtonInteractor('Hello Modal!').is({ focused: true }));
+    it('does not focus the close button', () => IconButtonInteractor({ icon: 'times' }).is({ focused: false }));
   });
 });

--- a/util/README.md
+++ b/util/README.md
@@ -23,10 +23,12 @@ http://localhost:3000/users?filters=active.Active&sort=Water&query=Email
 The `filters` query parameter is unaffected (since it was not included in the parameters passed in), the old `sort` value `Name` is replaced by the new value `Email`, and the new parameter `query` is added with the value `water`.
 
 ## getFocusableElements
+
   getFocusableElements.js exposes four functions to help track focus elements within a given container. They construct a "focus list" and then allow the user to sweep through it, or jump to the beginning/end of said list.
 
 
 ### getNextFocusable/getPreviousFocusable(currentElement, includeContained = true, onlyContained = false, loop = true, nullOnExit = false)
+
   These functions will return the "next" or "previous" focusable element within some scope.
 
   `currentElement` takes a HTML element, such as given by `someRef.current`, or `document.getElementById('some-id')`;.
@@ -42,4 +44,20 @@ The `filters` query parameter is unaffected (since it was not included in the pa
   For example, calling `getNextFocusable(someRef.current, true, true, false)` will return the next focusable element (what you would normally expect 'Tab' to focus on) within the scope of `someRef.current`, and `getPreviousFocusable(someRef.current, true, false, false, false)` will return the previous focusable element (what you would normally expect 'Shift + Tab' to focus on) in the entire document, with the caveat that if focus happens to already be on the first focusable element in the document it will not loop to the end, instead returning the first element in the list (the element currently focused).
 
 ### getFirstFocusable/getLastFocusable(container)
+
  These functions will return the first or last element in the "focus list" described above respectively for some `container` element, which is analogous to the `currentElement` above.
+
+### Avoiding selection for focus
+
+Components can apply the data attribute `data-focus-exclude` if they wish to be excluded for focus selection.
+
+```
+<IconButton
+  className={css.closeModal}
+  id={id && `${id}-close-button`}
+  onClick={onClose}
+  aria-label={intlLabel}
+  data-focus-exclude  {/* will be excluded from focus consideration*/}
+  icon="times"
+/>
+```


### PR DESCRIPTION
## [STCOM-1529](https://folio-org.atlassian.net/browse/STCOM-1529)

Focusing the ‘close button’ first causes an odd UX. It’s like greeting a guest by showing them to the exit. The focus logic of the modal, and possibly stripes-components' focus utilities should be adjusted so that the close button is no longer found as the candidate to focus.
This could happen by providing exception classes/selectors to the getFirstFocusable, or implement an attribute that could be applied to elements that need to be focus-ignored when finding the first element data-focus-exclude.
- If the Modal contains a form, the first interactive element of that form should be focused.
- If there is no form, if the Modal has a footer, the ‘primary’ action of the footer should be focused first.
- No form or footer, focus will be on the container, with the close button only a tab away.

### Approach
Apply the data-attribute `data-focus-exclude` to the close 'X'. It will cause the `getFocusableElement` utilities to ignore the element it's applied to.