### PR TITLE
STCOM-1535 - Revisit for false positives with Axe updates

### DIFF
--- a/.storybook/IntlWrap.js
+++ b/.storybook/IntlWrap.js
@@ -10,7 +10,7 @@ function updatePageDirection(direction) {
 
 const IntlWrap = ({ messages, children }) => {
   const [locale, updateLocale] = useState('en');
-  const [direction, updateDirection ] = useState('LTR');
+  const [direction, updateDirection] = useState('LTR');
 
   const handleDirectionChange = (e) => {
     updateDirection(e.target.value);
@@ -19,18 +19,19 @@ const IntlWrap = ({ messages, children }) => {
 
   return (
     <IntlProvider locale={locale} messages={messages['en']}>
-      <div className={css.iwControls} dir="ltr"><label className={css.iwLabel}>Locale: </label><select value={locale} onChange={e => updateLocale(e.target.value)}>
+      <div className={css.iwControls} dir="ltr"><label className={css.iwLabel}>Locale: <select value={locale} onChange={e => updateLocale(e.target.value)}>
         {
           Object.keys(messages).map(l => <option key={l}>{l}</option>)
         }
-        </select>
+      </select>
+      </label>
         <div className={css.iwFieldSet}>
           <label className={`${css.iwLegend} ${css.iwLabel}`} >Direction: </label>
-          <label><input type="radio" onChange={handleDirectionChange} name="direction" value="LTR" checked={direction === 'LTR'}/> LTR</label>
-          <label><input type="radio" onChange={handleDirectionChange} name="direction" value="RTL" checked={direction === 'RTL'}/> RTL</label>
+          <label><input type="radio" onChange={handleDirectionChange} name="direction" value="LTR" checked={direction === 'LTR'} /> LTR</label>
+          <label><input type="radio" onChange={handleDirectionChange} name="direction" value="RTL" checked={direction === 'RTL'} /> RTL</label>
         </div>
       </div>
-      { children }
+      {children}
     </IntlProvider>
   )
 }

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,6 +9,7 @@ const stories = [
 const config = {
   features: {
     postcss: false, // we use our own postcss setup
+    measure: false, // this button just presents an accessibility error :(
   },
 
   stories,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * Fix flaky test with virtualized `<MultiColumnList>`. Refs STCOM-1525.
 * `<Modal>` no longer focuses the close 'X' on initial open. Refs STCOM-1529.
 * Apply `nodeRef` prop to `react-transition-group` components to avoid `findDOMNode`. Refs STCOM-1531.
-
+* Update MCL rendering to conform to axe tests. Refs STCOM-1535.
 
 ## [13.1.0](https://github.com/folio-org/stripes-components/tree/v13.1.0) (2026-04-14)
 

--- a/lib/MultiColumnList/LoadMorePaginationRow.js
+++ b/lib/MultiColumnList/LoadMorePaginationRow.js
@@ -59,14 +59,16 @@ const LoadMorePaginationRow = ({
         <div
           key={`${localRowIndex}-load-button`}
           style={{ position: virtualize ? 'absolute' : 'relative', top: `${position}px`, marginTop: '1rem' }}
+          role="row"
         >
           <CenteredContainer
             width={width || prevWidth || undefined}
             innerRef={pagingButtonRef}
             visible
+            role="gridCell"
           >
             <FormattedMessage id="stripes-components.mcl.itemsRequestedMessage">
-              { ([message]) => (
+              {([message]) => (
                 <PagingButton
                   onClick={() => {
                     setFocusIndex(rowIndex);

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -1202,6 +1202,7 @@ class MCLRenderer extends React.Component {
               onFocus={(e) => this.handleRowFocus(e, localRowIndex + 2)}
               onBlur={this.handleRowBlur}
               positionedRowStyle={positionedRowStyle}
+              role="presentation"
             >
               {rowFormatter(injectedRowProps)}
             </RowMeasurer>
@@ -2003,7 +2004,7 @@ class MCLRenderer extends React.Component {
               className={classnames({ [css.hasMargin]: hasMargin })}
               data-total-count={totalCount}
             >
-              <div ref={this.headerContainer} className={css.mclHeaderContainer}>
+              <div ref={this.headerContainer} className={css.mclHeaderContainer} role="rowgroup">
                 <div
                   className={this.getHeaderStyle()}
                   style={{ display: 'flex' }}
@@ -2014,7 +2015,6 @@ class MCLRenderer extends React.Component {
                   {renderedHeaders}
                 </div>
               </div>
-              {/* eslint-disable jsx-a11y/no-static-element-interactions */}
               <div
                 className={css.mclScrollable}
                 style={this.getScrollableStyle()}
@@ -2022,10 +2022,10 @@ class MCLRenderer extends React.Component {
                 ref={this.scrollContainer}
                 {...getScrollableTabIndex(this.scrollContainer)}
                 onMouseDown={this.handleMouseDown}
+                role="rowgroup"
               >
                 <div
                   className={rowContainerClass}
-                  role="rowgroup"
                   style={this.getRowContainerStyle()}
                   ref={this.rowContainer}
                 >

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -2015,6 +2015,7 @@ class MCLRenderer extends React.Component {
                   {renderedHeaders}
                 </div>
               </div>
+              {/* eslint-disable jsx-a11y/no-static-element-interactions */}
               <div
                 className={css.mclScrollable}
                 style={this.getScrollableStyle()}

--- a/lib/MultiColumnList/stories/BasicMCL.js
+++ b/lib/MultiColumnList/stories/BasicMCL.js
@@ -19,11 +19,6 @@ export default class BasicMCL extends React.Component {
     };
   }
 
-  onRowClick = (e, row) => {
-    action('button-click');
-    this.setState({ selected: row });
-  }
-
   onHeaderClick = (e, { name }) => {
     this.setState({
       sorted: name,
@@ -39,7 +34,6 @@ export default class BasicMCL extends React.Component {
         sortedColumn={this.state.sorted}
         sortDirection="ascending"
         selectedRow={this.state.selected}
-        onRowClick={this.onRowClick}
         onHeaderClick={this.onHeaderClick}
         columnWidths={this.columnWidths}
         columnMapping={{

--- a/lib/MultiColumnList/stories/ColumnWidthHints.js
+++ b/lib/MultiColumnList/stories/ColumnWidthHints.js
@@ -31,11 +31,6 @@ export default class ColumnWidthHints extends React.Component {
     };
   }
 
-  onRowClick = (e, row) => {
-    action('button-click');
-    this.setState({ selected: row });
-  }
-
   onHeaderClick = (e, { name }) => {
     this.setState({
       sorted: name,
@@ -63,7 +58,6 @@ export default class ColumnWidthHints extends React.Component {
         sortedColumn={this.state.sorted}
         sortDirection="ascending"
         selectedRow={this.state.selected}
-        onRowClick={this.onRowClick}
         onHeaderClick={this.onHeaderClick}
         columnWidths={this.columnWidths}
         visibleColumns={[

--- a/lib/MultiColumnList/stories/Formatter.js
+++ b/lib/MultiColumnList/stories/Formatter.js
@@ -26,11 +26,6 @@ export default class Formatter extends React.Component {
     };
   }
 
-  onRowClick = (e, row) => {
-    action('button-click');
-    this.setState({ selected: row });
-  }
-
   resetMCL = () => {
     this.setState(curState => ({
       mclKey: curState.mclKey + 1
@@ -47,7 +42,6 @@ export default class Formatter extends React.Component {
           contentData={data}
           formatter={this.listFormatter}
           selectedRow={this.state.selected}
-          onRowClick={this.onRowClick}
           visibleColumns={['name', 'patronGroup', 'phone', 'action']}
           columnMapping={{
             name: 'Name',

--- a/lib/MultiColumnList/stories/ItemToView.js
+++ b/lib/MultiColumnList/stories/ItemToView.js
@@ -22,14 +22,6 @@ export default class ItemToView extends React.Component {
     };
   }
 
-  onRowClick = (e, row) => {
-    action('button-click');
-    this.setState(cur => ({
-      viewWidth: cur.viewWidth === '800px' ? '400px' : '800px',
-      selected: row
-    }));
-  }
-
   markItem = (item) => {
     this.setState({ viewItem: item });
   }
@@ -40,7 +32,7 @@ export default class ItemToView extends React.Component {
     });
   }
 
-  handleCheckbox = (e,item) => {
+  handleCheckbox = (e, item) => {
     this.setState(cur => {
       const rowIndex = cur.data.findIndex(i => item.email === i.email);
       const newData = cur.data;
@@ -55,7 +47,7 @@ export default class ItemToView extends React.Component {
   }
 
   formatter = {
-    active: (item) => <Checkbox onChange={(e) => this.handleCheckbox(e,item)} checked={item.active}/>
+    active: (item) => <Checkbox onChange={(e) => this.handleCheckbox(e, item)} checked={item.active} />
   }
 
   render() {

--- a/lib/MultiColumnList/stories/MultiColumnList.stories.js
+++ b/lib/MultiColumnList/stories/MultiColumnList.stories.js
@@ -11,7 +11,6 @@ import EndOfListMarker from './EndOfListMarker';
 import Formatter from './Formatter';
 import PagingType from './PagingType';
 import Resizing from './Resizing';
-import ClickableRows from './ClickableRows';
 import ColumnWidthHints from './ColumnWidthHints';
 import PrevNextPaging from './PrevNextPaging';
 import PrevNextOffsetPaging from './PrevNextOffsetPaging';
@@ -71,9 +70,6 @@ export const _PrevNextPaging = () => <PrevNextPaging />;
 _PrevNextPaging.storyName = 'Prev/Next Paging';
 
 export const _Resizing = () => <Resizing />;
-export const _ClickableRows = () => <ClickableRows />;
-
-_ClickableRows.storyName = 'Clickable rows';
 
 export const _StickyColumns = () => <StickyColumns />;
 export const _WithInputs = () => <WithInputs />;

--- a/lib/MultiColumnList/stories/WithInputs.js
+++ b/lib/MultiColumnList/stories/WithInputs.js
@@ -38,7 +38,7 @@ export default class Formatter extends React.Component {
 
     this.cellStyles = (defaultClass, row, col) => {
       return col === 'patronGroup' ?
-        `${ defaultClass} ${ css.overflowCell }` :
+        `${defaultClass} ${css.overflowCell}` :
         defaultClass
     };
 
@@ -61,8 +61,8 @@ export default class Formatter extends React.Component {
                 <li>Example 2</li>
               </ul>
             </DropdownMenu>
-              )}
-            />
+          )}
+        />
       ),
       phone: () => (
         <Selection
@@ -83,11 +83,6 @@ export default class Formatter extends React.Component {
     };
   }
 
-  onRowClick = (e, row) => {
-    action('button-click');
-    this.setState({ selected: row });
-  }
-
   resetMCL = () => {
     this.setState(curState => ({
       mclKey: curState.mclKey + 1
@@ -104,7 +99,6 @@ export default class Formatter extends React.Component {
           contentData={data}
           formatter={this.listFormatter}
           selectedRow={this.state.selected}
-          onRowClick={this.onRowClick}
           visibleColumns={['name', 'patronGroup', 'phone', 'action']}
           columnMapping={{
             name: 'Name',

--- a/lib/MultiColumnList/tests/MCLHarness.js
+++ b/lib/MultiColumnList/tests/MCLHarness.js
@@ -6,7 +6,6 @@ import Button from '../../Button';
 import { generate } from './generate';
 import { asyncGenerate, syncGenerate } from '../stories/service';
 
-
 class MCLHarness extends React.Component {
   static defaultProps = {
     displayGrid: true
@@ -20,7 +19,7 @@ class MCLHarness extends React.Component {
       height: 400,
       selected: {},
       displayGrid: props.displayGrid,
-      columns: this.props.columns || ['name', 'email', 'phone'],
+      columns: this.props.columns || ['name', 'email', 'phone', 'select'],
       placeMarker: null,
     };
 
@@ -29,7 +28,6 @@ class MCLHarness extends React.Component {
     this.increaseHeight = this.increaseHeight.bind(this);
     this.loadData = this.loadData.bind(this);
     this.filterData = this.filterData.bind(this);
-    this.handleRowClick = this.handleRowClick.bind(this);
     this.markPosition = this.markPosition.bind(this);
   }
 
@@ -85,12 +83,6 @@ class MCLHarness extends React.Component {
     });
   }
 
-  handleRowClick(e, row) {
-    this.setState({
-      selected: row,
-    });
-  }
-
   displayGrid = () => {
     this.setState(curState => ({
       displayGrid: !curState.displayGrid,
@@ -110,9 +102,21 @@ class MCLHarness extends React.Component {
     });
   }
 
+  selectableFormatter = {
+    select: (item) => (<Button onClick={() => this.setState({ selected: item })}>Select</Button>)
+  }
+
   render() {
     const { displayGrid, placeMarker } = this.state;
-    const { initialData, onNeedMoreSpy, asyncPaging, ...rest } = this.props; // eslint-disable-line no-unused-vars
+    const { initialData, onNeedMoreSpy, asyncPaging, canSelectRows, visibleColumns, formatter, ...rest } = this.props; // eslint-disable-line no-unused-vars
+
+    let testFormatter;
+    if (canSelectRows) {
+      testFormatter = { ...formatter, ...this.selectableFormatter };
+    } else {
+      testFormatter = formatter;
+    }
+
     return (
       <div>
         <Button data-test-display-grid onClick={this.displayGrid}>show grid</Button>
@@ -131,13 +135,14 @@ class MCLHarness extends React.Component {
             contentData={this.state.data}
             onNeedMoreData={this.onNeedMore}
             visibleColumns={this.state.columns}
+            formatter={testFormatter}
             autosize
             virtualize
             selectedRow={this.state.selected}
-            onRowClick={this.handleRowClick}
             onHeaderClick={this.fakeSort}
             onMarkPosition={this.markPosition}
             itemToView={placeMarker}
+            isSelected={({ item }) => this.state.selected?.index === item.index}
             {...rest}
           />
         </div>

--- a/lib/MultiColumnList/tests/MultiColumnList-test.js
+++ b/lib/MultiColumnList/tests/MultiColumnList-test.js
@@ -428,6 +428,8 @@ describe('MultiColumnList', () => {
           key="1"
           initialData={[]}
           columnWidths={{ 'name': '200px' }}
+          visibleColumns="['select', 'name', 'email', 'phone', 'userName']"
+          canSelectRows
         />
       );
     });
@@ -447,10 +449,10 @@ describe('MultiColumnList', () => {
 
       describe('selecting a row', () => {
         beforeEach(async () => {
-          await mcl.click({ row: 2, columnIndex: 1 });
+          await mcl.find(RowInteractor({ index: 14 })).find(ButtonInteractor('Select')).click();
         });
 
-        it('applies the selected class', () => mcl.find(CellInteractor({ row: 2, columnIndex: 1 })).is({ selected: true }));
+        it.only('applies the selected class', () => mcl.find(RowInteractor({ index: 14 })).is({ selected: true }));
 
         describe('adjusting to width change', () => {
           beforeEach(async () => {
@@ -460,10 +462,10 @@ describe('MultiColumnList', () => {
 
           describe('selecting another', () => {
             beforeEach(async () => {
-              await mcl.click({ row: 24, columnIndex: 1 });
+              await mcl.find(RowInteractor({ index: 24 })).find(ButtonInteractor('Select')).click();
             });
 
-            it('applies the class to the updated selection', () => mcl.find(CellInteractor({ row: 24, columnIndex: 1 })).is({ selected: true }));
+            it('applies the class to the updated selection', () => mcl.find(RowInteractor({ index: 24 })).is({ selected: true }));
           });
         });
       });
@@ -481,7 +483,7 @@ describe('MultiColumnList', () => {
       await mountWithContext(
         <MCLHarness
           initialData={[]}
-          visibleColumns={visibleCol}
+          columns={visibleCol}
           formatter={
             {
               identity: (item) => (


### PR DESCRIPTION
This update primarily affects MCL. It's never been flagged in accessibility audits, but axe continues to disagree. We really need to move our axe version forward, but false-positives make things difficult for everyone. Failures in stripes-components will mean failures reported in modules, false or not. As long as whatever we do to appease axe does not disrupt the clean accessibilty tree, I consider us in fine shape...

Before: Axe report: (Full disclosure, one of the 2 errors were in the storybook UI)
<img width="1152" height="576" alt="image" src="https://github.com/user-attachments/assets/dd4820c0-aeaa-4d3f-a6ee-966da8d1d6cc" />

Before: accessibility tree (chrome dev tools)
<img width="1698" height="586" alt="image" src="https://github.com/user-attachments/assets/1c819c38-cc6a-435c-9ad6-d8119edf95bf" />


After: - Axe report...
<img width="1740" height="683" alt="image" src="https://github.com/user-attachments/assets/9f143e67-0f9f-45ad-bcea-c653e17745df" />

After - Accessibility tree:
<img width="1741" height="648" alt="image" src="https://github.com/user-attachments/assets/e9edf9f9-79aa-477c-ae4a-d7c21197f75a" />

Approach/what happened.
Shifting the `role=rowgroup` from the MCL RowContainer to the MCL Scrollable seems to have made the difference that axe was looking for. My A11y tree is unharmed.
Additionally, I applied the `rowgroup` role to the header container, since it's effectively a `head` of a table.

Also, removed the offending usage examples from storybook - no more `onRowClick` in example code.

It's bound to be an error that UI-modules will see if they are *still not implementing links in their first columns.

Update: checked in Inventory - Before
<img width="1812" height="605" alt="image" src="https://github.com/user-attachments/assets/346a0fa2-4b0f-48e9-8f52-db8a65b508ff" />

After -
<img width="1653" height="600" alt="image" src="https://github.com/user-attachments/assets/a6dc3f1c-968f-46c1-bb75-976968cfb749" />
