### PR TITLE
STCOM-1552 Header clipping title when subtitle has large line-height

### DIFF
--- a/lib/PaneHeader/PaneHeader.css
+++ b/lib/PaneHeader/PaneHeader.css
@@ -5,11 +5,11 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex: 1 0 var(--control-min-size-touch);
   border-bottom: 1px solid var(--color-border-p2);
   position: relative;
   will-change: transform;
   padding: 0 var(--gutter-static);
-  min-height: var(--control-min-size-touch);
   background-color: var(--color-fill);
   outline: 0;
 
@@ -30,7 +30,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0 var(--gutter-static-one-third);
+  padding: var(--gutter-static-one-third);
 }
 
 /* Inner part of pane header


### PR DESCRIPTION
`min-height` alone wasn't reliably driving the box's actual rendered size in this layout context. something in the surrounding flex/parent sizing caused the header to be constrained near that touch-target minimum rather than growing to fit content, so `align-items: center` clipped the overflow symmetrically instead of expanding the box.

**Fix:** 
Replaced the fixed `min-height` with a flexible `flex-basis`, and used padding to preserve consistent spacing.

<img width="1747" height="153" alt="image" src="https://github.com/user-attachments/assets/a013a59d-b5bc-468f-b2a0-41326f46f2af" />

<img width="1682" height="142" alt="image" src="https://github.com/user-attachments/assets/070220ad-dfe8-47dd-85ce-16b341604e96" />

Refs: [STCOM-1552](https://folio-org.atlassian.net/browse/STCOM-1552)