### PR TITLE
STCOM-1548 Improve labels and icons positioning in `<RepeatableField>` component when some labels are not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Resolve color contrast issues on selected MCL rows, IconButtons, focus styles. Refs STCOM-1541.
 * Add color variable for `color-text-active` for interactive elements in the `:active` state. Resolves Button's text disappearing when in the `:active` state. Refs STCOM-1544.
 * Bug-fix. Subsequent, post-onConfirm could call onConfirm again (`<SessionConfirmationModal>`). Refs STCOM-1545
+* Improve labels and icons positioning in `<RepeatableField>` component when some labels are not present. Refs STCOM-1548.
 
 ## [13.1.0](https://github.com/folio-org/stripes-components/tree/v13.1.0) (2026-04-14)
 

--- a/lib/RepeatableField/RepeatableField.css
+++ b/lib/RepeatableField/RepeatableField.css
@@ -4,6 +4,10 @@
   padding: 0;
 }
 
+.legend {
+  margin-bottom: var(--control-label-margin-bottom);
+}
+
 .hasMargin {
   margin: var(--gutter) 0;
 }
@@ -11,6 +15,7 @@
 .repeatableFieldList {
   list-style-type: none;
   padding: 0;
+  margin: 0;
 }
 
 .repeatableFieldItem,
@@ -33,8 +38,11 @@
 
 .repeatableFieldRemoveItem {
   flex: 0 0 3em;
-  margin-top: 1.75em;
   text-align: center;
+
+  &.hasMargin {
+    margin-top: 1.75em;
+  }
 }
 
 .repeatableFieldRemoveUnlabeledItem {

--- a/lib/RepeatableField/RepeatableField.js
+++ b/lib/RepeatableField/RepeatableField.js
@@ -16,6 +16,7 @@ const RepeatableField = ({
   canAdd = true,
   canRemove = true,
   hasMargin = true,
+  hasRemoveButtonMargin = true,
   getFieldUniqueKey = (_field, index) => index,
   addLabel,
   className,
@@ -90,6 +91,7 @@ const RepeatableField = ({
         <Headline
           data-test-repeatable-field-legend
           tag="legend"
+          className={css.legend}
         >
           {legend}
         </Headline>
@@ -133,9 +135,11 @@ const RepeatableField = ({
               {
                 showDeleteBtn && (
                   <div
-                    className={
-                      `${css.repeatableFieldRemoveItem} ${headLabels ? css.repeatableFieldRemoveUnlabeledItem : ''}`
-                    }
+                    className={classnames(
+                      css.repeatableFieldRemoveItem,
+                      { [`${css.repeatableFieldRemoveUnlabeledItem}`]: Boolean(headLabels) },
+                      { [`${css.hasMargin}`]: hasRemoveButtonMargin }
+                    )}
                   >
                     <FormattedMessage id="stripes-components.deleteThisItem">
                       { ([label]) => (

--- a/lib/RepeatableField/readme.md
+++ b/lib/RepeatableField/readme.md
@@ -162,7 +162,8 @@ className | string | Adds a custom class name for the root element |
 emptyMessage | string | Text for when there are no rows; can be left blank |
 fields | array or object | Values that go with field rows | &#10004;
 getFieldUniqueKey | func | A function that returns a unique value as the `key` prop for each field in an array. If not provided, it will default to the index of the field in the array. |
-hasMargin | bool | Applies margin on top and bottom | true | 
+hasMargin | bool | Applies margin on top and bottom | true |
+hasRemoveButtonMargin | bool | Applies top margin to remove field button | true |
 headLabels | node | Element that displays heading field labels. Developer should care about accessibility if this property is used (see an example).   |
 id | string | Adds an ID for the root element and prefixed ID's for the default add button |
 legend | node or string | Legend text that accompanies the fieldset; can be left blank |


### PR DESCRIPTION
## Description
Make margin of the `legend` element of the repeatable field consistend with other labels in folio
Add a `hasRemoveButtonMargin` prop to be able to control margins of the remove field button. Currently, when individual field's labels are not present - remove icon will be out of alignment with the field.

## Screenshots
<img width="1919" height="870" alt="image" src="https://github.com/user-attachments/assets/3052b995-a401-4182-8dfc-95436a2775d0" />

## Issues
[STCOM-1548](https://folio-org.atlassian.net/browse/STCOM-1548)