### PR TITLE
STCOM-1536 rnd 2 - MCL CSS vs JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * `<Modal>` no longer focuses the close 'X' on initial open. Refs STCOM-1529.
 * Apply `nodeRef` prop to `react-transition-group` components to avoid `findDOMNode`. Refs STCOM-1531.
 * Update MCL rendering to conform to axe tests. Refs STCOM-1535.
+* Convert MCL layout elements to a `flex-box` column. Resolves issues where pagination buttons would not show up on the first render. Refs STCOM-1536.
 
 ## [13.1.0](https://github.com/folio-org/stripes-components/tree/v13.1.0) (2026-04-14)
 

--- a/lib/MultiColumnList/MCLRenderer.css
+++ b/lib/MultiColumnList/MCLRenderer.css
@@ -19,6 +19,7 @@
 .mclRowContainer {
   position: absolute;
   min-width: 100%;
+  min-height: 100%;
 
   /* first descendants all display: block for height measurment */
   & > * {
@@ -160,11 +161,17 @@
   font-feature-settings: 'tnum';
 }
 
+.mclGridBody {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
 .mclHeaderContainer {
   display: flex;
   flex-direction: column;
-  flex-grow: 0;
-  flex-shrink: 0;
+  flex: 0 0 auto;
   overflow: hidden;
   width: 100%;
 }
@@ -322,8 +329,8 @@
 }
 
 .mclScrollable {
-  flex-grow: 1;
-  flex-shrink: 0;
+  flex: 1 1 auto;
+  min-height: 0;
   overflow: auto;
   width: 100%;
 }
@@ -393,6 +400,10 @@
   & .mclRow {
     margin: 0 var(--gutter-static);
   }
+}
+
+.mclPaginationRow {
+  flex: 0 0 auto;
 }
 
 .mclPaginationCenterContainer {

--- a/lib/MultiColumnList/MCLRenderer.js
+++ b/lib/MultiColumnList/MCLRenderer.js
@@ -310,7 +310,6 @@ class MCLRenderer extends React.Component {
 
     this.rowContainer = React.createRef();
     this.headerRow = React.createRef();
-    this.paginationContainer = React.createRef();
     this.headerContainer = React.createRef();
     this.scrollContainer = React.createRef();
     this.endOfList = React.createRef();
@@ -318,8 +317,6 @@ class MCLRenderer extends React.Component {
     this.status = React.createRef();
     this.shortcutsRef = React.createRef();
 
-    this.headerHeight = 0;
-    this.paginationHeight = 40;
     this.focusedRowIndex = null;
     this.maximumRowHeight = 30;
     this.keyId = uniqueId('mcl');
@@ -490,10 +487,6 @@ class MCLRenderer extends React.Component {
     if (contentData.length > 0) {
       this.resetIfGridHidden();
 
-      if (this.headerRow.current) {
-        this.headerHeight = this.headerRow.current.offsetHeight;
-      }
-
       let newState = {};
       // if there's no set width prop, column widths should be re-evaluated after mount
       // based on the width of the containing element.
@@ -646,15 +639,6 @@ class MCLRenderer extends React.Component {
     }
 
     if (contentData.length > 0) {
-      // headerRow height is used to calculate the height of the scrollContainer
-      if (this.headerRow.current) {
-        this.headerHeight = this.headerRow.current.offsetHeight;
-      }
-
-      if (this.paginationContainer.current) {
-        this.paginationHeight = this.paginationContainer.current.offsetHeight;
-      }
-
       // update average height if we don't have it...
       if (this.rowHeightCache.length > 0 && this.state.averageRowHeight === 0) {
         const avg = this.updateAverageHeight();
@@ -1794,6 +1778,8 @@ class MCLRenderer extends React.Component {
 
     if (this.props.height) {
       containerStyle.height = this.props.height;
+    } else if (this.props.maxHeight) {
+      containerStyle.maxHeight = this.props.maxHeight;
     }
 
     if (!containerStyle.height) {
@@ -1839,13 +1825,9 @@ class MCLRenderer extends React.Component {
     */
     if (height !== undefined) {
       // if we have a totalCount, we can set size based on that... if not, the receivedRows count.
-      const scrollBarHeight = 20;
-      const paginationHeight = pagingType === pagingTypes.PREV_NEXT ? this.paginationHeight : 0;
-
-      newHeight = Math.max(
-        ((pagingType !== pagingTypes.SCROLL ? receivedRows : totalCount || receivedRows) * minimumRowHeight),
-        (height - this.headerHeight - scrollBarHeight - paginationHeight)
-      );
+      // (the "fill the visible viewport even with sparse data" floor is handled by
+      // .mclRowContainer's min-height: 100% in CSS, against the flex-sized scrollable parent.)
+      newHeight = (pagingType !== pagingTypes.SCROLL ? receivedRows : totalCount || receivedRows) * minimumRowHeight;
 
       const rowContainerStyles = {
         position,
@@ -1874,10 +1856,9 @@ class MCLRenderer extends React.Component {
     const {
       height,
       maxHeight,
-      pagingType,
     } = this.props;
 
-    const { bodyHeight, prevHeight } = this.state;
+    const { prevHeight } = this.state;
 
     const scrollableStyle = {
       position: 'static'
@@ -1886,31 +1867,10 @@ class MCLRenderer extends React.Component {
     const heightVar = height || prevHeight;
 
     // body will be scrollable if a physical height limit is applied...
+    // sizing itself against that limit (minus the header/pagination row) is left to the
+    // browser via the flex layout on the .mclGridBody/.mclScrollable ancestors.
     if (heightVar || maxHeight) {
       scrollableStyle.overflow = 'auto';
-    }
-
-    const paginationHeight = pagingType === pagingTypes.PREV_NEXT ? this.paginationHeight : 0;
-
-    /* State.bodyHeight will be filled in later if it isn't already...
-    *  which will set the height for the extent of the data rows;
-    */
-
-    // maxHeight will use bodyHeight if bodyHeight is less...
-    if (bodyHeight && maxHeight) {
-      scrollableStyle.height = Math.min(bodyHeight, maxHeight - this.headerHeight - paginationHeight);
-    } else if (heightVar > 0) { // if we've got a positive height prop, use it...
-      scrollableStyle.height = heightVar - this.headerHeight - paginationHeight;
-    }
-
-    // avoid setting a 0px height
-    if (scrollableStyle.height === 0) {
-      delete scrollableStyle.height;
-    }
-
-    // set maxHeight if we've got it...
-    if (maxHeight) {
-      scrollableStyle.maxHeight = maxHeight - this.headerHeight;
     }
 
     scrollableStyle.width = '100%';
@@ -2001,7 +1961,7 @@ class MCLRenderer extends React.Component {
               ref={this.container}
               role="grid"
               aria-rowcount={this.getAccessibleRowCount()}
-              className={classnames({ [css.hasMargin]: hasMargin })}
+              className={classnames(css.mclGridBody, { [css.hasMargin]: hasMargin })}
               data-total-count={totalCount}
             >
               <div ref={this.headerContainer} className={css.mclHeaderContainer} role="rowgroup">
@@ -2070,7 +2030,6 @@ class MCLRenderer extends React.Component {
                   dataEndIndex={typeof pagingOffset !== 'undefined' ? pagingOffset + dataEndIndex + 1 : dataEndIndex + 1} // eslint-disable-line
                   hidePageIndices={hidePageIndices}
                   pagingOffset={pagingOffset}
-                  containerRef={this.paginationContainer}
                 />
               )
             }

--- a/lib/MultiColumnList/PrevNextPaginationRow.js
+++ b/lib/MultiColumnList/PrevNextPaginationRow.js
@@ -8,7 +8,6 @@ import css from './MCLRenderer.css';
 const propTypes = {
   activeNext: PropTypes.bool,
   activePrevious: PropTypes.bool,
-  containerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   dataEndIndex: PropTypes.number,
   dataEndReached: PropTypes.bool,
   dataStartIndex: PropTypes.number,
@@ -29,7 +28,6 @@ const propTypes = {
 const PrevNextPaginationRow = ({
   activeNext,
   activePrevious,
-  containerRef,
   dataEndReached,
   handleLoadMore,
   id,
@@ -71,7 +69,7 @@ const PrevNextPaginationRow = ({
   const message = formatMessage({ id: 'stripes-components.mcl.itemsRequestedMessage' });
 
   return (
-    <div style={{ padding: '8px 0' }} ref={containerRef}>
+    <div className={css.mclPaginationRow} style={{ padding: '8px 0' }}>
       <div className={css.mclPaginationCenterContainer}>
         <PagingButton
           onClick={() => {

--- a/lib/MultiColumnList/tests/MultiColumnList-test.js
+++ b/lib/MultiColumnList/tests/MultiColumnList-test.js
@@ -85,7 +85,7 @@ const tabIndexedElement = HTMLInteractor.extend('tab-indexed')
 
 let headerClicked = false;
 
-describe('MultiColumnList', () => {
+describe.only('MultiColumnList', () => {
   const mcl = Interactor();
   const mclRow = RowInteractor();
   describe('column width ranges', () => {
@@ -452,7 +452,7 @@ describe('MultiColumnList', () => {
           await mcl.find(RowInteractor({ index: 14 })).find(ButtonInteractor('Select')).click();
         });
 
-        it.only('applies the selected class', () => mcl.find(RowInteractor({ index: 14 })).is({ selected: true }));
+        it('applies the selected class', () => mcl.find(RowInteractor({ index: 14 })).is({ selected: true }));
 
         describe('adjusting to width change', () => {
           beforeEach(async () => {
@@ -700,7 +700,7 @@ describe('MultiColumnList', () => {
       );
     });
 
-    it('click paging type has no axe errors', runAxeTest);
+    it.only('click paging type has no axe errors', runAxeTest);
 
     it('renders the paging button', () => loadMore.exists());
 

--- a/lib/MultiColumnList/tests/MultiColumnList-test.js
+++ b/lib/MultiColumnList/tests/MultiColumnList-test.js
@@ -85,7 +85,7 @@ const tabIndexedElement = HTMLInteractor.extend('tab-indexed')
 
 let headerClicked = false;
 
-describe.only('MultiColumnList', () => {
+describe('MultiColumnList', () => {
   const mcl = Interactor();
   const mclRow = RowInteractor();
   describe('column width ranges', () => {
@@ -700,7 +700,7 @@ describe.only('MultiColumnList', () => {
       );
     });
 
-    it.only('click paging type has no axe errors', runAxeTest);
+    it('click paging type has no axe errors', runAxeTest);
 
     it('renders the paging button', () => loadMore.exists());
 


### PR DESCRIPTION
This essentially converts the MCL layout to a flexbox layout with `flex-direction: column` set - so that the positioning/height of its major containers will just be handled without requiring measuring and calculation by JS.

Why? Why don't we just let the browser do the work rather than the uh.. browser/library/developer do the work - and we'll get to carve out a bunch of the JS in the process.

This removes multiple reads of `offsetHeight` - which are sure-fire culprits for layout-thrashing (inefficiency) since they incur  a reflow in the browser when they're executed every render. This is the stuff that janky UI's are made of and we don't need that life anymore.

The bug this ultimately does resolve:
Before:

https://github.com/user-attachments/assets/73f9c233-c87e-4637-a344-c45b0b714f39


After:

https://github.com/user-attachments/assets/ee012f0c-757f-4bae-ac1a-549a47f63f4c

