### PR TITLE
STCOM-1531 - Use 'nodeRef' prop with react-transition-group components to avoid `findDOMNode` for R19 migration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * `<Pane>` - remove focus outline from `<PaneHeader>`. Refs STCOM-1523.
 * bugfix - `<Selection>` - Escape regex metacharacters when filtering, so filtering by `*` (or other special characters) no longer throws. Refs STCOM-
 * Fix flaky test with virtualized `<MultiColumnList>`. Refs STCOM-1525.
+* Apply `nodeRef` prop to `react-transition-group` components to avoid `findDOMNode`. Refs STCOM-1531.
 
 ## [13.1.0](https://github.com/folio-org/stripes-components/tree/v13.1.0) (2026-04-14)
 

--- a/lib/Callout/CalloutElement.js
+++ b/lib/Callout/CalloutElement.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Transition } from 'react-transition-group';
 import IconButton from '../IconButton';
@@ -42,14 +42,16 @@ const CalloutElement = ({
   ...rest
 }) => {
   const props = { timeout, transition, type, ...rest };
+  const nodeRef = useRef(null);
   return (
     <Transition
       {...props}
       timeout={300}
       appear
+      nodeRef={nodeRef}
     >
       {transitionState => (
-        <div className={css.calloutRow}>
+        <div className={css.calloutRow} ref={nodeRef}>
           <div
             className={getClassNamefromTransitionState(transitionState, props.type, css.calloutBase, props.transition)}
             data-test-callout-element

--- a/lib/MessageBanner/MessageBanner.js
+++ b/lib/MessageBanner/MessageBanner.js
@@ -2,7 +2,7 @@
  * MessageBanner
  */
 
-import React, { forwardRef, useState, useEffect } from 'react';
+import React, { forwardRef, useRef, useState, useEffect } from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
@@ -50,6 +50,8 @@ const MessageBanner = forwardRef(
     ref
   ) => {
     const [visible, setVisible] = useState(show);
+    const internalRef = useRef(null);
+    const nodeRef = ref || internalRef;
     const onDismiss = () => setVisible(false);
 
     useEffect(() => {
@@ -89,6 +91,7 @@ const MessageBanner = forwardRef(
           in={visible}
           timeout={200}
           unmountOnExit
+          nodeRef={nodeRef}
           onExit={onExit}
           onExited={onExited}
           onEnter={onEnter}
@@ -109,7 +112,7 @@ const MessageBanner = forwardRef(
                 className
               )
             }
-            ref={ref}
+            ref={nodeRef}
             {...rest}
           >
             {renderIcon()}

--- a/lib/MultiColumnList/CellMeasurer.js
+++ b/lib/MultiColumnList/CellMeasurer.js
@@ -33,7 +33,6 @@ class CellMeasurer extends React.Component {
   measureNode = () => {
     const { widthCache, rowIndex, shouldMeasure, onMeasure, columnName } = this.props;
     if (shouldMeasure) {
-      // const elem = ReactDOM.findDOMNode(this); // eslint-disable-line react/no-find-dom-node
       if (this.element.current && this.element.current.offsetParent !== null) {
         const width = this.element.current.offsetWidth;
         widthCache.set(rowIndex, width);

--- a/lib/Popover/LegacyPopover/LegacyPopover.js
+++ b/lib/Popover/LegacyPopover/LegacyPopover.js
@@ -50,6 +50,7 @@ class LegacyPopover extends React.Component {
     this.handleToggle = this.handleToggle.bind(this);
     this.handleScroll = this.handleScroll.bind(this);
     this.popoverRef = createRef(null);
+    this.transitionRef = createRef(null);
     this.popRAF = null;
   }
 
@@ -330,9 +331,10 @@ class LegacyPopover extends React.Component {
           timeout={70}
           in={this.state.visible}
           onExited={() => this.setState({ open: false })}
+          nodeRef={this.transitionRef}
         >
           {status => (
-            <div className={classnames(css.transition, css[`transition-${status}`])}>
+            <div className={classnames(css.transition, css[`transition-${status}`])} ref={this.transitionRef}>
               {this.rendered_popover}
             </div>
           )}

--- a/lib/Popover/Popover.js
+++ b/lib/Popover/Popover.js
@@ -130,7 +130,7 @@ const Popover = forwardRef(({
         {...popperProps}
       >
         <RootCloseWrapper onRootClose={handleClickOutside} ref={popoverRef}>
-          <Transition appear timeout={70} in={open}>
+          <Transition appear timeout={70} in={open} nodeRef={popoverRef}>
             {renderPopover}
           </Transition>
         </RootCloseWrapper>


### PR DESCRIPTION
## [STCOM-1531](https://folio-org.atlassian.net/browse/STCOM-1531)

- `Callout`/`CalloutElement.js` — added a `useRef`, attached it to the transitioned wrapper div, passed as `nodeRef`.
- `Popover` — reused the existing `popoverRef` (already attached to the overlay div) as `nodeRef`.
- `MessageBanner`  — since the forwarded ref can be `null`, added an `internalRef` fallback (matching Popover.js's existing `ref || internalRef` idiom) and used that combined ref for both the DOM node and `nodeRef`.
- `Popover`/`LegacyPopover` — added a new `this.transitionRef`, attached it to the transition wrapper div, passed as `nodeRef`

Also - MCL - it was a comment! thanks for the heartburn, past self!
