### PR TITLE
STCOM-1543 <TransitionGroup> creates random div with <Modal>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Update MCL rendering to conform to axe tests. Refs STCOM-1535.
 * Convert MCL layout elements to a `flex-box` column. Resolves issues where pagination buttons would not show up on the first render. Refs STCOM-1536.
 * Resolve color contrast issues on selected MCL rows, IconButtons, focus styles. Refs STCOM-1541.
+* Remove random, empty, attributeless div created by TransitionGroup for `<Modal>`. Refs STCOM-1543.
 
 ## [13.1.0](https://github.com/folio-org/stripes-components/tree/v13.1.0) (2026-04-14)
 

--- a/lib/Modal/Modal.js
+++ b/lib/Modal/Modal.js
@@ -271,7 +271,7 @@ const Modal = forwardRef((props, ref) => {
   ) : null;
 
   return modalElement !== null ? (
-    <TransitionGroup>
+    <TransitionGroup component={null}>
       <Transition
         in={open}
         unmountOnExit


### PR DESCRIPTION
## [STCOM-1543](https://folio-org.atlassian.net/browse/STCOM-1543)

### Problem
In this day an age of flexbox, random divs can bork your nice layout. `<TransitionGroup>` commits this sin. It makes elements wrap unexpectedly, throwing the user into another world of distraction. It's enough to make a designer's eye twitch.

### Approach
Add component={null} prop to `<TransitionGroup>` in `<Modal>`

### Offensive

https://github.com/user-attachments/assets/5652113a-7ce6-42f2-86c0-defc70fece48

