### PR TITLE
STCOM-1545 Shield `onConfirm()` with ref so that it only happens once per open.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Update MCL rendering to conform to axe tests. Refs STCOM-1535.
 * Convert MCL layout elements to a `flex-box` column. Resolves issues where pagination buttons would not show up on the first render. Refs STCOM-1536.
 * Resolve color contrast issues on selected MCL rows, IconButtons, focus styles. Refs STCOM-1541.
+* Bug-fix. Subsequent, post-onConfirm could call onConfirm again (`<SessionConfirmationModal>`). Refs STCOM-1545
 
 ## [13.1.0](https://github.com/folio-org/stripes-components/tree/v13.1.0) (2026-04-14)
 

--- a/lib/ConfirmationModal/SessionConfirmationModal.js
+++ b/lib/ConfirmationModal/SessionConfirmationModal.js
@@ -29,6 +29,8 @@ const SessionConfirmationModal = ({ sessionKey, checkboxLabel, onConfirm, open, 
       // Reset for the next time this modal is opened.
       justConfirmedRef.current = false;
     } else if (suppressStorage && !justConfirmedRef.current) {
+      // mark justConfirmed here so it only gets called once in a suppressed modal.
+      justConfirmedRef.current = true;
       onConfirm();
     }
   }, [suppressStorage, open, onConfirm]);

--- a/lib/ConfirmationModal/SessionConfirmationModal.js
+++ b/lib/ConfirmationModal/SessionConfirmationModal.js
@@ -29,7 +29,8 @@ const SessionConfirmationModal = ({ sessionKey, checkboxLabel, onConfirm, open, 
       // Reset for the next time this modal is opened.
       justConfirmedRef.current = false;
     } else if (suppressStorage && !justConfirmedRef.current) {
-      // mark justConfirmed here so it only gets called once in a suppressed modal.
+      // mark justConfirmed here so it only gets called once in a suppressed modal, avoiding repeat
+      // calls on re-renders.
       justConfirmedRef.current = true;
       onConfirm();
     }

--- a/lib/ConfirmationModal/SessionConfirmationModal.js
+++ b/lib/ConfirmationModal/SessionConfirmationModal.js
@@ -18,19 +18,25 @@ const SessionConfirmationModal = ({ sessionKey, checkboxLabel, onConfirm, open, 
   const sessionKeyRef = useRef(sessionKey || uniqueId('confirmation-modal-'));
   const [suppressStorage, setSuppressStorage] = useSessionStorage(sessionKeyRef.current, false);
   const [suppress, setSuppress] = useState(false);
+  const justConfirmedRef = useRef(false);
 
   useEffect(() => {
-    if (suppressStorage && open) {
+    if (!open) {
+      justConfirmedRef.current = false;
+    } else if (suppressStorage && !justConfirmedRef.current) {
       onConfirm();
     }
   }, [suppressStorage, open, onConfirm]);
 
   const handleSessionConfirm = useCallback(() => {
+    justConfirmedRef.current = true;
     onConfirm();
     if (suppress) {
       setSuppressStorage(suppress);
     }
   }, [onConfirm, suppress, setSuppressStorage]);
+
+  if (suppressStorage) return null;
 
   const appendedMessage = (
     <>

--- a/lib/ConfirmationModal/SessionConfirmationModal.js
+++ b/lib/ConfirmationModal/SessionConfirmationModal.js
@@ -18,8 +18,7 @@ const SessionConfirmationModal = ({ sessionKey, checkboxLabel, onConfirm, open, 
   const sessionKeyRef = useRef(sessionKey || uniqueId('confirmation-modal-'));
   const [suppressStorage, setSuppressStorage] = useSessionStorage(sessionKeyRef.current, false);
   const [suppress, setSuppress] = useState(false);
-  // Tracks whether onConfirm was already invoked by the user's own click in this
-  // "open" session, so the effect below doesn't fire onConfirm a second time.
+  // Used as a sentinal so that onConfirm is not called a second time.
   const justConfirmedRef = useRef(false);
 
   // Auto-confirms when the modal opens and confirmation is already suppressed from
@@ -29,6 +28,9 @@ const SessionConfirmationModal = ({ sessionKey, checkboxLabel, onConfirm, open, 
       // Reset for the next time this modal is opened.
       justConfirmedRef.current = false;
     } else if (suppressStorage && !justConfirmedRef.current) {
+      // Mark that onConfirm is being called, so future re-renders while open
+      // won't fire onConfirm again.
+      justConfirmedRef.current = true;
       onConfirm();
     }
   }, [suppressStorage, open, onConfirm]);

--- a/lib/ConfirmationModal/SessionConfirmationModal.js
+++ b/lib/ConfirmationModal/SessionConfirmationModal.js
@@ -18,10 +18,15 @@ const SessionConfirmationModal = ({ sessionKey, checkboxLabel, onConfirm, open, 
   const sessionKeyRef = useRef(sessionKey || uniqueId('confirmation-modal-'));
   const [suppressStorage, setSuppressStorage] = useSessionStorage(sessionKeyRef.current, false);
   const [suppress, setSuppress] = useState(false);
+  // Tracks whether onConfirm was already invoked by the user's own click in this
+  // "open" session, so the effect below doesn't fire onConfirm a second time.
   const justConfirmedRef = useRef(false);
 
+  // Auto-confirms when the modal opens and confirmation is already suppressed from
+  // a *prior* session (i.e. the user previously checked "do not display again").
   useEffect(() => {
     if (!open) {
+      // Reset for the next time this modal is opened.
       justConfirmedRef.current = false;
     } else if (suppressStorage && !justConfirmedRef.current) {
       onConfirm();
@@ -29,6 +34,8 @@ const SessionConfirmationModal = ({ sessionKey, checkboxLabel, onConfirm, open, 
   }, [suppressStorage, open, onConfirm]);
 
   const handleSessionConfirm = useCallback(() => {
+    // Mark that onConfirm is being called here so the effect above skips its own
+    // call if setSuppressStorage below causes a re-render while open is still true.
     justConfirmedRef.current = true;
     onConfirm();
     if (suppress) {

--- a/lib/ConfirmationModal/tests/SessionConfirmationModal-test.js
+++ b/lib/ConfirmationModal/tests/SessionConfirmationModal-test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { after, describe, beforeEach, it } from 'mocha';
+import { after, describe, beforeEach, afterEach, it } from 'mocha';
 import { runAxeTest, converge, Bigtest, ConfirmationModal as ConfirmationModalInteractor, Keyboard, Button, Checkbox } from '@folio/stripes-testing';
 import { mountWithContext } from '../../../tests/helpers';
 
@@ -118,6 +118,23 @@ describe('SessionConfirmationModal', () => {
 
   describe('Checking the suppression checkbox', () => {
     beforeEach(async () => {
+      sessionStorage.removeItem(sessionKey);
+      confirmCount = 0;
+      await mountWithContext(
+        <SessionConfirmationModal
+          open
+          id="confirmation-modal-test"
+          heading={heading}
+          message={message}
+          bodyTag="div"
+          onConfirm={() => { confirmed = true; confirmCount += 1; }}
+          onCancel={() => { cancelled = true; }}
+          cancelLabel={cancelLabel}
+          confirmLabel={confirmLabel}
+          sessionKey={sessionKey}
+        />
+      );
+
       await Checkbox('Do not display this message again.').click();
       await confirmationModal.confirm();
     });
@@ -134,38 +151,38 @@ describe('SessionConfirmationModal', () => {
     it('should call the confirm callback exactly once, even though the modal remains open', () => converge(() => {
       if (confirmCount !== 1) { throw Error(`Expected onConfirm to be called once, but it was called ${confirmCount} times`); }
     }));
-  });
 
-  describe('and reopening the modal', () => {
-    beforeEach(async () => {
+    describe('and reopening the modal', () => {
+      beforeEach(async () => {
 
-      confirmCount = 0;
+        confirmCount = 0;
 
-      await mountWithContext(
-        <SessionConfirmationModal
-          open
-          id="confirmation-modal-test"
-          heading={heading}
-          message={message}
-          bodyTag="div"
-          isConfirmButtonDisabled
-          onConfirm={() => { confirmed = true; confirmCount += 1; }}
-          onCancel={() => { cancelled = true; }}
-          cancelLabel={cancelLabel}
-          confirmLabel={confirmLabel}
-          sessionKey={sessionKey}
-        />
-      );
+        await mountWithContext(
+          <SessionConfirmationModal
+            open
+            id="confirmation-modal-test"
+            heading={heading}
+            message={message}
+            bodyTag="div"
+            isConfirmButtonDisabled
+            onConfirm={() => { confirmed = true; confirmCount += 1; }}
+            onCancel={() => { cancelled = true; }}
+            cancelLabel={cancelLabel}
+            confirmLabel={confirmLabel}
+            sessionKey={sessionKey}
+          />
+        );
+      });
+
+      after(() => {
+        sessionStorage.removeItem(sessionKey);
+      });
+
+      it('the modal should not be displayed', () => confirmationModal.absent());
+
+      it('should call the confirm callback exactly once', () => converge(() => {
+        if (confirmCount !== 1) { throw Error(`Expected onConfirm to be called once, but it was called ${confirmCount} times`); }
+      }));
     });
-
-    after(() => {
-      sessionStorage.removeItem(sessionKey);
-    });
-
-    it('the modal should not be displayed', () => confirmationModal.absent());
-
-    it('should call the confirm callback exactly once', () => converge(() => {
-      if (confirmCount !== 1) { throw Error(`Expected onConfirm to be called once, but it was called ${confirmCount} times`); }
-    }));
   });
 });

--- a/lib/ConfirmationModal/tests/SessionConfirmationModal-test.js
+++ b/lib/ConfirmationModal/tests/SessionConfirmationModal-test.js
@@ -1,7 +1,3 @@
-/**
- * ConfirmationModal test
- */
-
 import React from 'react';
 
 import { after, describe, beforeEach, it } from 'mocha';
@@ -21,6 +17,7 @@ describe('SessionConfirmationModal', () => {
   const confirmationModal = ConfirmationModalInteractor();
   let confirmed;
   let cancelled;
+  let confirmCount;
 
   const sessionKey = 'test-session-key';
   const message = 'Something will happen if you do this.';
@@ -31,6 +28,7 @@ describe('SessionConfirmationModal', () => {
   beforeEach(async () => {
     confirmed = false;
     cancelled = false;
+    confirmCount = 0;
 
     await mountWithContext(
       <SessionConfirmationModal
@@ -39,7 +37,7 @@ describe('SessionConfirmationModal', () => {
         heading={heading}
         message={message}
         bodyTag="div"
-        onConfirm={() => { confirmed = true; }}
+        onConfirm={() => { confirmed = true; confirmCount += 1; }}
         onCancel={() => { cancelled = true; }}
         cancelLabel={cancelLabel}
         confirmLabel={confirmLabel}
@@ -86,6 +84,10 @@ describe('SessionConfirmationModal', () => {
     });
 
     it('The onConfirm callback should be fired', () => converge(() => { if (!confirmed) { throw Error('The onConfirm callback should be fired'); } }));
+
+    it('The onConfirm callback should be fired exactly once', () => converge(() => {
+      if (confirmCount !== 1) { throw Error(`Expected onConfirm to be called once, but it was called ${confirmCount} times`); }
+    }));
   });
 
   describe('When clicking the cancel button', () => {
@@ -128,10 +130,17 @@ describe('SessionConfirmationModal', () => {
         converge(() => { if (!confirmed) { throw Error('The onConfirm callback should be fired'); } }),
       ])
     );
+
+    it('should call the confirm callback exactly once, even though the modal remains open', () => converge(() => {
+      if (confirmCount !== 1) { throw Error(`Expected onConfirm to be called once, but it was called ${confirmCount} times`); }
+    }));
   });
 
   describe('and reopening the modal', () => {
     beforeEach(async () => {
+
+      confirmCount = 0;
+
       await mountWithContext(
         <SessionConfirmationModal
           open
@@ -140,7 +149,7 @@ describe('SessionConfirmationModal', () => {
           message={message}
           bodyTag="div"
           isConfirmButtonDisabled
-          onConfirm={() => { confirmed = true; }}
+          onConfirm={() => { confirmed = true; confirmCount += 1; }}
           onCancel={() => { cancelled = true; }}
           cancelLabel={cancelLabel}
           confirmLabel={confirmLabel}
@@ -154,5 +163,9 @@ describe('SessionConfirmationModal', () => {
     });
 
     it('the modal should not be displayed', () => confirmationModal.absent());
+
+    it('should call the confirm callback exactly once', () => converge(() => {
+      if (confirmCount !== 1) { throw Error(`Expected onConfirm to be called once, but it was called ${confirmCount} times`); }
+    }));
   });
 });

--- a/translations/stripes-components/en.json
+++ b/translations/stripes-components/en.json
@@ -29,7 +29,7 @@
   "next": "Next",
   "selectDay": "Choose {dayOfWeek}, {date}",
   "ConfirmationModal.suppressLabel": "Do not show this message again.",
-  "ConfirmationModal.suppressMessage": "If checked, this message will be automatically confirmed for the rest of the session.",
+  "ConfirmationModal.suppressMessage": "If checked, this action will be automatically confirmed for the rest of the session.",
   "dateSelected": "{date} selected",
   "Datepicker.monthControl": "month",
   "Datepicker.yearControl": "year",


### PR DESCRIPTION
## [STCOM-1545](https://folio-org.atlassian.net/browse/STCOM-1545)
### Problem
1. Click → `handleSessionConfirm` runs → `onConfirm()` → `onConfirm()` Logic fires. No guarantee that `open` was set to `false`.
2. box was checked, so `handleSessionConfirm` then calls `setSuppressStorage(true)`.
3. Re-render: `suppressStorage=true`, `open` still `true` → effect condition `suppressStorage && open` is now true → `onConfirm()` runs a second time . 💥 

### Approach
Shield it up with a ref. `onConfirm()` is set to run if `suppressStorage` is true AND `open` is true (the suppressed case where the use checked the 'never display again' box) - this can run a second time as described above, so if the effect has run, set a ref when it runs with the user's click that will prevent it from being run if the modal hasn't been closed and re-open.

Very effect-y... so comments!

Also in this PR:
Don't even render the ConfirmationModal if `suppressStorage=true` (can prevent flashes of the modal from showing up.)