### PR TITLE
typo: sessionKey, not storageKey

### DIFF
--- a/lib/ConfirmationModal/readme.md
+++ b/lib/ConfirmationModal/readme.md
@@ -52,7 +52,7 @@ Name | type | description | default | required
 
 ## SessionConfirmationModal
 
-Has a checkbox connected to session storage that will not display the modal if the supplied `storageKey` prop is set. The `useNamespace` hook from `stripes-core` can be used to generate a string for the key based on module hierarchy.
+Has a checkbox connected to session storage that will not display the modal if the supplied `sessionKey` prop is set. The `useNamespace` hook from `stripes-core` can be used to generate a string for the key based on module hierarchy.
 
 ```
 import { useNamespace } from '@folio/stripes/core';


### PR DESCRIPTION
Update documentation so it matches the implementation, and the provided examples. 