### PR TITLE
STCOM-1547 correctly parse locale strings in Datepicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Convert MCL layout elements to a `flex-box` column. Resolves issues where pagination buttons would not show up on the first render. Refs STCOM-1536.
 * Resolve color contrast issues on selected MCL rows, IconButtons, focus styles. Refs STCOM-1541.
 * Bug-fix. Subsequent, post-onConfirm could call onConfirm again (`<SessionConfirmationModal>`). Refs STCOM-1545
+* `Datepicker` correctly checks configured locale. Refs STCOM-1547.
 
 ## [13.1.0](https://github.com/folio-org/stripes-components/tree/v13.1.0) (2026-04-14)
 

--- a/lib/Datepicker/Calendar.js
+++ b/lib/Datepicker/Calendar.js
@@ -124,8 +124,14 @@ class Calendar extends React.Component {
   constructor(props) {
     super(props);
 
+    // locale may or may not include a region (e.g. -SA) or number-format
+    // specifier (e.g. -u-nu-latn) after the locale prefix (e.g. ar). moment
+    // will search through the substrings from most-specific to least-specific,
+    // so given a locale like ar-SA-u-nu-latn it will first try ar-SA-u-nu-latn,
+    // then ar-SA-u-nu, then ar-SA-u, etc. input may come in a form moment lacks
+    // support for (👋 en-SE) but we will still end up with a valid locale (en)
+    // thanks to this algorithm.
     moment.locale(this.props.intl.locale || this.props.locale);
-
     const { selectedDate, dateFormat } = this.props;
 
     this.selectedMoment = new moment(); // eslint-disable-line new-cap
@@ -139,26 +145,20 @@ class Calendar extends React.Component {
       cursorDate = new moment(); // eslint-disable-line new-cap
     }
 
-    // if the stripes locale has no region (only 2 letters), it needs to be normalized to a
-    // common form of {language}-{region} ex: "en-SE" (english spoken in Sweden)
-    // We adjust it by mapping from a set of common default regions (staticRegions);
-    // the first weekday in calendar rendering is derived from region.
-    // Hopefully it will be implemented in browser Intl API soon..
-    // but until then...
+    // canonicalize the locale to guarantee the presence of a region code since
+    // region is used to configure the first day of the week (sa, su, mo).
+    // happily, the Intl.Locale API can parse the (rather elaborate) locale
+    // identifier format and spit out the pieces we need. A simple,
+    // two-character locale like `en` or `es` will be canonicalized to a
+    // language-region code using the staticRegions table that provides a
+    // default region when the locale string doesn't include one.
+    const { language, region } = new Intl.Locale(props.intl.locale || props.locale);
+    const adjustedLocale = region ? `${language}-${region}` : `${language}-${staticRegions[language]}`;
 
-    let dayOffset = 0;
-    let adjustedLocale = props.intl.locale || props.locale;
-    if (adjustedLocale.length === 2) {
-      const regionDefault = staticRegions[adjustedLocale];
-      adjustedLocale = `${adjustedLocale}-${regionDefault}`;
-    }
-
-    // if moment doesn't have the requested locale from above (intl/stripes), it falls back to 'en'. If this
-    // is the case, we need to set an offset value for correct calendar day rendering -
-    // otherwise, the calendar columns will be off, resulting misaligned weekdays/calendar days.
-    if (moment.locale() === 'en') {
-      dayOffset = getFirstWeekday(adjustedLocale);
-    }
+    // moment falls back to 'en' if it doesn't have a match for the requested
+    // locale. since we draw our own calendar, however, we still need to set
+    // the dayOffset to keep day-of-week labels correctly alligned with dates
+    const dayOffset = moment.locale() === 'en' ? getFirstWeekday(adjustedLocale) : 0;
 
     const base = new moment(cursorDate); // eslint-disable-line new-cap
     const month = base.month();


### PR DESCRIPTION
Use `Intl.Locale` to parse locale-strings since that API is now baseline widely available. Overly simplistic parsing in the previous implementation faltered when locales included number format settings, e.g. `es-u-nu-latn`. While there was not a good reason to provide such settings (number format only needs to be specified when you want to override a locale's default), providing it shouldn't cause errors.

Refs [STCOM-1547](https://folio-org.atlassian.net/browse/STCOM-1547)