### PR TITLE
STCOM-1550 Provide extension on dayJS locale import so webpack can be upgraded.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Bug-fix. Subsequent, post-onConfirm could call onConfirm again (`<SessionConfirmationModal>`). Refs STCOM-1545
 * `Datepicker` correctly checks configured locale. Refs STCOM-1547.
 * Improve labels and icons positioning in `<RepeatableField>` component when some labels are not present. Refs STCOM-1548.
+* Add `.js` extension to DayJS local import. Refs STCOM-1550.
 
 ## [13.1.0](https://github.com/folio-org/stripes-components/tree/v13.1.0) (2026-04-14)
 

--- a/util/dateTimeUtils.js
+++ b/util/dateTimeUtils.js
@@ -210,7 +210,7 @@ export function loadDayJSLocale(locale, cb = noop) {
       import(
         /* webpackChunkName: "dayjs-locale-[request]" */
         /* webpackExclude: /\.d\.ts$/ */
-        `dayjs/locale/${localeToLoad}`
+        `dayjs/locale/${localeToLoad}.js`
       ).then(() => {
         dayjs.locale(localeToLoad);
         cb(localeToLoad);


### PR DESCRIPTION
## [STCOM-1550](https://folio-org.atlassian.net/browse/STCOM-1550)

~5.10.0 webpack's been doing under-the-hood work with lazy imports. Our DayJS locale import is just that. This previously worked fine thanks to the 'magic comment' just working to exclude the `.ts` file. This import should work in the current state, as all of those locale files are `.js` files.