### PR TITLE
remove committed 'only' in test 

### DIFF
--- a/lib/MultiColumnList/LoadMorePaginationRow.js
+++ b/lib/MultiColumnList/LoadMorePaginationRow.js
@@ -65,7 +65,7 @@ const LoadMorePaginationRow = ({
             width={width || prevWidth || undefined}
             innerRef={pagingButtonRef}
             visible
-            role="gridCell"
+            role="gridcell"
           >
             <FormattedMessage id="stripes-components.mcl.itemsRequestedMessage">
               {([message]) => (

--- a/lib/MultiColumnList/tests/MultiColumnList-test.js
+++ b/lib/MultiColumnList/tests/MultiColumnList-test.js
@@ -452,7 +452,7 @@ describe('MultiColumnList', () => {
           await mcl.find(RowInteractor({ index: 14 })).find(ButtonInteractor('Select')).click();
         });
 
-        it.only('applies the selected class', () => mcl.find(RowInteractor({ index: 14 })).is({ selected: true }));
+        it('applies the selected class', () => mcl.find(RowInteractor({ index: 14 })).is({ selected: true }));
 
         describe('adjusting to width change', () => {
           beforeEach(async () => {


### PR DESCRIPTION
aka John is a bonehead.
aka can we just get oxlint?

This also ended up including a fix for an axe failure. It's `gridcell` not `gridCell`, aka John is a double bonehead.