### PR TITLE
Clean up dead storybook pages

### DIFF
--- a/guides/ux-guidelines/examples/MiniAdvancedSearchExample.js
+++ b/guides/ux-guidelines/examples/MiniAdvancedSearchExample.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import Button from '../../../lib/Button';
-import AdvancedSearch from '../../../lib/AdvancedSearch';
+import { AdvancedSearch } from '../../../lib/AdvancedSearch';
 
 const searchOptions = [
   { id: 'keyword', label: 'Keyword', value: 'keyword' },

--- a/guides/ux-guidelines/examples/MiniConflictDetectionBannerExample.js
+++ b/guides/ux-guidelines/examples/MiniConflictDetectionBannerExample.js
@@ -1,14 +1,17 @@
 import React, { useRef } from 'react';
+import { HashRouter } from 'react-router-dom';
 import ConflictDetectionBanner from '../../../lib/ConflictDetectionBanner';
 
 export default function MiniConflictDetectionBannerExample() {
   const bannerRef = useRef(null);
 
   return (
-    <ConflictDetectionBanner
-      latestVersionLink="/records/123/view"
-      conflictDetectionBannerRef={bannerRef}
-      focusConflictDetectionBanner={() => bannerRef.current?.focus()}
-    />
+    <HashRouter>
+      <ConflictDetectionBanner
+        latestVersionLink="/records/123/view"
+        conflictDetectionBannerRef={bannerRef}
+        focusConflictDetectionBanner={() => bannerRef.current?.focus()}
+      />
+    </HashRouter >
   );
 }

--- a/guides/ux-guidelines/examples/MiniFilterPaneSearchExample.js
+++ b/guides/ux-guidelines/examples/MiniFilterPaneSearchExample.js
@@ -6,7 +6,7 @@ export default function MiniFilterPaneSearchExample() {
   const resultsRef = useRef(null);
 
   return (
-    <div>
+    <div style={{ width: '150px', height: '40px', margin: '1rem', position: 'relative' }}>
       <FilterPaneSearch
         searchFieldId="ux-filter-pane-search"
         clearSearchId="ux-filter-pane-search-clear"

--- a/guides/ux-guidelines/examples/MiniLoadingExample.js
+++ b/guides/ux-guidelines/examples/MiniLoadingExample.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Loading from '../../../lib/Loading';
+import { Loading } from '../../../lib/Loading';
 
 export default function MiniLoadingExample() {
   return <Loading />;

--- a/guides/ux-guidelines/examples/MiniPaneCloseLinkExample.js
+++ b/guides/ux-guidelines/examples/MiniPaneCloseLinkExample.js
@@ -4,6 +4,7 @@ import PaneCloseLink from '../../../lib/PaneCloseLink';
 import PaneHeader from '../../../lib/PaneHeader';
 import PaneMenu from '../../../lib/PaneMenu';
 import Paneset from '../../../lib/Paneset';
+import { HashRouter } from 'react-router-dom';
 
 export default function MiniPaneCloseLinkExample() {
   const firstMenu = (
@@ -13,21 +14,23 @@ export default function MiniPaneCloseLinkExample() {
   );
 
   return (
-    <div style={{ margin: '-1rem' }}>
-      <Paneset>
-        <Pane
-          defaultWidth="fill"
-          renderHeader={(renderProps) => (
-            <PaneHeader
-              {...renderProps}
-              firstMenu={firstMenu}
-              paneTitle="Detail view"
-            />
-          )}
-        >
-          Pane content
-        </Pane>
-      </Paneset>
-    </div>
+    <HashRouter>
+      <div style={{ margin: '-1rem' }}>
+        <Paneset>
+          <Pane
+            defaultWidth="fill"
+            renderHeader={(renderProps) => (
+              <PaneHeader
+                {...renderProps}
+                firstMenu={firstMenu}
+                paneTitle="Detail view"
+              />
+            )}
+          >
+            Pane content
+          </Pane>
+        </Paneset>
+      </div>
+    </HashRouter>
   );
 }


### PR DESCRIPTION
Was mostly bad imports (default -> named) and missing router wrapping.

Had a handful of dead soldiers stood up after the AI migration of content from the old UX site. This PR gets the handful of pages working again.